### PR TITLE
'enableProdMode' without using environment file

### DIFF
--- a/src/frontend/citizen-portal/src/app/app-routing.module.ts
+++ b/src/frontend/citizen-portal/src/app/app-routing.module.ts
@@ -11,28 +11,29 @@ import { LandingComponent } from './components/landing/landing.component';
 import { StepperComponent } from './components/stepper/stepper.component';
 
 const routes: Routes = [
-  // {
-  //   path: AppRoutes.DISPUTE,
-  //   component: DisputePageComponent,
-  //   children: [
-  //     {
-  //       path: AppRoutes.FIND,
-  //       component: FindTicketComponent,
-  //     },
-  //     {
-  //       path: AppRoutes.SUCCESS,
-  //       component: DisputeSubmitComponent,
-  //     },
-  //     {
-  //       path: AppRoutes.SUMMARY,
-  //       component: DisputeSummaryComponent,
-  //     },
-  //     {
-  //       path: AppRoutes.PHOTO,
-  //       component: PhotoComponent,
-  //     },
-  //   ],
-  // },
+  {
+    path: AppRoutes.DISPUTE,
+    component: DisputePageComponent,
+    children: [
+      {
+        path: AppRoutes.FIND,
+        redirectTo: '/home',
+        // component: FindTicketComponent,
+      },
+      //     {
+      //       path: AppRoutes.SUCCESS,
+      //       component: DisputeSubmitComponent,
+      //     },
+      //     {
+      //       path: AppRoutes.SUMMARY,
+      //       component: DisputeSummaryComponent,
+      //     },
+      //     {
+      //       path: AppRoutes.PHOTO,
+      //       component: PhotoComponent,
+      //     },
+    ],
+  },
   // {
   //   path: AppRoutes.STEPPER,
   //   component: StepperComponent,

--- a/src/frontend/citizen-portal/src/main.ts
+++ b/src/frontend/citizen-portal/src/main.ts
@@ -1,12 +1,18 @@
 import { enableProdMode } from '@angular/core';
 import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
+import { AppConfigService } from 'app/services/app-config.service';
 
 import { AppModule } from './app/app.module';
-import { environment } from './environments/environment';
 
-if (environment.production) {
-  enableProdMode();
-}
+fetch('/assets/app.config.json')
+  .then((response) => response.json())
+  .then((config) => {
+    console.log('Is production?', config.production);
+    if (config.production) {
+      enableProdMode();
+    }
 
-platformBrowserDynamic().bootstrapModule(AppModule)
-  .catch(err => console.error(err));
+    platformBrowserDynamic([{ provide: AppConfigService, useValue: config }])
+      .bootstrapModule(AppModule)
+      .catch((err) => console.error(err));
+  });


### PR DESCRIPTION
# Description

'enableProdMode' was still looking at the environment files. Update this to use config

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [x] No

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
