### PR TITLE
TCVP-1214 Exposed staff-api to docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,6 +35,23 @@ services:
       - "${APPDATA}/Microsoft/UserSecrets:/root/.microsoft/usersecrets:ro"
 
   #############################################################################################
+  ### Citizen API                                                                           ###
+  #############################################################################################
+  staff-api:
+    container_name: staff-api
+    build:
+      context: ./src/backend/TrafficCourts
+      dockerfile: ./Staff.Service/Dockerfile
+    environment:
+      ASPNETCORE_ENVIRONMENT: ${ASPNETCORE_ENVIRONMENT:-Development}
+      ASPNETCORE_URLS: http://*:8080
+    ports:
+      - "5005:8080"
+    restart: always
+    depends_on:
+      - oracle-data-api    
+  
+  #############################################################################################
   ### Ticket Search API                                                                     ###
   #############################################################################################
   ticket-search:

--- a/src/backend/README.md
+++ b/src/backend/README.md
@@ -8,7 +8,8 @@ After running `docker-compose up` from the project root, these services should b
 
 | Name                  | URL                                          | Notes
 | --------------------- | -------------------------------------------- | --------------------------------------------
-| oracle-data-api | http://localhost:5010/swagger-ui/index.html  | 
+| oracle-data-api       | http://localhost:5010/swagger-ui/index.html  | 
+| staff-api             | http://localhost:5005/swagger/index.html     | A bearer token is required to access the api
 | TrafficCourts         | http://localhost:5000/swagger/index.html     | 
 | Splunk                | http://localhost:8000                        | login with admin/password
 

--- a/src/backend/TrafficCourts/Staff.Service/Dockerfile
+++ b/src/backend/TrafficCourts/Staff.Service/Dockerfile
@@ -7,10 +7,10 @@ EXPOSE 443
 
 FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
 WORKDIR /src
-COPY ["TrafficCourts.Staff.Service/TrafficCourts.Staff.Service.csproj", "TrafficCourts.Staff.Service/"]
-RUN dotnet restore "TrafficCourts.Staff.Service/TrafficCourts.Staff.Service.csproj"
+COPY ["Staff.Service/TrafficCourts.Staff.Service.csproj", "Staff.Service/"]
+RUN dotnet restore "Staff.Service/TrafficCourts.Staff.Service.csproj"
 COPY . .
-WORKDIR "/src/TrafficCourts.Staff.Service"
+WORKDIR "/src/Staff.Service"
 RUN dotnet build "TrafficCourts.Staff.Service.csproj" -c Release -o /app/build
 
 FROM build AS publish


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

[TCVP-1214](https://justice.gov.bc.ca/jira/browse/TCVP-1214)

- Fixed staff-api Dockerfile
- Created staff-api in docker-compose

`docker-compose up -d` now will launch the staff-api (a wrapper to oracle-data-api)

Swagger spec is at: http://localhost:5005/swagger/index.html

![image](https://user-images.githubusercontent.com/55215368/164268028-7b819d09-6d2d-4288-a97b-88ef7730efb8.png)


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [x] Yes
- [ ] No

If Yes: Has Docker been updated accordingly?

- [x] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
