### PR TITLE
Docker - added staff-portal to docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -77,6 +77,23 @@ services:
     networks:
       - traffic-court-net
 
+
+  # #############################################################################################
+  # ###                                 TrafficCourt Staff FRONTEND                           ###
+  # #############################################################################################
+  staff-portal:
+    container_name: staff-portal
+    build:
+      context: ./src/frontend/staff-portal
+      args:
+        - API_BASE_PATH=${API_BASE_PATH:-http://citizen-api:8080/api/}
+    restart: always
+    ports:
+      - "8081:8080"
+    depends_on: [citizen-api]
+    networks:
+      - traffic-court-net
+    
   #############################################################################################
   ###                           RABBITMQ                                                    ###
   #############################################################################################

--- a/src/frontend/staff-portal/Dockerfile
+++ b/src/frontend/staff-portal/Dockerfile
@@ -28,7 +28,7 @@ RUN envsubst '${API_BASE_PATH}' < /usr/src/app/nginx.conf.template > /usr/src/ap
 FROM registry.access.redhat.com/ubi8/nginx-120
 
 COPY --from=build-deps /usr/src/app/src/favicon.ico /usr/share/nginx/html
-COPY --from=build-deps /usr/src/app/dist/citizen-portal /usr/share/nginx/html
+COPY --from=build-deps /usr/src/app/dist/staff-portal /usr/share/nginx/html
 COPY --from=build-deps /usr/src/app/nginx.conf /opt/app-root/etc/nginx.default.d/default.conf
 
 EXPOSE 8080


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

Added staff-portal to docker-compose.

At the moment, the API_BASE_PATH references the http://citizen-api:8080/api/, but I assume this will change at some point to reference the staff-api

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [x] Yes
- [ ] No

If Yes: Has Docker been updated accordingly?

- [x] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
