### PR TITLE
TCVP-1058 added staff-api endpoints for reject, cancel, and submit

### DIFF
--- a/src/backend/TrafficCourts/Staff.Service/Controllers/DisputeController.cs
+++ b/src/backend/TrafficCourts/Staff.Service/Controllers/DisputeController.cs
@@ -1,6 +1,7 @@
 ﻿using MediatR;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using System.ComponentModel.DataAnnotations;
 using System.Net;
 using TrafficCourts.Staff.Service.Authentication;
 using TrafficCourts.Staff.Service.OpenAPIs.OracleDataApi.v1_0;
@@ -49,7 +50,7 @@ public class DisputeController : ControllerBase
         catch (Exception e)
         {
             _logger.LogError("Error retrieving Disputes from oracle-data-api:", e);
-            return StatusCode(StatusCodes.Status500InternalServerError);
+            return new HttpError(StatusCodes.Status500InternalServerError, e.Message);
         }
     }
 
@@ -79,21 +80,21 @@ public class DisputeController : ControllerBase
         }
         catch (TrafficCourts.Staff.Service.OpenAPIs.OracleDataApi.v1_0.ApiException e) when (e.StatusCode == StatusCodes.Status400BadRequest)
         {
-            return BadRequest();
+            return new HttpError(e.StatusCode, e.Message);
         }
         catch (TrafficCourts.Staff.Service.OpenAPIs.OracleDataApi.v1_0.ApiException e) when (e.StatusCode == StatusCodes.Status404NotFound)
         {
-            return NotFound();
+            return new HttpError(e.StatusCode, e.Message);
         }
         catch (TrafficCourts.Staff.Service.OpenAPIs.OracleDataApi.v1_0.ApiException e)
         {
             _logger.LogError("Error retrieving Dispute from oracle-data-api:", e);
-            return StatusCode(StatusCodes.Status500InternalServerError);
+            return new HttpError(StatusCodes.Status500InternalServerError, e.Message);
         }
         catch (Exception e)
         {
             _logger.LogError("Error retrieving Dispute from oracle-data-api:", e);
-            return StatusCode(StatusCodes.Status500InternalServerError);
+            return new HttpError(StatusCodes.Status500InternalServerError, e.Message);
         }
     }
 
