### PR TITLE
Added jacoco coverage report to oraface-api

### DIFF
--- a/src/backend/oracle-data-interface/pom.xml
+++ b/src/backend/oracle-data-interface/pom.xml
@@ -101,6 +101,30 @@
 					</excludes>
 				</configuration>
 			</plugin>
+			
+			<!--jacoco code coverage -->
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.8</version>
+
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+
+                    <!-- attached to Maven test phase -->
+                    <execution>
+                        <id>report</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
 		</plugins>
 	</build>
 


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

Added jacoco coverage report to oraface-api pom.xml, hooked into the test target.

Running tests now also generates the code coverage report that can be consumed by github.
```
mvn clean test
```
(in \target\site\jacoco\index.html)
![image](https://user-images.githubusercontent.com/55215368/162261973-db0be1d5-0808-4d96-a0e8-ccc58bacc61c.png)


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

mvn test

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [x] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
