### PR TITLE
Add config map for citizen-web, change image name

### DIFF
--- a/.github/workflows/main-deploy.yml
+++ b/.github/workflows/main-deploy.yml
@@ -58,7 +58,7 @@ jobs:
           COMPOSE_DOCKER_CLI_BUILD: 1
           DOCKER_BUILDKIT: 1
           CONTEXT: ./src/frontend/citizen-portal
-          IMAGE: ${{secrets.OPENSHIFT_EXTERNAL_REPOSITORY}}/${{secrets.OPENSHIFT_TOOLS_NAMESPACE}}/citizen-portal:${{secrets.OC_APP}}
+          IMAGE: ${{secrets.OPENSHIFT_EXTERNAL_REPOSITORY}}/${{secrets.OPENSHIFT_TOOLS_NAMESPACE}}/citizen-web:${{secrets.OC_APP}}
         run: |  
           docker build \
             --tag ${IMAGE} \

--- a/infrastructure/openshift/dev/citizen-web-configuration-configmap.yaml
+++ b/infrastructure/openshift/dev/citizen-web-configuration-configmap.yaml
@@ -1,0 +1,6 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: citizen-web-configuration
+data:
+  app.config.json: "{\r\n  \"production\": false,\r\n  \"environment\": \"dev\",\r\n  \"version\": \"1.0.0\",\r\n  \"useMockServices\": true,\r\n  \"apiBaseUrl\": \"/api\",\r\n  \"understandYourTicketLink\": \"https://understandmyticket.gov.bc.ca/\",\r\n  \"paymentOptionsLink\": \"https://www2.gov.bc.ca/gov/content/justice/courthouse-services/fines-payments/pay-dispute-ticket/prov-violation-tickets/pay-ticket\",\r\n  \"resolutionOptionsLink\": \"https://www2.gov.bc.ca/gov/content/justice/courthouse-services/fines-payments/pay-dispute-ticket/prov-violation-tickets/dispute-ticket\"\r\n}\r\n"

--- a/infrastructure/openshift/test/tickets-test.gov.bc.ca-route.yaml
+++ b/infrastructure/openshift/test/tickets-test.gov.bc.ca-route.yaml
@@ -1,0 +1,1 @@
+# placeholder file to define the test environment vanity url route

--- a/infrastructure/openshift/traffic-courts-online-app.yml
+++ b/infrastructure/openshift/traffic-courts-online-app.yml
@@ -55,7 +55,7 @@ objects:
       spec:
         containers:
           - image: >-
-              image-registry.openshift-image-registry.svc:5000/${OC_NAMESPACE}-tools/citizen-portal:${OC_ENV}
+              image-registry.openshift-image-registry.svc:5000/${OC_NAMESPACE}-tools/citizen-web:${OC_ENV}
             name: ${FRONTEND_POD} 
             ports:
               - containerPort: 8080
@@ -66,6 +66,13 @@ objects:
               requests:
                 cpu: 10m
                 memory: 64Mi
+            volumeMounts:
+            - name: configuration-volume
+              mountPath: /usr/share/nginx/html/assets
+        volumes:
+          - name: configuration-volume
+            configMap:
+              name: citizen-web-configuration
     triggers:
       - type: ConfigChange
       - type: ImageChange
@@ -76,7 +83,7 @@ objects:
           from:
             kind: ImageStreamTag
             namespace: "${OC_NAMESPACE}-tools"
-            name: 'citizen-portal:${OC_ENV}'
+            name: 'citizen-web:${OC_ENV}'
   status: {}
 ### Citizen Portal Service ###
 - apiVersion: v1


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- Adds config map and volume mount for app.config.json
- Renames docker image name from `citizen-portal` to c`itizen-web`

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [ ] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
