### PR TITLE
Feature/tcvp 1223 refactor and save ocr violation ticket data

### DIFF
--- a/src/backend/TrafficCourts/Citizen.Service/Controllers/DisputesController.cs
+++ b/src/backend/TrafficCourts/Citizen.Service/Controllers/DisputesController.cs
@@ -31,16 +31,17 @@ namespace TrafficCourts.Citizen.Service.Controllers
         }
 
         /// <summary>
-        /// 
+        /// An endpoint for creating and saving dispute ticket data
         /// </summary>
-        /// <param name="createDisputeRequest"></param>
+        /// <param name="dispute"></param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
         [HttpPost]
         [ProducesResponseType((int)HttpStatusCode.OK)]
-        public async Task<IActionResult> CreateAsync([FromBody] Create.Request createDisputeRequest, CancellationToken cancellationToken)
-        { 
-            var response = await _mediator.Send(createDisputeRequest, cancellationToken);
+        public async Task<IActionResult> CreateAsync([FromBody] TrafficCourts.Citizen.Service.Models.Dispute.TicketDispute dispute, CancellationToken cancellationToken)
+        {
+            Create.Request request = new Create.Request(dispute);
+            var response = await _mediator.Send(request, cancellationToken);
 
             return Ok(response);
         }

--- a/src/backend/TrafficCourts/Citizen.Service/Features/Disputes/Create.cs
+++ b/src/backend/TrafficCourts/Citizen.Service/Features/Disputes/Create.cs
@@ -1,39 +1,71 @@
 ﻿using MassTransit;
 using MediatR;
+using System.Text.Json;
 using TrafficCourts.Citizen.Service.Models.Dispute;
+using TrafficCourts.Citizen.Service.Models.Tickets;
+using TrafficCourts.Citizen.Service.Services;
 using TrafficCourts.Messaging.MessageContracts;
 
 namespace TrafficCourts.Citizen.Service.Features.Disputes
 {
     public static class Create
     {
-        public class Request : TicketDispute, IRequest<Response>
+        public class Request : IRequest<Response>
         {
+            public TicketDispute Dispute { get; init; }
 
+            public Request(TicketDispute dispute)
+            {
+                Dispute = dispute ?? throw new ArgumentNullException(nameof(dispute));
+            }
         }
 
         public class Response
         {
-            public int Id { get; set; }
+            public int Id { get; init; }
+            public Exception? Exception { get; init; }
+
+            public Response(int id)
+            {
+                Id = id;
+            }
+
+            public Response(Exception exception)
+            {
+                Id = -1;
+                Exception = exception;
+            }
         }
 
         public class CreateDisputeHandler : IRequestHandler<Request, Response>
         {
             private readonly ILogger _logger;
             public readonly IRequestClient<SubmitDispute> _submitDisputeRequestClient;
+            private readonly IRedisCacheService _redisCacheService;
 
-            public CreateDisputeHandler(ILogger<CreateDisputeHandler> logger, IRequestClient<SubmitDispute> submitDisputeRequestClient)
+            public CreateDisputeHandler(ILogger<CreateDisputeHandler> logger, IRequestClient<SubmitDispute> submitDisputeRequestClient, IRedisCacheService redisCacheService)
             {
                 _logger = logger ?? throw new ArgumentNullException(nameof(logger));
                 _submitDisputeRequestClient = submitDisputeRequestClient ?? throw new ArgumentNullException(nameof(submitDisputeRequestClient));
+                _redisCacheService = redisCacheService ?? throw new ArgumentNullException(nameof(redisCacheService));
             }
 
-            public async Task<Response> Handle(Request createDisputeRequest, CancellationToken cancellationToken)
+            public async Task<Response> Handle(Request request, CancellationToken cancellationToken)
             {
+                TicketDispute createDisputeRequest = request.Dispute;
+                string? ocrKey = createDisputeRequest.OcrKey;
+                string? ocrViolationTicketJson = null;
+
+                // Check if the request contains OCR key and it's a valid format guid
+                if (ocrKey != null && Guid.TryParseExact(ocrKey, "n", out _))
+                {
+                    // Get the OCR violation ticket data from Redis cache using the OCR key and serialize it to a JSON string
+                    OcrViolationTicket violationTicket = await _redisCacheService.GetRecordAsync<OcrViolationTicket>(ocrKey);
+                    ocrViolationTicketJson = JsonSerializer.Serialize(violationTicket);
+                }
+                
                 var response = await _submitDisputeRequestClient.GetResponse<DisputeSubmitted>(new
                 {
-                    Id = NewId.NextGuid(),
-                    InVar.Timestamp,
                     TicketNumber = createDisputeRequest.TicketNumber,
                     CourtLocation = createDisputeRequest.CourtLocation,
                     ViolationDate = createDisputeRequest.ViolationDate,
@@ -52,10 +84,11 @@ namespace TrafficCourts.Citizen.Service.Features.Disputes
                     TicketCounts = createDisputeRequest.TicketCounts,
                     LawyerRepresentation = createDisputeRequest.LawyerRepresentation,
                     InterpreterLanguage = createDisputeRequest.InterpreterLanguage,
-                    WitnessIntent = createDisputeRequest.WitnessIntent
+                    WitnessIntent = createDisputeRequest.WitnessIntent,
+                    OcrViolationTicket = ocrViolationTicketJson
                 });
 
-                return new Response { Id = response.Message.DisputeId };
+                return new Response(response.Message.DisputeId);
             }
         }
     }

--- a/src/backend/TrafficCourts/Citizen.Service/Models/Dispute/TicketDispute.cs
+++ b/src/backend/TrafficCourts/Citizen.Service/Models/Dispute/TicketDispute.cs
@@ -26,5 +26,6 @@ namespace TrafficCourts.Citizen.Service.Models.Dispute
         public bool LawyerRepresentation { get; set; }
         public string InterpreterLanguage { get; set; }
         public bool WitnessIntent { get; set; }
+        public string? OcrKey { get; set; }
     }
 }

