### PR TITLE
Fix issue where duplicate key errors would occur randomly

### DIFF
--- a/src/backend/TrafficCourtsApi/DisputeApi.Web.Test/Features/Disputes/DisputeServiceTest.cs
+++ b/src/backend/TrafficCourtsApi/DisputeApi.Web.Test/Features/Disputes/DisputeServiceTest.cs
@@ -21,7 +21,8 @@ namespace DisputeApi.Web.Test.Features.Disputes
         private ViolationContext CreateContext()
         {
             var optionsBuilder = new DbContextOptionsBuilder<ViolationContext>();
-            optionsBuilder.UseInMemoryDatabase("DisputeApi");
+            // use a random name because the in-memory database is shared anywhere the same name is used.
+            optionsBuilder.UseInMemoryDatabase(Guid.NewGuid().ToString());
 
             var context = new ViolationContext(optionsBuilder.Options);
 

--- a/src/backend/TrafficCourtsApi/DisputeApi.Web.Test/Features/Tickets/TicketServiceTest.cs
+++ b/src/backend/TrafficCourtsApi/DisputeApi.Web.Test/Features/Tickets/TicketServiceTest.cs
@@ -23,7 +23,8 @@ namespace DisputeApi.Web.Test.Features.Tickets
         private ViolationContext CreateContext()
         {
             var optionsBuilder = new DbContextOptionsBuilder<ViolationContext>();
-            optionsBuilder.UseInMemoryDatabase("DisputeApi");
+            // use a random name because the in-memory database is shared anywhere the same name is used.
+            optionsBuilder.UseInMemoryDatabase(Guid.NewGuid().ToString());
 
             return new ViolationContext(optionsBuilder.Options);
         }


### PR DESCRIPTION
When using In Memory database, if the same name is used, the database will be shared db contexts