### PR TITLE
TVCP-933 Added OnlyMCAIsSelectedRule validation rule

### DIFF
--- a/src/backend/TrafficCourts/Citizen.Service/Models/Tickets/OcrViolationTicket.cs
+++ b/src/backend/TrafficCourts/Citizen.Service/Models/Tickets/OcrViolationTicket.cs
@@ -47,28 +47,68 @@ public class OcrViolationTicket
     /// A global confidence of correctly extracting the document. This value will be low if the title of this 
     /// Violation Ticket form is not found (or of low confidence itself) or if the main ticket number is missing or invalid.
     /// </summary>
-    public float Confidence { get; set; }
+    public float GlobalConfidence { get; set; }
 
     /// <summary>
     /// A list of global reasons why the global Confidence may be low (ie, missing ticket number, not a Violation Ticket, etc.)
     /// </summary>
-    public List<string> ValidationErrors { get; set; } = new List<string>();
+    public List<string> GlobalValidationErrors { get; set; } = new List<string>();
 
     /// <summary>
     /// An enumeration of all fields in this Violation Ticket.
     /// </summary>
     public Dictionary<string, Field> Fields { get; set; } = new Dictionary<string, Field>();
 
+    /// <summary>
+    /// Helper method to return the given field from the Fields Dictionary (workaround for KeyNotFoundException).
+    /// </summary>
+    public Field? GetField(string fieldName) {
+        Field? field;
+        if (Fields.TryGetValue(fieldName, out field)) {
+            return field;
+        }
+        else {
+            return null;
+        }
+    }
+
     public class Field
     {
+        public Field() {}
+
+        public Field(String? value) {
+            Value = value;
+        }
+
+        [JsonIgnore]
+        public String? Name { get; set; }
+
         public String? Value { get; set; }
-        public float? Confidence { get; set; }
+
+        public float? FieldConfidence { get; set; }
+
         /// <summary>
         /// A list of field-specific reasons why the field Confidence may be low
         /// </summary>
-        public List<string> Validation { get; set; } = new List<string>();
+        public List<string> FieldValidationErrors { get; set; } = new List<string>();
+
         public String? Type { get; set; }
+
         public List<BoundingBox> BoundingBoxes { get; set; } = new List<BoundingBox>();
+
+        /// <summary>Returns true if the given field's value is "selected", false if "unselected", otherwise null (unknown) value.</summary> 
+        public bool? IsCheckboxSelected()
+        {
+            if (Value?.Equals("selected") ?? false)
+            {
+                return true;
+            }
+            if (Value?.Equals("unselected") ?? false)
+            {
+                return false;
+            }
+            return null;
+        }
     }
 
     public class BoundingBox

