### PR TITLE
Added Oracle Data API as an OpenAPI connected service

### DIFF
--- a/src/backend/TrafficCourts/Staff.Service/Controllers/DisputeController.cs
+++ b/src/backend/TrafficCourts/Staff.Service/Controllers/DisputeController.cs
@@ -1,0 +1,48 @@
+﻿using MediatR;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using System.Net;
+using TrafficCourts.Staff.Service.Authentication;
+using TrafficCourts.Staff.Service.OpenAPIs.OracleDataApi.v1_0;
+
+namespace TrafficCourts.Staff.Service.Controllers;
+
+[ApiController]
+[Route("api")]
+public class DisputeController : ControllerBase
+{
+    private readonly IOracleDataApi_v1_0Client _oracleDataApi;
+    private readonly ILogger<DisputeController> _logger;
+
+    /// <summary>
+    /// Default Constructor
+    /// </summary>
+    /// <param name="oracleDataApi"></param>
+    /// <param name="logger"></param>
+    /// <exception cref="ArgumentNullException"><paramref name="logger"/> is null.</exception>
+    public DisputeController(IOracleDataApi_v1_0Client oracleDataApi, ILogger<DisputeController> logger)
+    {
+        ArgumentNullException.ThrowIfNull(oracleDataApi);
+        ArgumentNullException.ThrowIfNull(logger);
+        _oracleDataApi = oracleDataApi;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Returns a single Dispute with the given identifier from the Oracle Data Interface API.
+    /// </summary>
+    /// <param name="disputeId">Unique identifier for a specific Dispute record.</param>
+    /// <param name="cancellationToken"></param>
+    /// <returns></returns>
+    [HttpGet("/dispute/{disputeId}")]
+    [ProducesResponseType(typeof(Dispute), StatusCodes.Status200OK)]
+    public async Task<IActionResult> GetDisputeAsync(int disputeId, CancellationToken cancellationToken)
+    {
+        _logger.LogDebug("Retrieving Dispute from oraface-api");
+
+        Dispute dispute = await _oracleDataApi.GetDisputeAsync(disputeId, cancellationToken);
+
+        return Ok(dispute);
+    }
+
+}

--- a/src/backend/TrafficCourts/Staff.Service/OpenAPIs/OracleDataAPI/v1_0/IOracleDataApi_v1_0Client.cs
+++ b/src/backend/TrafficCourts/Staff.Service/OpenAPIs/OracleDataAPI/v1_0/IOracleDataApi_v1_0Client.cs
@@ -1,0 +1,14 @@
+﻿namespace TrafficCourts.Staff.Service.OpenAPIs.OracleDataApi.v1_0;
+
+/// <summary>
+/// Generated/Extracted from OracleDataApi_v1_0Client, partial extraction (only public methods with CancellationToken as a param)
+/// </summary>
+public interface IOracleDataApi_v1_0Client
+{
+    Task CodeTableRefreshAsync(CancellationToken cancellationToken);
+    Task DeleteDisputeAsync(int disputeId, CancellationToken cancellationToken);
+    Task<ICollection<Dispute>> GetAllDisputesAsync(CancellationToken cancellationToken);
+    Task<Dispute> GetDisputeAsync(int disputeId, CancellationToken cancellationToken);
+    Task<int> SaveDisputeAsync(Dispute body, CancellationToken cancellationToken);
+    Task<Dispute> UpdateAsync(Dispute body, CancellationToken cancellationToken);
+}

--- a/src/backend/TrafficCourts/Staff.Service/OpenAPIs/OracleDataAPI/v1_0/OracleDataApi.v1_0.json
+++ b/src/backend/TrafficCourts/Staff.Service/OpenAPIs/OracleDataAPI/v1_0/OracleDataApi.v1_0.json
@@ -1,0 +1,176 @@
+{
+  "openapi": "3.0.1",
+  "info": {
+    "title": "OpenAPI definition",
+    "version": "v0"
+  },
+  "servers": [
+    {
+      "url": "http://localhost:5010",
+      "description": "Generated server url"
+    }
+  ],
+  "paths": {
+    "/api/v1.0/dispute": {
+      "put": {
+        "tags": [ "dispute-controller" ],
+        "operationId": "update",
+        "requestBody": {
+          "content": { "application/json": { "schema": { "$ref": "#/components/schemas/Dispute" } } },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": { "*/*": { "schema": { "$ref": "#/components/schemas/Dispute" } } }
+          }
+        }
+      },
+      "post": {
+        "tags": [ "dispute-controller" ],
+        "operationId": "saveDispute",
+        "requestBody": {
+          "content": { "application/json": { "schema": { "$ref": "#/components/schemas/Dispute" } } },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "integer",
+                  "format": "int32"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1.0/disputes": {
+      "get": {
+        "tags": [ "dispute-controller" ],
+        "operationId": "getAllDisputes",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "array",
+                  "items": { "$ref": "#/components/schemas/Dispute" }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1.0/dispute/{disputeId}": {
+      "get": {
+        "tags": [ "dispute-controller" ],
+        "operationId": "getDispute",
+        "parameters": [
+          {
+            "name": "disputeId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": { "*/*": { "schema": { "$ref": "#/components/schemas/Dispute" } } }
+          }
+        }
+      },
+      "delete": {
+        "tags": [ "dispute-controller" ],
+        "operationId": "deleteDispute",
+        "parameters": [
+          {
+            "name": "disputeId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": { "200": { "description": "OK" } }
+      }
+    },
+    "/api/v1.0/codetable/refresh": {
+      "get": {
+        "tags": [ "dispute-controller" ],
+        "summary": "An endpoint hook to trigger a redis rebuild of cached codetable data.",
+        "description": "The codetables in redis are cached copies of data pulled from Oracle to ensure TCO remains stable. This data is periodically refreshed, but can be forced by hitting this endpoint.",
+        "operationId": "codeTableRefresh",
+        "responses": { "200": { "description": "OK" } }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Dispute": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "ticketNumber": { "type": "string" },
+          "courtLocation": { "type": "string" },
+          "violationDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "disputantSurname": { "type": "string" },
+          "givenNames": { "type": "string" },
+          "streetAddress": { "type": "string" },
+          "province": { "type": "string" },
+          "postalCode": { "type": "string" },
+          "homePhone": { "type": "string" },
+          "driversLicense": { "type": "string" },
+          "driversLicenseProvince": { "type": "string" },
+          "workPhone": { "type": "string" },
+          "dateOfBirth": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "enforcementOrganization": { "type": "string" },
+          "serviceDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "ticketCounts": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/TicketCount" }
+          },
+          "lawyerRepresentation": { "type": "boolean" },
+          "interpreterLanguage": { "type": "string" },
+          "witnessIntent": { "type": "boolean" }
+        }
+      },
+      "TicketCount": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "offenceDeclaration": { "type": "string" },
+          "timeToPayRequest": { "type": "boolean" },
+          "fineReductionRequest": { "type": "boolean" },
+          "dispute": { "$ref": "#/components/schemas/Dispute" }
+        }
+      }
+    }
+  }
+}

