### PR TITLE
TCVP-1210 versioned the oraface-api with a versioned-route strategy

### DIFF
--- a/src/backend/oracle-data-interface/src/main/java/ca/bc/gov/open/jag/tco/oracledatainterface/config/ApplicationConfig.java
+++ b/src/backend/oracle-data-interface/src/main/java/ca/bc/gov/open/jag/tco/oracledatainterface/config/ApplicationConfig.java
@@ -1,0 +1,18 @@
+package ca.bc.gov.open.jag.tco.oracledatainterface.config;
+
+import org.springdoc.core.GroupedOpenApi;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class ApplicationConfig {
+
+	/**
+	 * Group all APIs with `v1.0` in the path
+	 */
+	@Bean
+	GroupedOpenApi v1_0Apis() {
+		return GroupedOpenApi.builder().group("v1.0").pathsToMatch("/**/api/v1.0/**").build();
+	}
+
+}

--- a/src/backend/oracle-data-interface/src/main/java/ca/bc/gov/open/jag/tco/oracledatainterface/controller/v1_0/DisputeController.java
+++ b/src/backend/oracle-data-interface/src/main/java/ca/bc/gov/open/jag/tco/oracledatainterface/controller/v1_0/DisputeController.java
@@ -1,4 +1,4 @@
-package ca.bc.gov.open.jag.tco.oracledatainterface.controller;
+package ca.bc.gov.open.jag.tco.oracledatainterface.controller.v1_0;
 
 import java.util.Date;
 import java.util.List;
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import ca.bc.gov.open.jag.tco.oracledatainterface.model.Dispute;
@@ -19,7 +20,8 @@ import ca.bc.gov.open.jag.tco.oracledatainterface.service.DisputeService;
 import ca.bc.gov.open.jag.tco.oracledatainterface.service.LookupService;
 import io.swagger.v3.oas.annotations.Operation;
 
-@RestController
+@RestController()
+@RequestMapping("/api/v1.0")
 public class DisputeController {
 
 	@Autowired


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

In preparation for the TCVP-1210 ticket, this small change versions the oraface-api via a routing strategy (version in URL path).
- Prefixed all endpoints with /api/v1.0
- Added a swagger group to more easily switch between versions.
- Moved the DisputeController to a v1.0 package

Going forward, if there are changes to the endpoints or model changes to the Dispute object, we'll need to create a new controller (and likely refactor the old Dispute object to a v1.0 package in the model folder).

![image](https://user-images.githubusercontent.com/55215368/162803378-53e899e6-2e39-4736-b3a3-fec31e063b5e.png)


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
