### PR TITLE
disable minimum level sending to splunk and use global setting

### DIFF
--- a/src/backend/TrafficCourts/Common/Configuration/SerilogExtensions.cs
+++ b/src/backend/TrafficCourts/Common/Configuration/SerilogExtensions.cs
@@ -51,7 +51,7 @@ namespace TrafficCourts.Common.Configuration
                     splunkHost: splunk.Url,
                     eventCollectorToken: splunk.Token,
                     sourceType: typeof(TConfiguration).Assembly?.GetName()?.Name,
-                    restrictedToMinimumLevel: Serilog.Events.LogEventLevel.Information,
+                    //restrictedToMinimumLevel: Serilog.Events.LogEventLevel.Information,
                     messageHandler: handler);
             });
         }


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- disable min level of information when sending to splunk

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [ ] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