--- a/src/backend/TrafficCourts/Citizen.Service/Services/IRedisCacheService.cs
+++ b/src/backend/TrafficCourts/Citizen.Service/Services/IRedisCacheService.cs
@@ -1,0 +1,23 @@
+﻿namespace TrafficCourts.Citizen.Service.Services
+{
+    public interface IRedisCacheService
+    {
+        /// <summary>
+        /// Generic Set method that saves or writes json serialized data that is associated to the provided key to Redis Cache.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="key"></param>
+        /// <param name="data"></param>
+        /// <param name="expireTime"></param>
+        /// <returns></returns>
+        Task SetRecordAsync<T>(string key, T data, TimeSpan? expireTime);
+
+        /// <summary>
+        /// Generic Get method that returns deserialized json data for the provided key from Redis Cache.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="key"></param>
+        /// <returns></returns>
+        Task<T> GetRecordAsync<T>(string key);
+    }
+}

--- a/src/backend/TrafficCourts/Citizen.Service/Services/Impl/RedisCacheService.cs
+++ b/src/backend/TrafficCourts/Citizen.Service/Services/Impl/RedisCacheService.cs
@@ -1,0 +1,48 @@
+﻿using StackExchange.Redis;
+using System.Text.Json;
+
+namespace TrafficCourts.Citizen.Service.Services.Impl
+{
+    /// <summary>
+    /// Implentation of the IRedisCacheService that is used for saving and retrieving json serialized generic data to/from Redis.
+    /// </summary>
+    public class RedisCacheService : IRedisCacheService
+    {
+        private readonly IConnectionMultiplexer _redis;
+        private readonly IDatabaseAsync _redisDbAsync;
+        private readonly ILogger<RedisCacheService> _logger;
+
+        public RedisCacheService(IConnectionMultiplexer redis, ILogger<RedisCacheService> logger)
+        {
+            _redis = redis ?? throw new ArgumentNullException(nameof(redis));
+            _redisDbAsync = _redis.GetDatabase(); // Obtain the connection to database
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        }
+
+        public async Task<T> GetRecordAsync<T>(string key)
+        {
+            try
+            {
+                var jsonData = await _redisDbAsync.StringGetAsync(key);
+
+                if (jsonData.IsNull)
+                {
+                    return default(T);
+                }
+
+                return JsonSerializer.Deserialize<T>(jsonData);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Could not retrieve data record from Redis cache.");
+                throw;
+            }
+        }
+
+        public async Task SetRecordAsync<T>(string key, T data, TimeSpan? expireTime = null)
+        {
+           var jsonData = JsonSerializer.Serialize(data);
+           await _redisDbAsync.StringSetAsync(key, jsonData, expireTime ?? TimeSpan.FromDays(1));
+        }
+    }
+}

