### PR TITLE
TCVP-1177

### DIFF
--- a/src/backend/TrafficCourts/Citizen.Service/Features/Tickets/AnalyseHandler.cs
+++ b/src/backend/TrafficCourts/Citizen.Service/Features/Tickets/AnalyseHandler.cs
@@ -22,7 +22,7 @@ public static class AnalyseHandler
 
     public class AnalyseResponse
     {
-        public AnalyseResponse(OcrViolationTicket violationTicket) 
+        public AnalyseResponse(OcrViolationTicket violationTicket)
         {
             ArgumentNullException.ThrowIfNull(violationTicket);
             OcrViolationTicket = violationTicket;
@@ -40,7 +40,7 @@ public static class AnalyseHandler
         private readonly IMemoryStreamManager _memoryStreamManager;
 
         public Handler(
-            IFormRecognizerService formRegognizerService, 
+            IFormRecognizerService formRegognizerService,
             IFormRecognizerValidator formRecognizerValidator,
             IFilePersistenceService filePersistenceService,
             IMemoryStreamManager memoryStreamManager,
@@ -59,7 +59,7 @@ public static class AnalyseHandler
 
             var stream = GetStreamForFile(request.Image);
 
-            // TODO: do the save file and analyze in parallel
+            // FIXME: save should only happen iff there are no global validation errors - this needs to move *after* line 74
             var filename = await _filePersistenceService.SaveFileAsync(stream, cancellationToken);
             stream.Position = 0L; // reset file position
 
@@ -79,13 +79,12 @@ public static class AnalyseHandler
 
         private MemoryStream GetStreamForFile(IFormFile formFile)
         {
-            int length = (int)formFile.Length;
-            MemoryStream stream = _memoryStreamManager.GetStream(); ;
+            MemoryStream memoryStream = _memoryStreamManager.GetStream(); ;
 
             using var fileStream = formFile.OpenReadStream();
-            fileStream.CopyTo(stream);
+            fileStream.CopyTo(memoryStream);
 
-            return stream;
+            return memoryStream;
         }
     }
 }

--- a/src/backend/TrafficCourts/Citizen.Service/Models/Tickets/OcrViolationTicket.cs
+++ b/src/backend/TrafficCourts/Citizen.Service/Models/Tickets/OcrViolationTicket.cs
@@ -49,7 +49,7 @@ public class OcrViolationTicket
     /// <summary>
     /// Gets or sets the saved image filename.
     /// </summary>
-    public string ImageFilename { get; set; }
+    public string? ImageFilename { get; set; }
 
     /// <summary>
     /// A global confidence of correctly extracting the document. This value will be low if the title of this 
@@ -68,12 +68,45 @@ public class OcrViolationTicket
     /// </summary>
     public Dictionary<string, Field> Fields { get; set; } = new Dictionary<string, Field>();
 
+    /// <summary>
+    /// Return true if any of the 4 Count fields has a value.
+    /// </summary>
+    public bool IsCount1Populated()
+    {
+        return Fields[Count1Description].IsPopulated()
+            || Fields[Count1ActRegs].IsPopulated()
+            || Fields[Count1Section].IsPopulated()
+            || Fields[Count1TicketAmount].IsPopulated();
+    }
+    
+    /// <summary>
+    /// Return true if any of the 4 Count fields has a value.
+    /// </summary>
+    public bool IsCount2Populated()
+    {
+        return Fields[Count2Description].IsPopulated()
+            || Fields[Count2ActRegs].IsPopulated()
+            || Fields[Count2Section].IsPopulated()
+            || Fields[Count2TicketAmount].IsPopulated();
+    }
+    
+    /// <summary>
+    /// Return true if any of the 4 Count fields has a value.
+    /// </summary>
+    public bool IsCount3Populated()
+    {
+        return Fields[Count3Description].IsPopulated()
+            || Fields[Count3ActRegs].IsPopulated()
+            || Fields[Count3Section].IsPopulated()
+            || Fields[Count3TicketAmount].IsPopulated();
+    }
+
     public class Field
     {
 
-        private static readonly string DateRegex = @"^(\d{2}|\d{4})\D+(\d{1,2})\D+(\d{1,2})$";
-        private static readonly string TimeRegex = @"^(\d{1,2})\D*(\d{1,2})$";
-        private static readonly string CurrencyRegex = @"^\$?(\d{1,3}(\,\d{3})*|(\d+))(\.\d{2})?$";
+        private static readonly string _dateRegex = @"^(\d{2}|\d{4})\D+(\d{1,2})\D+(\d{1,2})$";
+        private static readonly string _timeRegex = @"^(\d{1,2})\D*(\d{1,2})$";
+        private static readonly string _currencyRegex = @"^\$?(\d{1,3}(\,\d{3})*|(\d+))(\.\d{2})?$";
 
         public Field() { }
 
@@ -122,7 +155,7 @@ public class OcrViolationTicket
             {
                 try
                 {
-                    Regex rg = new(DateRegex);
+                    Regex rg = new(_dateRegex);
                     Match match = rg.Match(Value);
                     if (match.Groups.Count == 4) // 3 + index 0 (the Value itself)
                     {
@@ -163,7 +196,7 @@ public class OcrViolationTicket
             {
                 try
                 {
-                    Regex rg = new(TimeRegex);
+                    Regex rg = new(_timeRegex);
                     Match match = rg.Match(Value);
                     if (match.Groups.Count == 3 && Value.Length > 2) // 2 + index 0 (the Value itself)
                     {
@@ -198,8 +231,8 @@ public class OcrViolationTicket
             {
                 try
                 {
-                    Regex rg = new(CurrencyRegex);
-                    if (Regex.IsMatch(Value, CurrencyRegex))
+                    Regex rg = new(_currencyRegex);
+                    if (Regex.IsMatch(Value, _currencyRegex))
                     {
                         return float.Parse(Value.Replace("$", "").Replace(",", ""));
                     }
@@ -210,6 +243,11 @@ public class OcrViolationTicket
                 }
             }
             return null;
+        }
+
+        public bool IsPopulated()
+        {
+            return !String.IsNullOrEmpty(Value);
         }
     }
 

--- a/src/backend/TrafficCourts/Citizen.Service/Validators/Rules/LowConfidenceGlobalRule.cs
+++ b/src/backend/TrafficCourts/Citizen.Service/Validators/Rules/LowConfidenceGlobalRule.cs
@@ -5,29 +5,40 @@ namespace TrafficCourts.Citizen.Service.Validators.Rules;
 
 public class LowConfidenceGlobalRule
 {
-    private static readonly float MinViableConfidence = 0.8f;
+    private static readonly float _minViableConfidence = 0.8f;
 
     public static void Run(OcrViolationTicket violationTicket)
     {
-        // If any 3 out of the below fields have a low confidence, reject the entire ticket
+        // If any {minViableThreshold} out of the below fields have a low confidence, reject the entire ticket,
+        // where {minViableThreshold} is 4, 6, or 8 for 1 Count, 2 Counts, 3 Counts populated respectively.
         int numOfLowConfFields = 0;
-        numOfLowConfFields += (violationTicket.Fields[Surname].FieldConfidence < MinViableConfidence) ? 1 : 0;
-        numOfLowConfFields += (violationTicket.Fields[GivenName].FieldConfidence < MinViableConfidence) ? 1 : 0;
-        numOfLowConfFields += (violationTicket.Fields[DriverLicenceNumber].FieldConfidence < MinViableConfidence) ? 1 : 0;
-        numOfLowConfFields += (violationTicket.Fields[DriverLicenceProvince].FieldConfidence < MinViableConfidence) ? 1 : 0;
-        numOfLowConfFields += (violationTicket.Fields[Count1Description].FieldConfidence < MinViableConfidence) ? 1 : 0;
-        numOfLowConfFields += (violationTicket.Fields[Count1ActRegs].FieldConfidence < MinViableConfidence) ? 1 : 0;
-        numOfLowConfFields += (violationTicket.Fields[Count1Section].FieldConfidence < MinViableConfidence) ? 1 : 0;
-        numOfLowConfFields += (violationTicket.Fields[Count1TicketAmount].FieldConfidence < MinViableConfidence) ? 1 : 0;
-        numOfLowConfFields += (violationTicket.Fields[Count2Description].FieldConfidence < MinViableConfidence) ? 1 : 0;
-        numOfLowConfFields += (violationTicket.Fields[Count2ActRegs].FieldConfidence < MinViableConfidence) ? 1 : 0;
-        numOfLowConfFields += (violationTicket.Fields[Count2Section].FieldConfidence < MinViableConfidence) ? 1 : 0;
-        numOfLowConfFields += (violationTicket.Fields[Count2TicketAmount].FieldConfidence < MinViableConfidence) ? 1 : 0;
-        numOfLowConfFields += (violationTicket.Fields[Count3Description].FieldConfidence < MinViableConfidence) ? 1 : 0;
-        numOfLowConfFields += (violationTicket.Fields[Count3ActRegs].FieldConfidence < MinViableConfidence) ? 1 : 0;
-        numOfLowConfFields += (violationTicket.Fields[Count3Section].FieldConfidence < MinViableConfidence) ? 1 : 0;
-        numOfLowConfFields += (violationTicket.Fields[Count3TicketAmount].FieldConfidence < MinViableConfidence) ? 1 : 0;
-        if (numOfLowConfFields >= 3) {
+        int minViableThreshold = 4;
+        numOfLowConfFields += (violationTicket.Fields[Surname].FieldConfidence < _minViableConfidence) ? 1 : 0;
+        numOfLowConfFields += (violationTicket.Fields[GivenName].FieldConfidence < _minViableConfidence) ? 1 : 0;
+        numOfLowConfFields += (violationTicket.Fields[DriverLicenceNumber].FieldConfidence < _minViableConfidence) ? 1 : 0;
+        numOfLowConfFields += (violationTicket.Fields[DriverLicenceProvince].FieldConfidence < _minViableConfidence) ? 1 : 0;
+        numOfLowConfFields += (violationTicket.Fields[Count1Description].FieldConfidence < _minViableConfidence) ? 1 : 0;
+        numOfLowConfFields += (violationTicket.Fields[Count1ActRegs].FieldConfidence < _minViableConfidence) ? 1 : 0;
+        numOfLowConfFields += (violationTicket.Fields[Count1Section].FieldConfidence < _minViableConfidence) ? 1 : 0;
+        numOfLowConfFields += (violationTicket.Fields[Count1TicketAmount].FieldConfidence < _minViableConfidence) ? 1 : 0;
+        if (violationTicket.IsCount2Populated())
+        {
+            numOfLowConfFields += (violationTicket.Fields[Count2Description].FieldConfidence < _minViableConfidence) ? 1 : 0;
+            numOfLowConfFields += (violationTicket.Fields[Count2ActRegs].FieldConfidence < _minViableConfidence) ? 1 : 0;
+            numOfLowConfFields += (violationTicket.Fields[Count2Section].FieldConfidence < _minViableConfidence) ? 1 : 0;
+            numOfLowConfFields += (violationTicket.Fields[Count2TicketAmount].FieldConfidence < _minViableConfidence) ? 1 : 0;
+            minViableThreshold += 2;
+        }
+        if (violationTicket.IsCount3Populated())
+        {
+            numOfLowConfFields += (violationTicket.Fields[Count3Description].FieldConfidence < _minViableConfidence) ? 1 : 0;
+            numOfLowConfFields += (violationTicket.Fields[Count3ActRegs].FieldConfidence < _minViableConfidence) ? 1 : 0;
+            numOfLowConfFields += (violationTicket.Fields[Count3Section].FieldConfidence < _minViableConfidence) ? 1 : 0;
+            numOfLowConfFields += (violationTicket.Fields[Count3TicketAmount].FieldConfidence < _minViableConfidence) ? 1 : 0;
+            minViableThreshold += 2;
+        }
+        if (numOfLowConfFields >= minViableThreshold)
+        {
             violationTicket.GlobalValidationErrors.Add(ValidationMessages.LowConfidenceError);
         }
     }

--- a/src/backend/TrafficCourts/Test/Citizen.Service/Validators/Rules/LowConfidenceGlobalRuleTest.cs
+++ b/src/backend/TrafficCourts/Test/Citizen.Service/Validators/Rules/LowConfidenceGlobalRuleTest.cs
@@ -10,101 +10,101 @@ public class LowConfidenceGlobalRuleTest
 {
 
     [Theory]
-    [InlineData(0,  new float[] {0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f}, false)]
-    [InlineData(1,  new float[] {0.80f,0.79f,0.79f,0.79f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f}, false)]
-    [InlineData(2,  new float[] {0.80f,0.80f,0.79f,0.79f,0.79f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f}, true)]
-    [InlineData(3,  new float[] {0.80f,0.80f,0.80f,0.79f,0.79f,0.79f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f}, true)]
-    [InlineData(4,  new float[] {0.80f,0.80f,0.80f,0.80f,0.79f,0.79f,0.79f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f}, false)]
-    [InlineData(5,  new float[] {0.80f,0.80f,0.80f,0.80f,0.80f,0.79f,0.79f,0.79f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f}, false)]
-    [InlineData(6,  new float[] {0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.79f,0.79f,0.79f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f}, false)]
-    [InlineData(7,  new float[] {0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.79f,0.79f,0.79f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f}, false)]
-    [InlineData(8,  new float[] {0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.79f,0.79f,0.79f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f}, false)]
-    [InlineData(9,  new float[] {0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.79f,0.79f,0.79f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f}, false)]
-    [InlineData(10, new float[] {0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.79f,0.79f,0.79f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f}, false)]
-    [InlineData(11, new float[] {0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.79f,0.79f,0.79f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f}, false)]
-    [InlineData(12, new float[] {0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.79f,0.79f,0.79f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f}, false)]
-    [InlineData(13, new float[] {0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.79f,0.79f,0.79f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f}, false)]
-    [InlineData(14, new float[] {0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.79f,0.79f,0.79f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f}, false)]
-    [InlineData(15, new float[] {0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.79f,0.79f,0.79f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f}, false)]
-    [InlineData(16, new float[] {0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.79f,0.79f,0.79f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f}, false)]
-    [InlineData(17, new float[] {0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.79f,0.79f,0.79f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f}, false)]
-    [InlineData(18, new float[] {0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.79f,0.79f,0.79f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f}, false)]
-    [InlineData(19, new float[] {0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.79f,0.79f,0.79f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f}, false)]
-    [InlineData(20, new float[] {0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.79f,0.79f,0.79f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f}, true)]
-    [InlineData(21, new float[] {0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.79f,0.79f,0.79f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f}, true)]
-    [InlineData(22, new float[] {0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.79f,0.79f,0.79f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f}, false)]
-    [InlineData(23, new float[] {0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.79f,0.79f,0.79f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f}, false)]
-    [InlineData(24, new float[] {0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.79f,0.79f,0.79f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f}, false)]
-    [InlineData(25, new float[] {0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.79f,0.79f,0.79f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f}, false)]
-    [InlineData(26, new float[] {0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.79f,0.79f,0.79f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f}, true)]
-    [InlineData(27, new float[] {0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.79f,0.79f,0.79f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f}, true)]
-    [InlineData(28, new float[] {0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.79f,0.79f,0.79f,0.80f,0.80f,0.80f,0.80f,0.80f}, false)]
-    [InlineData(29, new float[] {0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.79f,0.79f,0.79f,0.80f,0.80f,0.80f,0.80f}, false)]
-    [InlineData(30, new float[] {0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.79f,0.79f,0.79f,0.80f,0.80f,0.80f}, false)]
-    [InlineData(31, new float[] {0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.79f,0.79f,0.79f,0.80f,0.80f}, false)]
-    [InlineData(32, new float[] {0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.79f,0.79f,0.79f,0.80f}, false)]
-    [InlineData(33, new float[] {0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.80f,0.79f,0.79f,0.79f}, false)]
-    public void TestLowConfidence(int testNum, float[] fieldConfidences, bool expectError)
+    [ClassData(typeof(TestData))]
+    public void TestLowConfidence(int testNum, float?[] fieldConfidences, bool expectValid)
     {
-        // TCVP-932 if 3 of a set of specific fields have a low (<80%) confidence, expect to see a global validation error
+        // TCVP-932 if 4, 6, or 8 of a set of specific fields have a low (<80%) confidence, expect to see a global validation error
         // Given
         OcrViolationTicket violationTicket = new();
-        AddField(violationTicket, ViolationTicketTitle, fieldConfidences[0]);
-        AddField(violationTicket, ViolationTicketNumber, fieldConfidences[1]);
-        AddField(violationTicket, Surname, fieldConfidences[2]);
-        AddField(violationTicket, GivenName, fieldConfidences[3]);
-        AddField(violationTicket, DriverLicenceProvince, fieldConfidences[4]);
-        AddField(violationTicket, DriverLicenceNumber, fieldConfidences[5]);
-        AddField(violationTicket, ViolationDate, fieldConfidences[6]);
-        AddField(violationTicket, ViolationTime, fieldConfidences[7]);
-        AddField(violationTicket, OffenceIsMVA, fieldConfidences[8]);
-        AddField(violationTicket, OffenceIsMCA, fieldConfidences[9]);
-        AddField(violationTicket, OffenceIsCTA, fieldConfidences[10]);
-        AddField(violationTicket, OffenceIsWLA, fieldConfidences[11]);
-        AddField(violationTicket, OffenceIsFAA, fieldConfidences[12]);
-        AddField(violationTicket, OffenceIsLCA, fieldConfidences[13]);
-        AddField(violationTicket, OffenceIsTCR, fieldConfidences[14]);
-        AddField(violationTicket, OffenceIsOther, fieldConfidences[15]);
-        AddField(violationTicket, Count1Description, fieldConfidences[16]);
-        AddField(violationTicket, Count1ActRegs, fieldConfidences[17]);
-        AddField(violationTicket, Count1IsACT, fieldConfidences[18]);
-        AddField(violationTicket, Count1IsREGS, fieldConfidences[19]);
-        AddField(violationTicket, Count1Section, fieldConfidences[20]);
-        AddField(violationTicket, Count1TicketAmount, fieldConfidences[21]);
-        AddField(violationTicket, Count2Description, fieldConfidences[22]);
-        AddField(violationTicket, Count2ActRegs, fieldConfidences[23]);
-        AddField(violationTicket, Count2IsACT, fieldConfidences[24]);
-        AddField(violationTicket, Count2IsREGS, fieldConfidences[25]);
-        AddField(violationTicket, Count2Section, fieldConfidences[26]);
-        AddField(violationTicket, Count2TicketAmount, fieldConfidences[27]);
-        AddField(violationTicket, Count3Description, fieldConfidences[28]);
-        AddField(violationTicket, Count3ActRegs, fieldConfidences[29]);
-        AddField(violationTicket, Count3IsACT, fieldConfidences[30]);
-        AddField(violationTicket, Count3IsREGS, fieldConfidences[31]);
-        AddField(violationTicket, Count3Section, fieldConfidences[32]);
-        AddField(violationTicket, Count3TicketAmount, fieldConfidences[33]);
-        AddField(violationTicket, HearingLocation, fieldConfidences[34]);
-        AddField(violationTicket, DetachmentLocation, fieldConfidences[35]);
+        AddField(violationTicket, ViolationTicketTitle, 0.80f);
+        AddField(violationTicket, ViolationTicketNumber, 0.80f);
+        AddField(violationTicket, ViolationDate, 0.80f);
+        AddField(violationTicket, ViolationTime, 0.80f);
+        AddField(violationTicket, OffenceIsMVA, 0.80f);
+        AddField(violationTicket, OffenceIsMCA, 0.80f);
+        AddField(violationTicket, OffenceIsCTA, 0.80f);
+        AddField(violationTicket, OffenceIsWLA, 0.80f);
+        AddField(violationTicket, OffenceIsFAA, 0.80f);
+        AddField(violationTicket, OffenceIsLCA, 0.80f);
+        AddField(violationTicket, OffenceIsTCR, 0.80f);
+        AddField(violationTicket, OffenceIsOther, 0.80f);
+
+        AddField(violationTicket, Surname, fieldConfidences[0]);
+        AddField(violationTicket, GivenName, fieldConfidences[1]);
+        AddField(violationTicket, DriverLicenceProvince, fieldConfidences[2]);
+        AddField(violationTicket, DriverLicenceNumber, fieldConfidences[3]);
+        AddField(violationTicket, Count1Description, fieldConfidences[4]);
+        AddField(violationTicket, Count1ActRegs, fieldConfidences[5]);
+        AddField(violationTicket, Count1Section, fieldConfidences[6]);
+        AddField(violationTicket, Count1TicketAmount, fieldConfidences[7]);
+        AddField(violationTicket, Count2Description, fieldConfidences[8]);
+        AddField(violationTicket, Count2ActRegs, fieldConfidences[9]);
+        AddField(violationTicket, Count2Section, fieldConfidences[10]);
+        AddField(violationTicket, Count2TicketAmount, fieldConfidences[11]);
+        AddField(violationTicket, Count3Description, fieldConfidences[12]);
+        AddField(violationTicket, Count3ActRegs, fieldConfidences[13]);
+        AddField(violationTicket, Count3Section, fieldConfidences[14]);
+        AddField(violationTicket, Count3TicketAmount, fieldConfidences[15]);
 
         // When
         LowConfidenceGlobalRule.Run(violationTicket);
 
         // Then
-        if (expectError)
+        if (expectValid)
+        {
+            Assert.Empty(violationTicket.GlobalValidationErrors);
+        }
+        else
         {
             Assert.True(violationTicket.GlobalValidationErrors.Count == 1, "Test number: " + testNum);
             Assert.Equal(ValidationMessages.LowConfidenceError, violationTicket.GlobalValidationErrors[0]);
         }
-        else
-        {
-            Assert.Empty(violationTicket.GlobalValidationErrors);
-        }
     }
 
-    private static void AddField(OcrViolationTicket violationTicket, string fieldName, float fieldConfidence)
+    private static void AddField(OcrViolationTicket violationTicket, string fieldName, float? fieldConfidence)
     {
         Field field = new();
         field.FieldConfidence = fieldConfidence;
+        if (fieldConfidence is not null)
+        {
+            field.Value = "a";
+        }
         violationTicket.Fields.Add(fieldName, field);
+    }
+
+    public class TestData : TheoryData<int, float?[], bool>
+    {
+        public TestData()
+        {
+            // 1 count, < 4 fields with low confidence
+            Add(1, new float?[] { 0.79f, 0.79f, 0.79f, 0.80f, 0.80f, 0.80f, 0.80f, 0.80f, null, null, null, null, null, null, null, null }, true);
+            Add(2, new float?[] { 0.80f, 0.80f, 0.80f, 0.80f, 0.80f, 0.79f, 0.79f, 0.79f, null, null, null, null, null, null, null, null }, true);
+
+            // 1 count, >= 4 fields with low confidence
+            Add(3, new float?[] { 0.79f, 0.79f, 0.79f, 0.79f, 0.80f, 0.80f, 0.80f, 0.80f, null, null, null, null, null, null, null, null }, false);
+            Add(4, new float?[] { 0.80f, 0.79f, 0.79f, 0.79f, 0.79f, 0.80f, 0.80f, 0.80f, null, null, null, null, null, null, null, null }, false);
+            Add(5, new float?[] { 0.80f, 0.80f, 0.79f, 0.79f, 0.79f, 0.79f, 0.80f, 0.80f, null, null, null, null, null, null, null, null }, false);
+            Add(6, new float?[] { 0.80f, 0.80f, 0.80f, 0.79f, 0.79f, 0.79f, 0.79f, 0.80f, null, null, null, null, null, null, null, null }, false);
+            Add(7, new float?[] { 0.80f, 0.80f, 0.80f, 0.80f, 0.79f, 0.79f, 0.79f, 0.79f, null, null, null, null, null, null, null, null }, false);
+
+            // 2 counts, < 6 fields with low confidence
+            Add(8, new float?[] { 0.80f, 0.80f, 0.80f, 0.80f, 0.80f, 0.79f, 0.79f, 0.79f, 0.79f, null, null, null, null, null, null, null }, true);
+            Add(9, new float?[] { 0.80f, 0.80f, 0.80f, 0.80f, 0.80f, 0.79f, 0.79f, 0.79f, 0.79f, 0.79f, null, null, null, null, null, null }, true);
+            Add(10, new float?[] { 0.80f, 0.80f, 0.80f, 0.80f, 0.80f, 0.79f, 0.79f, 0.79f, null, null, null, null, 0.79f, null, null, null }, true);
+            Add(11, new float?[] { 0.80f, 0.80f, 0.80f, 0.80f, 0.80f, 0.79f, 0.79f, 0.79f, null, null, null, null, 0.79f, 0.79f, null, null }, true);
+            // // 2 counts, >= 6 fields with low confidence
+            Add(12, new float?[] { 0.80f, 0.80f, 0.80f, 0.80f, 0.80f, 0.79f, 0.79f, 0.79f, 0.79f, 0.79f, 0.79f, null, null, null, null, null }, false);
+            Add(13, new float?[] { 0.80f, 0.80f, 0.80f, 0.80f, 0.80f, 0.80f, 0.79f, 0.79f, 0.79f, 0.79f, 0.79f, 0.79f, null, null, null, null }, false);
+            Add(14, new float?[] { 0.80f, 0.80f, 0.80f, 0.80f, 0.80f, 0.79f, 0.79f, 0.79f, null, null, null, null, 0.79f, 0.79f, 0.79f, null }, false);
+            Add(15, new float?[] { 0.80f, 0.80f, 0.80f, 0.80f, 0.80f, 0.80f, 0.79f, 0.79f, null, null, null, null, 0.79f, 0.79f, 0.79f, 0.79f }, false);
+
+            // 3 counts, < 8 fields with low confidence
+            Add(16, new float?[] { 0.80f, 0.80f, 0.80f, 0.80f, 0.80f, 0.79f, 0.79f, 0.79f, 0.79f, 0.79f, null, null, 0.79f, 0.79f, null, null }, true);
+            // 3 counts, >= 8 fields with low confidence
+            Add(17, new float?[] { 0.80f, 0.80f, 0.80f, 0.80f, 0.80f, 0.79f, 0.79f, 0.79f, 0.79f, 0.79f, 0.79f, null, 0.79f, 0.79f, null, null }, false);
+
+            // 3 counts, all okay
+            Add(18, new float?[] { 0.80f, 0.80f, 0.80f, 0.80f, 0.80f, 0.80f, 0.80f, 0.80f, 0.80f, 0.80f, 0.80f, 0.80f, 0.80f, 0.80f, 0.80f, 0.80f }, true);
+        }
     }
 }


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

[TCVP-1177](https://justice.gov.bc.ca/jira/browse/TCVP-1177)

Validation rules around OCR changed. The parent ticket ([TCVP-932](https://justice.gov.bc.ca/jira/browse/TCVP-932)) to this task explains the details, but mainly:

> The OCR process will reject a scan as invalid if the confidence rating is below 80%:
> 
> If only 1 Count, for 4 of the 8 the mandatory fields. 
> If 2 Counts, for 6 of the 12 mandatory fields
> If 3 Counts, for 8 of the 16 mandatory fields

- some refactoring per C# standards
- updated xunit tests

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

dotnet test

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
