### PR TITLE
Fix dotnet unit tests to try to avoid random failures

### DIFF
--- a/.github/workflows/pr-label.yml
+++ b/.github/workflows/pr-label.yml
@@ -16,6 +16,5 @@ jobs:
     steps:
     - uses: actions/labeler@v2
       # only label if the GITHUB_TOKEN is available, PRs from external repos do not have access to secrets vars
-      if: ${{ secrets.GITHUB_TOKEN }}
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/src/backend/TrafficCourtsApi/DisputeApi.Web/Features/Disputes/DisputeService.cs
+++ b/src/backend/TrafficCourtsApi/DisputeApi.Web/Features/Disputes/DisputeService.cs
@@ -61,7 +61,8 @@ namespace DisputeApi.Web.Features.Disputes
                 var updatedDispute = _context.Disputes.Update(dispute);
                 await _context.SaveChangesAsync();
                 return updatedDispute.Entity;
-            }catch(Exception e)
+            }
+            catch (Exception e)
             {
                 string str = e.Message;
                 return null;
@@ -88,7 +89,7 @@ namespace DisputeApi.Web.Features.Disputes
 
         public async Task<Dispute> FindTicketDisputeAsync(string ticketNumber)
         {
-            _logger.LogDebug("Find dispute for ticketNumber {ticketNumber}",ticketNumber);
+            _logger.LogDebug("Find dispute for ticketNumber {ticketNumber}", ticketNumber);
 
             var dispute = await _context.Disputes.FirstOrDefaultAsync(_ => _.ViolationTicketNumber == ticketNumber);
             if (dispute != null)


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- Adjusts the dotnet unit test so that it does not use instance fields

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [ ] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
