### PR TITLE
Change NUnit to xUnit, it is just better

### DIFF
--- a/src/backend/TrafficCourtsApi/DisputeApi.Web.Test/Auth/OAuthClientTest.cs
+++ b/src/backend/TrafficCourtsApi/DisputeApi.Web.Test/Auth/OAuthClientTest.cs
@@ -4,7 +4,6 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Moq;
 using Moq.Protected;
-using NUnit.Framework;
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Net;
@@ -12,6 +11,7 @@ using System.Net.Http;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
+using Xunit;
 
 namespace DisputeApi.Web.Test.Auth
 {
@@ -25,8 +25,7 @@ namespace DisputeApi.Web.Test.Auth
         private Mock<ILogger<OAuthClient>> _loggerMock = new Mock<ILogger<OAuthClient>>();
         private Token _token;
 
-        [SetUp]
-        public void SetUp()
+        public OAuthClientTest()
         {
             Fixture fixture = new Fixture();
             // use real http client with mocked handler here
@@ -38,7 +37,8 @@ namespace DisputeApi.Web.Test.Auth
             _token = fixture.Create<Token>();
             _sut = new OAuthClient(_httpClient, _optionsMock.Object, _loggerMock.Object);
         }
-        [Test]
+
+        [Fact]
         public async Task GetRefreshToken_if_http_return_token_correctly_return_this_token()
         {
             _httpMessageHandlerMock
@@ -57,13 +57,13 @@ namespace DisputeApi.Web.Test.Auth
                 .Verifiable();
 
             Token token = await _sut.GetRefreshToken(CancellationToken.None);
-            Assert.AreEqual(_token.AccessToken, token.AccessToken);
-            Assert.AreEqual(_token.TokenType, token.TokenType);
-            Assert.AreEqual(_token.ExpiresIn, token.ExpiresIn);
-            Assert.AreEqual(_token.Scope, token.Scope);
+            Assert.Equal(_token.AccessToken, token.AccessToken);
+            Assert.Equal(_token.TokenType, token.TokenType);
+            Assert.Equal(_token.ExpiresIn, token.ExpiresIn);
+            Assert.Equal(_token.Scope, token.Scope);
         }
 
-        [Test]
+        [Fact]
         public void fixture_GetRefreshToken_if_http_return_token_correctly_return_this_token()
         {
             

--- a/src/backend/TrafficCourtsApi/DisputeApi.Web.Test/Auth/OAuthHandlerTest.cs
+++ b/src/backend/TrafficCourtsApi/DisputeApi.Web.Test/Auth/OAuthHandlerTest.cs
@@ -1,11 +1,11 @@
-﻿using AutoFixture.NUnit3;
-using DisputeApi.Web.Auth;
+﻿using DisputeApi.Web.Auth;
 using DisputeApi.Web.Test.Utils;
 using Moq;
-using NUnit.Framework;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
+using AutoFixture.Xunit2;
+using Xunit;
 
 namespace DisputeApi.Web.Test.Auth
 {
@@ -15,13 +15,14 @@ namespace DisputeApi.Web.Test.Auth
         {
             protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
             {
-                Assert.AreEqual("accessToken", request.Headers?.Authorization?.Parameter);
-                Assert.AreEqual("Bearer", request.Headers?.Authorization?.Scheme);
+                Assert.Equal("accessToken", request.Headers?.Authorization?.Parameter);
+                Assert.Equal("Bearer", request.Headers?.Authorization?.Scheme);
                 return await base.SendAsync(request, cancellationToken);
             }
         }
 
-        [Test, AutoMockAutoData]
+        [Theory]
+        [AutoMockAutoData]
         public async Task with_token_it_should_add_it_to_header(            
             [Frozen]Mock<ITokenService> tokenServiceMock,
             OAuthHandler sut,

--- a/src/backend/TrafficCourtsApi/DisputeApi.Web.Test/Auth/TokenServiceTest.cs
+++ b/src/backend/TrafficCourtsApi/DisputeApi.Web.Test/Auth/TokenServiceTest.cs
@@ -1,21 +1,20 @@
-﻿using AutoFixture;
-using AutoFixture.AutoMoq;
-using AutoFixture.NUnit3;
+﻿using AutoFixture.Xunit2;
 using DisputeApi.Web.Auth;
 using DisputeApi.Web.Test.Utils;
 using Microsoft.Extensions.Caching.Memory;
 using Moq;
-using NUnit.Framework;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
+using Xunit;
 
 namespace DisputeApi.Web.Test.Auth
 {
     [ExcludeFromCodeCoverage]
     public class TokenServiceTest
     {
-        [Test, AutoMockAutoData]
+        [Theory]
+        [AutoMockAutoData]
         public async Task GetTokenAsync_if_token_not_expired_return_token_from_memory(
             [Frozen]Mock<IMemoryCache> memoryMock, 
             TokenService sut, 
@@ -28,10 +27,11 @@ namespace DisputeApi.Web.Test.Auth
                 .Returns(true);
 
             Token token = await sut.GetTokenAsync(cancellationToken);
-            Assert.AreEqual(expectedToken, token);
+            Assert.Equal(expectedToken, token);
         }
 
-        [Test, AutoMockAutoData]
+        [Theory]
+        [AutoMockAutoData]
         public async Task GetTokenAsync_if_token_expired_get_new_token_from_client(
             [Frozen] Mock<IMemoryCache> memoryMock,
             [Frozen] Mock<IOAuthClient> authClientMock,
@@ -48,7 +48,7 @@ namespace DisputeApi.Web.Test.Auth
                 .Returns(Task.FromResult(expectedToken));
 
             Token token = await sut.GetTokenAsync(CancellationToken.None);
-            Assert.AreEqual(expectedToken, token);
+            Assert.Equal(expectedToken, token);
         }
     }
 }

--- a/src/backend/TrafficCourtsApi/DisputeApi.Web.Test/DisputeApi.Web.Test.csproj
+++ b/src/backend/TrafficCourtsApi/DisputeApi.Web.Test/DisputeApi.Web.Test.csproj
@@ -8,16 +8,19 @@
 
   <ItemGroup>
     <PackageReference Include="AutoFixture.AutoMoq" Version="4.15.0" />
-    <PackageReference Include="AutoFixture.NUnit3" Version="4.15.0" />
+    <PackageReference Include="AutoFixture.Xunit2" Version="4.17.0" />
     <PackageReference Include="coverlet.msbuild" Version="3.0.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="5.0.3" />
     <PackageReference Include="Moq" Version="4.16.1" />
-    <PackageReference Include="NUnit" Version="3.13.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/backend/TrafficCourtsApi/DisputeApi.Web.Test/Features/ApiResponseTest.cs
+++ b/src/backend/TrafficCourtsApi/DisputeApi.Web.Test/Features/ApiResponseTest.cs
@@ -3,39 +3,42 @@ using AutoFixture.Kernel;
 using DisputeApi.Web.Features;
 using DisputeApi.Web.Test.Utils;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
-using NUnit.Framework;
 using System;
 using System.Linq;
+using Xunit;
 
 namespace DisputeApi.Web.Test.Features
 {
     public class ApiResponseTest
     {
-        [Test, AutoMockAutoData]
+        [Theory]
+        [AutoMockAutoData]
         public void Result_T_will_create_ApiResultResponse_T(Type type)
         {
             var fixture = new Fixture();
             var obj = fixture.Create(type, new SpecimenContext(fixture));
             var result = ApiResponse.Result(obj);
-            Assert.IsInstanceOf<ApiResultResponse<object>>(result);
+            Assert.IsAssignableFrom<ApiResultResponse<object>>(result);
 
         }
 
-        [Test, AutoMockAutoData]
+        [Theory]
+        [AutoMockAutoData]
         public void Message_str_will_create_ApiMessageResponse(string msg)
         {
             var result = ApiResponse.Message(msg);
-            Assert.IsInstanceOf<ApiMessageResponse>(result);
-            Assert.AreEqual(msg, result.Message);
+            Assert.IsAssignableFrom<ApiMessageResponse>(result);
+            Assert.Equal(msg, result.Message);
         }
 
-        [Test, AutoMockAutoData]
+        [Theory]
+        [AutoMockAutoData]
         public void BadRequest_will_create_ApiBadRequestResponse(ModelStateDictionary modelState, string key, string errorMsg)
         {
             modelState.AddModelError(key, errorMsg);
             var result = ApiResponse.BadRequest(modelState);
-            Assert.IsInstanceOf<ApiBadRequestResponse>(result);
-            Assert.AreEqual(errorMsg, result.Errors.First());
+            Assert.IsAssignableFrom<ApiBadRequestResponse>(result);
+            Assert.Equal(errorMsg, result.Errors.First());
         }
     }
 }

--- a/src/backend/TrafficCourtsApi/DisputeApi.Web.Test/Features/Disputes/Commands/CreateDisputeCommandHandlerTest.cs
+++ b/src/backend/TrafficCourtsApi/DisputeApi.Web.Test/Features/Disputes/Commands/CreateDisputeCommandHandlerTest.cs
@@ -1,5 +1,4 @@
-﻿using AutoFixture.NUnit3;
-using AutoMapper;
+﻿using AutoMapper;
 using DisputeApi.Web.Features.Disputes;
 using DisputeApi.Web.Features.Disputes.Commands;
 using DisputeApi.Web.Messaging.Configuration;
@@ -7,7 +6,6 @@ using DisputeApi.Web.Test.Utils;
 using MassTransit;
 using Microsoft.Extensions.Logging;
 using Moq;
-using NUnit.Framework;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 using DisputeApi.Web.Features.Disputes.DBModel;
@@ -16,6 +14,8 @@ using TrafficCourts.Common.Contract;
 using Microsoft.Extensions.Options;
 using System;
 using AutoFixture;
+using AutoFixture.Xunit2;
+using Xunit;
 
 namespace DisputeApi.Web.Test.Features.Disputes.Commands
 {
@@ -31,8 +31,7 @@ namespace DisputeApi.Web.Test.Features.Disputes.Commands
         private CreateDisputeCommandHandler _sut;
         private Fixture _fixture;
 
-        [SetUp]
-        public void SetUp()
+        public CreateDisputeCommandHandlerTest()
         {
             _fixture = new Fixture();
             _fixture.Behaviors.Remove(new ThrowingRecursionBehavior());
@@ -61,7 +60,8 @@ namespace DisputeApi.Web.Test.Features.Disputes.Commands
                 _sendEndPointProviderMock.Object, _rabbitConfigMock.Object, _mapperMock.Object);
         }
 
-        [Test, AutoData]
+        [Theory]
+        [AutoData]
         public async Task CreateDisputeCommandHandler_handle_will_call_service_and_send_to_queue(
             CreateDisputeCommand createDisputeCommand, DisputeContract contractDispute)
         {
@@ -78,7 +78,7 @@ namespace DisputeApi.Web.Test.Features.Disputes.Commands
             //    x => x.Send<DisputeContract>(It.IsAny<DisputeContract>(), It.IsAny<CancellationToken>()),
             //    () => { return Times.Once(); });
             ////temp
-            Assert.AreEqual(createdDispute.Id, result.Id);
+            Assert.Equal(createdDispute.Id, result.Id);
         }
     }
 }

--- a/src/backend/TrafficCourtsApi/DisputeApi.Web.Test/Features/Disputes/Commands/CreateOffenceDisputeCommandHandlerTest.cs
+++ b/src/backend/TrafficCourtsApi/DisputeApi.Web.Test/Features/Disputes/Commands/CreateOffenceDisputeCommandHandlerTest.cs
@@ -1,5 +1,4 @@
-﻿using AutoFixture.NUnit3;
-using AutoMapper;
+﻿using AutoMapper;
 using DisputeApi.Web.Features.Disputes;
 using DisputeApi.Web.Features.Disputes.Commands;
 using DisputeApi.Web.Messaging.Configuration;
@@ -7,7 +6,6 @@ using DisputeApi.Web.Test.Utils;
 using MassTransit;
 using Microsoft.Extensions.Logging;
 using Moq;
-using NUnit.Framework;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 using DisputeApi.Web.Features.Disputes.DBModel;
@@ -15,7 +13,7 @@ using System.Threading;
 using TrafficCourts.Common.Contract;
 using Microsoft.Extensions.Options;
 using System;
-using AutoFixture;
+using Xunit;
 
 namespace DisputeApi.Web.Test.Features.Disputes.Commands
 {
@@ -30,8 +28,7 @@ namespace DisputeApi.Web.Test.Features.Disputes.Commands
         private Mock<ISendEndpoint> _sendEndpointMock;
         private CreateOffenceDisputeCommandHandler _sut;
 
-        [SetUp]
-        public void SetUp()
+        public CreateOffenceDisputeCommandHandlerTest()
         {
             _loggerMock = LoggerServiceMock.LoggerMock<CreateOffenceDisputeCommandHandler>();
             _disputeServiceMock = new Mock<IDisputeService>();
@@ -57,7 +54,8 @@ namespace DisputeApi.Web.Test.Features.Disputes.Commands
                 _sendEndPointProviderMock.Object, _rabbitConfigMock.Object, _mapperMock.Object);
         }
 
-        [Test, AllowCirculationAutoData]
+        [Theory]
+        [AllowCirculationAutoData]
         public async Task CreateOffenceDisputeCommandHandler_handle_will_call_service_and_send_to_queue(
             CreateOffenceDisputeCommand createOffenceDisputeCommand,
             Dispute updatedDispute, 
@@ -79,7 +77,7 @@ namespace DisputeApi.Web.Test.Features.Disputes.Commands
             //    x => x.Send<DisputeContract>(It.IsAny<DisputeContract>(), It.IsAny<CancellationToken>()),
             //    () => { return Times.Once(); });
             //temp
-            Assert.AreEqual(updatedDispute.Id, result.Id);
+            Assert.Equal(updatedDispute.Id, result.Id);
         }
     }
 }