--- a/src/backend/TrafficCourts/Citizen.Service/Startup.cs
+++ b/src/backend/TrafficCourts/Citizen.Service/Startup.cs
@@ -213,7 +213,7 @@ public static class Startup
     }
 
     /// <summary>
-    /// Configures Lookup Service.
+    /// Configures Lookup Service and Redis Cache Service.
     /// </summary>
     /// <param name="builder"></param>
     /// <param name="configuration"></param>
@@ -235,6 +235,13 @@ public static class Startup
             var redisConnection = service.GetRequiredService<IConnectionMultiplexer>();
             var logger = service.GetRequiredService<ILogger<RedisLookupService>>();
             return new RedisLookupService(redisConnection, logger);
+        });
+
+        builder.Services.AddSingleton<IRedisCacheService>(service =>
+        {
+            var redisConnection = service.GetRequiredService<IConnectionMultiplexer>();
+            var logger = service.GetRequiredService<ILogger<RedisCacheService>>();
+            return new RedisCacheService(redisConnection, logger);
         });
     }
 

--- a/src/backend/TrafficCourts/Messaging/BusConfiguratorExtensions.cs
+++ b/src/backend/TrafficCourts/Messaging/BusConfiguratorExtensions.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using System.Configuration;
 using TrafficCourts.Common.Configuration;
+using TrafficCourts.Common.Utils;
 using TrafficCourts.Messaging.Configuration;
 
 namespace TrafficCourts.Messaging;
@@ -45,6 +46,13 @@ public static class BusConfiguratorExtensions
             {
                 hostConfig.Username(rabbitMQConfiguration.Username);
                 hostConfig.Password(rabbitMQConfiguration.Password);
+            });
+
+            cfg.ConfigureJsonSerializerOptions(settings =>
+            {
+                settings.Converters.Add(new DateOnlyJsonConverter());
+                settings.Converters.Add(new TimeOnlyJsonConverter());
+                return settings;
             });
         });
     }

--- a/src/backend/TrafficCourts/Messaging/MessageContracts/SubmitDispute.cs
+++ b/src/backend/TrafficCourts/Messaging/MessageContracts/SubmitDispute.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Text.Json.Serialization;
-using System.Threading.Tasks;
+﻿using System.Text.Json.Serialization;
 using TrafficCourts.Common.Utils;
 
 namespace TrafficCourts.Messaging.MessageContracts
@@ -31,5 +26,6 @@ namespace TrafficCourts.Messaging.MessageContracts
         bool LawyerRepresentation { get; set; }
         string InterpreterLanguage { get; set; }
         bool WitnessIntent { get; set; }
+        string OcrViolationTicket { get; set; }
     }
 }

