### PR TITLE
Only register worker if using RSI ticket search

### DIFF
--- a/src/backend/TrafficCourts/TrafficCourts.Ticket.Search.Service/Startup.cs
+++ b/src/backend/TrafficCourts/TrafficCourts.Ticket.Search.Service/Startup.cs
@@ -65,6 +65,8 @@ namespace TrafficCourts.Ticket.Search.Service
 
                 builder.Services.AddTransient<ITicketSearchService, RoadSafetyTicketSearchService>();
                 builder.Services.AddTransient<ITokenCache, TokenCache>();
+
+                builder.Services.AddHostedService<AccessTokenUpdateWorker>();
             }
             else
             {
@@ -84,8 +86,6 @@ namespace TrafficCourts.Ticket.Search.Service
                     builder.Services.AddTransient<IMockDataProvider, EmbeddedMockDataProvider>();
                 }
             }
-
-            builder.Services.AddHostedService<AccessTokenUpdateWorker>();
 
             // Add services to the container.
             logger.Information("Configuring services");


### PR DESCRIPTION
# Description

fixes issue where background worker was being registered regardless of search time. Mock does not register dependent services.