--- a/src/backend/TrafficCourtsApi/DisputeApi.Web.Test/Features/Disputes/Configuration/DisputeServiceConfigurationTest.cs
+++ b/src/backend/TrafficCourtsApi/DisputeApi.Web.Test/Features/Disputes/Configuration/DisputeServiceConfigurationTest.cs
@@ -3,14 +3,14 @@ using System.Linq;
 using DisputeApi.Web.Features.Disputes;
 using DisputeApi.Web.Features.Disputes.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using NUnit.Framework;
+using Xunit;
 
 namespace DisputeApi.Web.Test.Features.Disputes.Configuration
 {
     [ExcludeFromCodeCoverage]
     public class DisputeServiceConfigurationExtensionTest
     {
-        [Test]
+        [Fact]
         public void should_register_necessary_service()
         {
             var services = new ServiceCollection();

--- a/src/backend/TrafficCourtsApi/DisputeApi.Web.Test/Features/Disputes/DisputeControllerTest.cs
+++ b/src/backend/TrafficCourtsApi/DisputeApi.Web.Test/Features/Disputes/DisputeControllerTest.cs
@@ -4,7 +4,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using AutoFixture.NUnit3;
+using AutoFixture.Xunit2;
 using DisputeApi.Web.Features;
 using DisputeApi.Web.Features.Disputes;
 using DisputeApi.Web.Features.Disputes.Commands;
@@ -14,7 +14,7 @@ using MediatR;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using Moq;
-using NUnit.Framework;
+using Xunit;
 
 namespace DisputeApi.Web.Test.Features.Disputes
 {
@@ -24,14 +24,13 @@ namespace DisputeApi.Web.Test.Features.Disputes
         private Mock<ILogger<DisputesController>> _loggerMock;
         private Mock<IMediator> _mediatorMock;
 
-        [SetUp]
-        public void SetUp()
+        public DisputeControllerTest()
         {
             _loggerMock = LoggerServiceMock.LoggerMock<DisputesController>();
             _mediatorMock = new Mock<IMediator>();
         }
 
-        [Test]
+        [Fact]
         public void throw_ArgumentNullException_if_passed_null()
         {
             Assert.Throws<ArgumentNullException>(() => new DisputesController(null, _mediatorMock.Object));
@@ -50,14 +49,14 @@ namespace DisputeApi.Web.Test.Features.Disputes
             var sut = new DisputesController(_loggerMock.Object, _mediatorMock.Object);
 
             var result = await sut.GetDisputes();
-            Assert.IsNotNull(result);
-            Assert.IsInstanceOf<OkObjectResult>(result);
+            Assert.NotNull(result);
+            Assert.IsAssignableFrom<OkObjectResult>(result);
 
             var objectResult = (ObjectResult) result;
-            Assert.IsInstanceOf<ApiResultResponse<IEnumerable<GetDisputeResponse>>>(objectResult.Value);
+            Assert.IsAssignableFrom<ApiResultResponse<IEnumerable<GetDisputeResponse>>>(objectResult.Value);
 
             var values = ((ApiResultResponse<IEnumerable<GetDisputeResponse>>) objectResult.Value).Result;
-            Assert.AreEqual(values.Count(), 1);
+            Assert.Equal(values.Count(), 1);
 
             _mediatorMock.Verify(x => x.Send(It.IsAny<GetAllDisputesQuery>(), It.IsAny<CancellationToken>()),
                 Times.Once);
@@ -73,10 +72,10 @@ namespace DisputeApi.Web.Test.Features.Disputes
             var sut = new DisputesController(_loggerMock.Object, _mediatorMock.Object);
 
             var result = await sut.GetDispute(expected.Id);
-            Assert.IsNotNull(result);
-            Assert.IsInstanceOf<OkObjectResult>(result);
+            Assert.NotNull(result);
+            Assert.IsAssignableFrom<OkObjectResult>(result);
 
-            Assert.IsInstanceOf<ApiResultResponse<GetDisputeResponse>>(((OkObjectResult) result).Value);
+            Assert.IsAssignableFrom<ApiResultResponse<GetDisputeResponse>>(((OkObjectResult) result).Value);
             _mediatorMock.Verify(x => x.Send(It.IsAny<GetDisputeQuery>(), It.IsAny<CancellationToken>()), Times.Once);
         }
 
@@ -90,8 +89,8 @@ namespace DisputeApi.Web.Test.Features.Disputes
             var sut = new DisputesController(_loggerMock.Object, _mediatorMock.Object);
 
             var result = await sut.GetDispute(disputeId);
-            Assert.IsNotNull(result);
-            Assert.IsInstanceOf<NoContentResult>(result);
+            Assert.NotNull(result);
+            Assert.IsAssignableFrom<NoContentResult>(result);
         }
 
         [Theory]
@@ -104,8 +103,8 @@ namespace DisputeApi.Web.Test.Features.Disputes
             var sut = new DisputesController(_loggerMock.Object, _mediatorMock.Object);
 
             var result = await sut.TicketDispute(dispute);
-            Assert.IsNotNull(result);
-            Assert.IsInstanceOf<OkResult>(result);
+            Assert.NotNull(result);
+            Assert.IsAssignableFrom<OkResult>(result);
             _mediatorMock.Verify(x => x.Send(It.IsAny<CreateDisputeCommand>(), It.IsAny<CancellationToken>()),
                 Times.Once);
         }
@@ -122,10 +121,10 @@ namespace DisputeApi.Web.Test.Features.Disputes
             var sut = new DisputesController(_loggerMock.Object, _mediatorMock.Object);
 
             var result = (BadRequestObjectResult) await sut.TicketDispute(dispute);
-            Assert.IsNotNull(result);
+            Assert.NotNull(result);
             _mediatorMock.Verify(x => x.Send(It.IsAny<CreateDisputeCommand>(), It.IsAny<CancellationToken>()),
                 Times.Once);
-            Assert.AreEqual(400, result.StatusCode);
+            Assert.Equal(400, result.StatusCode);
         }
 
         [Theory]
@@ -138,8 +137,8 @@ namespace DisputeApi.Web.Test.Features.Disputes
             var sut = new DisputesController(_loggerMock.Object, _mediatorMock.Object);
 
             var result = await sut.OffenceDispute(dispute);
-            Assert.IsNotNull(result);
-            Assert.IsInstanceOf<OkResult>(result);
+            Assert.NotNull(result);
+            Assert.IsAssignableFrom<OkResult>(result);
             _mediatorMock.Verify(x => x.Send(It.IsAny<CreateOffenceDisputeCommand>(), It.IsAny<CancellationToken>()),
                 Times.Once);
         }
