### PR TITLE
TCVP-1214 Added staff-api wrapper for all disputes

### DIFF
--- a/src/backend/TrafficCourts/Staff.Service/Controllers/DisputeController.cs
+++ b/src/backend/TrafficCourts/Staff.Service/Controllers/DisputeController.cs
@@ -29,6 +29,30 @@ public class DisputeController : ControllerBase
     }
 
     /// <summary>
+    /// Returns all Disputes from the Oracle Data Interface API.
+    /// </summary>
+    /// <param name="cancellationToken"></param>
+    /// <returns></returns>
+    [HttpGet("/disputes")]
+    [ProducesResponseType(typeof(ICollection<Dispute>), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+    public async Task<IActionResult> GetDisputesAsync(CancellationToken cancellationToken)
+    {
+        _logger.LogDebug("Retrieving all Disputes from oracle-data-api");
+
+        try
+        {
+            ICollection<Dispute> disputes = await _oracleDataApi.GetAllDisputesAsync(cancellationToken);
+            return Ok(disputes);
+        }
+        catch (Exception e)
+        {
+            _logger.LogError("Error retrieving Disputes from oracle-data-api:", e);
+            return StatusCode(StatusCodes.Status500InternalServerError);
+        }
+    }
+
+    /// <summary>
     /// Returns a single Dispute with the given identifier from the Oracle Data Interface API.
     /// </summary>
     /// <param name="disputeId">Unique identifier for a specific Dispute record.</param>

--- a/src/backend/TrafficCourts/TrafficCourts.Staff.Service.Test/Controllers/DisputeControllerTest.cs
+++ b/src/backend/TrafficCourts/TrafficCourts.Staff.Service.Test/Controllers/DisputeControllerTest.cs
@@ -1,6 +1,8 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using Moq;
+using System.Collections.Generic;
 using System.Threading;
 using TrafficCourts.Staff.Service.Controllers;
 using TrafficCourts.Staff.Service.OpenAPIs.OracleDataApi.v1_0;
@@ -10,9 +12,38 @@ namespace TrafficCourts.Staff.Service.Test.Controllers;
 
 public class DisputeControllerTest
 {
+    
+    [Fact]
+    public async void TestGetDisputes200Result()
+    {
+        // Mock the OracleDataApi to return a couple Disputes, confirm controller returns them.
+
+        // Arrange
+        Dispute dispute1 = new();
+        dispute1.Id = 1;
+        Dispute dispute2 = new();
+        dispute2.Id = 1;
+        List<Dispute> disputes = new List<Dispute> { dispute1, dispute2 };
+        var oracleDataApi = new Mock<IOracleDataApi_v1_0Client>();
+        oracleDataApi
+            .Setup(_ => _.GetAllDisputesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(disputes);
+        var mockLogger = new Mock<ILogger<DisputeController>>();
+        DisputeController disputeController = new(oracleDataApi.Object, mockLogger.Object);
+
+        // Act
+        IActionResult? result = await disputeController.GetDisputesAsync(CancellationToken.None);
+
+        // Assert
+        var okResult = Assert.IsType<OkObjectResult>(result);
+        Assert.NotNull(okResult.Value);
+        Assert.Equal(2, ((List<Dispute>)okResult.Value).Count);
+        Assert.Equal(dispute1, ((List<Dispute>)okResult.Value)[0]);
+        Assert.Equal(dispute2, ((List<Dispute>)okResult.Value)[1]);
+    }
 
     [Fact]
-    public async void TestGetDisputeOkResult()
+    public async void TestGetDispute200Result()
     {
         // Mock the OracleDataApi to return a specific Dispute for (1), confirm controller returns the dispute.
 
@@ -32,5 +63,51 @@ public class DisputeControllerTest
         // Assert
         var okResult = Assert.IsType<OkObjectResult>(result);
         Assert.Equal(dispute, okResult.Value);
+    }
+
+    [Fact]
+    public async void TestGetDispute400Result()
+    {
+        // Mock the OracleDataApi to return a specific Dispute for (1), confirm controller returns 400 when retrieving.
+
+        // Arrange
+        Dispute dispute = new();
+        dispute.Id = 1;
+        var oracleDataApi = new Mock<IOracleDataApi_v1_0Client>();
+        oracleDataApi
+            .Setup(_ => _.GetDisputeAsync(It.Is<int>(v => v == 1), It.IsAny<CancellationToken>()))
+            .Throws(new ApiException("msg", StatusCodes.Status400BadRequest, "rsp", null, null));
+        var mockLogger = new Mock<ILogger<DisputeController>>();
+        DisputeController disputeController = new(oracleDataApi.Object, mockLogger.Object);
+
+        // Act
+        IActionResult? result = await disputeController.GetDisputeAsync(1, CancellationToken.None);
+
+        // Assert
+        var badRequestResult = Assert.IsType<BadRequestResult>(result);
+        Assert.Equal(StatusCodes.Status400BadRequest, badRequestResult.StatusCode);
+    }
+
+    [Fact]
+    public async void TestGetDispute404Result()
+    {
+        // Mock the OracleDataApi to return a specific Dispute for (1), confirm controller returns 404 when retrieving.
+
+        // Arrange
+        Dispute dispute = new();
+        dispute.Id = 1;
+        var oracleDataApi = new Mock<IOracleDataApi_v1_0Client>();
+        oracleDataApi
+            .Setup(_ => _.GetDisputeAsync(It.Is<int>(v => v == 1), It.IsAny<CancellationToken>()))
+            .Throws(new ApiException("msg", StatusCodes.Status404NotFound, "rsp", null, null));
+        var mockLogger = new Mock<ILogger<DisputeController>>();
+        DisputeController disputeController = new(oracleDataApi.Object, mockLogger.Object);
+
+        // Act
+        IActionResult? result = await disputeController.GetDisputeAsync(1, CancellationToken.None);
+
+        // Assert
+        var notFoundResult = Assert.IsType<NotFoundResult>(result);
+        Assert.Equal(StatusCodes.Status404NotFound, notFoundResult.StatusCode);
     }
 }


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

[TCVP-1214](https://justice.gov.bc.ca/jira/browse/TCVP-1214)

Added an endpoint to the staff-api (a wrapper to the oracle-data-api endpoint) that retrieves all Disputes.
Added xunit tests

![image](https://user-images.githubusercontent.com/55215368/163483103-39f84ea0-4b1e-48c6-bf54-06924de3c5fb.png)


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

dotnet test

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [x] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
