### PR TITLE
Fixed broken docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,7 @@ services:
     ports:
       - "5000:8080"
     restart: always
-    depends_on: [rabbitmq, ticket-search, seq]
+    depends_on: [rabbitmq, ticket-search]
     volumes:
       # mount the current users usersecrets folder
       - "${APPDATA}/Microsoft/UserSecrets:/root/.microsoft/usersecrets:ro"


### PR DESCRIPTION
"citizen-api" would not start due to invalid reference to "seq".  "seq" was removed from docker-compose, but references to it was not.