### PR TITLE
fix dependencies when using seq or splunk logging, add examples

### DIFF
--- a/.docker/docker-compose.seq.yml
+++ b/.docker/docker-compose.seq.yml
@@ -10,7 +10,7 @@ services:
   seq:
     image: datalust/seq
     ports:
-      - 80:80
+      - 8001:80
       - 5341:5341
     environment:
       ACCEPT_EULA: "Y"
@@ -20,9 +20,11 @@ services:
       Serilog__Using__0: Serilog.Sinks.Seq
       Serilog__WriteTo__0__Name: Seq
       Serilog__WriteTo__0__Args__serverUrl: "http://seq:5341"
+    depends_on: [seq]
 
   ticket-search:
     environment:
       Serilog__Using__0: Serilog.Sinks.Seq
       Serilog__WriteTo__0__Name: Seq
       Serilog__WriteTo__0__Args__serverUrl: "http://seq:5341"
+    depends_on: [seq]

--- a/.docker/docker-compose.splunk.yml
+++ b/.docker/docker-compose.splunk.yml
@@ -29,6 +29,7 @@ services:
       Serilog__WriteTo__0__Name: EventCollector
       Serilog__WriteTo__0__Args:splunkHost": "http://splunk:8088"
       Serilog__WriteTo__0__Args:eventCollectorToken": "token"
+    depends_on: [splunk]
 
   ticket-search:
     environment:
@@ -36,3 +37,4 @@ services:
       Serilog__WriteTo__0__Name: EventCollector
       Serilog__WriteTo__0__Args:splunkHost": "http://splunk:8088"
       Serilog__WriteTo__0__Args:eventCollectorToken": "token"
+    depends_on: [splunk]

--- a/README.md
+++ b/README.md
@@ -63,6 +63,44 @@ REDIS__HOST will be `redis` which is the service name.
 docker-compose up
 ```
 
+### Examples
+
+Develop the `citizen-portal`. Run the associated API, `citizen-api`.  This starts the required services:
+
+* citizen-api
+* rabbitmq
+* ticket-search
+
+```
+docker-compose -f docker-compose.yml up -d citizen-api
+```
+
+Run `citizen-api` and have the backend logs go to [local Seq](http://localhost:8001),
+
+```
+docker-compose -f docker-compose.yml -f ./.docker/docker-compose.seq.yml up -d citizen-api
+```
+
+To stop when running Seq,
+
+```
+docker-compose -f docker-compose.yml -f ./.docker/docker-compose.seq.yml down
+```
+
+Run `citizen-api` and have the backend logs go to [local Splunk](http://localhost:8000)
+
+Note, this is currently getting an error: "Error response from daemon: network ... not found"
+
+```
+docker-compose -f docker-compose.yml -f ./.docker/docker-compose.splunk.yml up -d citizen-api
+```
+
+To stop when running Splunk,
+
+```
+docker-compose -f docker-compose.yml -f ./.docker/docker-compose.splunk.yml down
+```
+
 The frontend app citizen-portal will be accessible in the browser at http://localhost:8080 
 
 To remove services run (all services and networking)
@@ -80,11 +118,11 @@ docker-compose down
 | ticket-search                   | n/a                                          | grpc  |
 | oraface-api                     | http://localhost:5010/                       |       |
 | rabbitmq                        | localhost:5672, localhost:15672              |       |
-| minio                           | localhost:9000, localhost:9001               |       |
+| minio                           | http://localhost:9001/login                  |       |
 | redis                           | localhost:6379                               |       |
 | redis-commander                 | http://localhost:8082                        |       |
 | splunk                          | http://localhost:8000                        |       |
-| seq                             | http://localhost:5341                        |       |
+| seq                             | http://localhost:8001                        |       |
 | jaeger                          | http://localhost:16686                       |       |
 
 ### Logging
@@ -116,4 +154,4 @@ See [Splunk Docker examples](https://splunk.github.io/docker-splunk/EXAMPLES.htm
 docker-compose -f docker-compose.yml -f ./.docker/docker-compose.seq.yml up
 ```
 
-Open [Local Seq](http://localhost:5341) to view logs.
+Open [Local Seq](http://localhost:8001) to view logs.


### PR DESCRIPTION

# Description

This PR includes the following proposed change(s):

- ensure services are configured to depend on seq or splunk respectively
- add examples of running just the `citizen-api` for front end dev.
- the splunk config is currently giving an error about not finding the network

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring / Documentation
- [ ] Version change