@@ -156,10 +155,10 @@ namespace DisputeApi.Web.Test.Features.Disputes
             var sut = new DisputesController(_loggerMock.Object, _mediatorMock.Object);
 
             var result = (BadRequestObjectResult)await sut.OffenceDispute(dispute);
-            Assert.IsNotNull(result);
+            Assert.NotNull(result);
             _mediatorMock.Verify(x => x.Send(It.IsAny<CreateOffenceDisputeCommand>(), It.IsAny<CancellationToken>()),
                 Times.Once);
-            Assert.AreEqual(400, result.StatusCode);
+            Assert.Equal(400, result.StatusCode);
         }
     }
 }

--- a/src/backend/TrafficCourtsApi/DisputeApi.Web.Test/Features/Disputes/DisputeServiceTest.cs
+++ b/src/backend/TrafficCourtsApi/DisputeApi.Web.Test/Features/Disputes/DisputeServiceTest.cs
@@ -2,8 +2,6 @@
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
-using AutoFixture;
-using AutoFixture.NUnit3;
 using DisputeApi.Web.Features.Disputes;
 using DisputeApi.Web.Features.Disputes.DBModel;
 using DisputeApi.Web.Infrastructure;
@@ -11,7 +9,7 @@ using DisputeApi.Web.Test.Utils;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Moq;
-using NUnit.Framework;
+using Xunit;
 
 namespace DisputeApi.Web.Test.Features.Disputes
 {
@@ -30,51 +28,52 @@ namespace DisputeApi.Web.Test.Features.Disputes
             return new ViolationContext(optionsBuilder.Options);
         }
 
