### PR TITLE
Add missing Serilog.Enrichers.Context package reference

### DIFF
--- a/src/backend/TrafficCourts/Common/TrafficCourts.Common.csproj
+++ b/src/backend/TrafficCourts/Common/TrafficCourts.Common.csproj
@@ -19,6 +19,7 @@
     <PackageReference Include="NodaTime" Version="3.0.10" />
     <PackageReference Include="Serilog" Version="2.10.0" />
     <PackageReference Include="Serilog.AspNetCore" Version="4.1.0" />
+    <PackageReference Include="Serilog.Enrichers.Context" Version="4.2.0" />
     <PackageReference Include="Serilog.Enrichers.Environment" Version="2.2.0" />
     <PackageReference Include="Serilog.Enrichers.Process" Version="2.0.2" />
     <PackageReference Include="Serilog.Enrichers.Thread" Version="3.1.0" />


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- This adds Serilog.Enrichers.Context to the common library that was being reference in the app settings.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

