### PR TITLE
Fixed return type of analyse endpoint

### DIFF
--- a/src/backend/TrafficCourts/Citizen.Service/Controllers/TicketsController.cs
+++ b/src/backend/TrafficCourts/Citizen.Service/Controllers/TicketsController.cs
@@ -1,9 +1,9 @@
-﻿using System.ComponentModel.DataAnnotations;
-using MediatR;
+﻿using MediatR;
 using Microsoft.AspNetCore.Mvc;
+using System.ComponentModel.DataAnnotations;
 using System.Net;
 using TrafficCourts.Citizen.Service.Features.Tickets;
-using Microsoft.OpenApi.Models;
+using TrafficCourts.Citizen.Service.Models.Tickets;
 
 namespace TrafficCourts.Citizen.Service.Controllers
 {
@@ -53,19 +53,28 @@ namespace TrafficCourts.Citizen.Service.Controllers
         }
 
         [HttpPost("analyse")]
-        [ProducesResponseType(typeof(Search.Response), (int)HttpStatusCode.OK)]
-        [ProducesResponseType(typeof(Search.Response), (int)HttpStatusCode.BadRequest)]
+        [ProducesResponseType(typeof(OcrViolationTicket), (int)HttpStatusCode.OK)]
+        [ProducesResponseType((int)HttpStatusCode.BadRequest)]
         [DisableRequestSizeLimit]
         public async Task<IActionResult> AnalyseAsync([Required] IFormFile image, CancellationToken cancellationToken)
         {
             AnalyseHandler.AnalyseRequest request = new AnalyseHandler.AnalyseRequest(image);
             AnalyseHandler.AnalyseResponse response = await _mediator.Send(request, cancellationToken);
-            if (response.OcrViolationTicket is null)
+            if (response.OcrViolationTicket.ValidationErrors.Count > 0)
             {
+                string? detail = "";
+                string? instance = null;
+                int? statusCode = (int)HttpStatusCode.BadRequest;
+                string? title = "Violation Ticket is not valid or could not be read.";
+                string? type = null;
+                response.OcrViolationTicket.ValidationErrors.ForEach(_ => detail += _ + " ");
+
                 // Return BadRequest 
-                // - if the image is not an image of a TrafficViolation
-                // - if the TicketNumber could not be extracted
-                return BadRequest();
+                // - if the image is not an image of a TrafficViolation (could not read title)
+                // - if the TicketNumber could not be extracted or is invalid (ie doesn't start with an A)
+                // - if MVA is not the only checkbox selected under the 'Did commit the offence(s) indicated' section
+                // - if ViolationDate is > 30 days ago
+                return Problem(detail, instance, statusCode, title, type);
             }
             return Ok(response.OcrViolationTicket);
         }

--- a/src/backend/TrafficCourts/Citizen.Service/Features/Tickets/AnalyseHandler.cs
+++ b/src/backend/TrafficCourts/Citizen.Service/Features/Tickets/AnalyseHandler.cs
@@ -20,7 +20,11 @@ public static class AnalyseHandler
 
     public class AnalyseResponse
     {
-        public OcrViolationTicket? OcrViolationTicket { get; set; }
+        public AnalyseResponse(OcrViolationTicket violationTicket) {
+            OcrViolationTicket = violationTicket;
+        }
+
+        public OcrViolationTicket OcrViolationTicket { get; set; }
     }
 
     public class Handler : IRequestHandler<AnalyseRequest, AnalyseResponse>
@@ -49,8 +53,7 @@ public static class AnalyseHandler
             // Validate the violationTicket and adjust confidence values (invalid ticket number, invalid count section text, etc)
             _formRecognizerValidator.ValidateViolationTicket(violationTicket);
 
-            AnalyseResponse response = new AnalyseResponse();
-            response.OcrViolationTicket = violationTicket;
+            AnalyseResponse response = new AnalyseResponse(violationTicket);
             return response;
         }
     }


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

Fixed the return type for the /analyse endpoint, updated xUnit test.
The endpoint now returns a ProblemDetails object detailing why the request failed with a 400 BAD REQUEST response.

Swagger is now responsive again!

This is an example when submitting a ticket with an invalid ticket number:
![image](https://user-images.githubusercontent.com/55215368/150578791-96e81feb-9dbd-4594-90a5-dfba2082130c.png)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [x] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