--- a/src/backend/TrafficCourts/Citizen.Service/Services/FormRecognizerService.cs
+++ b/src/backend/TrafficCourts/Citizen.Service/Services/FormRecognizerService.cs
@@ -74,7 +74,7 @@ public class FormRecognizerService : IFormRecognizerService
         OcrViolationTicket violationTicket = new OcrViolationTicket();
         foreach (AnalyzedDocument document in result.Documents)
         {
-            violationTicket.Confidence = document.Confidence;
+            violationTicket.GlobalConfidence = document.Confidence;
 
             if (document.Fields is not null)
             {
@@ -84,8 +84,9 @@ public class FormRecognizerService : IFormRecognizerService
                     if (pair.Key is not null && FieldLabels.Keys.Contains<string>(pair.Key))
                     {
                         OcrViolationTicket.Field field = new OcrViolationTicket.Field();
+                        field.Name = pair.Key;
                         field.Value = pair.Value.Content;
-                        field.Confidence = pair.Value.Confidence;
+                        field.FieldConfidence = pair.Value.Confidence;
                         field.Type = Enum.GetName(pair.Value.ValueType);
                         foreach (BoundingRegion region in pair.Value.BoundingRegions)
                         {

--- a/src/backend/TrafficCourts/Citizen.Service/Validators/FormRecognizerValidator.cs
+++ b/src/backend/TrafficCourts/Citizen.Service/Validators/FormRecognizerValidator.cs
@@ -19,20 +19,20 @@ public class FormRecognizerValidator : IFormRecognizerValidator
         List<ValidationRule> rules = new List<ValidationRule>();
         rules.Add(new FieldMatchesRegexRule(violationTicket.Fields[OcrViolationTicket.ViolationTicketTitle], TicketTitleRegex, ValidationMessages.TicketTitleInvalid));
         rules.Add(new FieldMatchesRegexRule(violationTicket.Fields[OcrViolationTicket.ViolationTicketNumber], ViolationTicketNumberRegex, ValidationMessages.TicketNumberInvalid));
-        // TODO: Add OnlyMCAIsSelectedRule
+        rules.Add(new OnlyMCAIsSelectedRule(violationTicket));
         // TODO: Add ViolationDateLT30Rule
 
         // Run each rule and aggregate the results
         rules.ForEach(_ =>
         {
             _.Run();
-            violationTicket.ValidationErrors.AddRange(_.ValidationErrors);
+            violationTicket.GlobalValidationErrors.AddRange(_.ValidationErrors);
         });
 
         // drop global Confidence to 0 if this does not appear to be a valid ticket
-        if (violationTicket.ValidationErrors.Count > 0)
+        if (violationTicket.GlobalValidationErrors.Count > 0)
         {
-            violationTicket.Confidence = 0f;
+            violationTicket.GlobalConfidence = 0f;
         }
     }
 }

--- a/src/backend/TrafficCourts/Citizen.Service/Validators/Rules/FieldMatchesRegexRule.cs
+++ b/src/backend/TrafficCourts/Citizen.Service/Validators/Rules/FieldMatchesRegexRule.cs
@@ -18,9 +18,13 @@ public class FieldMatchesRegexRule : ValidationRule
 
     public override void Run()
     {
-        if (_field is null || _field.Value is null)
+        if (_field is null)
         {
-            ValidationErrors.Add(FieldIsBlankError);
+            ValidationErrors.Add(String.Format(ValidationMessages.FieldIsBlankError, "Field"));
+        }
+        else if (_field.Value is null)
+        {
+            ValidationErrors.Add(String.Format(ValidationMessages.FieldIsBlankError, _field.Name));
         }
         else if (!Regex.IsMatch(_field.Value, _pattern))
         {

--- a/src/backend/TrafficCourts/Citizen.Service/Validators/Rules/OnlyMCAIsSelectedRule.cs
+++ b/src/backend/TrafficCourts/Citizen.Service/Validators/Rules/OnlyMCAIsSelectedRule.cs
@@ -1,0 +1,77 @@
+using TrafficCourts.Citizen.Service.Models.Tickets;
+using static TrafficCourts.Citizen.Service.Models.Tickets.OcrViolationTicket;
+
+namespace TrafficCourts.Citizen.Service.Validators.Rules;
+
+/// <summary>
+/// In the "Did commit offence(s) indicated, under the following act or its regulations" section, only 'MVA' can be selected.
+/// If any of the checkboxes in this section are unreadable (namely not "selected" or "unselected") then this rule cannot be verified.
+/// </summary>
+public class OnlyMCAIsSelectedRule : ValidationRule
+{
+    private readonly OcrViolationTicket _violationTicket;
+
+    public OnlyMCAIsSelectedRule(OcrViolationTicket violationTicket)
+    {
+        this._violationTicket = violationTicket;
+    }
+
+    public override void Run()
+    {
+        bool? mva = _violationTicket.GetField(OcrViolationTicket.OffenseIsMVA)?.IsCheckboxSelected();
+        bool? mca = _violationTicket.GetField(OcrViolationTicket.OffenseIsMCA)?.IsCheckboxSelected();
+        bool? cta = _violationTicket.GetField(OcrViolationTicket.OffenseIsCTA)?.IsCheckboxSelected();
+        bool? wla = _violationTicket.GetField(OcrViolationTicket.OffenseIsWLA)?.IsCheckboxSelected();
+        bool? faa = _violationTicket.GetField(OcrViolationTicket.OffenseIsFAA)?.IsCheckboxSelected();
+        bool? lca = _violationTicket.GetField(OcrViolationTicket.OffenseIsLCA)?.IsCheckboxSelected();
+        bool? tcr = _violationTicket.GetField(OcrViolationTicket.OffenseIsTCR)?.IsCheckboxSelected();
+        bool? other = _violationTicket.GetField(OcrViolationTicket.OffenseIsOther)?.IsCheckboxSelected();
+        
+        // If any of the 8 checkboxes is neither "selected" or "unselected", add a validation error.  These values are the only two values from Azure Form Recognizer.
+        if (mva is null)
+        {
+            ValidationErrors.Add(ValidationMessages.UnknownMVAValueError);
+        }
+        if (mca is null)
+        {
+            ValidationErrors.Add(ValidationMessages.UnknownMCAValueError);
+        }
+        if (cta is null)
+        {
+            ValidationErrors.Add(ValidationMessages.UnknownCTAValueError);
+        }
+        if (wla is null)
+        {
+            ValidationErrors.Add(ValidationMessages.UnknownWLAValueError);
+        }
+        if (faa is null)
+        {
+            ValidationErrors.Add(ValidationMessages.UnknownFAAValueError);
+        }
+        if (lca is null)
+        {
+            ValidationErrors.Add(ValidationMessages.UnknownLCAValueError);
+        }
+        if (tcr is null)
+        {
+            ValidationErrors.Add(ValidationMessages.UnknownTCRValueError);
+        }
+        if (other is null)
+        {
+            ValidationErrors.Add(ValidationMessages.UnknownOtherValueError);
+        }
+
+        // If all checkboxes have valid values, ensure only MVA is selected.
+        if ((mva is not null) && (mca is not null) && (cta is not null) && (wla is not null) && (faa is not null) && (lca is not null) && (tcr is not null) && (other is not null))
+        {
+            if (!mva ?? false)
+            {
+                ValidationErrors.Add(ValidationMessages.MVAMustBeSelectedError);
+            }
+            if ((mca ?? false) || (cta ?? false) || (wla ?? false) || (faa ?? false) || (lca ?? false) || (tcr ?? false) || (other ?? false))
+            {
+                ValidationErrors.Add(ValidationMessages.OnlyMVAMustBeSelectedError);
+            }
+        }
+    }
+}

--- a/src/backend/TrafficCourts/Citizen.Service/Validators/Rules/ValidationRule.cs
+++ b/src/backend/TrafficCourts/Citizen.Service/Validators/Rules/ValidationRule.cs
@@ -3,8 +3,6 @@ namespace TrafficCourts.Citizen.Service.Validators.Rules;
 public abstract class ValidationRule
 {
 
-    public static readonly string FieldIsBlankError = "Field is blank";
-
     public List<string> ValidationErrors { get; set; } = new List<string>();
 
     public bool IsValid() {

--- a/src/backend/TrafficCourts/Citizen.Service/Validators/ValidationMessages.cs
+++ b/src/backend/TrafficCourts/Citizen.Service/Validators/ValidationMessages.cs
@@ -2,6 +2,17 @@ namespace TrafficCourts.Citizen.Service.Validators;
 
 public static class ValidationMessages
 {
-    internal static readonly string TicketTitleInvalid = "Ticket title must be 'VIOLATION TICKET'";
-    internal static readonly string TicketNumberInvalid = "Violation ticket number must start with an A and be of the form 'AX00000000'";
+    internal static readonly string FieldIsBlankError = "{0} is blank";
+    internal static readonly string TicketTitleInvalid = @"Ticket title must be 'VIOLATION TICKET'.";
+    internal static readonly string TicketNumberInvalid = @"Violation ticket number must start with an A and be of the form 'AX00000000'.";
+    internal static readonly string UnknownMVAValueError = @"Unknown MVA selection. Could not determine if MVA is the only checkbox selected under 'Did commit the offence(s)' section.";
+    internal static readonly string UnknownMCAValueError = @"Unknown MCA selection. Could not determine if MVA is the only checkbox selected under 'Did commit the offence(s)' section.";
+    internal static readonly string UnknownCTAValueError = @"Unknown CTA selection. Could not determine if MVA is the only checkbox selected under 'Did commit the offence(s)' section.";
+    internal static readonly string UnknownWLAValueError = @"Unknown WLA selection. Could not determine if MVA is the only checkbox selected under 'Did commit the offence(s)' section.";
+    internal static readonly string UnknownFAAValueError = @"Unknown FAA selection. Could not determine if MVA is the only checkbox selected under 'Did commit the offence(s)' section.";
+    internal static readonly string UnknownLCAValueError = @"Unknown LCA selection. Could not determine if MVA is the only checkbox selected under 'Did commit the offence(s)' section.";
+    internal static readonly string UnknownTCRValueError = @"Unknown TCR selection. Could not determine if MVA is the only checkbox selected under 'Did commit the offence(s)' section.";
+    internal static readonly string UnknownOtherValueError = @"Unknown Other selection. Could not determine if MVA is the only checkbox selected under the 'Did commit the offence(s)' section.";
+    internal static readonly string MVAMustBeSelectedError = @"MVA must be selected under the 'Did commit the offence(s)' section.";
+    internal static readonly string OnlyMVAMustBeSelectedError = @"MVA must be the only selected ACT under the 'Did commit the offence(s) indicated' section.";
 }

--- a/src/backend/TrafficCourts/Test/Citizen.Service/Validators/Rules/FieldMatchesRegexRuleTest.cs
+++ b/src/backend/TrafficCourts/Test/Citizen.Service/Validators/Rules/FieldMatchesRegexRuleTest.cs
@@ -44,6 +44,7 @@ public class FieldMatchesRegexRuleTest
     {
         // Given
         Field field = new Field();
+        field.Name = "Field";
         field.Value = null;
         FieldMatchesRegexRule rule = new FieldMatchesRegexRule(field, "AAAA", "Field is blank");
 

--- a/src/backend/TrafficCourts/Test/Citizen.Service/Validators/Rules/OnlyMCAIsSelectedRuleTest.cs
+++ b/src/backend/TrafficCourts/Test/Citizen.Service/Validators/Rules/OnlyMCAIsSelectedRuleTest.cs
@@ -1,0 +1,80 @@
+using System;
+using System.Text.RegularExpressions;
+using TrafficCourts.Citizen.Service.Models.Tickets;
+using TrafficCourts.Citizen.Service.Validators;
+using TrafficCourts.Citizen.Service.Validators.Rules;
+using Xunit;
+using static TrafficCourts.Citizen.Service.Models.Tickets.OcrViolationTicket;
+
+namespace TrafficCourts.Test.Citizen.Service.Validators.Rules;
+
+public class OnlyMCAIsSelectedRuleTest
+{
+    [Fact]
+    public void TestFieldsMissing()
+    {
+        // Given
+        OcrViolationTicket violationTicket = new OcrViolationTicket();
+        OnlyMCAIsSelectedRule rule = new OnlyMCAIsSelectedRule(violationTicket);
+
+        // When
+        rule.Run();
+
+        // Then. There should be 8 errors, all of the form "Unknown ... selection."
+        Assert.Equal(8, rule.ValidationErrors.Count);
+        foreach (string errorMsg in rule.ValidationErrors)
+        {
+            Assert.Matches(@"^Unknown \w+ selection.*", errorMsg);
+        }
+    }
+
+    [Theory]
+    [InlineData("selected", "unselected", "unselected", "unselected", "unselected", "unselected", "unselected", "unselected", null)]
+    [InlineData("unselected", "unselected", "unselected", "unselected", "unselected", "unselected", "unselected", "unselected", @"^MVA must be selected.*")]
+    [InlineData("selected", "selected", "unselected", "unselected", "unselected", "unselected", "unselected", "unselected", @"^MVA must be the only selected.*")]
+    [InlineData("selected", "unselected", "selected", "unselected", "unselected", "unselected", "unselected", "unselected", @"^MVA must be the only selected.*")]
+    [InlineData("selected", "unselected", "unselected", "selected", "unselected", "unselected", "unselected", "unselected", @"^MVA must be the only selected.*")]
+    [InlineData("selected", "unselected", "unselected", "unselected", "selected", "unselected", "unselected", "unselected", @"^MVA must be the only selected.*")]
+    [InlineData("selected", "unselected", "unselected", "unselected", "unselected", "selected", "unselected", "unselected", @"^MVA must be the only selected.*")]
+    [InlineData("selected", "unselected", "unselected", "unselected", "unselected", "unselected", "selected", "unselected", @"^MVA must be the only selected.*")]
+    [InlineData("selected", "unselected", "unselected", "unselected", "unselected", "unselected", "unselected", "selected", @"^MVA must be the only selected.*")]
+    [InlineData(null, "unselected", "unselected", "unselected", "unselected", "unselected", "unselected", "unselected", @"^Unknown \w+ selection.*")]
+    [InlineData("selected", null, "unselected", "unselected", "unselected", "unselected", "unselected", "unselected", @"^Unknown \w+ selection.*")]
+    [InlineData("selected", "unselected", null, "unselected", "unselected", "unselected", "unselected", "unselected", @"^Unknown \w+ selection.*")]
+    [InlineData("selected", "unselected", "unselected", null, "unselected", "unselected", "unselected", "unselected", @"^Unknown \w+ selection.*")]
+    [InlineData("selected", "unselected", "unselected", "unselected", null, "unselected", "unselected", "unselected", @"^Unknown \w+ selection.*")]
+    [InlineData("selected", "unselected", "unselected", "unselected", "unselected", null, "unselected", "unselected", @"^Unknown \w+ selection.*")]
+    [InlineData("selected", "unselected", "unselected", "unselected", "unselected", "unselected", null, "unselected", @"^Unknown \w+ selection.*")]
+    [InlineData("selected", "unselected", "unselected", "unselected", "unselected", "unselected", "unselected", null, @"^Unknown \w+ selection.*")]
+    public void TestFieldsBlank(string? mva, string? mca, string? cta, string? wla, string? faa, string? lca, string? tcr, string? other, string? expectedPattern)
+    {
+        // Given
+        OcrViolationTicket violationTicket = new OcrViolationTicket();
+        violationTicket.Fields.Add(OcrViolationTicket.OffenseIsMVA, new Field(mva));
+        violationTicket.Fields.Add(OcrViolationTicket.OffenseIsMCA, new Field(mca));
+        violationTicket.Fields.Add(OcrViolationTicket.OffenseIsCTA, new Field(cta));
+        violationTicket.Fields.Add(OcrViolationTicket.OffenseIsWLA, new Field(wla));
+        violationTicket.Fields.Add(OcrViolationTicket.OffenseIsFAA, new Field(faa));
+        violationTicket.Fields.Add(OcrViolationTicket.OffenseIsLCA, new Field(lca));
+        violationTicket.Fields.Add(OcrViolationTicket.OffenseIsTCR, new Field(tcr));
+        violationTicket.Fields.Add(OcrViolationTicket.OffenseIsOther, new Field(other));
+        OnlyMCAIsSelectedRule rule = new OnlyMCAIsSelectedRule(violationTicket);
+
+        // When
+        rule.Run();
+
+        // Then.
+        if (expectedPattern is not null)
+        {
+            Assert.Single(rule.ValidationErrors);
+            foreach (string errorMsg in rule.ValidationErrors)
+            {
+                Assert.True(Regex.IsMatch(errorMsg, expectedPattern), String.Format("Expected '{0}', Actual '{1}'", expectedPattern, errorMsg));
+            }
+        }
+        else
+        {
+            Assert.Empty(rule.ValidationErrors);
+        }
+    }
+}


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

[TCVP-933](https://justice.gov.bc.ca/jira/browse/TCVP-933)

- Added new OnlyMCAIsSelectedRule to ensure only the MCA checkbox is selected in the "Did commit the offense(s) indicated" section
- Added xUnit tests
- To be more clear, refactored Confidence to be either GlobalConfidence or FieldConfidence.
- To be more clear, refactored ValidationErrors to be either GlobalValidationErrors or FieldValidationErrors.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

dotnet test

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [x] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