-        [SetUp]
-        public void SetUp()
+        public DisputeServiceTest()
         {
             _violationContext = CreateContext();
             _service = new DisputeService(_loggerMock.Object, _violationContext);
         }
 
-        [Test]
+        [Fact]
         public void throw_ArgumentNullException_if_passed_null()
         {
             Assert.Throws<ArgumentNullException>(() => new DisputeService(null, CreateContext()));
             Assert.Throws<ArgumentNullException>(() => new DisputeService(_loggerMock.Object, null));
         }
 
-        [Test]
+        [Fact]
         public async Task get_disputes()
         {
             var result = await _service.GetAllAsync();
-            Assert.IsInstanceOf<IEnumerable<Dispute>>(result);
+            Assert.IsAssignableFrom<IEnumerable<Dispute>>(result);
             _loggerMock.VerifyLog(LogLevel.Debug, "Getting all disputes", Times.Once());
         }
 
-        [Theory, AllowCirculationAutoData]
+        [Theory]
+        [AllowCirculationAutoData]
         public async Task create_new_and_get_dispute(Dispute toCreate)
         {
             var result = await _service.CreateAsync(toCreate);
-            Assert.IsInstanceOf<Dispute>(result);
-            Assert.AreNotEqual(0, result.Id);
+            Assert.IsAssignableFrom<Dispute>(result);
+            Assert.NotEqual(0, result.Id);
 
             result = await _service.GetAsync(result.Id);
-            Assert.IsInstanceOf<Dispute>(result);
-            Assert.IsNotNull(result);
+            Assert.IsAssignableFrom<Dispute>(result);
+            Assert.NotNull(result);
         }
 
-        [Theory, AllowCirculationAutoData]
+        [Theory]
+        [AllowCirculationAutoData]
         public async Task create_existed_dispute_get_id0(Dispute toCreate)
         {
             var result = await _service.CreateAsync(toCreate);
-            Assert.IsInstanceOf<Dispute>(result);
-            Assert.AreNotEqual(0, result.Id);
+            Assert.IsType<Dispute>(result);
+            Assert.NotEqual(0, result.Id);
             _loggerMock.VerifyLog(LogLevel.Debug, "Creating dispute", Times.Once());
 
             result = await _service.CreateAsync(toCreate);
-            Assert.IsInstanceOf<Dispute>(result);
-            Assert.AreEqual(0, result.Id);
+            Assert.IsAssignableFrom<Dispute>(result);
+            Assert.Equal(0, result.Id);
         }
 
         [Theory]
@@ -84,15 +83,16 @@ namespace DisputeApi.Web.Test.Features.Disputes
             toCreate.ViolationTicketNumber = findTicketNumber;
             //toCreate.OffenceNumber = findOffenceNumber;
             var result = await _service.CreateAsync(toCreate);
-            Assert.IsInstanceOf<Dispute>(result);
+            Assert.IsAssignableFrom<Dispute>(result);
 
             result = await _service.FindTicketDisputeAsync(findTicketNumber);
-            Assert.IsInstanceOf<Dispute>(result);
-            Assert.AreEqual(findTicketNumber, result.ViolationTicketNumber);
-            //Assert.AreEqual(findOffenceNumber, result.OffenceNumber);
+            Assert.IsAssignableFrom<Dispute>(result);
+            Assert.Equal(findTicketNumber, result.ViolationTicketNumber);
+            //Assert.Equal(findOffenceNumber, result.OffenceNumber);
         }
 
-        [Theory, AllowCirculationAutoData]
+        [Theory]
+        [AllowCirculationAutoData]
         public async Task update_dispute_get_return_updatedRecords(Dispute toUpdate)
         {
             _violationContext.Disputes.Add(toUpdate);
@@ -100,9 +100,9 @@ namespace DisputeApi.Web.Test.Features.Disputes
             toUpdate.DisputantFirstName = "updatedFirstName";
 
             var result = await _service.UpdateAsync(toUpdate);
-            Assert.IsInstanceOf<Dispute>(result);
-            Assert.AreEqual(toUpdate.Id, result.Id);
-            Assert.AreEqual("updatedFirstName", result.DisputantFirstName);
+            Assert.IsAssignableFrom<Dispute>(result);
+            Assert.Equal(toUpdate.Id, result.Id);
+            Assert.Equal("updatedFirstName", result.DisputantFirstName);
             _loggerMock.VerifyLog(LogLevel.Debug, "Update dispute", Times.Once());
         }
     }

--- a/src/backend/TrafficCourtsApi/DisputeApi.Web.Test/Features/Disputes/Models/DisputeModelTest.cs
+++ b/src/backend/TrafficCourtsApi/DisputeApi.Web.Test/Features/Disputes/Models/DisputeModelTest.cs
@@ -1,24 +1,23 @@
 ﻿using System.Diagnostics.CodeAnalysis;
-using AutoFixture.NUnit3;
+using AutoFixture.Xunit2;
 using DisputeApi.Web.Features.Disputes.DBModel;
 using DisputeApi.Web.Test.Utils;
-using NUnit.Framework;
+using Xunit;
 
 namespace DisputeApi.Web.Test.Features.Disputes.Models
 {
     [ExcludeFromCodeCoverage]
     public class DisputeModelTest
     {
-        [Theory]
-        [AutoData]
+        [Fact]
         public void can_create_class()
         {
             var expected = new Dispute { DisputantEmailAddress = "test@test.com", InformationCertified = true };
             var actual = PropertyCopy.CopyProperties(expected);
 
             // to do: check all properties
-            Assert.AreEqual(expected.DisputantEmailAddress, actual.DisputantEmailAddress);
-            Assert.AreEqual(expected.InformationCertified, actual.InformationCertified);
+            Assert.Equal(expected.DisputantEmailAddress, actual.DisputantEmailAddress);
+            Assert.Equal(expected.InformationCertified, actual.InformationCertified);
         }
     }
 }

--- a/src/backend/TrafficCourtsApi/DisputeApi.Web.Test/Features/Disputes/Queries/GetAllDisputesQueryHandlerTest.cs
+++ b/src/backend/TrafficCourtsApi/DisputeApi.Web.Test/Features/Disputes/Queries/GetAllDisputesQueryHandlerTest.cs
@@ -1,16 +1,15 @@
-﻿using AutoFixture.NUnit3;
-using AutoMapper;
+﻿using AutoMapper;
 using DisputeApi.Web.Features.Disputes;
+using DisputeApi.Web.Features.Disputes.DBModel;
+using DisputeApi.Web.Features.Disputes.Queries;
 using DisputeApi.Web.Test.Utils;
 using Microsoft.Extensions.Logging;
 using Moq;
