### PR TITLE
Added missing .dockerignore file to frontend

### DIFF
--- a/src/frontend/citizen-portal/.dockerignore
+++ b/src/frontend/citizen-portal/.dockerignore
@@ -1,0 +1,1 @@
+node_modules

--- a/src/frontend/citizen-portal/.dockerignore
+++ b/src/frontend/citizen-portal/.dockerignore
@@ -1,1 +1,2 @@
+dist
 node_modules

--- a/src/frontend/citizen-portal/README.md
+++ b/src/frontend/citizen-portal/README.md
@@ -21,6 +21,13 @@ git clone https://github.com/bcgov/jag-traffic-courts-online
 #### Node
 
 [Download](https://nodejs.org/en/) and install **Node v14.x**
+NOTE: ensure to use v14.x. More recent versions (i.e. v17.x) do not work.
+It's useful to install different versions of node (https://docs.microsoft.com/en-us/windows/dev-environment/javascript/nodejs-on-windows)
+For this project, before building any code perform a:
+```bash
+nvm install 14.19.0
+nvm use 14.19.0
+```
 
 #### Angular cli
 


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

Added missing `.dockerignore` file for frontend.  Without this, docker-compose will include the large `node_modules` dependencies and any locally built files - these should be generated every time, not copied from local development.

This file must exist at the same level as the build context invoked from docker-compose, which in this case is:
```
    build:
      context: ./src/frontend/citizen-portal
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [x] Yes
- [ ] No

If Yes: Has Docker been updated accordingly?

- [x] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
