### PR TITLE
TCVP-1058 added DisputeService to handle service layer tasks

### DIFF
--- a/src/backend/TrafficCourts/Staff.Service/Controllers/DisputeController.cs
+++ b/src/backend/TrafficCourts/Staff.Service/Controllers/DisputeController.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Mvc;
 using System.Net;
 using TrafficCourts.Staff.Service.Authentication;
 using TrafficCourts.Staff.Service.OpenAPIs.OracleDataApi.v1_0;
+using TrafficCourts.Staff.Service.Services;
 
 namespace TrafficCourts.Staff.Service.Controllers;
 
@@ -11,28 +12,28 @@ namespace TrafficCourts.Staff.Service.Controllers;
 [Route("api")]
 public class DisputeController : ControllerBase
 {
-    private readonly IOracleDataApi_v1_0Client _oracleDataApi;
+    private readonly IDisputeService _disputeService;
     private readonly ILogger<DisputeController> _logger;
 
     /// <summary>
     /// Default Constructor
     /// </summary>
-    /// <param name="oracleDataApi"></param>
+    /// <param name="disputeService"></param>
     /// <param name="logger"></param>
     /// <exception cref="ArgumentNullException"><paramref name="logger"/> is null.</exception>
-    public DisputeController(IOracleDataApi_v1_0Client oracleDataApi, ILogger<DisputeController> logger)
+    public DisputeController(IDisputeService disputeService, ILogger<DisputeController> logger)
     {
-        ArgumentNullException.ThrowIfNull(oracleDataApi);
+        ArgumentNullException.ThrowIfNull(disputeService);
         ArgumentNullException.ThrowIfNull(logger);
-        _oracleDataApi = oracleDataApi;
+        _disputeService = disputeService;
         _logger = logger;
     }
 
     /// <summary>
-    /// Returns all Disputes from the Oracle Data Interface API.
+    /// Returns all Disputes from the Oracle Data API.
     /// </summary>
     /// <param name="cancellationToken"></param>
-    /// <returns></returns>
+    /// <returns>A collection of Dispute records</returns>
     [HttpGet("/disputes")]
     [ProducesResponseType(typeof(ICollection<Dispute>), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
@@ -42,7 +43,7 @@ public class DisputeController : ControllerBase
 
         try
         {
-            ICollection<Dispute> disputes = await _oracleDataApi.GetAllDisputesAsync(cancellationToken);
+            ICollection<Dispute> disputes = await _disputeService.GetAllDisputesAsync(cancellationToken);
             return Ok(disputes);
         }
         catch (Exception e)
@@ -53,11 +54,11 @@ public class DisputeController : ControllerBase
     }
 
     /// <summary>
-    /// Returns a single Dispute with the given identifier from the Oracle Data Interface API.
+    /// Returns a single Dispute with the given identifier from the Oracle Data API.
     /// </summary>
     /// <param name="disputeId">Unique identifier for a specific Dispute record.</param>
     /// <param name="cancellationToken"></param>
-    /// <returns></returns>
+    /// <returns>A single Dispute record</returns>
     /// <response code="200">The Dispute was found.</response>
     /// <response code="400">The request was not well formed. Check the parameters.</response>
     /// <response code="404">The Dispute was not found.</response>
@@ -73,7 +74,7 @@ public class DisputeController : ControllerBase
 
         try
         {
-            Dispute dispute = await _oracleDataApi.GetDisputeAsync(disputeId, cancellationToken);
+            Dispute dispute = await _disputeService.GetDisputeAsync(disputeId, cancellationToken);
             return Ok(dispute);
         }
         catch (TrafficCourts.Staff.Service.OpenAPIs.OracleDataApi.v1_0.ApiException e) when (e.StatusCode == StatusCodes.Status400BadRequest)
@@ -118,7 +119,7 @@ public class DisputeController : ControllerBase
 
         try
         {
-            await _oracleDataApi.UpdateDisputeAsync(disputeId, dispute, cancellationToken);
+            await _disputeService.UpdateDisputeAsync(disputeId, dispute, cancellationToken);
             return Ok(dispute);
         }
         catch (TrafficCourts.Staff.Service.OpenAPIs.OracleDataApi.v1_0.ApiException e) when (e.StatusCode == StatusCodes.Status400BadRequest)

--- a/src/backend/TrafficCourts/Staff.Service/OpenAPIs/OracleDataAPI/v1_0/IOracleDataApi_v1_0Client.cs
+++ b/src/backend/TrafficCourts/Staff.Service/OpenAPIs/OracleDataAPI/v1_0/IOracleDataApi_v1_0Client.cs
@@ -1,14 +1,15 @@
 ﻿namespace TrafficCourts.Staff.Service.OpenAPIs.OracleDataApi.v1_0;
 
-/// <summary>
-/// Generated/Extracted from OracleDataApi_v1_0Client, partial extraction (only public methods with CancellationToken as a param)
-/// </summary>
 public interface IOracleDataApi_v1_0Client
 {
-    Task CodeTableRefreshAsync(CancellationToken cancellationToken);
-    Task DeleteDisputeAsync(int disputeId, CancellationToken cancellationToken);
+    string BaseUrl { get; set; }
+
+    Task CancelDisputeAsync(int id, CancellationToken cancellationToken);
+    Task DeleteDisputeAsync(int id, CancellationToken cancellationToken);
     Task<ICollection<Dispute>> GetAllDisputesAsync(CancellationToken cancellationToken);
-    Task<Dispute> GetDisputeAsync(int disputeId, CancellationToken cancellationToken);
+    Task<Dispute> GetDisputeAsync(int id, CancellationToken cancellationToken);
+    Task RejectDisputeAsync(int id, string body, CancellationToken cancellationToken);
     Task<int> SaveDisputeAsync(Dispute body, CancellationToken cancellationToken);
-    Task<Dispute> UpdateDisputeAsync(int disputeId, Dispute body, CancellationToken cancellationToken);
+    Task SubmitDisputeAsync(int id, CancellationToken cancellationToken);
+    Task<Dispute> UpdateDisputeAsync(int id, Dispute body, CancellationToken cancellationToken);
 }

--- a/src/backend/TrafficCourts/Staff.Service/OpenAPIs/OracleDataAPI/v1_0/OracleDataApi_v1_0Client.cs
+++ b/src/backend/TrafficCourts/Staff.Service/OpenAPIs/OracleDataAPI/v1_0/OracleDataApi_v1_0Client.cs
@@ -1,8 +1,8 @@
 ﻿namespace TrafficCourts.Staff.Service.OpenAPIs.OracleDataApi.v1_0;
 
-/// <summary>
-/// This partial class is only needed to be able to create Moq tests that stub out the implementation.
-/// </summary>
+/// <summary> 
+/// This partial class is only needed to be able to create Moq tests that stub out the implementation. 
+/// </summary> 
 public partial class OracleDataApi_v1_0Client : IOracleDataApi_v1_0Client
 {
 }

--- a/src/backend/TrafficCourts/Staff.Service/Program.cs
+++ b/src/backend/TrafficCourts/Staff.Service/Program.cs
@@ -12,6 +12,7 @@ using TrafficCourts.Common.Configuration;
 using TrafficCourts.Staff.Service.Authentication;
 using TrafficCourts.Staff.Service.Logging;
 using TrafficCourts.Staff.Service.OpenAPIs.OracleDataApi.v1_0;
+using TrafficCourts.Staff.Service.Services;
 
 var builder = WebApplication.CreateBuilder(args);
 var logger = GetLogger(builder);
@@ -30,16 +31,14 @@ builder.Services.AddControllers();
 
 Authentication.Initialize(builder.Services, builder.Configuration);
 
-// Add OracleDataApi service
-builder.Services.AddSingleton<IOracleDataApi_v1_0Client, OracleDataApi_v1_0Client>(services =>
+// Add DisputeService
+builder.Services.AddSingleton<IDisputeService, DisputeService>(service =>
 {
-    string baseUrl = builder.Configuration.GetValue<string>("OracleDataApi:BaseUrl");
-    ArgumentNullException.ThrowIfNull(baseUrl);
+    string oracleDataApiBaseUrl = builder.Configuration.GetValue<string>("OracleDataApi:BaseUrl");
+    ArgumentNullException.ThrowIfNull(oracleDataApiBaseUrl);
 
-    return new OracleDataApi_v1_0Client(new HttpClient())
-    {
-        BaseUrl = baseUrl
-    };
+    var logger = service.GetRequiredService<ILogger<DisputeService>>();
+    return new DisputeService(oracleDataApiBaseUrl, logger);
 });
 
 builder.Services.AddMediatR(Assembly.GetExecutingAssembly());

--- a/src/backend/TrafficCourts/Staff.Service/Services/DisputeService.cs
+++ b/src/backend/TrafficCourts/Staff.Service/Services/DisputeService.cs
@@ -1,0 +1,57 @@
+﻿using TrafficCourts.Staff.Service.OpenAPIs.OracleDataApi.v1_0;
+
+namespace TrafficCourts.Staff.Service.Services;
+
+/// <summary>
+/// Summary description for Class1
+/// </summary>
+public class DisputeService : IDisputeService
+{
+    private readonly string _oracleDataApiBaseUrl;
+    private readonly ILogger<DisputeService> _logger;
+
+    public DisputeService(String oracleDataApiBaseUrl, ILogger<DisputeService> logger)
+    {
+        ArgumentNullException.ThrowIfNull(oracleDataApiBaseUrl);
+        ArgumentNullException.ThrowIfNull(logger);
+        _oracleDataApiBaseUrl = oracleDataApiBaseUrl;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Returns a new inialized instance of the OracleDataApi_v1_0Client
+    /// </summary>
+    /// <returns></returns>
+    private OracleDataApi_v1_0Client GetOracleDataApi()
+    {
+        OracleDataApi_v1_0Client client = new(new HttpClient());
+        client.BaseUrl = _oracleDataApiBaseUrl;
+        return client;
+    }
+
+    public async Task<ICollection<Dispute>> GetAllDisputesAsync(CancellationToken cancellationToken)
+    {
+        return await GetOracleDataApi().GetAllDisputesAsync(cancellationToken);
+    }
+
+    public async Task<int> SaveDisputeAsync(Dispute dispute, CancellationToken cancellationToken)
+    {
+        // TODO: trigger submit Dispute to ARC, send email to client
+        return await GetOracleDataApi().SaveDisputeAsync(dispute, cancellationToken);
+    }
+
+    public async Task<Dispute> GetDisputeAsync(int disputeId, CancellationToken cancellationToken)
+    {
+        return await GetOracleDataApi().GetDisputeAsync(disputeId, cancellationToken);
+    }
+
+    public async Task<Dispute> UpdateDisputeAsync(int id, Dispute dispute, System.Threading.CancellationToken cancellationToken)
+    {
+        return await GetOracleDataApi().UpdateDisputeAsync(id, dispute, cancellationToken);
+    }
+
+    public async Task DeleteDisputeAsync(int disputeId, CancellationToken cancellationToken)
+    {
+        await GetOracleDataApi().DeleteDisputeAsync(disputeId, cancellationToken);
+    }
+}

--- a/src/backend/TrafficCourts/Staff.Service/Services/IDisputeService.cs
+++ b/src/backend/TrafficCourts/Staff.Service/Services/IDisputeService.cs
@@ -1,0 +1,41 @@
+﻿using TrafficCourts.Staff.Service.OpenAPIs.OracleDataApi.v1_0;
+
+namespace TrafficCourts.Staff.Service.Services;
+
+public interface IDisputeService
+{
+    /// <summary>Returns all the existing disputes from the database.</summary>
+    /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+    /// <returns>A collection of Dispute objects</returns>
+    /// <exception cref="ApiException">A server side error occurred.</exception>
+    Task<ICollection<Dispute>> GetAllDisputesAsync(CancellationToken cancellationToken);
+
+    /// <summary>Saves new dispute in the oracle database.</summary>
+    /// <param name="dispute"></param>
+    /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+    /// <returns>The identifier of the saved Dispute record.</returns>
+    /// <exception cref="ApiException">A server side error occurred.</exception>
+    Task<int> SaveDisputeAsync(Dispute dispute, CancellationToken cancellationToken);
+
+    /// <summary>Returns a specific dispute from the database.</summary>
+    /// <param name="id">Unique identifier of a Dispute record.</param>
+    /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+    /// <returns>OK</returns>
+    /// <exception cref="ApiException">A server side error occurred.</exception>
+    Task<Dispute> GetDisputeAsync(int id, CancellationToken cancellationToken);
+
+    /// <summary>Updates the properties of a particular Dispute record based on the given values.</summary>
+    /// <param name="id">Unique identifier of a Dispute record to modify.</param>
+    /// <param name="dispute">A modified version of the Dispute record to save.</param>    
+    /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+    /// <returns>The modified Dispute record.</returns>
+    /// <exception cref="ApiException">A server side error occurred.</exception>
+    Task<Dispute> UpdateDisputeAsync(int id, Dispute dispute, System.Threading.CancellationToken cancellationToken);
+
+    /// <summary>An endpoint to delete a specific dispute in the database.</summary>
+    /// <param name="id">Unique identifier of a Dispute record to delete.</param>
+    /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+    /// <returns></returns>
+    /// <exception cref="ApiException">A server side error occurred.</exception>
+    Task DeleteDisputeAsync(int id, CancellationToken cancellationToken);
+}

--- a/src/backend/TrafficCourts/TrafficCourts.Staff.Service.Test/Controllers/DisputeControllerTest.cs
+++ b/src/backend/TrafficCourts/TrafficCourts.Staff.Service.Test/Controllers/DisputeControllerTest.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Threading;
 using TrafficCourts.Staff.Service.Controllers;
 using TrafficCourts.Staff.Service.OpenAPIs.OracleDataApi.v1_0;
+using TrafficCourts.Staff.Service.Services;
 using Xunit;
 
 namespace TrafficCourts.Staff.Service.Test.Controllers;
@@ -16,20 +17,20 @@ public class DisputeControllerTest
     [Fact]
     public async void TestGetDisputes200Result()
     {
-        // Mock the OracleDataApi to return a couple Disputes, confirm controller returns them.
+        // Mock the IDisputeService to return a couple Disputes, confirm controller returns them.
 
         // Arrange
         Dispute dispute1 = new();
         dispute1.Id = 1;
         Dispute dispute2 = new();
         dispute2.Id = 1;
-        List<Dispute> disputes = new List<Dispute> { dispute1, dispute2 };
-        var oracleDataApi = new Mock<IOracleDataApi_v1_0Client>();
-        oracleDataApi
+        List<Dispute> disputes = new() { dispute1, dispute2 };
+        var disputeService = new Mock<IDisputeService>();
+        disputeService
             .Setup(_ => _.GetAllDisputesAsync(It.IsAny<CancellationToken>()))
             .ReturnsAsync(disputes);
         var mockLogger = new Mock<ILogger<DisputeController>>();
-        DisputeController disputeController = new(oracleDataApi.Object, mockLogger.Object);
+        DisputeController disputeController = new(disputeService.Object, mockLogger.Object);
 
         // Act
         IActionResult? result = await disputeController.GetDisputesAsync(CancellationToken.None);
@@ -45,17 +46,17 @@ public class DisputeControllerTest
     [Fact]
     public async void TestGetDispute200Result()
     {
-        // Mock the OracleDataApi to return a specific Dispute for (1), confirm controller returns the dispute.
+        // Mock the IDisputeService to return a specific Dispute for (1), confirm controller returns the dispute.
 
         // Arrange
         Dispute dispute = new();
         dispute.Id = 1;
-        var oracleDataApi = new Mock<IOracleDataApi_v1_0Client>();
-        oracleDataApi
+        var disputeService = new Mock<IDisputeService>();
+        disputeService
             .Setup(_ => _.GetDisputeAsync(It.Is<int>(v => v == 1), It.IsAny<CancellationToken>()))
             .ReturnsAsync(dispute);
         var mockLogger = new Mock<ILogger<DisputeController>>();
-        DisputeController disputeController = new (oracleDataApi.Object, mockLogger.Object);
+        DisputeController disputeController = new (disputeService.Object, mockLogger.Object);
 
         // Act
         IActionResult? result = await disputeController.GetDisputeAsync(1, CancellationToken.None);
@@ -68,17 +69,17 @@ public class DisputeControllerTest
     [Fact]
     public async void TestGetDispute400Result()
     {
-        // Mock the OracleDataApi to return a specific Dispute for (1), confirm controller returns 400 when retrieving.
+        // Mock the IDisputeService to return a specific Dispute for (1), confirm controller returns 400 when retrieving.
 
         // Arrange
         Dispute dispute = new();
         dispute.Id = 1;
-        var oracleDataApi = new Mock<IOracleDataApi_v1_0Client>();
-        oracleDataApi
+        var disputeService = new Mock<IDisputeService>();
+        disputeService
             .Setup(_ => _.GetDisputeAsync(It.Is<int>(v => v == 1), It.IsAny<CancellationToken>()))
             .Throws(new ApiException("msg", StatusCodes.Status400BadRequest, "rsp", null, null));
         var mockLogger = new Mock<ILogger<DisputeController>>();
-        DisputeController disputeController = new(oracleDataApi.Object, mockLogger.Object);
+        DisputeController disputeController = new(disputeService.Object, mockLogger.Object);
 
         // Act
         IActionResult? result = await disputeController.GetDisputeAsync(1, CancellationToken.None);
@@ -91,17 +92,17 @@ public class DisputeControllerTest
     [Fact]
     public async void TestGetDispute404Result()
     {
-        // Mock the OracleDataApi to return a specific Dispute for (1), confirm controller returns 404 when retrieving.
+        // Mock the IDisputeService to return a specific Dispute for (1), confirm controller returns 404 when retrieving.
 
         // Arrange
         Dispute dispute = new();
         dispute.Id = 1;
-        var oracleDataApi = new Mock<IOracleDataApi_v1_0Client>();
-        oracleDataApi
+        var disputeService = new Mock<IDisputeService>();
+        disputeService
             .Setup(_ => _.GetDisputeAsync(It.Is<int>(v => v == 1), It.IsAny<CancellationToken>()))
             .Throws(new ApiException("msg", StatusCodes.Status404NotFound, "rsp", null, null));
         var mockLogger = new Mock<ILogger<DisputeController>>();
-        DisputeController disputeController = new(oracleDataApi.Object, mockLogger.Object);
+        DisputeController disputeController = new(disputeService.Object, mockLogger.Object);
 
         // Act
         IActionResult? result = await disputeController.GetDisputeAsync(1, CancellationToken.None);
@@ -119,12 +120,12 @@ public class DisputeControllerTest
         // Arrange
         Dispute dispute = new();
         dispute.Id = 1;
-        var oracleDataApi = new Mock<IOracleDataApi_v1_0Client>();
-        oracleDataApi
+        var disputeService = new Mock<IDisputeService>();
+        disputeService
             .Setup(_ => _.UpdateDisputeAsync(It.Is<int>(v => v == 1), It.IsAny<Dispute>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(dispute);
         var mockLogger = new Mock<ILogger<DisputeController>>();
-        DisputeController disputeController = new(oracleDataApi.Object, mockLogger.Object);
+        DisputeController disputeController = new(disputeService.Object, mockLogger.Object);
 
         // Act
         IActionResult? result = await disputeController.UpdateDisputeAsync(1, dispute, CancellationToken.None);
@@ -142,12 +143,12 @@ public class DisputeControllerTest
         // Arrange
         Dispute dispute = new();
         dispute.Id = 1;
-        var oracleDataApi = new Mock<IOracleDataApi_v1_0Client>();
-        oracleDataApi
+        var disputeService = new Mock<IDisputeService>();
+        disputeService
             .Setup(_ => _.UpdateDisputeAsync(It.Is<int>(v => v == 1), It.IsAny<Dispute>(), It.IsAny<CancellationToken>()))
             .Throws(new ApiException("msg", StatusCodes.Status400BadRequest, "rsp", null, null));
         var mockLogger = new Mock<ILogger<DisputeController>>();
-        DisputeController disputeController = new(oracleDataApi.Object, mockLogger.Object);
+        DisputeController disputeController = new(disputeService.Object, mockLogger.Object);
 
         // Act
         IActionResult? result = await disputeController.UpdateDisputeAsync(1, dispute, CancellationToken.None);
@@ -165,12 +166,12 @@ public class DisputeControllerTest
         // Arrange
         Dispute dispute = new();
         dispute.Id = 1;
-        var oracleDataApi = new Mock<IOracleDataApi_v1_0Client>();
-        oracleDataApi
+        var disputeService = new Mock<IDisputeService>();
+        disputeService
             .Setup(_ => _.UpdateDisputeAsync(It.Is<int>(v => v == 2), It.IsAny<Dispute>(), It.IsAny<CancellationToken>()))
             .Throws(new ApiException("msg", StatusCodes.Status404NotFound, "rsp", null, null));
         var mockLogger = new Mock<ILogger<DisputeController>>();
-        DisputeController disputeController = new(oracleDataApi.Object, mockLogger.Object);
+        DisputeController disputeController = new(disputeService.Object, mockLogger.Object);
 
         // Act
         IActionResult? result = await disputeController.UpdateDisputeAsync(2, dispute, CancellationToken.None);


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

[TCVP-1058](https://justice.gov.bc.ca/jira/browse/TCVP-1058)

Refactored DisputeController, moved usage of the oracleDataApi client into a service layer so that other operations can be done at the same time, ie email the client when submitting a dispute.  Business logic should exist in the Service layer, not the main Controller layer.

For now the DisputeService is just a wrapper for the oracleDataApi client, but we can use this class to add other functionality to the endpoint logic.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

dotnet test

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