-using NUnit.Framework;
-using System.Diagnostics.CodeAnalysis;
-using System.Threading.Tasks;
-using DisputeApi.Web.Features.Disputes.DBModel;
-using System.Threading;
-using DisputeApi.Web.Features.Disputes.Queries;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
 
 namespace DisputeApi.Web.Test.Features.Disputes.Queries
 {
@@ -22,8 +21,7 @@ namespace DisputeApi.Web.Test.Features.Disputes.Queries
         private Mock<IMapper> _mapperMock;
         private GetAllDisputesQueryHandler _sut;
 
-        [SetUp]
-        public void SetUp()
+        public GetAllDisputesQueryHandlerTest()
         {
             _loggerMock = LoggerServiceMock.LoggerMock<GetAllDisputesQueryHandler>();
             _disputeServiceMock = new Mock<IDisputeService>();
@@ -32,7 +30,8 @@ namespace DisputeApi.Web.Test.Features.Disputes.Queries
             _sut = new GetAllDisputesQueryHandler(_loggerMock.Object, _disputeServiceMock.Object, _mapperMock.Object);
         }
 
-        [Test, AllowCirculationAutoData]
+        [Theory]
+        [AllowCirculationAutoData]
         public async Task GetAllDisputesQueryHandler_handle_will_call_service(GetAllDisputesQuery getAllDisputesQuery,
             IEnumerable<Dispute> createdDisputes, IEnumerable<GetDisputeResponse> responseDisputes)
         {
@@ -43,7 +42,7 @@ namespace DisputeApi.Web.Test.Features.Disputes.Queries
 
             var result = await _sut.Handle(getAllDisputesQuery, CancellationToken.None);
             _disputeServiceMock.Verify(x => x.GetAllAsync(), Times.Once);
-            Assert.AreEqual(responseDisputes, result);
+            Assert.Equal(responseDisputes, result);
         }
     }
 }

--- a/src/backend/TrafficCourtsApi/DisputeApi.Web.Test/Features/Disputes/Queries/GetDisputeQueryHandlerTest.cs
+++ b/src/backend/TrafficCourtsApi/DisputeApi.Web.Test/Features/Disputes/Queries/GetDisputeQueryHandlerTest.cs
@@ -1,15 +1,14 @@
-﻿using AutoFixture.NUnit3;
-using AutoMapper;
+﻿using AutoMapper;
 using DisputeApi.Web.Features.Disputes;
 using DisputeApi.Web.Test.Utils;
 using Microsoft.Extensions.Logging;
 using Moq;
-using NUnit.Framework;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 using DisputeApi.Web.Features.Disputes.DBModel;
 using System.Threading;
 using DisputeApi.Web.Features.Disputes.Queries;
+using Xunit;
 
 namespace DisputeApi.Web.Test.Features.Disputes.Queries
 {
@@ -21,8 +20,7 @@ namespace DisputeApi.Web.Test.Features.Disputes.Queries
         private Mock<IMapper> _mapperMock;
         private GetDisputeQueryHandler _sut;
 
-        [SetUp]
-        public void SetUp()
+        public GetDisputeQueryHandlerTest()
         {
             _loggerMock = LoggerServiceMock.LoggerMock<GetDisputeQueryHandler>();
             _disputeServiceMock = new Mock<IDisputeService>();
@@ -31,7 +29,8 @@ namespace DisputeApi.Web.Test.Features.Disputes.Queries
             _sut = new GetDisputeQueryHandler(_loggerMock.Object, _disputeServiceMock.Object, _mapperMock.Object);
         }
 
-        [Test, AllowCirculationAutoData]
+        [Theory]
+        [AllowCirculationAutoData]
         public async Task GetDisputeQueryHandler_handle_will_call_service(GetDisputeQuery getDisputesQuery,
             Dispute dispute, GetDisputeResponse responseDispute)
         {
@@ -40,7 +39,7 @@ namespace DisputeApi.Web.Test.Features.Disputes.Queries
 
             var result = await _sut.Handle(getDisputesQuery, CancellationToken.None);
             _disputeServiceMock.Verify(x => x.GetAsync(It.IsAny<int>()), Times.Once);
-            Assert.AreEqual(responseDispute, result);
+            Assert.Equal(responseDispute, result);
         }
     }
 }

--- a/src/backend/TrafficCourtsApi/DisputeApi.Web.Test/Features/TicketLookup/TicketDisputeFromRsiServiceTest.cs
+++ b/src/backend/TrafficCourtsApi/DisputeApi.Web.Test/Features/TicketLookup/TicketDisputeFromRsiServiceTest.cs
@@ -1,20 +1,21 @@
 ﻿using AutoFixture;
-using AutoFixture.NUnit3;
+using AutoFixture.Xunit2;
 using DisputeApi.Web.Features.TicketLookup;
 using DisputeApi.Web.Models;
 using DisputeApi.Web.Test.Utils;
 using Moq;
-using NUnit.Framework;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using Xunit;
 using static DisputeApi.Web.Features.TicketLookup.TicketLookup;
 
 namespace DisputeApi.Web.Test.Features.TicketLookup
 {
     public class TicketDisputeFromRsiServiceTest
     {
-        [Test, AutoMockAutoData]
+        [Theory]
+        [AutoMockAutoData]
         public async Task
             if_rsi_return_response_with_offence_RetrieveTicketDisputeAsync_should_return_response_correctly(           
             RawTicketSearchResponse rawResponse,
@@ -34,14 +35,15 @@ namespace DisputeApi.Web.Test.Features.TicketLookup
             rsiApiMock.Setup(m => m.GetTicket(It.IsAny<GetTicketParams>(), CancellationToken.None)).Returns(Task.FromResult(rawResponse));
             rsiApiMock.Setup(m => m.GetInvoice(It.Is<string>(m=>m=="EZ020004601"), CancellationToken.None)).Returns(Task.FromResult(invoice));
             var response = await sut.RetrieveTicketDisputeAsync(query.TicketNumber, query.Time, CancellationToken.None);
-            Assert.IsInstanceOf<TicketDispute>(response);
-            Assert.AreEqual(1, response.Offences.Count);
-            Assert.AreEqual("2020-09-18", response.ViolationDate);
-            Assert.AreEqual("21:40", response.ViolationTime);
-            Assert.AreEqual("2020-10-18", response.Offences[0].DiscountDueDate);
+            Assert.IsAssignableFrom<TicketDispute>(response);
+            Assert.Single(response.Offences);
+            Assert.Equal("2020-09-18", response.ViolationDate);
+            Assert.Equal("21:40", response.ViolationTime);
+            Assert.Equal("2020-10-18", response.Offences[0].DiscountDueDate);
         }
 
-        [Test, AutoMockAutoData]
+        [Theory]
+        [AutoMockAutoData]
         public async Task if_rsi_return_noOffences_RetrieveTicketDisputeAsync_should_return_null(
             RawTicketSearchResponse rawResponse,
             [Frozen] Mock<IRsiRestApi> rsiApiMock,
@@ -53,7 +55,7 @@ namespace DisputeApi.Web.Test.Features.TicketLookup
             rawResponse.Items = null;
             rsiApiMock.Setup(m => m.GetTicket(It.IsAny<GetTicketParams>(), CancellationToken.None)).Returns(Task.FromResult(rawResponse));
             var response = await sut.RetrieveTicketDisputeAsync(query.TicketNumber,query.Time,CancellationToken.None);
-            Assert.AreEqual(null, response);
+            Assert.Equal(null, response);
         }
     }
 }

