### PR TITLE
TCVP-1058 Added 405 error code rules and junit tests

### DIFF
--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/error/ControllerAdvisor.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/error/ControllerAdvisor.java
@@ -32,12 +32,12 @@ public class ControllerAdvisor {
 	}
 
 	/**
-	 * Returns an API HTTP error code of 400 if the endpoint has been deprecated.
+	 * Returns an API HTTP error code of 405 if the endpoint operation is not permitted (due to business rules).
 	 */
-	@ExceptionHandler(DeprecatedException.class)
+	@ExceptionHandler(NotAllowedException.class)
 	@ResponseStatus(HttpStatus.BAD_REQUEST)
-	public ResponseEntity<Object> handleDeprecatedException(DeprecatedException ex) {
-		return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
+	public ResponseEntity<Object> NotAllowedExceptionException(NotAllowedException ex) {
+		return new ResponseEntity<>(ex.getMessage(), HttpStatus.METHOD_NOT_ALLOWED);
 	}
 
 }

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/error/DeprecatedException.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/error/DeprecatedException.java
@@ -1,7 +1,0 @@
-package ca.bc.gov.open.jag.tco.oracledataapi.error;
-
-public class DeprecatedException extends RuntimeException {
-
-	private static final long serialVersionUID = 1L;
-
-}

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/error/NotAllowedException.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/error/NotAllowedException.java
@@ -1,0 +1,11 @@
+package ca.bc.gov.open.jag.tco.oracledataapi.error;
+
+public class NotAllowedException extends RuntimeException {
+
+	private static final long serialVersionUID = 1L;
+
+	public NotAllowedException(String reason, Object... args) {
+		super(String.format(reason, args));
+	}
+
+}

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/service/DisputeService.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/service/DisputeService.java
@@ -3,9 +3,12 @@ package ca.bc.gov.open.jag.tco.oracledataapi.service;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import ca.bc.gov.open.jag.tco.oracledataapi.error.NotAllowedException;
 import ca.bc.gov.open.jag.tco.oracledataapi.model.Dispute;
 import ca.bc.gov.open.jag.tco.oracledataapi.model.DisputeStatus;
 import ca.bc.gov.open.jag.tco.oracledataapi.model.TicketCount;
