### PR TITLE
Refactored ViolationTicket fields to be a Dictionary instead of a List

### DIFF
--- a/src/backend/TrafficCourts/Citizen.Service/Controllers/TicketsController.cs
+++ b/src/backend/TrafficCourts/Citizen.Service/Controllers/TicketsController.cs
@@ -65,7 +65,7 @@ namespace TrafficCourts.Citizen.Service.Controllers
                 // - if the TicketNumber could not be extracted
                 return BadRequest();
             }
-            return Ok(response);
+            return Ok(response.OcrViolationTicket);
         }
     }
 }

--- a/src/backend/TrafficCourts/Citizen.Service/Models/Tickets/OcrViolationTicket.cs
+++ b/src/backend/TrafficCourts/Citizen.Service/Models/Tickets/OcrViolationTicket.cs
@@ -1,3 +1,5 @@
+using System.Text.Json.Serialization;
+
 namespace TrafficCourts.Citizen.Service.Models.Tickets;
 
 /// <summary>
@@ -5,80 +7,41 @@ namespace TrafficCourts.Citizen.Service.Models.Tickets;
 /// </summary>
 public class OcrViolationTicket
 {
-    // This list of static variables are the labels used in the Azure Form Recognizer
-    public readonly static string TicketTitle = "Violation Ticket Label";
-    public readonly static string ViolationTicketNumber = "Violation Ticket Number";
-    public readonly static string Surname = "Surname";
-    public readonly static string GivenName = "Given Name";
-    public readonly static string ViolationDate = "Violation Date";
-    public readonly static string ViolationTime = "Violation Time";
-    public readonly static string OffenseIsMVA = "Offense is MVA";
-    public readonly static string OffenseIsMCA = "Offense is MCA";
-    public readonly static string OffenseIsCTA = "Offense is CTA";
-    public readonly static string OffenseIsWLA = "Offense is WLA";
-    public readonly static string OffenseIsFAA = "Offense is FAA";
-    public readonly static string OffenseIsLCA = "Offense is LCA";
-    public readonly static string OffenseIsTCR = "Offense is TCR";
-    public readonly static string OffenseIsOther = "Offense is Other";
-    public readonly static string Count1Description = "Count 1 Description";
-    public readonly static string Count1ActRegs = "Count 1 Act/Regs";
-    public readonly static string Count1IsACT = "Count 1 Is ACT";
-    public readonly static string Count1IsREGS = "Count 1 Is REGS";
-    public readonly static string Count1Section = "Count 1 Section";
-    public readonly static string Count1TicketAmount = "Count 1 Ticket Amount";    
-    public readonly static string Count2Description = "Count 2 Description";
-    public readonly static string Count2ActRegs = "Count 2 Act/Regs";
-    public readonly static string Count2IsACT = "Count 2 Is ACT";
-    public readonly static string Count2IsREGS = "Count 2 Is REGS";
-    public readonly static string Count2Section = "Count 2 Section";
-    public readonly static string Count2TicketAmount = "Count 2 Ticket Amount";    
-    public readonly static string Count3Description = "Count 3 Description";
-    public readonly static string Count3ActRegs = "Count 3 Act/Regs";
-    public readonly static string Count3IsACT = "Count 3 Is ACT";
-    public readonly static string Count3IsREGS = "Count 3 Is REGS";
-    public readonly static string Count3Section = "Count 3 Section";
-    public readonly static string Count3TicketAmount = "Count 3 Ticket Amount";
-    public readonly static string DetachmentLocation = "Detachment Location";
-    public readonly static string DriverLicenceNumber = "Drivers Licence Number";
 
-    /// Not all fields on the handwritten ticket are of value.
-    /// This is a list of fields that are to be saved in ARC
-    public readonly static List<string> FIELDS = new List<string>() {
-        TicketTitle,
-        ViolationTicketNumber,
-        Surname,
-        GivenName,
-        ViolationDate,
-        ViolationTime,
-        OffenseIsMVA,
-        OffenseIsMCA,
-        OffenseIsCTA,
-        OffenseIsWLA,
-        OffenseIsFAA,
-        OffenseIsLCA,
-        OffenseIsTCR,
-        OffenseIsOther,
-        Count1Description,
-        Count1ActRegs,
-        Count1IsACT,
-        Count1IsREGS,
-        Count1Section,
-        Count1TicketAmount,
-        Count2Description,
-        Count2ActRegs,
-        Count2IsACT,
-        Count2IsREGS,
-        Count2Section,
-        Count2TicketAmount,
-        Count3Description,
-        Count3ActRegs,
-        Count3IsACT,
-        Count3IsREGS,
-        Count3Section,
-        Count3TicketAmount,
-        DetachmentLocation,
-        DriverLicenceNumber
-    };
+    public static readonly string ViolationTicketTitle = "violationTicketTitle";
+    public static readonly string ViolationTicketNumber = "violationTicketNumber";
+    public static readonly string Surname = "surname";
+    public static readonly string GivenName = "givenName";
+    public static readonly string DriverLicenceNumber = "driverLicenceNumber";
+    public static readonly string ViolationDate = "violationDate";
+    public static readonly string ViolationTime = "violationTime";
+    public static readonly string OffenseIsMVA = "offenseIsMVA";
+    public static readonly string OffenseIsMCA = "offenseIsMCA";
+    public static readonly string OffenseIsCTA = "offenseIsCTA";
+    public static readonly string OffenseIsWLA = "offenseIsWLA";
+    public static readonly string OffenseIsFAA = "offenseIsFAA";
+    public static readonly string OffenseIsLCA = "offenseIsLCA";
+    public static readonly string OffenseIsTCR = "offenseIsTCR";
+    public static readonly string OffenseIsOther = "offenseIsOther";
+    public static readonly string Count1Description = "count1Description";
+    public static readonly string Count1ActRegs = "count1ActRegs";
+    public static readonly string Count1IsACT = "count1IsACT";
+    public static readonly string Count1IsREGS = "count1IsREGS";
+    public static readonly string Count1Section = "count1Section";
+    public static readonly string Count1TicketAmount = "count1TicketAmount";
+    public static readonly string Count2Description = "count2Description";
+    public static readonly string Count2ActRegs = "count2ActRegs";
+    public static readonly string Count2IsACT = "count2IsACT";
+    public static readonly string Count2IsREGS = "count2IsREGS";
+    public static readonly string Count2Section = "count2Section";
+    public static readonly string Count2TicketAmount = "count2TicketAmount";
+    public static readonly string Count3Description = "count3Description";
+    public static readonly string Count3ActRegs = "count3ActRegs";
+    public static readonly string Count3IsACT = "count3IsACT";
+    public static readonly string Count3IsREGS = "count3IsREGS";
+    public static readonly string Count3Section = "count3Section";
+    public static readonly string Count3TicketAmount = "count3TicketAmount";
+    public static readonly string DetachmentLocation = "detachmentLocation";
 
     /// <summary>
     /// A global confidence of correctly extracting the document. This value will be low if the title of this 
@@ -94,18 +57,10 @@ public class OcrViolationTicket
     /// <summary>
     /// An enumeration of all fields in this Violation Ticket.
     /// </summary>
-    /// TODO: convert to a Dictionary or actual class Properties
-    public List<Field> Fields { get; set; } = new List<Field>();
-
-    /// <summary>Finds the field with the given name</summary>
-    public OcrViolationTicket.Field? GetField(String name)
-    {
-        return Fields.Find(_ => name.Equals(_.Name));
-    }
+    public Dictionary<string, Field> Fields { get; set; } = new Dictionary<string, Field>();
 
     public class Field
     {
-        public String? Name { get; set; }
         public String? Value { get; set; }
         public float? Confidence { get; set; }
         /// <summary>

--- a/src/backend/TrafficCourts/Citizen.Service/Services/FormRecognizerService.cs
+++ b/src/backend/TrafficCourts/Citizen.Service/Services/FormRecognizerService.cs
@@ -10,6 +10,45 @@ public class FormRecognizerService : IFormRecognizerService
     private readonly string _apiKey;
     private readonly Uri _endpoint;
 
+    // A mapping list of fields extracted from Azure Form Recognizer and their equivalent JSON name
+    private readonly static Dictionary<string, string> FieldLabels = new Dictionary<string, string>()
+    {
+        { "Violation Ticket Label",     OcrViolationTicket.ViolationTicketTitle },
+        { "Violation Ticket Number",    OcrViolationTicket.ViolationTicketNumber },
+        { "Surname",                    OcrViolationTicket.Surname },
+        { "Given Name",                 OcrViolationTicket.GivenName },
+        { "Drivers Licence Number",     OcrViolationTicket.DriverLicenceNumber },
+        { "Violation Date",             OcrViolationTicket.ViolationDate },
+        { "Violation Time",             OcrViolationTicket.ViolationTime },
+        { "Offense is MVA",             OcrViolationTicket.OffenseIsMVA },
+        { "Offense is MCA",             OcrViolationTicket.OffenseIsMCA },
+        { "Offense is CTA",             OcrViolationTicket.OffenseIsCTA },
+        { "Offense is WLA",             OcrViolationTicket.OffenseIsWLA },
+        { "Offense is FAA",             OcrViolationTicket.OffenseIsFAA },
+        { "Offense is LCA",             OcrViolationTicket.OffenseIsLCA },
+        { "Offense is TCR",             OcrViolationTicket.OffenseIsTCR },
+        { "Offense is Other",           OcrViolationTicket.OffenseIsOther },
+        { "Count 1 Description",        OcrViolationTicket.Count1Description },
+        { "Count 1 Act/Regs",           OcrViolationTicket.Count1ActRegs },
+        { "Count 1 Is ACT",             OcrViolationTicket.Count1IsACT },
+        { "Count 1 Is REGS",            OcrViolationTicket.Count1IsREGS },
+        { "Count 1 Section",            OcrViolationTicket.Count1Section },
+        { "Count 1 Ticket Amount",      OcrViolationTicket.Count1TicketAmount },
+        { "Count 2 Description",        OcrViolationTicket.Count2Description },
+        { "Count 2 Act/Regs",           OcrViolationTicket.Count2ActRegs },
+        { "Count 2 Is ACT",             OcrViolationTicket.Count2IsACT },
+        { "Count 2 Is REGS",            OcrViolationTicket.Count2IsREGS },
+        { "Count 2 Section",            OcrViolationTicket.Count2Section },
+        { "Count 2 Ticket Amount",      OcrViolationTicket.Count2TicketAmount },
+        { "Count 3 Description",        OcrViolationTicket.Count3Description },
+        { "Count 3 Act/Regs",           OcrViolationTicket.Count3ActRegs },
+        { "Count 3 Is ACT",             OcrViolationTicket.Count3IsACT },
+        { "Count 3 Is REGS",            OcrViolationTicket.Count3IsREGS },
+        { "Count 3 Section",            OcrViolationTicket.Count3Section },
+        { "Count 3 Ticket Amount",      OcrViolationTicket.Count3TicketAmount },
+        { "Detachment Location",        OcrViolationTicket.DetachmentLocation }
+    };
+
     public FormRecognizerService(String apiKey, Uri endpoint, ILogger<FormRecognizerService> logger)
     {
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
@@ -42,10 +81,9 @@ public class FormRecognizerService : IFormRecognizerService
                 foreach (KeyValuePair<String, DocumentField> pair in document.Fields)
                 {
                     // Only map fields of interest
-                    if (pair.Key is not null && OcrViolationTicket.FIELDS.Contains<string>(pair.Key))
+                    if (pair.Key is not null && FieldLabels.Keys.Contains<string>(pair.Key))
                     {
                         OcrViolationTicket.Field field = new OcrViolationTicket.Field();
-                        field.Name = pair.Key;
                         field.Value = pair.Value.Content;
                         field.Confidence = pair.Value.Confidence;
                         field.Type = Enum.GetName(pair.Value.ValueType);
@@ -59,7 +97,7 @@ public class FormRecognizerService : IFormRecognizerService
                             field.BoundingBoxes.Add(boundingBox);
                         }
 
-                        violationTicket.Fields.Add(field);
+                        violationTicket.Fields.Add(FieldLabels[pair.Key], field);
                     }
                 }
             }

--- a/src/backend/TrafficCourts/Citizen.Service/Validators/FormRecognizerValidator.cs
+++ b/src/backend/TrafficCourts/Citizen.Service/Validators/FormRecognizerValidator.cs
@@ -17,8 +17,8 @@ public class FormRecognizerValidator : IFormRecognizerValidator
         // - In "Did commit offence(s) indicated, under the following act or its regulations" section, only 'MVA' is selected.
         // - If the Violation Date is less than 30 days
         List<ValidationRule> rules = new List<ValidationRule>();
-        rules.Add(new FieldMatchesRegexRule(violationTicket.GetField(OcrViolationTicket.TicketTitle), TicketTitleRegex, ValidationMessages.TicketTitleInvalid));
-        rules.Add(new FieldMatchesRegexRule(violationTicket.GetField(OcrViolationTicket.ViolationTicketNumber), ViolationTicketNumberRegex, ValidationMessages.TicketNumberInvalid));
+        rules.Add(new FieldMatchesRegexRule(violationTicket.Fields[OcrViolationTicket.ViolationTicketTitle], TicketTitleRegex, ValidationMessages.TicketTitleInvalid));
+        rules.Add(new FieldMatchesRegexRule(violationTicket.Fields[OcrViolationTicket.ViolationTicketNumber], ViolationTicketNumberRegex, ValidationMessages.TicketNumberInvalid));
         // TODO: Add OnlyMCAIsSelectedRule
         // TODO: Add ViolationDateLT30Rule
 

--- a/src/backend/TrafficCourts/Test/Citizen.Service/Controllers/TicketsControllerTests.cs
+++ b/src/backend/TrafficCourts/Test/Citizen.Service/Controllers/TicketsControllerTests.cs
@@ -33,7 +33,7 @@ public class TicketsControllerTests
 
         // Assert
         var okResult = Assert.IsType<OkObjectResult>(result);
-        Assert.Equal(analyseResponse, okResult.Value);
+        Assert.Equal(analyseResponse.OcrViolationTicket, okResult.Value);
     }
 
     [Fact]


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

Refactored ViolationTicket fields to be a Dictionary instead of a List.  

Replaced 
`public List<Field> Fields { get; set; } = new List<Field>();`
With
`public Dictionary<string, Field> Fields { get; set; } = new Dictionary<string, Field>();`

Cleaned up serialization. Now looks like this:
![image](https://user-images.githubusercontent.com/55215368/150420173-71e6b455-9e9f-49cf-b73b-9036a25ccd83.png)



## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

dotnet test

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [x] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