--- a/src/backend/TrafficCourtsApi/DisputeApi.Web.Test/Features/TicketLookup/TicketLookupHandleTest.cs
+++ b/src/backend/TrafficCourtsApi/DisputeApi.Web.Test/Features/TicketLookup/TicketLookupHandleTest.cs
@@ -1,12 +1,12 @@
-﻿using System.Diagnostics.CodeAnalysis;
-using System.Threading;
-using System.Threading.Tasks;
-using AutoFixture.NUnit3;
+﻿using AutoFixture.Xunit2;
 using DisputeApi.Web.Features.TicketLookup;
 using DisputeApi.Web.Models;
 using DisputeApi.Web.Test.Utils;
 using Moq;
-using NUnit.Framework;
+using System.Diagnostics.CodeAnalysis;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
 using static DisputeApi.Web.Features.TicketLookup.TicketLookup;
 
 namespace DisputeApi.Web.Test.Features.TicketLookup
@@ -14,7 +14,8 @@ namespace DisputeApi.Web.Test.Features.TicketLookup
     [ExcludeFromCodeCoverage]
     public class TicketLookupHandleTest
     {
-        [Test, AutoMockAutoData]
+        [Theory]
+        [AutoMockAutoData]
         public async Task TicketDisputeHandler_handle_will_call_retrieveTicket(Query query, TicketDispute ticketDispute,
             [Frozen] Mock<ITicketDisputeService> ticketDisputeServiceMock, TicketDisputeHandler sut)
         {

--- a/src/backend/TrafficCourtsApi/DisputeApi.Web.Test/Features/Tickets/Configuration/TicketServiceConfigurationTest.cs
+++ b/src/backend/TrafficCourtsApi/DisputeApi.Web.Test/Features/Tickets/Configuration/TicketServiceConfigurationTest.cs
@@ -3,19 +3,19 @@ using System.Linq;
 using DisputeApi.Web.Features.Tickets;
 using DisputeApi.Web.Features.Tickets.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using NUnit.Framework;
+using Xunit;
 
 namespace DisputeApi.Web.Test.Features.Tickets.Configuration
 {
     [ExcludeFromCodeCoverage]
     public class TicketServiceConfigurationExtensionTest
     {
-        [Test]
+        [Fact]
         public void should_register_necessary_service()
         {
             var services = new ServiceCollection();
             services.AddTicketService();
-            Assert.IsTrue(services.Any(x => x.ServiceType == typeof(ITicketsService)));
+            Assert.Contains(services, x => x.ServiceType == typeof(ITicketsService));
         }
     }
 }

--- a/src/backend/TrafficCourtsApi/DisputeApi.Web.Test/Features/Tickets/Models/TicketModelTest.cs
+++ b/src/backend/TrafficCourtsApi/DisputeApi.Web.Test/Features/Tickets/Models/TicketModelTest.cs
@@ -1,8 +1,8 @@
 ﻿using System.Diagnostics.CodeAnalysis;
-using AutoFixture.NUnit3;
+using AutoFixture.Xunit2;
 using DisputeApi.Web.Models;
 using DisputeApi.Web.Test.Utils;
-using NUnit.Framework;
+using Xunit;
 
 namespace DisputeApi.Web.Test.Features.Tickets.Models
 {
@@ -16,8 +16,8 @@ namespace DisputeApi.Web.Test.Features.Tickets.Models
             var actual = PropertyCopy.CopyProperties(expected);
 
             // to do: check all properties
-            Assert.AreEqual(expected.GivenNames, actual.GivenNames);
-            Assert.AreEqual(expected.Licence, actual.Licence);
+            Assert.Equal(expected.GivenNames, actual.GivenNames);
+            Assert.Equal(expected.Licence, actual.Licence);
         }
     }
 }

--- a/src/backend/TrafficCourtsApi/DisputeApi.Web.Test/Features/Tickets/TicketServiceTest.cs
+++ b/src/backend/TrafficCourtsApi/DisputeApi.Web.Test/Features/Tickets/TicketServiceTest.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
-using AutoFixture.NUnit3;
+using AutoFixture.Xunit2;
 using DisputeApi.Web.Features.Tickets;
 using DisputeApi.Web.Infrastructure;
 using DisputeApi.Web.Models;
@@ -10,7 +10,7 @@ using DisputeApi.Web.Test.Utils;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Moq;
-using NUnit.Framework;
+using Xunit;
 
 namespace DisputeApi.Web.Test.Features.Tickets
 {
@@ -28,25 +28,24 @@ namespace DisputeApi.Web.Test.Features.Tickets
             return new ViolationContext(optionsBuilder.Options);
         }
 
-        [SetUp]
-        public void SetUp()
+        public TicketServiceTest()
         {
             _loggerMock = LoggerServiceMock.LoggerMock<TicketsService>();
             _service = new TicketsService(_loggerMock.Object, CreateContext());
         }
 
-        [Test]
+        [Fact]
         public void throw_ArgumentNullException_if_passed_null()
         {
             Assert.Throws<ArgumentNullException>(() => new TicketsService(null, CreateContext()));
             Assert.Throws<ArgumentNullException>(() => new TicketsService(_loggerMock.Object, null));
         }
 
-        [Test]
+        [Fact]
         public async Task get_tickets()
         {
             var result = await _service.GetTickets();
-            Assert.IsInstanceOf<IEnumerable<Ticket>>(result);
+            Assert.IsAssignableFrom<IEnumerable<Ticket>>(result);
             //_loggerMock.VerifyLog(LogLevel.Information, "Returning list of mock tickets", Times.Once());
         }
 
@@ -55,7 +54,7 @@ namespace DisputeApi.Web.Test.Features.Tickets
         public async Task save_ticket(Ticket ticket)
         {
             var result = await _service.SaveTicket(ticket);
-            Assert.IsInstanceOf<Ticket>(result);
+            Assert.IsAssignableFrom<Ticket>(result);
             //_loggerMock.VerifyLog(LogLevel.Information, "Saving mock ticket", Times.Once());
         }
     }

--- a/src/backend/TrafficCourtsApi/DisputeApi.Web.Test/Features/Tickets/TicketsControllerTest.cs
+++ b/src/backend/TrafficCourtsApi/DisputeApi.Web.Test/Features/Tickets/TicketsControllerTest.cs
@@ -4,7 +4,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using AutoFixture.NUnit3;
+using AutoFixture.Xunit2;
 using DisputeApi.Web.Features;
 using DisputeApi.Web.Features.Tickets;
 using DisputeApi.Web.Models;
@@ -13,7 +13,7 @@ using MediatR;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using Moq;
-using NUnit.Framework;
+using Xunit;
 using static DisputeApi.Web.Features.TicketLookup.TicketLookup;
 
 namespace DisputeApi.Web.Test.Features.Tickets
@@ -25,15 +25,14 @@ namespace DisputeApi.Web.Test.Features.Tickets
         private Mock<ITicketsService> _ticketsServiceMock;
         private Mock<IMediator> _mediatorMock;
 
-        [SetUp]
-        public void SetUp()
+        public TicketsControllerTest()
         {
             _loggerMock = LoggerServiceMock.LoggerMock<TicketsController>();
             _ticketsServiceMock = new Mock<ITicketsService>();
             _mediatorMock = new Mock<IMediator>();
         }
 
