### PR TITLE
Fix some keycloak issues - missing guard on dispute routes, directly navigating to specific urls when not logged in, and mocking the initializer function

### DIFF
--- a/src/frontend/citizen-portal/src/app/core/guards/auth.guard.ts
+++ b/src/frontend/citizen-portal/src/app/core/guards/auth.guard.ts
@@ -6,6 +6,7 @@ import {
   ActivatedRouteSnapshot,
   RouterStateSnapshot,
 } from '@angular/router';
+import { LoggerService } from '@core/services/logger.service';
 import { KeycloakService } from 'keycloak-angular';
 
 @Injectable()
@@ -14,7 +15,8 @@ export class AuthGuard implements CanActivate, CanActivateChild {
 
   constructor(
     protected router: Router,
-    protected keycloakService: KeycloakService
+    protected keycloakService: KeycloakService,
+    private logger: LoggerService
   ) {}
 
   public get isAuthenticated(): boolean {
@@ -40,7 +42,10 @@ export class AuthGuard implements CanActivate, CanActivateChild {
       try {
         this.authenticated = await this.keycloakService.isLoggedIn();
         if (!this.authenticated) {
-          this.keycloakService.login();
+          this.keycloakService.login().catch((e) => {
+            this.logger.error('keycloakService.login failure', e);
+            this.router.navigate(['/']);
+          });
         }
         const result = await this.canAccess(this.authenticated, url);
         resolve(result);

--- a/src/frontend/citizen-portal/src/app/core/keycloak/keycloak.module.ts
+++ b/src/frontend/citizen-portal/src/app/core/keycloak/keycloak.module.ts
@@ -16,11 +16,7 @@ function initializer(
   keycloak: KeycloakService,
   injector: Injector
 ): () => Promise<void> {
-  if (!environment.useKeycloak) {
-    return () => Promise.resolve();
-  }
-
-  const routeToDefault = () => injector.get(Router).navigateByUrl('/home');
+  const routeToDefault = () => injector.get(Router).navigateByUrl('/');
 
   return async (): Promise<void> => {
     const authenticated = await keycloak.init(
@@ -58,7 +54,11 @@ function initializer(
     },
     {
       provide: APP_INITIALIZER,
-      useFactory: initializer,
+      useFactory: () => {
+        return environment.useKeycloak
+          ? initializer
+          : MockKeycloakService.mockInitializer;
+      },
       multi: true,
       deps: [KeycloakService, Injector],
     },

--- a/src/frontend/citizen-portal/src/app/modules/auth/services/auth.service.spec.ts
+++ b/src/frontend/citizen-portal/src/app/modules/auth/services/auth.service.spec.ts
@@ -25,31 +25,31 @@ describe('AuthService', () => {
     expect(authService).toBeTruthy();
   });
 
-  // it('login should invoke keycloak login', () => {
-  //   spyOn(keycloakService, 'login').and.returnValue(Promise.resolve());
-  //   authService.login().then(() => {
-  //     expect(keycloakService.login()).toHaveBeenCalled();
-  //   });
-  // });
+  it('login should invoke keycloak login', () => {
+    spyOn(keycloakService, 'login').and.returnValue(Promise.resolve());
+    authService.login().then(() => {
+      expect(keycloakService.login).toHaveBeenCalled();
+    });
+  });
 
-  // it('isLoggedIn should invoke keycloak isLoggedIn', () => {
-  //   spyOn(keycloakService, 'isLoggedIn').and.returnValue(Promise.resolve(true));
-  //   authService.isLoggedIn().then((result) => {
-  //     expect(keycloakService.isLoggedIn()).toHaveBeenCalled();
-  //     expect(result).toEqual(true);
-  //   });
-  // });
+  it('isLoggedIn should invoke keycloak isLoggedIn', () => {
+    spyOn(keycloakService, 'isLoggedIn').and.returnValue(Promise.resolve(true));
+    authService.isLoggedIn().then((result) => {
+      expect(keycloakService.isLoggedIn).toHaveBeenCalled();
+      expect(result).toEqual(true);
+    });
+  });
 
-  // it('getUser should getUserInfo when loggedIn', () => {
-  //   spyOn(keycloakService, 'loadUserProfile').and.returnValue(
-  //     Promise.resolve(new Object())
-  //   );
-  //   authService.getUser().then((result) => {
-  //     expect(keycloakService.loadUserProfile()).toHaveBeenCalled();
-  //     expect(result.firstName).toEqual('mockFirstName');
-  //     expect(result.lastName).toEqual('mockLastName');
-  //   });
-  // });
+  it('getUser should getUserInfo when loggedIn', () => {
+    spyOn(keycloakService, 'loadUserProfile').and.returnValue(
+      Promise.resolve(new Object())
+    );
+    authService.getUser().then((result) => {
+      expect(keycloakService.loadUserProfile).toHaveBeenCalled();
+      expect(result.firstName).toEqual('mockFirstName');
+      expect(result.lastName).toEqual('mockLastName');
+    });
+  });
 
   it('getUser should reject when not loggedIn', () => {
     spyOn(keycloakService, 'isLoggedIn').and.returnValue(
@@ -67,10 +67,10 @@ describe('AuthService', () => {
     });
   });
 
-  // it('logout should invoke keycloak logout', () => {
-  //   spyOn(keycloakService, 'logout').and.returnValue(Promise.resolve());
-  //   authService.logout().then(() => {
-  //     expect(keycloakService.logout()).toHaveBeenCalled();
-  //   });
-  // });
+  it('logout should invoke keycloak logout', () => {
+    spyOn(keycloakService, 'logout').and.returnValue(Promise.resolve());
+    authService.logout().then(() => {
+      expect(keycloakService.logout).toHaveBeenCalled();
+    });
+  });
 });

--- a/src/frontend/citizen-portal/src/app/modules/auth/services/auth.service.spec.ts
+++ b/src/frontend/citizen-portal/src/app/modules/auth/services/auth.service.spec.ts
@@ -33,6 +33,7 @@ describe('AuthService', () => {
   });
 
   it('isLoggedIn should invoke keycloak isLoggedIn', () => {
+    spyOn(keycloakService, 'isLoggedIn').and.returnValue(Promise.resolve(true));
     authService.isLoggedIn().then((result) => {
       expect(keycloakService.isLoggedIn()).toHaveBeenCalled();
       expect(result).toEqual(true);
@@ -40,6 +41,7 @@ describe('AuthService', () => {
   });
 
   it('logout should invoke keycloak logout', () => {
+    spyOn(keycloakService, 'logout').and.returnValue(Promise.resolve());
     authService.logout().then(() => {
       expect(keycloakService.logout()).toHaveBeenCalled();
     });

--- a/src/frontend/citizen-portal/src/app/modules/auth/services/auth.service.spec.ts
+++ b/src/frontend/citizen-portal/src/app/modules/auth/services/auth.service.spec.ts
@@ -26,7 +26,7 @@ describe('AuthService', () => {
   });
 
   it('login should invoke keycloak login', () => {
-    spyOn(keycloakService, 'login').and.returnValue(Promise.resolve());
+    spyOn(keycloakService, 'login').and.callThrough();
     authService.login().then(() => {
       expect(keycloakService.login).toHaveBeenCalled();
     });
@@ -41,9 +41,7 @@ describe('AuthService', () => {
   });
 
   it('getUser should getUserInfo when loggedIn', () => {
-    spyOn(keycloakService, 'loadUserProfile').and.returnValue(
-      Promise.resolve(new Object())
-    );
+    spyOn(keycloakService, 'loadUserProfile').and.callThrough();
     authService.getUser().then((result) => {
       expect(keycloakService.loadUserProfile).toHaveBeenCalled();
       expect(result.firstName).toEqual('mockFirstName');
@@ -68,7 +66,7 @@ describe('AuthService', () => {
   });
 
   it('logout should invoke keycloak logout', () => {
-    spyOn(keycloakService, 'logout').and.returnValue(Promise.resolve());
+    spyOn(keycloakService, 'logout').and.callThrough();
     authService.logout().then(() => {
       expect(keycloakService.logout).toHaveBeenCalled();
     });

--- a/src/frontend/citizen-portal/src/app/modules/auth/services/auth.service.spec.ts
+++ b/src/frontend/citizen-portal/src/app/modules/auth/services/auth.service.spec.ts
@@ -25,50 +25,56 @@ describe('AuthService', () => {
     expect(authService).toBeTruthy();
   });
 
-  it('login should invoke keycloak login', () => {
+  it('login should invoke keycloak login', (done) => {
     spyOn(keycloakService, 'login').and.callThrough();
     authService.login().then(() => {
       expect(keycloakService.login).toHaveBeenCalled();
+      done();
     });
   });
 
-  it('isLoggedIn should invoke keycloak isLoggedIn', () => {
+  it('isLoggedIn should invoke keycloak isLoggedIn', (done) => {
     spyOn(keycloakService, 'isLoggedIn').and.returnValue(Promise.resolve(true));
     authService.isLoggedIn().then((result) => {
       expect(keycloakService.isLoggedIn).toHaveBeenCalled();
       expect(result).toEqual(true);
+      done();
     });
   });
 
-  it('getUser should getUserInfo when loggedIn', () => {
+  it('getUser should getUserInfo when loggedIn', (done) => {
     spyOn(keycloakService, 'loadUserProfile').and.callThrough();
     authService.getUser().then((result) => {
       expect(keycloakService.loadUserProfile).toHaveBeenCalled();
       expect(result.firstName).toEqual('mockFirstName');
       expect(result.lastName).toEqual('mockLastName');
+      done();
     });
   });
 
-  it('getUser should reject when not loggedIn', () => {
+  it('getUser should reject when not loggedIn', (done) => {
     spyOn(keycloakService, 'isLoggedIn').and.returnValue(
       Promise.resolve(false)
     );
     authService.getUser().catch((error) => {
       expect(error).toEqual('user not logged in.');
+      done();
     });
   });
 
-  it('getUser$ should get userInfo', () => {
+  it('getUser$ should get userInfo', (done) => {
     authService.getUser$().subscribe((result) => {
       expect(result.firstName).toEqual('mockFirstName');
       expect(result.lastName).toEqual('mockLastName');
+      done();
     });
   });
 
-  it('logout should invoke keycloak logout', () => {
+  it('logout should invoke keycloak logout', (done) => {
     spyOn(keycloakService, 'logout').and.callThrough();
     authService.logout().then(() => {
       expect(keycloakService.logout).toHaveBeenCalled();
+      done();
     });
   });
 });

--- a/src/frontend/citizen-portal/src/app/modules/auth/services/auth.service.spec.ts
+++ b/src/frontend/citizen-portal/src/app/modules/auth/services/auth.service.spec.ts
@@ -40,14 +40,10 @@ describe('AuthService', () => {
     });
   });
 
-  it('logout should invoke keycloak logout', () => {
-    spyOn(keycloakService, 'logout').and.returnValue(Promise.resolve());
-    authService.logout().then(() => {
-      expect(keycloakService.logout()).toHaveBeenCalled();
-    });
-  });
-
   it('getUser should getUserInfo when loggedIn', () => {
+    spyOn(keycloakService, 'loadUserProfile').and.returnValue(
+      Promise.resolve(new Object())
+    );
     authService.getUser().then((result) => {
       expect(keycloakService.loadUserProfile()).toHaveBeenCalled();
       expect(result.firstName).toEqual('mockFirstName');
@@ -70,4 +66,11 @@ describe('AuthService', () => {
       expect(result.lastName).toEqual('mockLastName');
     });
   });
+
+  // it('logout should invoke keycloak logout', () => {
+  //   spyOn(keycloakService, 'logout').and.returnValue(Promise.resolve());
+  //   authService.logout().then(() => {
+  //     expect(keycloakService.logout()).toHaveBeenCalled();
+  //   });
+  // });
 });

--- a/src/frontend/citizen-portal/src/app/modules/auth/services/auth.service.spec.ts
+++ b/src/frontend/citizen-portal/src/app/modules/auth/services/auth.service.spec.ts
@@ -25,31 +25,31 @@ describe('AuthService', () => {
     expect(authService).toBeTruthy();
   });
 
-  it('login should invoke keycloak login', () => {
-    // spyOn(keycloakService, 'login').and.returnValue(Promise.resolve());
-    authService.login().then(() => {
-      expect(keycloakService.login()).toHaveBeenCalled();
-    });
-  });
+  // it('login should invoke keycloak login', () => {
+  //   spyOn(keycloakService, 'login').and.returnValue(Promise.resolve());
+  //   authService.login().then(() => {
+  //     expect(keycloakService.login()).toHaveBeenCalled();
+  //   });
+  // });
 
-  it('isLoggedIn should invoke keycloak isLoggedIn', () => {
-    // spyOn(keycloakService, 'isLoggedIn').and.returnValue(Promise.resolve(true));
-    authService.isLoggedIn().then((result) => {
-      expect(keycloakService.isLoggedIn()).toHaveBeenCalled();
-      expect(result).toEqual(true);
-    });
-  });
+  // it('isLoggedIn should invoke keycloak isLoggedIn', () => {
+  //   spyOn(keycloakService, 'isLoggedIn').and.returnValue(Promise.resolve(true));
+  //   authService.isLoggedIn().then((result) => {
+  //     expect(keycloakService.isLoggedIn()).toHaveBeenCalled();
+  //     expect(result).toEqual(true);
+  //   });
+  // });
 
-  it('getUser should getUserInfo when loggedIn', () => {
-    // spyOn(keycloakService, 'loadUserProfile').and.returnValue(
-    //   Promise.resolve(new Object())
-    // );
-    authService.getUser().then((result) => {
-      expect(keycloakService.loadUserProfile()).toHaveBeenCalled();
-      expect(result.firstName).toEqual('mockFirstName');
-      expect(result.lastName).toEqual('mockLastName');
-    });
-  });
+  // it('getUser should getUserInfo when loggedIn', () => {
+  //   spyOn(keycloakService, 'loadUserProfile').and.returnValue(
+  //     Promise.resolve(new Object())
+  //   );
+  //   authService.getUser().then((result) => {
+  //     expect(keycloakService.loadUserProfile()).toHaveBeenCalled();
+  //     expect(result.firstName).toEqual('mockFirstName');
+  //     expect(result.lastName).toEqual('mockLastName');
+  //   });
+  // });
 
   it('getUser should reject when not loggedIn', () => {
     spyOn(keycloakService, 'isLoggedIn').and.returnValue(
@@ -67,10 +67,10 @@ describe('AuthService', () => {
     });
   });
 
-  it('logout should invoke keycloak logout', () => {
-    // spyOn(keycloakService, 'logout').and.returnValue(Promise.resolve());
-    authService.logout().then(() => {
-      expect(keycloakService.logout()).toHaveBeenCalled();
-    });
-  });
+  // it('logout should invoke keycloak logout', () => {
+  //   spyOn(keycloakService, 'logout').and.returnValue(Promise.resolve());
+  //   authService.logout().then(() => {
+  //     expect(keycloakService.logout()).toHaveBeenCalled();
+  //   });
+  // });
 });

--- a/src/frontend/citizen-portal/src/app/modules/auth/services/auth.service.spec.ts
+++ b/src/frontend/citizen-portal/src/app/modules/auth/services/auth.service.spec.ts
@@ -26,14 +26,14 @@ describe('AuthService', () => {
   });
 
   it('login should invoke keycloak login', () => {
-    spyOn(keycloakService, 'login').and.returnValue(Promise.resolve());
+    // spyOn(keycloakService, 'login').and.returnValue(Promise.resolve());
     authService.login().then(() => {
       expect(keycloakService.login()).toHaveBeenCalled();
     });
   });
 
   it('isLoggedIn should invoke keycloak isLoggedIn', () => {
-    spyOn(keycloakService, 'isLoggedIn').and.returnValue(Promise.resolve(true));
+    // spyOn(keycloakService, 'isLoggedIn').and.returnValue(Promise.resolve(true));
     authService.isLoggedIn().then((result) => {
       expect(keycloakService.isLoggedIn()).toHaveBeenCalled();
       expect(result).toEqual(true);
@@ -41,9 +41,9 @@ describe('AuthService', () => {
   });
 
   it('getUser should getUserInfo when loggedIn', () => {
-    spyOn(keycloakService, 'loadUserProfile').and.returnValue(
-      Promise.resolve(new Object())
-    );
+    // spyOn(keycloakService, 'loadUserProfile').and.returnValue(
+    //   Promise.resolve(new Object())
+    // );
     authService.getUser().then((result) => {
       expect(keycloakService.loadUserProfile()).toHaveBeenCalled();
       expect(result.firstName).toEqual('mockFirstName');
@@ -67,10 +67,10 @@ describe('AuthService', () => {
     });
   });
 
-  // it('logout should invoke keycloak logout', () => {
-  //   spyOn(keycloakService, 'logout').and.returnValue(Promise.resolve());
-  //   authService.logout().then(() => {
-  //     expect(keycloakService.logout()).toHaveBeenCalled();
-  //   });
-  // });
+  it('logout should invoke keycloak logout', () => {
+    // spyOn(keycloakService, 'logout').and.returnValue(Promise.resolve());
+    authService.logout().then(() => {
+      expect(keycloakService.logout()).toHaveBeenCalled();
+    });
+  });
 });

--- a/src/frontend/citizen-portal/src/app/modules/dashboard/components/dashboard-header/dashboard-header.component.spec.ts
+++ b/src/frontend/citizen-portal/src/app/modules/dashboard/components/dashboard-header/dashboard-header.component.spec.ts
@@ -54,11 +54,12 @@ describe('DashboardHeaderComponent', () => {
     expect(component.fullName).toBeUndefined();
   });
 
-  it('should call logout after angular call logout', () => {
+  it('should call logout after angular call logout', (done) => {
     spyOn(authService, 'logout').and.callThrough();
     component.onLogout().then(() => {
       expect(component.fullName).toBeUndefined();
       expect(authService.logout).toHaveBeenCalled();
+      done();
     });
   });
 });

--- a/src/frontend/citizen-portal/src/app/modules/dashboard/components/dashboard-header/dashboard-header.component.spec.ts
+++ b/src/frontend/citizen-portal/src/app/modules/dashboard/components/dashboard-header/dashboard-header.component.spec.ts
@@ -9,7 +9,7 @@ import { LoggerService } from '@core/services/logger.service';
 import { NgxMaterialModule } from '@shared/modules/ngx-material/ngx-material.module';
 import { NgxProgressModule } from '@shared/modules/ngx-progress/ngx-progress.module';
 import { AuthService } from 'app/modules/auth/services/auth.service';
-import { EMPTY, Observable, of } from 'rxjs';
+import { EMPTY } from 'rxjs';
 import { MockAuthService } from 'tests/mocks/mock-auth.service';
 import { DashboardHeaderComponent } from './dashboard-header.component';
 

--- a/src/frontend/citizen-portal/src/app/modules/dispute/dispute-routing.module.ts
+++ b/src/frontend/citizen-portal/src/app/modules/dispute/dispute-routing.module.ts
@@ -6,11 +6,13 @@ import { FindTicketComponent } from './components/find-ticket/find-ticket.compon
 import { DisputePageComponent } from './components/dispute-page/dispute-page.component';
 import { DisputeSubmitComponent } from './components/dispute-submit/dispute-submit.component';
 import { DisputeListComponent } from './components/dispute-list/dispute-list.component';
+import { AuthGuard } from '@core/guards/auth.guard';
 
 const routes: Routes = [
   {
     path: DisputeRoutes.DISPUTE,
     component: DisputePageComponent,
+    canActivate: [AuthGuard],
     children: [
       {
         path: DisputeRoutes.LIST,

--- a/src/frontend/citizen-portal/src/tests/mocks/mock-keycloak.service.ts
+++ b/src/frontend/citizen-portal/src/tests/mocks/mock-keycloak.service.ts
@@ -1,10 +1,17 @@
-import { Injectable } from '@angular/core';
+import { Injectable, Injector } from '@angular/core';
 import { KeycloakService } from 'keycloak-angular';
 
 @Injectable({
   providedIn: 'root',
 })
 export class MockKeycloakService {
+  public static mockInitializer(
+    keycloak: KeycloakService,
+    injector: Injector
+  ): () => Promise<void> {
+    return () => Promise.resolve();
+  }
+
   public init(): Promise<boolean> {
     return Promise.resolve(true);
   }


### PR DESCRIPTION
# Description

Fix some keycloak issues 
- missing guard on dispute routes, 
- directly navigating to specific urls when not logged in, and 
- mocking the initializer function

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [ ] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