--- a/src/backend/TrafficCourts/Staff.Service/OpenAPIs/OracleDataAPI/v1_0/OracleDataApi_v1_0Client.cs
+++ b/src/backend/TrafficCourts/Staff.Service/OpenAPIs/OracleDataAPI/v1_0/OracleDataApi_v1_0Client.cs
@@ -1,0 +1,8 @@
+﻿namespace TrafficCourts.Staff.Service.OpenAPIs.OracleDataApi.v1_0;
+
+/// <summary>
+/// This partial class is only needed to be able to create Moq tests that stub out the implementation.
+/// </summary>
+public partial class OracleDataApi_v1_0Client : IOracleDataApi_v1_0Client
+{
+}

--- a/src/backend/TrafficCourts/Staff.Service/Program.cs
+++ b/src/backend/TrafficCourts/Staff.Service/Program.cs
@@ -11,6 +11,7 @@ using System.Reflection;
 using TrafficCourts.Common.Configuration;
 using TrafficCourts.Staff.Service.Authentication;
 using TrafficCourts.Staff.Service.Logging;
+using TrafficCourts.Staff.Service.OpenAPIs.OracleDataApi.v1_0;
 
 var builder = WebApplication.CreateBuilder(args);
 var logger = GetLogger(builder);
@@ -28,6 +29,18 @@ builder.Host.UseSerilog((hostingContext, loggerConfiguration) => {
 builder.Services.AddControllers();
 
 Authentication.Initialize(builder.Services, builder.Configuration);
+
+// Add OracleDataApi service
+builder.Services.AddSingleton<IOracleDataApi_v1_0Client, OracleDataApi_v1_0Client>(services =>
+{
+    string baseUrl = builder.Configuration.GetValue<string>("OracleDataApi:BaseUrl");
+    ArgumentNullException.ThrowIfNull(baseUrl);
+
+    return new OracleDataApi_v1_0Client(new HttpClient())
+    {
+        BaseUrl = baseUrl
+    };
+});
 
 builder.Services.AddMediatR(Assembly.GetExecutingAssembly());
 

--- a/src/backend/TrafficCourts/Staff.Service/TrafficCourts.Staff.Service.csproj
+++ b/src/backend/TrafficCourts/Staff.Service/TrafficCourts.Staff.Service.csproj
@@ -18,10 +18,23 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Content Remove="OpenAPIs\OracleDataApi\v1_0\OracleDataApi.v1_0.json" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="MediatR" Version="10.0.1" />
     <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="10.0.1" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="6.0.3" />
+    <PackageReference Include="Microsoft.Extensions.ApiDescription.Client" Version="3.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.15.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="NSwag.ApiDescription.Client" Version="13.0.5">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="OpenTelemetry" Version="1.2.0-rc4" />
     <PackageReference Include="OpenTelemetry.Exporter.Jaeger" Version="1.2.0-rc4" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.0.0-rc9.1" />
@@ -44,6 +57,10 @@
     <ProjectReference Include="..\Common\TrafficCourts.Common.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <OpenApiReference Include="OpenAPIs\OracleDataAPI\v1_0\OracleDataApi.v1_0.json" CodeGenerator="NSwagCSharp" Namespace="TrafficCourts.Staff.Service.OpenAPIs.OracleDataApi.v1_0" />
+  </ItemGroup>
+	
   <ItemGroup>
     <Folder Include="Controllers\" />
   </ItemGroup>

--- a/src/backend/TrafficCourts/TrafficCourts.Staff.Service.Test/Controllers/DisputeControllerTest.cs
+++ b/src/backend/TrafficCourts/TrafficCourts.Staff.Service.Test/Controllers/DisputeControllerTest.cs
@@ -1,0 +1,36 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Moq;
+using System.Threading;
+using TrafficCourts.Staff.Service.Controllers;
+using TrafficCourts.Staff.Service.OpenAPIs.OracleDataApi.v1_0;
+using Xunit;
+
+namespace TrafficCourts.Staff.Service.Test.Controllers;
+
+public class DisputeControllerTest
+{
+
+    [Fact]
+    public async void TestGetDisputeOkResult()
+    {
+        // Mock the OracleDataApi to return a specific Dispute for (1), confirm controller returns the dispute.
+
+        // Arrange
+        Dispute dispute = new();
+        dispute.Id = 1;
+        var oracleDataApi = new Mock<IOracleDataApi_v1_0Client>();
+        oracleDataApi
+            .Setup(_ => _.GetDisputeAsync(It.Is<int>(v => v == 1), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(dispute);
+        var mockLogger = new Mock<ILogger<DisputeController>>();
+        DisputeController disputeController = new (oracleDataApi.Object, mockLogger.Object);
+
+        // Act
+        IActionResult? result = await disputeController.GetDisputeAsync(1, CancellationToken.None);
+
+        // Assert
+        var okResult = Assert.IsType<OkObjectResult>(result);
+        Assert.Equal(dispute, okResult.Value);
+    }
+}

--- a/src/backend/TrafficCourts/TrafficCourts.Staff.Service.Test/TrafficCourts.Staff.Service.Test.csproj
+++ b/src/backend/TrafficCourts/TrafficCourts.Staff.Service.Test/TrafficCourts.Staff.Service.Test.csproj
@@ -14,6 +14,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+    <PackageReference Include="Moq" Version="4.17.2" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

[TCVP-1210](https://justice.gov.bc.ca/jira/browse/TCVP-1210)

- Added an OpenApi connected service to the staff-api project to consume the oracle-data-api swagger spec.
- Added a static copy of the OracleDataApi, v1.0 json swagger spec.
- Added a new DisputeController as a wrapper to the OracleDataApi to retrieve a single Dispute.
- Extracted interface of OracleDataApi to be able to create unit tests
- Created a single unit test, happy path
- PR updated to reflect new "oracle-data-api" project name.

UserSecrets should include a new property for the Oracle Data API basePath:
`OracleDataApi:BaseUrl`

TODO: create tests for other HTTP return codes.

![image](https://user-images.githubusercontent.com/55215368/163437865-2560854b-4e6a-43c7-a977-0819755ad989.png)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

dotnet test

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
