### PR TITLE
Added swagger, moved frontend port

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,33 +40,33 @@ services:
     command: "nginx -g 'daemon off;'"
     restart: always
     ports:
-      - "4201:8080"
+      - "8080:8080"
     networks:
       - traffic-court-net
 
   #############################################################################################
   ###                                 TrafficCourt DEMO                                     ###
   #############################################################################################
-  citizen-portal-demo:
-    container_name: citizen-portal-demo
-    build:
-      context: ./src/frontend/citizen-portal
-      args:
-        USE_MOCK_SERVICES: "true"
-        USE_KEYCLOAK: "false"
-        API_URL: ${API_URL}
-        KEYCLOAK_URL: ${KEYCLOAK_URL}
-        KEYCLOAK_REALM: ${KEYCLOAK_REALM}
-        KEYCLOAK_CLIENT_ID: ${KEYCLOAK_CLIENT_ID}
-    environment:
-      - USE_MOCK_SERVICES=true
-      - USE_KEYCLOAK=false
-    command: "nginx -g 'daemon off;'"
-    restart: always
-    ports:
-      - "4200:8080"
-    networks:
-      - traffic-court-net
+  # citizen-portal-demo:
+  #   container_name: citizen-portal-demo
+  #   build:
+  #     context: ./src/frontend/citizen-portal
+  #     args:
+  #       USE_MOCK_SERVICES: "true"
+  #       USE_KEYCLOAK: "false"
+  #       API_URL: ${API_URL}
+  #       KEYCLOAK_URL: ${KEYCLOAK_URL}
+  #       KEYCLOAK_REALM: ${KEYCLOAK_REALM}
+  #       KEYCLOAK_CLIENT_ID: ${KEYCLOAK_CLIENT_ID}
+  #   environment:
+  #     USE_MOCK_SERVICES: "true"
+  #     USE_KEYCLOAK: "false"
+  #   command: "nginx -g 'daemon off;'"
+  #   restart: always
+  #   ports:
+  #     - "4200:8080"
+  #   networks:
+  #     - traffic-court-net
 
   #############################################################################################
   ###                                  KEYCLOAK                                             ###

--- a/src/frontend/citizen-portal/nginx.conf
+++ b/src/frontend/citizen-portal/nginx.conf
@@ -26,3 +26,6 @@ location = /50x.html {
 location /api/ {
     proxy_pass http://dispute-api:8080/api/;
 }
+location /swagger/ {
+    proxy_pass http://dispute-api:8080/swagger/;
+}


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- Moved the frontend from 4200 to 8080 on local docker
- no longer need demo because of mock and keycloak now disabled on frontend too
- added swagger endpoint
- changes were required to handle reverse-proxying properly

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Built and tested locally
Updated dev and rebuild with new environmental variable for API_URL successfully

## Does the change impact or break the Docker build?

- [X] Yes
- [ ] No

If Yes: Has Docker been updated accordingly?

- [X] Yes
- [ ] No

## Checklist:

- [ ] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
