### PR TITLE
Remove api and swagger locations from defailt nginx.conf

### DIFF
--- a/src/frontend/citizen-portal/nginx.conf
+++ b/src/frontend/citizen-portal/nginx.conf
@@ -22,10 +22,3 @@ error_page   500 502 503 504  /50x.html;
 location = /50x.html {
   root   /usr/share/nginx/html;
 }
-
-location /api/ {
-    proxy_pass http://dispute-api:8080/api/;
-}
-location /swagger/ {
-    proxy_pass http://dispute-api:8080/swagger/;
-}


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- removes the `/api` and `/swagger` locations from the nginx.conf that is added to the container. In future changes, we will re-add the `/api` location. `/swagger` should added via config map change per env.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [ ] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
