### PR TITLE
disable CSP which prev OCR from working for demo session

### DIFF
--- a/src/frontend/citizen-portal/nginx.conf
+++ b/src/frontend/citizen-portal/nginx.conf
@@ -9,7 +9,7 @@ location / {
 
   # default-src: list valid sources
   # script-src: we also need www2.gov.bc.ca for snowplow
-  add_header Content-Security-Policy "default-src 'self' https://spt.apps.gov.bc.ca; script-src 'self' https://www2.gov.bc.ca 'unsafe-inline' 'unsafe-eval'; font-src 'self' https://*; style-src 'self' 'unsafe-inline';";
+  #add_header Content-Security-Policy "default-src 'self' https://spt.apps.gov.bc.ca; script-src 'self' https://www2.gov.bc.ca 'unsafe-inline' 'unsafe-eval'; font-src 'self' https://*; style-src 'self' 'unsafe-inline';";
   add_header X-XSS-Protection "1; mode=block";
   add_header Cache-Control "no-store";
   add_header Pragma "no-cache";


### PR DESCRIPTION
# Description

Comments out the Content-Security-Policy header preventing the OCR working. Need to have task to add this url or move OCR to backend.