@@ -124,21 +125,172 @@ public class DisputeController : ControllerBase
         }
         catch (TrafficCourts.Staff.Service.OpenAPIs.OracleDataApi.v1_0.ApiException e) when (e.StatusCode == StatusCodes.Status400BadRequest)
         {
-            return BadRequest();
+            return new HttpError(e.StatusCode, e.Message);
         }
         catch (TrafficCourts.Staff.Service.OpenAPIs.OracleDataApi.v1_0.ApiException e) when (e.StatusCode == StatusCodes.Status404NotFound)
         {
-            return NotFound();
+            return new HttpError(e.StatusCode, e.Message);
         }
         catch (TrafficCourts.Staff.Service.OpenAPIs.OracleDataApi.v1_0.ApiException e)
         {
             _logger.LogError("Error retrieving Dispute from oracle-data-api:", e);
-            return StatusCode(StatusCodes.Status500InternalServerError);
+            return new HttpError(StatusCodes.Status500InternalServerError, e.Message);
         }
         catch (Exception e)
         {
             _logger.LogError("Error updating Dispute in oracle-data-api:", e);
-            return StatusCode(StatusCodes.Status500InternalServerError);
+            return new HttpError(StatusCodes.Status500InternalServerError, e.Message);
+        }
+    }
+
+    /// <summary>
+    /// Updates the status of a particular Dispute record to REJECTED.
+    /// </summary>
+    /// <param name="disputeId">Unique identifier for a specific Dispute record to cancel.</param>
+    /// <param name="rejectedReason">The reason or note (max 256 characters) the Dispute was cancelled.</param>
+    /// <param name="cancellationToken"></param>
+    /// <returns></returns>
+    /// <response code="200">The Dispute is updated.</response>
+    /// <response code="400">The request was not well formed. Check the parameters.</response>
+    /// <response code="404">Dispute record not found. Update failed.</response>
+    /// <response code="405">A Dispute status can only be set to REJECTED iff status is NEW, CANCELLED, or REJECTED and the rejected reason must be &lt;= 256 characters. Update failed.</response>
+    /// <response code="500">There was a server error that prevented the update from completing successfully.</response>
+    [HttpPut("/dispute/{disputeId}/reject")]
+    public async Task<IActionResult> RejectDisputeAsync(
+        int disputeId, 
+        [FromForm] 
+        [Required]
+        [StringLength(256, ErrorMessage = "Rejected reason cannot exceed 256 characters.")] string rejectedReason, 
+        CancellationToken cancellationToken)
+    {
+        _logger.LogDebug("Updating the Dispute status");
+
+        try
+        {
+            await _disputeService.RejectDisputeAsync(disputeId, rejectedReason, cancellationToken);
+            return Ok();
+        }
+        catch (TrafficCourts.Staff.Service.OpenAPIs.OracleDataApi.v1_0.ApiException e) when (e.StatusCode == StatusCodes.Status400BadRequest)
+        {
+            return new HttpError(e.StatusCode, e.Message);
+        }
+        catch (TrafficCourts.Staff.Service.OpenAPIs.OracleDataApi.v1_0.ApiException e) when (e.StatusCode == StatusCodes.Status404NotFound)
+        {
+            return new HttpError(e.StatusCode, e.Message);
+        }
+        catch (TrafficCourts.Staff.Service.OpenAPIs.OracleDataApi.v1_0.ApiException e) when (e.StatusCode == StatusCodes.Status405MethodNotAllowed)
+        {
+            return new HttpError(e.StatusCode, e.Message);
+        }
+        catch (TrafficCourts.Staff.Service.OpenAPIs.OracleDataApi.v1_0.ApiException e)
+        {
+            _logger.LogError("Error updating Dispute status:", e);
+            return new HttpError(StatusCodes.Status500InternalServerError, e.Message);
+        }
+        catch (Exception e)
+        {
+            _logger.LogError("Error updating Dispute status:", e);
+            return new HttpError(StatusCodes.Status500InternalServerError, e.Message);
+        }
+    }
+
+    /// <summary>
+    /// Updates the status of a particular Dispute record to CANCELLED.
+    /// </summary>
+    /// <param name="disputeId">Unique identifier for a specific Dispute record to cancel.</param>
+    /// <param name="cancellationToken"></param>
+    /// <returns></returns>
+    /// <response code="200">The Dispute is updated.</response>
+    /// <response code="400">The request was not well formed. Check the parameters.</response>
+    /// <response code="404">Dispute record not found. Update failed.</response>
+    /// <response code="405">A Dispute status can only be set to CANCELLED iff status is REJECTED or PROCESSING.Update failed.</response>
+    /// <response code="500">There was a server error that prevented the update from completing successfully.</response>
+    [HttpPut("/dispute/{disputeId}/cancel")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status405MethodNotAllowed)]
+    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+    public async Task<IActionResult> CancelDisputeAsync(int disputeId, CancellationToken cancellationToken)
+    {
+        _logger.LogDebug("Updating the Dispute status");
+
+        try
+        {
+            await _disputeService.CancelDisputeAsync(disputeId, cancellationToken);
+            return Ok();
+        }
+        catch (TrafficCourts.Staff.Service.OpenAPIs.OracleDataApi.v1_0.ApiException e) when (e.StatusCode == StatusCodes.Status400BadRequest)
+        {
+            return new HttpError(e.StatusCode, e.Message);
+        }
+        catch (TrafficCourts.Staff.Service.OpenAPIs.OracleDataApi.v1_0.ApiException e) when (e.StatusCode == StatusCodes.Status404NotFound)
+        {
+            return new HttpError(e.StatusCode, e.Message);
+        }
+        catch (TrafficCourts.Staff.Service.OpenAPIs.OracleDataApi.v1_0.ApiException e) when (e.StatusCode == StatusCodes.Status405MethodNotAllowed)
+        {
+            return new HttpError(e.StatusCode, e.Message);
+        }
+        catch (TrafficCourts.Staff.Service.OpenAPIs.OracleDataApi.v1_0.ApiException e)
+        {
+            _logger.LogError("Error updating Dispute status:", e);
+            return new HttpError(StatusCodes.Status500InternalServerError, e.Message);
+        }
+        catch (Exception e)
+        {
+            _logger.LogError("Error updating Dispute status:", e);
+            return new HttpError(StatusCodes.Status500InternalServerError, e.Message);
+        }
+    }
+
+    /// <summary>
+    /// Submits a Dispute record, setting it's status to PROCESSING
+    /// </summary>
+    /// <param name="disputeId">Unique identifier for a specific Dispute record to submit.</param>
+    /// <param name="cancellationToken"></param>
+    /// <returns></returns>
+    /// <response code="200">The Dispute is updated.</response>
+    /// <response code="400">The request was not well formed. Check the parameters.</response>
+    /// <response code="404">Dispute record not found. Update failed.</response>
+    /// <response code="405">A Dispute can only be submitted if the status is NEW or is already set to PROCESSING. Update failed.</response>
+    /// <response code="500">There was a server error that prevented the update from completing successfully.</response>
+    [HttpPut("/dispute/{disputeId}/submit")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status405MethodNotAllowed)]
+    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+    public async Task<IActionResult> SubmitDisputeAsync(int disputeId, CancellationToken cancellationToken)
+    {
+        _logger.LogDebug("Updating the Dispute status");
+
+        try
+        {
+            await _disputeService.SubmitDisputeAsync(disputeId, cancellationToken);
+            return Ok();
+        }
+        catch (TrafficCourts.Staff.Service.OpenAPIs.OracleDataApi.v1_0.ApiException e) when (e.StatusCode == StatusCodes.Status400BadRequest)
+        {
+            return new HttpError(e.StatusCode, e.Message);
+        }
+        catch (TrafficCourts.Staff.Service.OpenAPIs.OracleDataApi.v1_0.ApiException e) when (e.StatusCode == StatusCodes.Status404NotFound)
+        {
+            return new HttpError(e.StatusCode, e.Message);
+        }
+        catch (TrafficCourts.Staff.Service.OpenAPIs.OracleDataApi.v1_0.ApiException e) when (e.StatusCode == StatusCodes.Status405MethodNotAllowed)
+        {
+            return new HttpError(e.StatusCode, e.Message);
+        }
+        catch (TrafficCourts.Staff.Service.OpenAPIs.OracleDataApi.v1_0.ApiException e)
+        {
+            _logger.LogError("Error updating Dispute status:", e);
+            return new HttpError(StatusCodes.Status500InternalServerError, e.Message);
+        }
+        catch (Exception e)
+        {
+            _logger.LogError("Error updating Dispute status:", e);
+            return new HttpError(StatusCodes.Status500InternalServerError, e.Message);
         }
     }
 

