### PR TITLE
Added ssh key authentication option for sftp client config

### DIFF
--- a/src/backend/TrafficCourts/TrafficCourts.Arc.Dispute.Service/Configuration/SftpConfig.cs
+++ b/src/backend/TrafficCourts/TrafficCourts.Arc.Dispute.Service/Configuration/SftpConfig.cs
@@ -7,5 +7,6 @@
         public int Port { get; set; }
         public string? Username { get; set; }
         public string? Password { get; set; }
+        public string? SshPrivateKeyPath { get; set; }
     }
 }

--- a/src/backend/TrafficCourts/TrafficCourts.Arc.Dispute.Service/appsettings.json
+++ b/src/backend/TrafficCourts/TrafficCourts.Arc.Dispute.Service/appsettings.json
@@ -11,6 +11,7 @@
     "Host": "localhost",
     "Port": 22,
     "Username": "demo",
-    "Password": "demo"
+    "Password": "demo",
+    "SshPrivateKeyPath": "C:\\some\\path\\key.ppk"
   }
 }


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- Adds ssh key auth option by reading the key file from a path as part of SFTP client configuration.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [ ] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