@@ -13,6 +16,8 @@ import ca.bc.gov.open.jag.tco.oracledataapi.repository.DisputeRepository;
 
 @Service
 public class DisputeService {
+
+	private Logger logger = LoggerFactory.getLogger(DisputeService.class);
 
 	@Autowired
 	DisputeRepository disputeRepository;
@@ -79,11 +84,46 @@ public class DisputeService {
 	 * @param rejectedReason the rejected reason if the status is REJECTED.
 	 */
 	public void setStatus(Integer id, DisputeStatus disputeStatus, String rejectedReason) {
-		Dispute dispute = disputeRepository.findById(id).orElseThrow();
-		dispute.setStatus(disputeStatus);
-		if (DisputeStatus.REJECTED.equals(disputeStatus)) {
-			dispute.setRejectedReason(rejectedReason);
+		if (disputeStatus == null) {
+			logger.error("Attempting to set Dispute status to null - bad method call.");
+			throw new NotAllowedException("Cannot set Dispute status to null");
 		}
+
+		Dispute dispute = disputeRepository.findById(id).orElseThrow();
+
+		// TCVP-1058 - business rules
+		// - current status must be NEW,PROCESSING to change to PROCESSING
+		// - current status must be REJECTED,PROCESSING to change to CANCELLED
+		// - current status must be NEW,CANCELLED,REJECTED to change to REJECTED
+		switch (disputeStatus) {
+		case PROCESSING:
+			if (!List.of(DisputeStatus.NEW, DisputeStatus.PROCESSING).contains(dispute.getStatus())) {
+				throw new NotAllowedException("Changing the status of a Dispute record from %s to %s is not permitted.", dispute.getStatus(), DisputeStatus.PROCESSING);
+			}
+			break;
+		case CANCELLED:
+			if (!List.of(DisputeStatus.REJECTED, DisputeStatus.PROCESSING).contains(dispute.getStatus())) {
+				throw new NotAllowedException("Changing the status of a Dispute record from %s to %s is not permitted.", dispute.getStatus(), DisputeStatus.CANCELLED);
+			}
+			break;
+		case REJECTED:
+			if (!List.of(DisputeStatus.NEW, DisputeStatus.CANCELLED, DisputeStatus.REJECTED).contains(dispute.getStatus())) {
+				throw new NotAllowedException("Changing the status of a Dispute record from %s to %s is not permitted.", dispute.getStatus(), DisputeStatus.REJECTED);
+			}
+			break;
+		case NEW:
+			// This should never happen since setting the status to NEW should only happen during initial creation of the Dispute record.
+			// If we got here, then this means the Dispute record is in an invalid state.
+			logger.error("Attempting to set the status of a Dispute record to NEW after it was created - bad object state.");
+			throw new NotAllowedException("Changing the status of a Dispute record to %s is not permitted.", DisputeStatus.NEW);
+		default:
+			// This should never happen, but if so, then it means a new DisputeStatus was added and these business rules were not updated accordingly.
+			logger.error("A Dispute record has an unknown status '{}' - bad object state.", dispute.getStatus());
+			throw new NotAllowedException("Unknown status of a Dispute record: %s", dispute.getStatus());
+		}
+
+		dispute.setStatus(disputeStatus);
+		dispute.setRejectedReason(DisputeStatus.REJECTED.equals(disputeStatus) ? rejectedReason : null);
 		disputeRepository.save(dispute);
 	}
 

--- a/src/backend/oracle-data-api/src/test/java/ca/bc/gov/open/jag/tco/oracledataapi/BaseTestSuite.java
+++ b/src/backend/oracle-data-api/src/test/java/ca/bc/gov/open/jag/tco/oracledataapi/BaseTestSuite.java
@@ -12,7 +12,7 @@ import ca.bc.gov.open.jag.tco.oracledataapi.repository.DisputeRepository;
 public class BaseTestSuite {
 
 	@Autowired
-	DisputeRepository disputeRepository;
+	protected DisputeRepository disputeRepository;
 
     @BeforeEach
     protected void beforeEach() throws Exception {

--- a/src/backend/oracle-data-api/src/test/java/ca/bc/gov/open/jag/tco/oracledataapi/controller/v1_0/DisputeControllerTest.java
+++ b/src/backend/oracle-data-api/src/test/java/ca/bc/gov/open/jag/tco/oracledataapi/controller/v1_0/DisputeControllerTest.java
@@ -10,7 +10,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 
 import ca.bc.gov.open.jag.tco.oracledataapi.BaseTestSuite;
-import ca.bc.gov.open.jag.tco.oracledataapi.controller.v1_0.DisputeController;
 import ca.bc.gov.open.jag.tco.oracledataapi.model.Dispute;
 import ca.bc.gov.open.jag.tco.oracledataapi.model.DisputeStatus;
 import ca.bc.gov.open.jag.tco.oracledataapi.util.RandomUtil;
@@ -96,7 +95,10 @@ class DisputeControllerTest extends BaseTestSuite {
 		assertEquals(disputeId, dispute.getId());
 		assertEquals(DisputeStatus.NEW, dispute.getStatus());
 
-		// Set the status to CANCELLED
+		// Set the status to PROCESSING
+		disputeController.submitDispute(disputeId);
+
+		// Set the status to CANCELLED (can only be set to Cancelled after it's first been set to PROCESSING.
 		disputeController.cancelDispute(disputeId);
 
 		// Assert status is set, rejected reason is NOT set.

--- a/src/backend/oracle-data-api/src/test/java/ca/bc/gov/open/jag/tco/oracledataapi/service/DisputeServiceTest.java
+++ b/src/backend/oracle-data-api/src/test/java/ca/bc/gov/open/jag/tco/oracledataapi/service/DisputeServiceTest.java
@@ -1,0 +1,91 @@
+package ca.bc.gov.open.jag.tco.oracledataapi.service;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import ca.bc.gov.open.jag.tco.oracledataapi.BaseTestSuite;
+import ca.bc.gov.open.jag.tco.oracledataapi.error.NotAllowedException;
+import ca.bc.gov.open.jag.tco.oracledataapi.model.Dispute;
+import ca.bc.gov.open.jag.tco.oracledataapi.model.DisputeStatus;
+
+class DisputeServiceTest extends BaseTestSuite {
+
+	@Autowired
+	private DisputeService disputeService;
+
+	@ParameterizedTest
+	@EnumSource(value = DisputeStatus.class, names = { "NEW", "PROCESSING" })
+	void testSetStatusToPROCESSING_200(DisputeStatus disputeStatus) {
+		Integer id = saveDispute(disputeStatus);
+		disputeService.setStatus(id, DisputeStatus.PROCESSING);
+	}
+
+	@ParameterizedTest
+	@EnumSource(value = DisputeStatus.class, names = { "REJECTED", "CANCELLED" })
+	void testSetStatusToPROCESSING_405(DisputeStatus disputeStatus) {
+		Integer id = saveDispute(disputeStatus);
+		assertThrows(NotAllowedException.class, () -> {
+			disputeService.setStatus(id, DisputeStatus.PROCESSING);
+		});
+	}
+
+	@ParameterizedTest
+	@EnumSource(value = DisputeStatus.class, names = { "NEW", "REJECTED", "CANCELLED" })
+	void testSetStatusToREJECTED_200(DisputeStatus disputeStatus) {
+		Integer id = saveDispute(disputeStatus);
+		disputeService.setStatus(id, DisputeStatus.REJECTED);
+	}
+
+	@ParameterizedTest
+	@EnumSource(value = DisputeStatus.class, names = { "PROCESSING" })
+	void testSetStatusToREJECTED_405(DisputeStatus disputeStatus) {
+		Integer id = saveDispute(disputeStatus);
+		assertThrows(NotAllowedException.class, () -> {
+			disputeService.setStatus(id, DisputeStatus.REJECTED);
+		});
+	}
+
+	@ParameterizedTest
+	@EnumSource(value = DisputeStatus.class, names = { "REJECTED", "PROCESSING" })
+	void testSetStatusToCANCELLED_200(DisputeStatus disputeStatus) {
+		Integer id = saveDispute(disputeStatus);
+		disputeService.setStatus(id, DisputeStatus.CANCELLED);
+	}
+
+	@ParameterizedTest
+	@EnumSource(value = DisputeStatus.class, names = { "NEW", "CANCELLED" })
+	void testSetStatusToCANCELLED_405(DisputeStatus disputeStatus) {
+		Integer id = saveDispute(disputeStatus);
+		assertThrows(NotAllowedException.class, () -> {
+			disputeService.setStatus(id, DisputeStatus.CANCELLED);
+		});
+	}
+
+	@Test
+	void testSetStatusToNEW_405() {
+		Integer id = saveDispute(DisputeStatus.NEW);
+		assertThrows(NotAllowedException.class, () -> {
+			disputeService.setStatus(id, DisputeStatus.NEW);
+		});
+	}
+
+	@Test
+	void testSetStatusToNULL_405() {
+		Integer id = saveDispute(null);
+		assertThrows(NotAllowedException.class, () -> {
+			disputeService.setStatus(id, null);
+		});
+	}
+
+	private Integer saveDispute(DisputeStatus disputeStatus) {
+		Dispute dispute = new Dispute();
+		dispute.setStatus(disputeStatus);
+
+		return disputeRepository.save(dispute).getId();
+	}
+
+}


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

[TCVP-1058](https://justice.gov.bc.ca/jira/browse/TCVP-1058)

Added HTML 405 error code rules to Dispute status change PUT endpoints
In short:
- a Dispute status can only be set to PROCESSING iff status is NEW or PROCESSING
- a Dispute status can only be set to CANCELLED iff status is REJECTED or PROCESSING
- a Dispute status can only be set to REJECTED iff status is NEW, CANCELLED, or REJECTED

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

mvn verify

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