--- a/src/backend/TrafficCourts/Staff.Service/Controllers/HttpError.cs
+++ b/src/backend/TrafficCourts/Staff.Service/Controllers/HttpError.cs
@@ -1,0 +1,25 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
+
+namespace TrafficCourts.Staff.Service.Controllers;
+
+/// <summary>
+/// A simple wrapper for a ProblemDetails return object
+/// </summary>
+public class HttpError : ObjectResult
+{
+    public HttpError(int status, string message) : base(null)
+    {
+        // Remove excess added to the message by the generated OpenAPI spec.
+        int index = message.IndexOf("\n\nStatus");
+        message = index > 0 ? message[..index] : message;
+
+        ProblemDetails problemDetails = new ();
+        problemDetails.Status = status;
+        problemDetails.Extensions.Add("errors", new List<string>() { message });
+
+        this.StatusCode = status;
+        this.Value = problemDetails;
+    }
+}

--- a/src/backend/TrafficCourts/Staff.Service/Program.cs
+++ b/src/backend/TrafficCourts/Staff.Service/Program.cs
@@ -8,6 +8,7 @@ using Serilog;
 using Serilog.Exceptions;
 using Serilog.Exceptions.Core;
 using System.Reflection;
+using System.Text.Json.Serialization;
 using TrafficCourts.Common.Configuration;
 using TrafficCourts.Staff.Service.Authentication;
 using TrafficCourts.Staff.Service.Logging;
@@ -27,7 +28,8 @@ builder.Host.UseSerilog((hostingContext, loggerConfiguration) => {
         .Enrich.WithExceptionDetails(new DestructuringOptionsBuilder().WithDefaultDestructurers());
 });
 
-builder.Services.AddControllers();
+// Render enums as strings rather than ints
+builder.Services.AddControllers().AddJsonOptions(options => options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter()));
 
 Authentication.Initialize(builder.Services, builder.Configuration);
 

--- a/src/backend/TrafficCourts/Staff.Service/Services/DisputeService.cs
+++ b/src/backend/TrafficCourts/Staff.Service/Services/DisputeService.cs
@@ -45,9 +45,24 @@ public class DisputeService : IDisputeService
         return await GetOracleDataApi().GetDisputeAsync(disputeId, cancellationToken);
     }
 
-    public async Task<Dispute> UpdateDisputeAsync(int id, Dispute dispute, System.Threading.CancellationToken cancellationToken)
+    public async Task<Dispute> UpdateDisputeAsync(int disputeId, Dispute dispute, System.Threading.CancellationToken cancellationToken)
     {
-        return await GetOracleDataApi().UpdateDisputeAsync(id, dispute, cancellationToken);
+        return await GetOracleDataApi().UpdateDisputeAsync(disputeId, dispute, cancellationToken);
+    }
+
+    public async Task CancelDisputeAsync(int disputeId, CancellationToken cancellationToken)
+    {
+        await GetOracleDataApi().CancelDisputeAsync(disputeId, cancellationToken);
+    }
+
+    public async Task RejectDisputeAsync(int disputeId, string rejectedReason, CancellationToken cancellationToken)
+    {
+        await GetOracleDataApi().RejectDisputeAsync(disputeId, rejectedReason, cancellationToken);
+    }
+
+    public async Task SubmitDisputeAsync(int disputeId, CancellationToken cancellationToken)
+    {
+        await GetOracleDataApi().SubmitDisputeAsync(disputeId, cancellationToken);
     }
 
     public async Task DeleteDisputeAsync(int disputeId, CancellationToken cancellationToken)

