### PR TITLE
updates dynamic validators logic on witnesses inputs

### DIFF
--- a/src/frontend/citizen-portal/src/app/components/stepper/step-additional/step-additional.component.html
+++ b/src/frontend/citizen-portal/src/app/components/stepper/step-additional/step-additional.component.html
@@ -120,7 +120,7 @@
 
       <div class="row">
         <div class="col">
-          <mat-checkbox class="me-4 mb-2" color="primary" formControlName="witnessPresent">
+          <mat-checkbox class="me-4 mb-2" color="primary" formControlName="witnessPresent" (change)="onChangeCallWitnesses($event)">
             I intend to call a witness(es).
           </mat-checkbox>
         </div>
@@ -138,14 +138,14 @@
               <mat-option [value]=5>5</mat-option>
               <mat-option (click)="customWitnessOption = true" [value]=6>Custom</mat-option>
             </mat-select>
-            <mat-error *ngIf="numberOfWitnesses.hasError('requiredIfTrue')">
+            <mat-error *ngIf="numberOfWitnesses.hasError('required')">
               {{ "error.required" | translate }}
             </mat-error>
           </mat-form-field>
           <mat-form-field *ngIf="customWitnessOption">
             <mat-label>Number of witnesses</mat-label>
             <input matInput type="number" min="0" step="1" formControlName="numberOfWitnesses" />
-            <mat-error *ngIf="numberOfWitnesses.hasError('requiredIfTrue')">
+            <mat-error *ngIf="numberOfWitnesses.hasError('required')">
               {{ "error.required" | translate }}
             </mat-error>
             <mat-error *ngIf="numberOfWitnesses.hasError('min')">

--- a/src/frontend/citizen-portal/src/app/components/stepper/step-additional/step-additional.component.ts
+++ b/src/frontend/citizen-portal/src/app/components/stepper/step-additional/step-additional.component.ts
@@ -1,5 +1,6 @@
 import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
-import { FormBuilder, FormControl } from '@angular/forms';
+import { FormBuilder, FormControl, Validators } from '@angular/forms';
+import { MatCheckboxChange } from '@angular/material/checkbox';
 import { MatStepper } from '@angular/material/stepper';
 import { ActivatedRoute, Router } from '@angular/router';
 import { Config } from '@config/config.model';
@@ -75,6 +76,14 @@ export class StepAdditionalComponent
 
   public onBack() {
     this.stepper.previous();
+  }
+
+  public onChangeCallWitnesses(event: MatCheckboxChange) {
+    if (event.checked) {
+      this.form.controls.numberOfWitnesses.setValidators([Validators.min(0), Validators.required]);
+    } else {
+      this.form.controls.numberOfWitnesses.setValidators([]);
+    }
   }
 
   public get interpreterLanguage(): FormControl {

--- a/src/frontend/citizen-portal/src/app/services/dispute-form-state.service.ts
+++ b/src/frontend/citizen-portal/src/app/services/dispute-form-state.service.ts
@@ -305,10 +305,6 @@ export class DisputeFormStateService extends AbstractFormStateService<TicketDisp
             'interpreterRequired',
             'interpreterLanguage'
           ),
-          FormGroupValidators.requiredIfTrue(
-            'witnessPresent',
-            'numberOfWitnesses'
-          ),
           FormGroupValidators.requiredIfFlags(
             '_isReductionNotInCourt',
             'requestReduction',


### PR DESCRIPTION
# Description
We removed requiredIfTrue as it would overwrite validators exactly when we didn't want to effect default ones.

This PR includes the following proposed change(s):

- updates dynamic validators logic for input, select and checkbox on witnesses
- Now shows `Enter positive number` when a negative number typed
- Still shows `Required`

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Ran through no witnesses called, 1 witness selected from dropdown, and witnesses selected on inputs. Meanwhile testing the bug for typing a manual negative number. 

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