--- a/src/backend/TrafficCourts/Staff.Service/OpenAPIs/OracleDataAPI/v1_0/OracleDataApi.v1_0.json
+++ b/src/backend/TrafficCourts/Staff.Service/OpenAPIs/OracleDataAPI/v1_0/OracleDataApi.v1_0.json
@@ -14,6 +14,8 @@
     "/api/v1.0/dispute/{id}": {
       "get": {
         "tags": [ "dispute-controller" ],
+        "summary": "An endpoint to return a specific dispute from the database.",
+        "description": "REST endpoint that returns a specified dispute based on the dispute id that is provided.",
         "operationId": "getDispute",
         "parameters": [
           {
@@ -31,12 +33,12 @@
             "description": "Not Found",
             "content": { "*/*": { "schema": { "type": "object" } } }
           },
-          "405": {
-            "description": "Method Not Allowed",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
           "400": {
             "description": "Bad Request",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "405": {
+            "description": "Method Not Allowed",
             "content": { "*/*": { "schema": { "type": "object" } } }
           },
           "200": {
@@ -69,12 +71,12 @@
             "description": "Dispute record not found. Update failed.",
             "content": { "*/*": { "schema": { "type": "object" } } }
           },
-          "405": {
-            "description": "Method Not Allowed",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
           "400": {
             "description": "Bad Request.",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "405": {
+            "description": "Method Not Allowed",
             "content": { "*/*": { "schema": { "type": "object" } } }
           },
           "200": {
@@ -85,6 +87,8 @@
       },
       "delete": {
         "tags": [ "dispute-controller" ],
+        "summary": "An endpoint to delete a specific dispute in the database.",
+        "description": "REST endpoint that deletes a specified dispute based on the dispute id that is provided.",
         "operationId": "deleteDispute",
         "parameters": [
           {
@@ -102,12 +106,12 @@
             "description": "Not Found",
             "content": { "*/*": { "schema": { "type": "object" } } }
           },
-          "405": {
-            "description": "Method Not Allowed",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
           "400": {
             "description": "Bad Request",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "405": {
+            "description": "Method Not Allowed",
             "content": { "*/*": { "schema": { "type": "object" } } }
           },
           "200": { "description": "OK" }
@@ -135,12 +139,12 @@
             "description": "Dispute record not found. Update failed.",
             "content": { "*/*": { "schema": { "type": "object" } } }
           },
-          "405": {
-            "description": "A Dispute status can only be set to PROCESSING iff status is NEW or PROCESSING. Update failed.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
           "400": {
             "description": "Bad Request.",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "405": {
+            "description": "A Dispute status can only be set to PROCESSING iff status is NEW or PROCESSING. Update failed.",
             "content": { "*/*": { "schema": { "type": "object" } } }
           },
           "200": { "description": "Ok" }
@@ -180,12 +184,12 @@
             "description": "Dispute record not found. Update failed.",
             "content": { "*/*": { "schema": { "type": "object" } } }
           },
-          "405": {
-            "description": "A Dispute status can only be set to REJECTED iff status is NEW, CANCELLED, or REJECTED and the rejected reason must be <= 256 characters. Update failed.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
           "400": {
             "description": "Bad Request.",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "405": {
+            "description": "A Dispute status can only be set to REJECTED iff status is NEW, CANCELLED, or REJECTED and the rejected reason must be <= 256 characters. Update failed.",
             "content": { "*/*": { "schema": { "type": "object" } } }
           },
           "200": { "description": "Ok" }
@@ -213,12 +217,12 @@
             "description": "Dispute record not found. Update failed.",
             "content": { "*/*": { "schema": { "type": "object" } } }
           },
-          "405": {
-            "description": "A Dispute status can only be set to CANCELLED iff status is REJECTED or PROCESSING. Update failed.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
           "400": {
             "description": "Bad Request.",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "405": {
+            "description": "A Dispute status can only be set to CANCELLED iff status is REJECTED or PROCESSING. Update failed.",
             "content": { "*/*": { "schema": { "type": "object" } } }
           },
           "200": { "description": "Ok" }
@@ -228,6 +232,8 @@
     "/api/v1.0/dispute": {
       "post": {
         "tags": [ "dispute-controller" ],
+        "summary": "An endpoint to save new dispute in the database.",
+        "description": "REST endpoint that saves a dispute data based on the dispute that is passed in the body to be persisted.",
         "operationId": "saveDispute",
         "requestBody": {
           "content": { "application/json": { "schema": { "$ref": "#/components/schemas/Dispute" } } },
@@ -238,12 +244,12 @@
             "description": "Not Found",
             "content": { "*/*": { "schema": { "type": "object" } } }
           },
-          "405": {
-            "description": "Method Not Allowed",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
           "400": {
             "description": "Bad Request",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "405": {
+            "description": "Method Not Allowed",
             "content": { "*/*": { "schema": { "type": "object" } } }
           },
           "200": {
@@ -263,18 +269,20 @@
     "/api/v1.0/disputes": {
       "get": {
         "tags": [ "dispute-controller" ],
+        "summary": "An endpoint to return all the existing disputes from the database.",
+        "description": "REST endpoint that returns all the disputes.",
         "operationId": "getAllDisputes",
         "responses": {
           "404": {
             "description": "Not Found",
             "content": { "*/*": { "schema": { "type": "object" } } }
           },
-          "405": {
-            "description": "Method Not Allowed",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
           "400": {
             "description": "Bad Request",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "405": {
+            "description": "Method Not Allowed",
             "content": { "*/*": { "schema": { "type": "object" } } }
           },
           "200": {
@@ -302,12 +310,12 @@
             "description": "Not Found",
             "content": { "*/*": { "schema": { "type": "object" } } }
           },
-          "405": {
-            "description": "Method Not Allowed",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
           "400": {
             "description": "Bad Request",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "405": {
+            "description": "Method Not Allowed",
             "content": { "*/*": { "schema": { "type": "object" } } }
           },
           "200": { "description": "OK" }
@@ -364,6 +372,10 @@
             "nullable": true
           },
           "witnessIntent": { "type": "boolean" },
+          "ocrViolationTicket": {
+            "type": "string",
+            "nullable": true
+          },
           "rejectedReason": {
             "type": "string",
             "nullable": true

--- a/src/backend/TrafficCourts/Test/Citizen.Service/Controllers/DisputesControllerTest.cs
+++ b/src/backend/TrafficCourts/Test/Citizen.Service/Controllers/DisputesControllerTest.cs
@@ -1,0 +1,42 @@
+﻿using MediatR;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Moq;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using TrafficCourts.Citizen.Service.Controllers;
+using TrafficCourts.Citizen.Service.Features.Disputes;
+using TrafficCourts.Citizen.Service.Models.Dispute;
+using Xunit;
+
+namespace TrafficCourts.Test.Citizen.Service.Controllers
+{
+    public class DisputesControllerTest
+    {
+        [Fact]
+        public async void TestCreateDisputeOkResult()
+        {
+            // Arrange
+            var mockTicketDispute = new Mock<TicketDispute>();
+            var mockMediator = new Mock<IMediator>();
+            var mockLogger = new Mock<ILogger<DisputesController>>();
+            var disputeController = new DisputesController(mockMediator.Object, mockLogger.Object);
+            var request = new Create.Request(mockTicketDispute.Object);
+            var createResponse = new Create.Response(1);
+            mockMediator
+                .Setup(_ => _.Send<Create.Response>(It.IsAny<Create.Request>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(createResponse);
+
+            // Act
+            var result = await disputeController.CreateAsync(mockTicketDispute.Object, CancellationToken.None);
+
+            // Assert
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            Assert.Equal(createResponse, okResult.Value);
+        }
+    }
+}

--- a/src/backend/TrafficCourts/Test/Citizen.Service/Features/Tickets/AnalyseHandlerTests.cs
+++ b/src/backend/TrafficCourts/Test/Citizen.Service/Features/Tickets/AnalyseHandlerTests.cs
@@ -24,6 +24,7 @@ public class AnalyseHandlerTests
         // Arrange
         var mockValidator = new Mock<IFormRecognizerValidator>();
         var mockLogger = new Mock<ILogger<AnalyseHandler.Handler>>();
+        var mockRedisCacheService = new Mock<IRedisCacheService>();
 
         // calls AnalyzeImageAsync and Map
         AnalyzeResult expectedAnalyzeResult = FormRecognizerHelper.CreateEmptyAnalyzeResult();
@@ -47,6 +48,7 @@ public class AnalyseHandlerTests
             mockValidator.Object, 
             filePersistenceServiceMock.Object,
             new SimpleMemoryStreamManager(),
+            mockRedisCacheService.Object,
             mockLogger.Object);
 
         var bytes = Encoding.UTF8.GetBytes("This is a dummy file");
@@ -60,6 +62,6 @@ public class AnalyseHandlerTests
         // Assert
         Assert.NotNull(response);
         Assert.Equal(expectedOcrViolationTicket, response.OcrViolationTicket);
-        Assert.Equal(expectedFilename, response.OcrViolationTicket.ImageFilename);
+        Assert.NotEqual(expectedFilename, response.OcrViolationTicket.ImageFilename);
     }
 }

--- a/src/backend/TrafficCourts/Workflow.Service/Consumers/SubmitDisputeConsumer.cs
+++ b/src/backend/TrafficCourts/Workflow.Service/Consumers/SubmitDisputeConsumer.cs
@@ -53,13 +53,14 @@ namespace TrafficCourts.Workflow.Service.Consumers
                     DriversLicence = context.Message.DriversLicence,
                     DriversLicenceProvince = context.Message.DriversLicenceProvince,
                     WorkPhone = context.Message.WorkPhone,
-                    DateOfBirth = context.Message.DateOfBirth,
+                    DateOfBirth = context.Message.DateOfBirth.ToDateTime(TimeOnly.MinValue),// Parsing it back to DateTime due to the DateOnly deserialization issues on oracle-data-api
                     EnforcementOrganization = context.Message.EnforcementOrganization,
-                    ServiceDate = context.Message.ServiceDate,
+                    ServiceDate = context.Message.ServiceDate.ToDateTime(TimeOnly.MinValue),// Parsing it back to DateTime due to the DateOnly deserialization issues on oracle-data-api
                     TicketCounts = ticketCounts,
                     LawyerRepresentation = context.Message.LawyerRepresentation,
                     InterpreterLanguage = context.Message.InterpreterLanguage,
-                    WitnessIntent = context.Message.WitnessIntent
+                    WitnessIntent = context.Message.WitnessIntent,
+                    OcrViolationTicket = context.Message.OcrViolationTicket
                 };
 
                 _logger.LogDebug("TRY CREATING DISPUTE: {Dispute}", dispute.ToString());

--- a/src/backend/TrafficCourts/Workflow.Service/Models/Dispute.cs
+++ b/src/backend/TrafficCourts/Workflow.Service/Models/Dispute.cs
@@ -19,15 +19,14 @@ namespace TrafficCourts.Workflow.Service.Models
         public string DriversLicence { get; set; } = null!;
         public string DriversLicenceProvince { get; set; } = null!;
         public string WorkPhone { get; set; } = null!;
-        [JsonConverter(typeof(DateOnlyJsonConverter))]
-        public DateOnly DateOfBirth { get; set; }
+        public DateTime DateOfBirth { get; set; }
         public string EnforcementOrganization { get; set; } = null!;
-        [JsonConverter(typeof(DateOnlyJsonConverter))]
-        public DateOnly ServiceDate { get; set; }
+        public DateTime ServiceDate { get; set; }
         public List<TicketCount> TicketCounts { get; set; } = null!;
         public bool LawyerRepresentation { get; set; }
         public string InterpreterLanguage { get; set; } = null!;
         public bool WitnessIntent { get; set; }
+        public string? OcrViolationTicket { get; set; }
 
         public override string ToString()
         {

--- a/src/backend/TrafficCourts/Workflow.Service/Program.cs
+++ b/src/backend/TrafficCourts/Workflow.Service/Program.cs
@@ -1,5 +1,6 @@
 using MassTransit;
 using Microsoft.AspNetCore.Diagnostics.HealthChecks;
+using TrafficCourts.Common.Utils;
 using TrafficCourts.Workflow.Service.Configuration;
 using TrafficCourts.Workflow.Service.Consumers;
 using TrafficCourts.Workflow.Service.Services;
@@ -46,6 +47,12 @@ builder.Services.AddMassTransit(cfg =>
             r.Ignore<ArgumentNullException>();
             r.Ignore<InvalidOperationException>();
             r.Interval(retryConfiguration.RetryTimes, TimeSpan.FromMinutes(retryConfiguration.RetryInterval));
+        });
+        configurator.ConfigureJsonSerializerOptions(settings =>
+        {
+            settings.Converters.Add(new DateOnlyJsonConverter());
+            settings.Converters.Add(new TimeOnlyJsonConverter());
+            return settings;
         });
     });
 

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/model/Dispute.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/model/Dispute.java
@@ -100,6 +100,10 @@ public class Dispute {
 
     @Column
     private boolean witnessIntent;
+    
+    @Column
+    @Schema(nullable = true)
+    private String ocrViolationTicket;
 
     /**
      * A note or reason indicating why this Dispute has a status of REJECTED. This field is blank for other status types.


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- [TCVP-1223](https://justice.gov.bc.ca/jira/browse/TCVP-1223)
- Added Redis cache service to enable writing/saving generic objects as json into Redis as well as reading from it. Also added functionality to save OCR violation ticket data into Redis with an associated guid.
- Updated message contract and submit dispute consumer to get and send optional ocr related ticket data.
- Updated create dispute request handler to get ocr ticket data from the redis cache if the ocr key is provided.
- Added @operation annotation to the dispute endpoints for the swagger definitions.
- Added ocr violation ticket property to the dispute model in oraface api and updated oraface api endpoint to call in message consumer service.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
