### PR TITLE
Persisted correctly parsed datatypes back onto the field value

### DIFF
--- a/src/backend/TrafficCourts/Citizen.Service/Validators/Rules/TicketAmountValidRule.cs
+++ b/src/backend/TrafficCourts/Citizen.Service/Validators/Rules/TicketAmountValidRule.cs
@@ -14,9 +14,18 @@ public class TicketAmountValidRule : ValidationRule
 
     public override void Run()
     {
-        if (Field.Value is not null && Field.GetCurrency() is null)
+        if (Field.Value is not null)
         {
-            AddValidationError(String.Format(ValidationMessages.CurrencyInvalid, Field.Value));
+            float? currency = Field.GetCurrency();
+            if (currency is null)
+            {
+                AddValidationError(String.Format(ValidationMessages.CurrencyInvalid, Field.Value));
+            }
+            else
+            {
+                // Format the Field Value as recognized by the validator
+                Field.Value =  String.Format("{0:C}", currency);
+            }
         }
     }
 }

--- a/src/backend/TrafficCourts/Citizen.Service/Validators/Rules/TimeRule.cs
+++ b/src/backend/TrafficCourts/Citizen.Service/Validators/Rules/TimeRule.cs
@@ -27,6 +27,11 @@ public class TimeRule : ValidationRule
             {
                 AddValidationError(String.Format(ValidationMessages.TimeInvalid, Field.Value));
             }
+            else
+            {
+                // Format the Field Value as recognized by the validator
+                Field.Value = time.Value.ToString(@"hh\:mm");
+            }
         }
     }
 }

--- a/src/backend/TrafficCourts/Citizen.Service/Validators/Rules/ViolationDateLT30Rule.cs
+++ b/src/backend/TrafficCourts/Citizen.Service/Validators/Rules/ViolationDateLT30Rule.cs
@@ -23,6 +23,9 @@ public class ViolationDateLT30Rule : ValidationRule
         }
         else
         {
+            // Format the Field Value as recognized by the validator
+            Field.Value = violationDate.Value.ToString("yyyy-MM-dd");
+
             DateTime dateTime = DateTime.Now;
             // remove time portion (which may affect the below calculations)
             DateTime now = new(dateTime.Year, dateTime.Month, dateTime.Day);


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

Persisted correctly parsed datatypes back onto their respective field value.
This way, Violation Date will always be of the standard ISO 8601 format:
ie. yyyy-MM-dd

Any Violation Time will consistently be formatted as an ISO 8601 value.
ie. hh:mm

Currency will always be formatted the same per US currency: $xx.xx

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

dotnet test

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [x] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
