### PR TITLE
Fixed docker-compose so the frontend works

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -64,6 +64,8 @@ services:
     container_name: citizen-portal
     build:
       context: ./src/frontend/citizen-portal
+      args:
+        - API_BASE_PATH=${API_BASE_PATH:-http://citizen-api:8080/api/}
     restart: always
     ports:
       - "8080:8080"

--- a/src/frontend/citizen-portal/Dockerfile
+++ b/src/frontend/citizen-portal/Dockerfile
@@ -1,6 +1,9 @@
 # Build image
 FROM node:14.18 as build-deps
 
+ARG API_BASE_PATH=http://citizen-api/api/
+ENV API_BASE_PATH=${API_BASE_PATH}
+
 # set working directory
 ENV NODE_ROOT /usr/src/app
 
@@ -15,6 +18,11 @@ RUN yarn install
 COPY . .
 
 RUN NODE_OPTIONS=--max_old_space_size=4096 yarn run build-prod
+
+# replace the API_BASE_PATH env var in nginx.conf
+RUN apt-get update; \
+    apt-get install -y gettext-base
+RUN envsubst '${API_BASE_PATH}' < /usr/src/app/nginx.conf.template > /usr/src/app/nginx.conf
 
 # Runtime image
 FROM registry.access.redhat.com/ubi8/nginx-120

--- a/src/frontend/citizen-portal/nginx.conf.template
+++ b/src/frontend/citizen-portal/nginx.conf.template
@@ -38,7 +38,7 @@ location /nginx_status {
 }
 
 location /api/ {
-    proxy_pass http://citizen-api/api/;
+    proxy_pass ${API_BASE_PATH};
 }
 
 # Disables emitting nginx version in error messages and in the “Server” response header field.


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

There was a disconnect between the front and backend services when using docker-compose. This fix addresses that - the frontend now properly references the backend both when launching the citizen-portal locally (in vscode) or in docker via docker-compose.

Added API_BASE_PATH as a env variable in docker-compose so the citizen-portal properly references the API.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [x] Yes
- [ ] No

If Yes: Has Docker been updated accordingly?

- [x] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