--- a/src/backend/TrafficCourts/Staff.Service/Services/IDisputeService.cs
+++ b/src/backend/TrafficCourts/Staff.Service/Services/IDisputeService.cs
@@ -32,6 +32,28 @@ public interface IDisputeService
     /// <exception cref="ApiException">A server side error occurred.</exception>
     Task<Dispute> UpdateDisputeAsync(int id, Dispute dispute, System.Threading.CancellationToken cancellationToken);
 
+    /// <summary>Updates the status of a particular Dispute record to CANCELLED.</summary>
+    /// <param name="id">Unique identifier of a Dispute record to cancel.</param>
+    /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+    /// <returns></returns>
+    /// <exception cref="ApiException">A server side error occurred.</exception>
+    Task CancelDisputeAsync(int id, CancellationToken cancellationToken);
+
+    /// <summary>Updates the status of a particular Dispute record to REJECTED.</summary>
+    /// <param name="id">Unique identifier of a Dispute record to cancel.</param>
+    /// <param name="rejectedReason">The reason or note (max 256 characters) for the rejection.</param>
+    /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+    /// <returns></returns>
+    /// <exception cref="ApiException">A server side error occurred.</exception>
+    Task RejectDisputeAsync(int id, string rejectedReason, CancellationToken cancellationToken);
+
+    /// <summary>Submits a Dispute, setting it's status to PROCESSING.</summary>
+    /// <param name="id">Unique identifier of a Dispute record to submit.</param>
+    /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+    /// <returns></returns>
+    /// <exception cref="ApiException">A server side error occurred.</exception>
+    Task SubmitDisputeAsync(int id, CancellationToken cancellationToken);
+
     /// <summary>An endpoint to delete a specific dispute in the database.</summary>
     /// <param name="id">Unique identifier of a Dispute record to delete.</param>
     /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>

--- a/src/backend/TrafficCourts/TrafficCourts.Staff.Service.Test/Controllers/DisputeControllerTest.cs
+++ b/src/backend/TrafficCourts/TrafficCourts.Staff.Service.Test/Controllers/DisputeControllerTest.cs
@@ -85,7 +85,7 @@ public class DisputeControllerTest
         IActionResult? result = await disputeController.GetDisputeAsync(1, CancellationToken.None);
 
         // Assert
-        var badRequestResult = Assert.IsType<BadRequestResult>(result);
+        var badRequestResult = Assert.IsType<HttpError>(result);
         Assert.Equal(StatusCodes.Status400BadRequest, badRequestResult.StatusCode);
     }
 
@@ -108,7 +108,7 @@ public class DisputeControllerTest
         IActionResult? result = await disputeController.GetDisputeAsync(1, CancellationToken.None);
 
         // Assert
-        var notFoundResult = Assert.IsType<NotFoundResult>(result);
+        var notFoundResult = Assert.IsType<HttpError>(result);
         Assert.Equal(StatusCodes.Status404NotFound, notFoundResult.StatusCode);
     }
     
@@ -154,7 +154,7 @@ public class DisputeControllerTest
         IActionResult? result = await disputeController.UpdateDisputeAsync(1, dispute, CancellationToken.None);
 
         // Assert
-        var badRequestResult = Assert.IsType<BadRequestResult>(result);
+        var badRequestResult = Assert.IsType<HttpError>(result);
         Assert.Equal(StatusCodes.Status400BadRequest, badRequestResult.StatusCode);
     }
 
@@ -177,7 +177,7 @@ public class DisputeControllerTest
         IActionResult? result = await disputeController.UpdateDisputeAsync(2, dispute, CancellationToken.None);
 
         // Assert
-        var notFoundResult = Assert.IsType<NotFoundResult>(result);
+        var notFoundResult = Assert.IsType<HttpError>(result);
         Assert.Equal(StatusCodes.Status404NotFound, notFoundResult.StatusCode);
     }
 }


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

[TCVP-1058](https://justice.gov.bc.ca/jira/browse/TCVP-1058)

Added PUT endpoints to the staff-api for **reject**, **cancel**, and **submit**.  These endpoints are simple wrappers for the oracle-data-api.
- enhanced error returns by using ProblemDetails instead. 

TODO: add xunit tests
TODO: more logic per the JIRA ticket to
- auto delete submissions after a year
- email citizen
- submit Dispute to ARC
- etc.

![image](https://user-images.githubusercontent.com/55215368/164801480-757c7a82-e35d-4e82-866a-306b3e92e2fd.png)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

dotnet test

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