-        [Test]
+        [Fact]
         public void throw_ArgumentNullException_if_passed_null()
         {
             Assert.Throws<ArgumentNullException>(() => new TicketsController(null, _ticketsServiceMock.Object, _mediatorMock.Object));
@@ -54,9 +53,11 @@ namespace DisputeApi.Web.Test.Features.Tickets
             TicketsController sut = new TicketsController(_loggerMock.Object, _ticketsServiceMock.Object, _mediatorMock.Object);
 
             var result = (OkObjectResult)await sut.GetTickets();
-            Assert.IsInstanceOf<IEnumerable<Ticket>>(result.Value);
-            Assert.IsNotNull(result);
-            Assert.AreEqual(((IEnumerable<Ticket>)result.Value).Count(), 1);
+            Assert.IsAssignableFrom<IEnumerable<Ticket>>(result.Value);
+            Assert.NotNull(result);
+            var actual = result.Value as IEnumerable<Ticket>;
+
+            Assert.Single(actual);
 
             _ticketsServiceMock.Verify(x => x.GetTickets(), Times.Once);
         }
@@ -72,8 +73,8 @@ namespace DisputeApi.Web.Test.Features.Tickets
             TicketsController sut = new TicketsController(_loggerMock.Object, _ticketsServiceMock.Object, _mediatorMock.Object);
 
             var result = (OkObjectResult)await sut.SaveTicket(ticket);
-            Assert.IsInstanceOf<Ticket>(result.Value);
-            Assert.IsNotNull(result.Value);
+            Assert.IsAssignableFrom<Ticket>(result.Value);
+            Assert.NotNull(result.Value);
 
             _ticketsServiceMock.Verify(x => x.SaveTicket(ticket), Times.Once);
         }
@@ -87,9 +88,9 @@ namespace DisputeApi.Web.Test.Features.Tickets
             query.TicketNumber = "EZ02000460";
             query.Time = "09:21";
             var result = (OkObjectResult)await sut.GetTicket(query);
-            Assert.IsInstanceOf<ApiResultResponse<TicketDispute>>(result.Value);
-            Assert.IsNotNull(result.Value);
-            Assert.AreEqual(200, result.StatusCode);
+            Assert.IsAssignableFrom<ApiResultResponse<TicketDispute>>(result.Value);
+            Assert.NotNull(result.Value);
+            Assert.Equal(200, result.StatusCode);
         }
 
         [Theory]
@@ -101,7 +102,7 @@ namespace DisputeApi.Web.Test.Features.Tickets
             query.TicketNumber = "EZ02000460";
             query.Time = "09:21";
             var result = (NoContentResult)await sut.GetTicket(query);
-            Assert.AreEqual(204, result.StatusCode);
+            Assert.Equal(204, result.StatusCode);
         }
     }
 }

--- a/src/backend/TrafficCourtsApi/DisputeApi.Web.Test/Health/DisputeApiHealthCheckTest.cs
+++ b/src/backend/TrafficCourtsApi/DisputeApi.Web.Test/Health/DisputeApiHealthCheckTest.cs
@@ -3,9 +3,9 @@ using DisputeApi.Web.Health;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Logging;
 using Moq;
-using NUnit.Framework;
 using System.Threading;
 using System.Threading.Tasks;
+using Xunit;
 
 namespace DisputeApi.Web.Test.Health
 {
@@ -15,18 +15,16 @@ namespace DisputeApi.Web.Test.Health
         private DisputeApiHealthCheck _sut;
         private readonly Mock<ILogger<DisputeApiHealthCheck>> _apiServiceLogger = new Mock<ILogger<DisputeApiHealthCheck>>();
 
-
-        [SetUp]
-        public void SetUp()
+        public DisputeApiHealthCheckTest()
         {
             _sut = new DisputeApiHealthCheck(_apiServiceLogger.Object);
         }
 
-        [Test]
+        [Fact]
         public async Task return_health_service_for_dispute()
         {
             var result = await _sut.CheckHealthAsync(new HealthCheckContext(), CancellationToken.None);
-            Assert.AreEqual(HealthStatus.Healthy, result.Status);
+            Assert.Equal(HealthStatus.Healthy, result.Status);
         }
     }
 }

--- a/src/backend/TrafficCourtsApi/DisputeApi.Web.Test/StartUpTest.cs
+++ b/src/backend/TrafficCourtsApi/DisputeApi.Web.Test/StartUpTest.cs
@@ -7,13 +7,11 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Moq;
 using NSwag.Generation;
-using NUnit.Framework;
 using System.Collections.Generic;
 using System.Configuration;
 using System.Diagnostics.CodeAnalysis;
-using System.Net;
-using System.Threading.Tasks;
 using DisputeApi.Web.Features.Tickets;
+using Xunit;
 
 namespace DisputeApi.Web.Test
 {
@@ -24,8 +22,7 @@ namespace DisputeApi.Web.Test
         private Mock<IWebHostEnvironment> _webHostEnvironmentMock;
         private IConfiguration _configuration;
 
-        [SetUp]
-        public void SetUp()
+        public StartUpTest()
         {
             var configuration = new Dictionary<string, string>
             {
@@ -51,7 +48,7 @@ namespace DisputeApi.Web.Test
                 .Build();
         }
 
-        [Test]
+        [Fact]
         public void ConfigureOpenApi_does_not_throw_error()
         {
             var services = new ServiceCollection();
@@ -60,7 +57,7 @@ namespace DisputeApi.Web.Test
             sut.ConfigureOpenApi(services);
         }
         
-        [Test]
+        [Fact]
         public void ConfigureServices_does_not_throw_error()
         {
             var services = new ServiceCollection();
@@ -70,7 +67,7 @@ namespace DisputeApi.Web.Test
         }
 
         //do not know why it fails on openshift.
-        //[Test]
+        //[Fact]
         //public async Task Returns_ok_if_for_health_check()
         //{
         //using var httpClient = _webApplicationFactory.CreateClient();
@@ -79,7 +76,7 @@ namespace DisputeApi.Web.Test
         //}
 
         /* TODO Add back once authentication is figured out
-        [Test]
+        [Fact]
         public async Task Returns_unauthorized_for_missing_token()
         {
             using var httpClient = WebAppFactoryObj.CreateClient();
@@ -88,7 +85,7 @@ namespace DisputeApi.Web.Test
         }
         */
 
-        [Test]
+        [Fact]
         public void missing_jwt_config()
         {
             Dictionary<string, string> emptyConfig = new Dictionary<string, string>
@@ -104,28 +101,28 @@ namespace DisputeApi.Web.Test
             Assert.Throws<ConfigurationErrorsException>(() => target.ConfigureJwtBearerAuthentication(new JwtBearerOptions()));
         }
 
-        [Test]
+        [Fact]
         public void success_jwt_config()
         {
             var target = new Startup(_webHostEnvironmentMock.Object, _configuration);
             JwtBearerOptions options = new JwtBearerOptions();
             target.ConfigureJwtBearerAuthentication(options);
-            Assert.That(options.Authority, Is.EqualTo("http://localhost:8080/auth/realms/myrealm/"));
-            Assert.That(options.RequireHttpsMetadata, Is.EqualTo(false));
-            Assert.That(options.MetadataAddress, Is.EqualTo("http://localhost:8080/auth/realms/myrealm/.well-known/uma2-configuration"));
+            Assert.Equal("http://localhost:8080/auth/realms/myrealm/", options.Authority);
+            Assert.False(options.RequireHttpsMetadata);
+            Assert.Equal("http://localhost:8080/auth/realms/myrealm/.well-known/uma2-configuration", options.MetadataAddress);
         }
 
-        [Test]
+        [Fact]
         public void startup_should_registered_all_required_services()
         {
             var webHost = Microsoft.AspNetCore.WebHost.CreateDefaultBuilder().UseStartup<Startup>().Build();
-            Assert.IsNotNull(webHost);
-            Assert.IsNotNull(webHost.Services.GetService<HealthCheckService>());
-            Assert.IsNotNull(webHost.Services.GetService<ITicketsService>());
-            Assert.IsNotNull(webHost.Services.GetService<IOpenApiDocumentGenerator>());
+            Assert.NotNull(webHost);
+            Assert.NotNull(webHost.Services.GetService<HealthCheckService>());
+            Assert.NotNull(webHost.Services.GetService<ITicketsService>());
+            Assert.NotNull(webHost.Services.GetService<IOpenApiDocumentGenerator>());
         }
 
-        [Test]
+        [Fact]
         public void configure_services_should_inject_services()
         {
             IServiceCollection services = new ServiceCollection();
@@ -134,8 +131,8 @@ namespace DisputeApi.Web.Test
             target.ConfigureServices(services);
             
             var serviceProvider = services.BuildServiceProvider();
-            Assert.IsNotNull(serviceProvider);
-            Assert.IsTrue(services.Count > 0);
+            Assert.NotNull(serviceProvider);
+            Assert.True(services.Count > 0);
         }
     }
 }

