### PR TITLE
Added missing env var to staff-api

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,6 +45,7 @@ services:
     environment:
       ASPNETCORE_ENVIRONMENT: ${ASPNETCORE_ENVIRONMENT:-Development}
       ASPNETCORE_URLS: http://*:8080
+      ORACLEDATAAPI__BASEURL: ${ORACLEDATAAPI__BASEURL:-http://oracle-data-api:8080/}
     ports:
       - "5005:8080"
     restart: always


### PR DESCRIPTION
Added a missing ORACLEDATAAPI__BASEURL env var to staff-api in docker-compose.yml
This should default to the oracle-data-api container.