--- a/src/backend/TrafficCourtsApi/DisputeApi.Web.Test/Utils/AllowCirculationAutoDataAttribute.cs
+++ b/src/backend/TrafficCourtsApi/DisputeApi.Web.Test/Utils/AllowCirculationAutoDataAttribute.cs
@@ -1,5 +1,5 @@
 ﻿using AutoFixture;
-using AutoFixture.NUnit3;
+using AutoFixture.Xunit2;
 
 
 namespace DisputeApi.Web.Test.Utils

--- a/src/backend/TrafficCourtsApi/DisputeApi.Web.Test/Utils/AutoMockAutoDataAttribute.cs
+++ b/src/backend/TrafficCourtsApi/DisputeApi.Web.Test/Utils/AutoMockAutoDataAttribute.cs
@@ -1,6 +1,6 @@
 ﻿using AutoFixture;
 using AutoFixture.AutoMoq;
-using AutoFixture.NUnit3;
+using AutoFixture.Xunit2;
 
 namespace DisputeApi.Web.Test.Utils
 {

--- a/src/backend/TrafficCourtsApi/TrafficCourts.Common.Test/Configuration/SerilogLoggingTest.cs
+++ b/src/backend/TrafficCourtsApi/TrafficCourts.Common.Test/Configuration/SerilogLoggingTest.cs
@@ -1,16 +1,15 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
-using NUnit.Framework;
 using Serilog;
 using TrafficCourts.Common.Configuration;
+using Xunit;
 
 namespace TrafficCourts.Common.Test.Configuration
 {
     [ExcludeFromCodeCoverage]
-    [TestFixture]
     public class SerilogLoggingTest
     {
-        [Test]
+        [Fact]
         public void GetDefaultLogger_returns_a_logger()
         {
             ILogger actual = SerilogLogging.GetDefaultLogger<SerilogLoggingTest>();
@@ -18,7 +17,7 @@ namespace TrafficCourts.Common.Test.Configuration
             Assert.NotNull(actual);
         }
 
-        [Test]
+        [Fact]
         public void GetDefaultLogger_returns_a_logger_in_development()
         {
             Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", "Development");

--- a/src/backend/TrafficCourtsApi/TrafficCourts.Common.Test/Configuration/SplunkEventCollectorTest.cs
+++ b/src/backend/TrafficCourtsApi/TrafficCourts.Common.Test/Configuration/SplunkEventCollectorTest.cs
@@ -1,7 +1,6 @@
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
 using Moq;
-using NUnit.Framework;
 using Serilog;
 using Serilog.Events;
 using Serilog.Sinks.TestCorrelator;
@@ -10,31 +9,29 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Net.Security;
-using System.Runtime.InteropServices;
 using TrafficCourts.Common.Configuration;
+using Xunit;
 
 namespace TrafficCourts.Common.Test.Configuration
 {
     [ExcludeFromCodeCoverage]
-    [TestFixture]
     public class SplunkEventCollectorTest
     {
-        [OneTimeSetUp]
-        public void OneTimeSetUp()
+        public SplunkEventCollectorTest()
         {
             Log.Logger = new LoggerConfiguration()
                 .WriteTo.TestCorrelator()
                 .CreateLogger();
         }
 
-        [Test]
+        [Fact]
         public void SplunkEventCollector_custom_server_certificate_validator_returns_true()
         {
             // there are no parameter validations
             Assert.True(SplunkEventCollector.ServerCertificateCustomValidation(null, null, null, SslPolicyErrors.None));
         }
 
-        [Test]
+        [Fact]
         public void Configure_checks_for_null_arguments()
         {
             var hostBuilderContext = new HostBuilderContext(new Dictionary<object, object>());
@@ -44,7 +41,7 @@ namespace TrafficCourts.Common.Test.Configuration
             Assert.Throws<ArgumentNullException>(() => SplunkEventCollector.Configure(hostBuilderContext, null));
         }
 
-        [Test]
+        [Fact]
         public void Configure_logs_warning_if_splunk_configuration_settings_not_found()
         {
             var configuration = new ConfigurationBuilder()
@@ -62,14 +59,13 @@ namespace TrafficCourts.Common.Test.Configuration
 
                 var logEvent = TestCorrelator.GetLogEventsFromCurrentContext().Single();
 
-                Assert.AreEqual(LogEventLevel.Warning, logEvent.Level);
+                Assert.Equal(LogEventLevel.Warning, logEvent.Level);
 
                 Assert.NotNull(logEvent.RenderMessage()); // assert anything about this message?
             }
         }
 
-        [Test]
-        [Ignore("Having troubles with Serilog reading the configuration and also our reading of the configuration")]
+        [Fact(Skip = "Having troubles with Serilog reading the configuration and also our reading of the configuration")]
         public void Configure_will_configure_EventCollector_if_url_and_token_are_available()
         {
             var configurationValues = new Mock<IDictionary<string, string>>();
@@ -97,7 +93,7 @@ namespace TrafficCourts.Common.Test.Configuration
                 SplunkEventCollector.Configure(hostBuilderContext, loggerConfiguration);
 
                 var logEvents = TestCorrelator.GetLogEventsFromCurrentContext().ToList();
-                Assert.AreEqual(0, logEvents.Count); // this will fail due to the GetEnumerator returning empty list
+                Assert.Empty(logEvents); // this will fail due to the GetEnumerator returning empty list
 
             }
 

--- a/src/backend/TrafficCourtsApi/TrafficCourts.Common.Test/TrafficCourts.Common.Test.csproj
+++ b/src/backend/TrafficCourtsApi/TrafficCourts.Common.Test/TrafficCourts.Common.Test.csproj
@@ -7,11 +7,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
     <PackageReference Include="Moq" Version="4.16.1" />
-    <PackageReference Include="NUnit" Version="3.13.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
     <PackageReference Include="Serilog.Sinks.TestCorrelator" Version="3.2.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- This PR changes the unit test library from NUnit to xUnit.  xUnit handles isolation between tests better.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [ ] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
