### PR TITLE
Feature tcvp 1281 - update oracle data api models to use guid

### DIFF
--- a/src/backend/TrafficCourts/Citizen.Service/Models/Dispute/TicketDispute.cs
+++ b/src/backend/TrafficCourts/Citizen.Service/Models/Dispute/TicketDispute.cs
@@ -15,6 +15,7 @@ namespace TrafficCourts.Citizen.Service.Models.Dispute
         public string Province { get; set; }
         public string PostalCode { get; set; }
         public string HomePhone { get; set; }
+        public string EmailAddress { get; set; }
         public string DriversLicence { get; set; }
         public string DriversLicenceProvince { get; set; }
         public string WorkPhone { get; set; }

--- a/src/backend/TrafficCourts/Messaging/MessageContracts/SubmitDispute.cs
+++ b/src/backend/TrafficCourts/Messaging/MessageContracts/SubmitDispute.cs
@@ -14,6 +14,7 @@ namespace TrafficCourts.Messaging.MessageContracts
         string Province { get; set; }
         string PostalCode { get; set; }
         string HomePhone { get; set; }
+        string EmailAddress { get; set; }
         string DriversLicence { get; set; }
         string DriversLicenceProvince { get; set; }
         string WorkPhone { get; set; }

--- a/src/backend/TrafficCourts/Staff.Service/Controllers/DisputeController.cs
+++ b/src/backend/TrafficCourts/Staff.Service/Controllers/DisputeController.cs
@@ -69,7 +69,7 @@ public class DisputeController : ControllerBase
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    public async Task<IActionResult> GetDisputeAsync(int disputeId, CancellationToken cancellationToken)
+    public async Task<IActionResult> GetDisputeAsync(Guid disputeId, CancellationToken cancellationToken)
     {
         _logger.LogDebug("Retrieving Dispute from oracle-data-api");
 
@@ -114,7 +114,7 @@ public class DisputeController : ControllerBase
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    public async Task<IActionResult> UpdateDisputeAsync(int disputeId, Dispute dispute, CancellationToken cancellationToken)
+    public async Task<IActionResult> UpdateDisputeAsync(Guid disputeId, Dispute dispute, CancellationToken cancellationToken)
     {
         _logger.LogDebug("Updating the Dispute in oracle-data-api");
 
@@ -157,7 +157,7 @@ public class DisputeController : ControllerBase
     /// <response code="500">There was a server error that prevented the update from completing successfully.</response>
     [HttpPut("/dispute/{disputeId}/reject")]
     public async Task<IActionResult> RejectDisputeAsync(
-        int disputeId, 
+        Guid disputeId, 
         [FromForm] 
         [Required]
         [StringLength(256, ErrorMessage = "Rejected reason cannot exceed 256 characters.")] string rejectedReason, 
@@ -211,7 +211,7 @@ public class DisputeController : ControllerBase
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [ProducesResponseType(StatusCodes.Status405MethodNotAllowed)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    public async Task<IActionResult> CancelDisputeAsync(int disputeId, CancellationToken cancellationToken)
+    public async Task<IActionResult> CancelDisputeAsync(Guid disputeId, CancellationToken cancellationToken)
     {
         _logger.LogDebug("Updating the Dispute status");
 
@@ -261,7 +261,7 @@ public class DisputeController : ControllerBase
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [ProducesResponseType(StatusCodes.Status405MethodNotAllowed)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    public async Task<IActionResult> SubmitDisputeAsync(int disputeId, CancellationToken cancellationToken)
+    public async Task<IActionResult> SubmitDisputeAsync(Guid disputeId, CancellationToken cancellationToken)
     {
         _logger.LogDebug("Updating the Dispute status");
 

--- a/src/backend/TrafficCourts/Staff.Service/OpenAPIs/OracleDataAPI/v1_0/OracleDataApi.v1_0.json
+++ b/src/backend/TrafficCourts/Staff.Service/OpenAPIs/OracleDataAPI/v1_0/OracleDataApi.v1_0.json
@@ -21,8 +21,8 @@
             "in": "path",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string",
+              "format": "uuid"
             }
           }
         ],
@@ -31,12 +31,12 @@
             "description": "Method Not Allowed",
             "content": { "*/*": { "schema": { "type": "object" } } }
           },
-          "404": {
-            "description": "Not Found",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
           "400": {
             "description": "Bad Request",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "404": {
+            "description": "Not Found",
             "content": { "*/*": { "schema": { "type": "object" } } }
           },
           "200": {
@@ -55,8 +55,8 @@
             "in": "path",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string",
+              "format": "uuid"
             }
           }
         ],
@@ -69,12 +69,12 @@
             "description": "Method Not Allowed",
             "content": { "*/*": { "schema": { "type": "object" } } }
           },
-          "404": {
-            "description": "Dispute record not found. Update failed.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
           "400": {
             "description": "Bad Request.",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "404": {
+            "description": "Dispute record not found. Update failed.",
             "content": { "*/*": { "schema": { "type": "object" } } }
           },
           "200": {
@@ -92,8 +92,8 @@
             "in": "path",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string",
+              "format": "uuid"
             }
           }
         ],
@@ -102,12 +102,12 @@
             "description": "Method Not Allowed",
             "content": { "*/*": { "schema": { "type": "object" } } }
           },
-          "404": {
-            "description": "Not Found",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
           "400": {
             "description": "Bad Request",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "404": {
+            "description": "Not Found",
             "content": { "*/*": { "schema": { "type": "object" } } }
           },
           "200": { "description": "OK" }
@@ -125,8 +125,8 @@
             "in": "path",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string",
+              "format": "uuid"
             }
           }
         ],
@@ -135,12 +135,12 @@
             "description": "A Dispute status can only be set to PROCESSING iff status is NEW or PROCESSING. Update failed.",
             "content": { "*/*": { "schema": { "type": "object" } } }
           },
-          "404": {
-            "description": "Dispute record not found. Update failed.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
           "400": {
             "description": "Bad Request.",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "404": {
+            "description": "Dispute record not found. Update failed.",
             "content": { "*/*": { "schema": { "type": "object" } } }
           },
           "200": {
@@ -161,8 +161,8 @@
             "in": "path",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string",
+              "format": "uuid"
             }
           }
         ],
@@ -183,12 +183,12 @@
             "description": "A Dispute status can only be set to REJECTED iff status is NEW, CANCELLED, or REJECTED and the rejected reason must be <= 256 characters. Update failed.",
             "content": { "*/*": { "schema": { "type": "object" } } }
           },
-          "404": {
-            "description": "Dispute record not found. Update failed.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
           "400": {
             "description": "Bad Request.",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "404": {
+            "description": "Dispute record not found. Update failed.",
             "content": { "*/*": { "schema": { "type": "object" } } }
           },
           "200": {
@@ -209,8 +209,8 @@
             "in": "path",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string",
+              "format": "uuid"
             }
           }
         ],
@@ -219,12 +219,12 @@
             "description": "A Dispute status can only be set to CANCELLED iff status is REJECTED or PROCESSING. Update failed.",
             "content": { "*/*": { "schema": { "type": "object" } } }
           },
-          "404": {
-            "description": "Dispute record not found. Update failed.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
           "400": {
             "description": "Bad Request.",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "404": {
+            "description": "Dispute record not found. Update failed.",
             "content": { "*/*": { "schema": { "type": "object" } } }
           },
           "200": {
@@ -247,12 +247,12 @@
             "description": "Method Not Allowed",
             "content": { "*/*": { "schema": { "type": "object" } } }
           },
-          "404": {
-            "description": "Not Found",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
           "400": {
             "description": "Bad Request",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "404": {
+            "description": "Not Found",
             "content": { "*/*": { "schema": { "type": "object" } } }
           },
           "200": {
@@ -260,8 +260,8 @@
             "content": {
               "*/*": {
                 "schema": {
-                  "type": "integer",
-                  "format": "int32"
+                  "type": "string",
+                  "format": "uuid"
                 }
               }
             }
@@ -278,12 +278,12 @@
             "description": "Method Not Allowed",
             "content": { "*/*": { "schema": { "type": "object" } } }
           },
-          "404": {
-            "description": "Not Found",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
           "400": {
             "description": "Bad Request",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "404": {
+            "description": "Not Found",
             "content": { "*/*": { "schema": { "type": "object" } } }
           },
           "200": {
@@ -311,12 +311,12 @@
             "description": "Method Not Allowed",
             "content": { "*/*": { "schema": { "type": "object" } } }
           },
-          "404": {
-            "description": "Not Found",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
           "400": {
             "description": "Bad Request",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "404": {
+            "description": "Not Found",
             "content": { "*/*": { "schema": { "type": "object" } } }
           },
           "200": { "description": "OK" }
@@ -330,9 +330,9 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "integer",
+            "type": "string",
             "description": "ID",
-            "format": "int32",
+            "format": "uuid",
             "readOnly": true
           },
           "status": {
@@ -387,9 +387,9 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "integer",
+            "type": "string",
             "description": "ID",
-            "format": "int32",
+            "format": "uuid",
             "readOnly": true
           },
           "offenceDeclaration": { "type": "string" },

--- a/src/backend/TrafficCourts/Staff.Service/OpenAPIs/OracleDataAPI/v1_0/OracleDataApi.v1_0.json
+++ b/src/backend/TrafficCourts/Staff.Service/OpenAPIs/OracleDataAPI/v1_0/OracleDataApi.v1_0.json
@@ -27,16 +27,16 @@
           }
         ],
         "responses": {
+          "404": {
+            "description": "Not Found",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
           "405": {
             "description": "Method Not Allowed",
             "content": { "*/*": { "schema": { "type": "object" } } }
           },
           "400": {
             "description": "Bad Request",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "404": {
-            "description": "Not Found",
             "content": { "*/*": { "schema": { "type": "object" } } }
           },
           "200": {
@@ -65,16 +65,16 @@
           "required": true
         },
         "responses": {
+          "404": {
+            "description": "Dispute record not found. Update failed.",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
           "405": {
             "description": "Method Not Allowed",
             "content": { "*/*": { "schema": { "type": "object" } } }
           },
           "400": {
             "description": "Bad Request.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "404": {
-            "description": "Dispute record not found. Update failed.",
             "content": { "*/*": { "schema": { "type": "object" } } }
           },
           "200": {
@@ -98,16 +98,16 @@
           }
         ],
         "responses": {
+          "404": {
+            "description": "Not Found",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
           "405": {
             "description": "Method Not Allowed",
             "content": { "*/*": { "schema": { "type": "object" } } }
           },
           "400": {
             "description": "Bad Request",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "404": {
-            "description": "Not Found",
             "content": { "*/*": { "schema": { "type": "object" } } }
           },
           "200": { "description": "OK" }
@@ -131,16 +131,16 @@
           }
         ],
         "responses": {
+          "404": {
+            "description": "Dispute record not found. Update failed.",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
           "405": {
             "description": "A Dispute status can only be set to PROCESSING iff status is NEW or PROCESSING. Update failed.",
             "content": { "*/*": { "schema": { "type": "object" } } }
           },
           "400": {
             "description": "Bad Request.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "404": {
-            "description": "Dispute record not found. Update failed.",
             "content": { "*/*": { "schema": { "type": "object" } } }
           },
           "200": {
@@ -179,16 +179,16 @@
           "required": true
         },
         "responses": {
+          "404": {
+            "description": "Dispute record not found. Update failed.",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
           "405": {
             "description": "A Dispute status can only be set to REJECTED iff status is NEW, CANCELLED, or REJECTED and the rejected reason must be <= 256 characters. Update failed.",
             "content": { "*/*": { "schema": { "type": "object" } } }
           },
           "400": {
             "description": "Bad Request.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "404": {
-            "description": "Dispute record not found. Update failed.",
             "content": { "*/*": { "schema": { "type": "object" } } }
           },
           "200": {
@@ -215,16 +215,16 @@
           }
         ],
         "responses": {
+          "404": {
+            "description": "Dispute record not found. Update failed.",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
           "405": {
             "description": "A Dispute status can only be set to CANCELLED iff status is REJECTED or PROCESSING. Update failed.",
             "content": { "*/*": { "schema": { "type": "object" } } }
           },
           "400": {
             "description": "Bad Request.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "404": {
-            "description": "Dispute record not found. Update failed.",
             "content": { "*/*": { "schema": { "type": "object" } } }
           },
           "200": {
@@ -243,16 +243,16 @@
           "required": true
         },
         "responses": {
+          "404": {
+            "description": "Not Found",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
           "405": {
             "description": "Method Not Allowed",
             "content": { "*/*": { "schema": { "type": "object" } } }
           },
           "400": {
             "description": "Bad Request",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "404": {
-            "description": "Not Found",
             "content": { "*/*": { "schema": { "type": "object" } } }
           },
           "200": {
@@ -274,16 +274,16 @@
         "tags": [ "dispute-controller" ],
         "operationId": "getAllDisputes",
         "responses": {
+          "404": {
+            "description": "Not Found",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
           "405": {
             "description": "Method Not Allowed",
             "content": { "*/*": { "schema": { "type": "object" } } }
           },
           "400": {
             "description": "Bad Request",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "404": {
-            "description": "Not Found",
             "content": { "*/*": { "schema": { "type": "object" } } }
           },
           "200": {
@@ -307,16 +307,16 @@
         "description": "The codetables in redis are cached copies of data pulled from Oracle to ensure TCO remains stable. This data is periodically refreshed, but can be forced by hitting this endpoint.",
         "operationId": "codeTableRefresh",
         "responses": {
+          "404": {
+            "description": "Not Found",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
           "405": {
             "description": "Method Not Allowed",
             "content": { "*/*": { "schema": { "type": "object" } } }
           },
           "400": {
             "description": "Bad Request",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "404": {
-            "description": "Not Found",
             "content": { "*/*": { "schema": { "type": "object" } } }
           },
           "200": { "description": "OK" }
@@ -351,6 +351,7 @@
           "province": { "type": "string" },
           "postalCode": { "type": "string" },
           "homePhone": { "type": "string" },
+          "emailAddress": { "type": "string" },
           "driversLicense": { "type": "string" },
           "driversLicenseProvince": { "type": "string" },
           "workPhone": { "type": "string" },

--- a/src/backend/TrafficCourts/Staff.Service/Services/DisputeService.cs
+++ b/src/backend/TrafficCourts/Staff.Service/Services/DisputeService.cs
@@ -34,40 +34,40 @@ public class DisputeService : IDisputeService
         return await GetOracleDataApi().GetAllDisputesAsync(cancellationToken);
     }
 
-    public async Task<int> SaveDisputeAsync(Dispute dispute, CancellationToken cancellationToken)
+    public async Task<Guid> SaveDisputeAsync(Dispute dispute, CancellationToken cancellationToken)
     {
         return await GetOracleDataApi().SaveDisputeAsync(dispute, cancellationToken);
     }
 
-    public async Task<Dispute> GetDisputeAsync(int disputeId, CancellationToken cancellationToken)
+    public async Task<Dispute> GetDisputeAsync(Guid disputeId, CancellationToken cancellationToken)
     {
         return await GetOracleDataApi().GetDisputeAsync(disputeId, cancellationToken);
     }
 
-    public async Task<Dispute> UpdateDisputeAsync(int disputeId, Dispute dispute, System.Threading.CancellationToken cancellationToken)
+    public async Task<Dispute> UpdateDisputeAsync(Guid disputeId, Dispute dispute, System.Threading.CancellationToken cancellationToken)
     {
         return await GetOracleDataApi().UpdateDisputeAsync(disputeId, dispute, cancellationToken);
     }
 
-    public async Task CancelDisputeAsync(int disputeId, CancellationToken cancellationToken)
+    public async Task CancelDisputeAsync(Guid disputeId, CancellationToken cancellationToken)
     {
         Dispute dispute = await GetOracleDataApi().CancelDisputeAsync(disputeId, cancellationToken);
         // TODO: push dispute to RabbitMQ message queue to be consumed by the email notification worker and ARC worker
     }
 
-    public async Task RejectDisputeAsync(int disputeId, string rejectedReason, CancellationToken cancellationToken)
+    public async Task RejectDisputeAsync(Guid disputeId, string rejectedReason, CancellationToken cancellationToken)
     {
         Dispute dispute = await GetOracleDataApi().RejectDisputeAsync(disputeId, rejectedReason, cancellationToken);
         // TODO: push dispute to RabbitMQ message queue to be consumed by the email notification worker
     }
 
-    public async Task SubmitDisputeAsync(int disputeId, CancellationToken cancellationToken)
+    public async Task SubmitDisputeAsync(Guid disputeId, CancellationToken cancellationToken)
     {
         Dispute dispute = await GetOracleDataApi().SubmitDisputeAsync(disputeId, cancellationToken);
         // TODO: push dispute to RabbitMQ message queue to be consumed by the email notification worker and ARC worker
     }
 
-    public async Task DeleteDisputeAsync(int disputeId, CancellationToken cancellationToken)
+    public async Task DeleteDisputeAsync(Guid disputeId, CancellationToken cancellationToken)
     {
         await GetOracleDataApi().DeleteDisputeAsync(disputeId, cancellationToken);
     }

--- a/src/backend/TrafficCourts/Staff.Service/Services/IDisputeService.cs
+++ b/src/backend/TrafficCourts/Staff.Service/Services/IDisputeService.cs
@@ -15,14 +15,14 @@ public interface IDisputeService
     /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
     /// <returns>The identifier of the saved Dispute record.</returns>
     /// <exception cref="ApiException">A server side error occurred.</exception>
-    Task<int> SaveDisputeAsync(Dispute dispute, CancellationToken cancellationToken);
+    Task<Guid> SaveDisputeAsync(Dispute dispute, CancellationToken cancellationToken);
 
     /// <summary>Returns a specific dispute from the database.</summary>
     /// <param name="id">Unique identifier of a Dispute record.</param>
     /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
     /// <returns>OK</returns>
     /// <exception cref="ApiException">A server side error occurred.</exception>
-    Task<Dispute> GetDisputeAsync(int id, CancellationToken cancellationToken);
+    Task<Dispute> GetDisputeAsync(Guid id, CancellationToken cancellationToken);
 
     /// <summary>Updates the properties of a particular Dispute record based on the given values.</summary>
     /// <param name="id">Unique identifier of a Dispute record to modify.</param>
@@ -30,14 +30,14 @@ public interface IDisputeService
     /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
     /// <returns>The modified Dispute record.</returns>
     /// <exception cref="ApiException">A server side error occurred.</exception>
-    Task<Dispute> UpdateDisputeAsync(int id, Dispute dispute, System.Threading.CancellationToken cancellationToken);
+    Task<Dispute> UpdateDisputeAsync(Guid id, Dispute dispute, System.Threading.CancellationToken cancellationToken);
 
     /// <summary>Updates the status of a particular Dispute record to CANCELLED.</summary>
     /// <param name="id">Unique identifier of a Dispute record to cancel.</param>
     /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
     /// <returns></returns>
     /// <exception cref="ApiException">A server side error occurred.</exception>
-    Task CancelDisputeAsync(int id, CancellationToken cancellationToken);
+    Task CancelDisputeAsync(Guid id, CancellationToken cancellationToken);
 
     /// <summary>Updates the status of a particular Dispute record to REJECTED.</summary>
     /// <param name="id">Unique identifier of a Dispute record to cancel.</param>
@@ -45,19 +45,19 @@ public interface IDisputeService
     /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
     /// <returns></returns>
     /// <exception cref="ApiException">A server side error occurred.</exception>
-    Task RejectDisputeAsync(int id, string rejectedReason, CancellationToken cancellationToken);
+    Task RejectDisputeAsync(Guid id, string rejectedReason, CancellationToken cancellationToken);
 
     /// <summary>Submits a Dispute, setting it's status to PROCESSING.</summary>
     /// <param name="id">Unique identifier of a Dispute record to submit.</param>
     /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
     /// <returns></returns>
     /// <exception cref="ApiException">A server side error occurred.</exception>
-    Task SubmitDisputeAsync(int id, CancellationToken cancellationToken);
+    Task SubmitDisputeAsync(Guid id, CancellationToken cancellationToken);
 
     /// <summary>An endpoint to delete a specific dispute in the database.</summary>
     /// <param name="id">Unique identifier of a Dispute record to delete.</param>
     /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
     /// <returns></returns>
     /// <exception cref="ApiException">A server side error occurred.</exception>
-    Task DeleteDisputeAsync(int id, CancellationToken cancellationToken);
+    Task DeleteDisputeAsync(Guid id, CancellationToken cancellationToken);
 }

--- a/src/backend/TrafficCourts/TrafficCourts.Staff.Service.Test/Controllers/DisputeControllerTest.cs
+++ b/src/backend/TrafficCourts/TrafficCourts.Staff.Service.Test/Controllers/DisputeControllerTest.cs
@@ -21,13 +21,10 @@ public class DisputeControllerTest
         // Mock the IDisputeService to return a couple Disputes, confirm controller returns them.
 
         // Arrange
-        Guid id = Guid.NewGuid();
         Dispute dispute1 = new();
         dispute1.Id = Guid.NewGuid();
         Dispute dispute2 = new();
         dispute2.Id = Guid.NewGuid();
-        Dispute dispute2 = new();
-        dispute2.Id = id;
         List<Dispute> disputes = new() { dispute1, dispute2 };
         var disputeService = new Mock<IDisputeService>();
         disputeService

--- a/src/backend/TrafficCourts/TrafficCourts.Staff.Service.Test/Controllers/DisputeControllerTest.cs
+++ b/src/backend/TrafficCourts/TrafficCourts.Staff.Service.Test/Controllers/DisputeControllerTest.cs
@@ -2,6 +2,7 @@
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using Moq;
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using TrafficCourts.Staff.Service.Controllers;
@@ -20,10 +21,11 @@ public class DisputeControllerTest
         // Mock the IDisputeService to return a couple Disputes, confirm controller returns them.
 
         // Arrange
+        Guid id = Guid.NewGuid();
         Dispute dispute1 = new();
-        dispute1.Id = 1;
+        dispute1.Id = id;
         Dispute dispute2 = new();
-        dispute2.Id = 1;
+        dispute2.Id = id;
         List<Dispute> disputes = new() { dispute1, dispute2 };
         var disputeService = new Mock<IDisputeService>();
         disputeService
@@ -50,16 +52,17 @@ public class DisputeControllerTest
 
         // Arrange
         Dispute dispute = new();
-        dispute.Id = 1;
+        Guid id = Guid.NewGuid();
+        dispute.Id = id;
         var disputeService = new Mock<IDisputeService>();
         disputeService
-            .Setup(_ => _.GetDisputeAsync(It.Is<int>(v => v == 1), It.IsAny<CancellationToken>()))
+            .Setup(_ => _.GetDisputeAsync(It.Is<Guid>(v => v == id), It.IsAny<CancellationToken>()))
             .ReturnsAsync(dispute);
         var mockLogger = new Mock<ILogger<DisputeController>>();
         DisputeController disputeController = new (disputeService.Object, mockLogger.Object);
 
         // Act
-        IActionResult? result = await disputeController.GetDisputeAsync(1, CancellationToken.None);
+        IActionResult? result = await disputeController.GetDisputeAsync(id, CancellationToken.None);
 
         // Assert
         var okResult = Assert.IsType<OkObjectResult>(result);
@@ -73,16 +76,17 @@ public class DisputeControllerTest
 
         // Arrange
         Dispute dispute = new();
-        dispute.Id = 1;
+        Guid id = Guid.NewGuid();
+        dispute.Id = id;
         var disputeService = new Mock<IDisputeService>();
         disputeService
-            .Setup(_ => _.GetDisputeAsync(It.Is<int>(v => v == 1), It.IsAny<CancellationToken>()))
+            .Setup(_ => _.GetDisputeAsync(It.Is<Guid>(v => v == id), It.IsAny<CancellationToken>()))
             .Throws(new ApiException("msg", StatusCodes.Status400BadRequest, "rsp", null, null));
         var mockLogger = new Mock<ILogger<DisputeController>>();
         DisputeController disputeController = new(disputeService.Object, mockLogger.Object);
 
         // Act
-        IActionResult? result = await disputeController.GetDisputeAsync(1, CancellationToken.None);
+        IActionResult? result = await disputeController.GetDisputeAsync(id, CancellationToken.None);
 
         // Assert
         var badRequestResult = Assert.IsType<HttpError>(result);
@@ -96,16 +100,17 @@ public class DisputeControllerTest
 
         // Arrange
         Dispute dispute = new();
-        dispute.Id = 1;
+        Guid id = Guid.NewGuid();
+        dispute.Id = id;
         var disputeService = new Mock<IDisputeService>();
         disputeService
-            .Setup(_ => _.GetDisputeAsync(It.Is<int>(v => v == 1), It.IsAny<CancellationToken>()))
+            .Setup(_ => _.GetDisputeAsync(It.Is<Guid>(v => v == id), It.IsAny<CancellationToken>()))
             .Throws(new ApiException("msg", StatusCodes.Status404NotFound, "rsp", null, null));
         var mockLogger = new Mock<ILogger<DisputeController>>();
         DisputeController disputeController = new(disputeService.Object, mockLogger.Object);
 
         // Act
-        IActionResult? result = await disputeController.GetDisputeAsync(1, CancellationToken.None);
+        IActionResult? result = await disputeController.GetDisputeAsync(id, CancellationToken.None);
 
         // Assert
         var notFoundResult = Assert.IsType<HttpError>(result);
@@ -119,16 +124,17 @@ public class DisputeControllerTest
 
         // Arrange
         Dispute dispute = new();
-        dispute.Id = 1;
+        Guid id = Guid.NewGuid();
+        dispute.Id = id;
         var disputeService = new Mock<IDisputeService>();
         disputeService
-            .Setup(_ => _.UpdateDisputeAsync(It.Is<int>(v => v == 1), It.IsAny<Dispute>(), It.IsAny<CancellationToken>()))
+            .Setup(_ => _.UpdateDisputeAsync(It.Is<Guid>(v => v == id), It.IsAny<Dispute>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(dispute);
         var mockLogger = new Mock<ILogger<DisputeController>>();
         DisputeController disputeController = new(disputeService.Object, mockLogger.Object);
 
         // Act
-        IActionResult? result = await disputeController.UpdateDisputeAsync(1, dispute, CancellationToken.None);
+        IActionResult? result = await disputeController.UpdateDisputeAsync(id, dispute, CancellationToken.None);
 
         // Assert
         var okResult = Assert.IsType<OkObjectResult>(result);
@@ -142,16 +148,17 @@ public class DisputeControllerTest
 
         // Arrange
         Dispute dispute = new();
-        dispute.Id = 1;
+        Guid id = Guid.NewGuid();
+        dispute.Id = id;
         var disputeService = new Mock<IDisputeService>();
         disputeService
-            .Setup(_ => _.UpdateDisputeAsync(It.Is<int>(v => v == 1), It.IsAny<Dispute>(), It.IsAny<CancellationToken>()))
+            .Setup(_ => _.UpdateDisputeAsync(It.Is<Guid>(v => v == id), It.IsAny<Dispute>(), It.IsAny<CancellationToken>()))
             .Throws(new ApiException("msg", StatusCodes.Status400BadRequest, "rsp", null, null));
         var mockLogger = new Mock<ILogger<DisputeController>>();
         DisputeController disputeController = new(disputeService.Object, mockLogger.Object);
 
         // Act
-        IActionResult? result = await disputeController.UpdateDisputeAsync(1, dispute, CancellationToken.None);
+        IActionResult? result = await disputeController.UpdateDisputeAsync(id, dispute, CancellationToken.None);
 
         // Assert
         var badRequestResult = Assert.IsType<HttpError>(result);
@@ -165,16 +172,18 @@ public class DisputeControllerTest
 
         // Arrange
         Dispute dispute = new();
-        dispute.Id = 1;
+        Guid id = Guid.NewGuid();
+        dispute.Id = id;
         var disputeService = new Mock<IDisputeService>();
+        Guid updatedId = Guid.NewGuid();
         disputeService
-            .Setup(_ => _.UpdateDisputeAsync(It.Is<int>(v => v == 2), It.IsAny<Dispute>(), It.IsAny<CancellationToken>()))
+            .Setup(_ => _.UpdateDisputeAsync(It.Is<Guid>(v => v == updatedId), It.IsAny<Dispute>(), It.IsAny<CancellationToken>()))
             .Throws(new ApiException("msg", StatusCodes.Status404NotFound, "rsp", null, null));
         var mockLogger = new Mock<ILogger<DisputeController>>();
         DisputeController disputeController = new(disputeService.Object, mockLogger.Object);
 
         // Act
-        IActionResult? result = await disputeController.UpdateDisputeAsync(2, dispute, CancellationToken.None);
+        IActionResult? result = await disputeController.UpdateDisputeAsync(updatedId, dispute, CancellationToken.None);
 
         // Assert
         var notFoundResult = Assert.IsType<HttpError>(result);

--- a/src/backend/TrafficCourts/TrafficCourts.Staff.Service.Test/Controllers/DisputeControllerTest.cs
+++ b/src/backend/TrafficCourts/TrafficCourts.Staff.Service.Test/Controllers/DisputeControllerTest.cs
@@ -23,7 +23,9 @@ public class DisputeControllerTest
         // Arrange
         Guid id = Guid.NewGuid();
         Dispute dispute1 = new();
-        dispute1.Id = id;
+        dispute1.Id = Guid.NewGuid();
+        Dispute dispute2 = new();
+        dispute2.Id = Guid.NewGuid();
         Dispute dispute2 = new();
         dispute2.Id = id;
         List<Dispute> disputes = new() { dispute1, dispute2 };

--- a/src/backend/TrafficCourts/Workflow.Service/Consumers/SubmitDisputeConsumer.cs
+++ b/src/backend/TrafficCourts/Workflow.Service/Consumers/SubmitDisputeConsumer.cs
@@ -53,6 +53,7 @@ namespace TrafficCourts.Workflow.Service.Consumers
                     DriversLicence = context.Message.DriversLicence,
                     DriversLicenceProvince = context.Message.DriversLicenceProvince,
                     WorkPhone = context.Message.WorkPhone,
+                    EmailAddress = context.Message.EmailAddress,
                     DateOfBirth = context.Message.DateOfBirth.ToDateTime(TimeOnly.MinValue),// Parsing it back to DateTime due to the DateOnly deserialization issues on oracle-data-api
                     EnforcementOrganization = context.Message.EnforcementOrganization,
                     ServiceDate = context.Message.ServiceDate.ToDateTime(TimeOnly.MinValue),// Parsing it back to DateTime due to the DateOnly deserialization issues on oracle-data-api

--- a/src/backend/TrafficCourts/Workflow.Service/Models/Dispute.cs
+++ b/src/backend/TrafficCourts/Workflow.Service/Models/Dispute.cs
@@ -18,6 +18,7 @@ namespace TrafficCourts.Workflow.Service.Models
         public string DriversLicence { get; set; } = null!;
         public string DriversLicenceProvince { get; set; } = null!;
         public string WorkPhone { get; set; } = null!;
+        public string EmailAddress { get; set; } = null!;
         public DateTime DateOfBirth { get; set; }
         public string EnforcementOrganization { get; set; } = null!;
         public DateTime ServiceDate { get; set; }

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/controller/v1_0/DisputeController.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/controller/v1_0/DisputeController.java
@@ -2,6 +2,7 @@ package ca.bc.gov.open.jag.tco.oracledataapi.controller.v1_0;
 
 import java.util.Date;
 import java.util.List;
+import java.util.UUID;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotBlank;
@@ -59,7 +60,7 @@ public class DisputeController {
 	 * @return {@link Dispute}
 	 */
 	@GetMapping("/dispute/{id}")
-	public Dispute getDispute(@PathVariable Integer id) {
+	public Dispute getDispute(@PathVariable UUID id) {
 		return disputeService.getDisputeById(id);
 	}
 
@@ -69,7 +70,7 @@ public class DisputeController {
 	 * @param id of the {@link Dispute} to be deleted
 	 */
 	@DeleteMapping("/dispute/{id}")
-	public void deleteDispute(@PathVariable Integer id) {
+	public void deleteDispute(@PathVariable UUID id) {
 		disputeService.delete(id);
 	}
 
@@ -80,7 +81,7 @@ public class DisputeController {
 	 * @return id of the saved {@link Dispute}
 	 */
 	@PostMapping("/dispute")
-	public Integer saveDispute(@RequestBody Dispute dispute) {
+	public UUID saveDispute(@RequestBody Dispute dispute) {
 		disputeService.save(dispute);
 		return dispute.getId();
 	}
@@ -101,7 +102,7 @@ public class DisputeController {
 		@ApiResponse(responseCode = "405", description = "A Dispute status can only be set to REJECTED iff status is NEW, CANCELLED, or REJECTED and the rejected reason must be <= 256 characters. Update failed.")
 	})
 	@PutMapping("/dispute/{id}/reject")
-	public Dispute rejectDispute(@PathVariable Integer id, @Valid @RequestBody @NotBlank @Size(min=1, max=256) String rejectedReason) {
+	public Dispute rejectDispute(@PathVariable UUID id, @Valid @RequestBody @NotBlank @Size(min=1, max=256) String rejectedReason) {
 		return disputeService.setStatus(id, DisputeStatus.REJECTED, rejectedReason);
 	}
 
@@ -120,7 +121,7 @@ public class DisputeController {
 		@ApiResponse(responseCode = "405", description = "A Dispute status can only be set to CANCELLED iff status is REJECTED or PROCESSING. Update failed.")
 	})
 	@PutMapping("/dispute/{id}/cancel")
-	public Dispute cancelDispute(@PathVariable Integer id) {
+	public Dispute cancelDispute(@PathVariable UUID id) {
 		return disputeService.setStatus(id, DisputeStatus.CANCELLED);
 	}
 
@@ -139,7 +140,7 @@ public class DisputeController {
 		@ApiResponse(responseCode = "405", description = "A Dispute status can only be set to PROCESSING iff status is NEW or PROCESSING. Update failed.")
 	})
 	@PutMapping("/dispute/{id}/submit")
-	public Dispute submitDispute(@PathVariable Integer id) {
+	public Dispute submitDispute(@PathVariable UUID id) {
 		return disputeService.setStatus(id, DisputeStatus.PROCESSING);
 	}
 
@@ -157,7 +158,7 @@ public class DisputeController {
 		@ApiResponse(responseCode = "404", description = "Dispute record not found. Update failed.")
 	})
 	@PutMapping("/dispute/{id}")
-	public Dispute updateDispute(@PathVariable Integer id, @RequestBody Dispute dispute) {
+	public Dispute updateDispute(@PathVariable UUID id, @RequestBody Dispute dispute) {
 		return disputeService.update(id, dispute);
 	}
 

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/model/Dispute.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/model/Dispute.java
@@ -3,6 +3,7 @@ package ca.bc.gov.open.jag.tco.oracledataapi.model;
 import java.sql.Date;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
@@ -35,8 +36,8 @@ public class Dispute {
 
 	@Schema(description = "ID", accessMode = Schema.AccessMode.READ_ONLY)
     @Id
-    @GeneratedValue (strategy = GenerationType.IDENTITY)
-    private Integer id;
+    @GeneratedValue
+    private UUID id;
 
     @Enumerated(EnumType.STRING)
     private DisputeStatus status;

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/model/Dispute.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/model/Dispute.java
@@ -12,11 +12,11 @@ import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
 import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.OneToMany;
 import javax.persistence.Table;
+import javax.validation.constraints.Email;
 
 import com.fasterxml.jackson.annotation.JsonManagedReference;
 
@@ -68,6 +68,10 @@ public class Dispute {
 
     @Column
     private String homePhone;
+    
+    @Column
+    @Email(regexp = ".+@.+\\..+")
+    private String emailAddress;
 
     @Column
     private String driversLicense;

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/model/TicketCount.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/model/TicketCount.java
@@ -6,16 +6,11 @@ import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.ManyToOne;
 import javax.persistence.Table;
 
-import org.hibernate.annotations.Type;
-
 import com.fasterxml.jackson.annotation.JsonBackReference;
-import com.fasterxml.jackson.annotation.JsonProperty;
-
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/model/TicketCount.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/model/TicketCount.java
@@ -1,5 +1,7 @@
 package ca.bc.gov.open.jag.tco.oracledataapi.model;
 
+import java.util.UUID;
+
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
@@ -8,6 +10,8 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.ManyToOne;
 import javax.persistence.Table;
+
+import org.hibernate.annotations.Type;
 
 import com.fasterxml.jackson.annotation.JsonBackReference;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -28,8 +32,8 @@ public class TicketCount {
 
 	@Schema(description = "ID", accessMode = Schema.AccessMode.READ_ONLY)
 	@Id
-	@GeneratedValue (strategy = GenerationType.IDENTITY)
-	private Integer id;
+	@GeneratedValue
+    private UUID id;
 
 	@Column
 	private String offenceDeclaration;

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/repository/DisputeRepository.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/repository/DisputeRepository.java
@@ -1,9 +1,11 @@
 package ca.bc.gov.open.jag.tco.oracledataapi.repository;
 
+import java.util.UUID;
+
 import org.springframework.data.repository.CrudRepository;
 
 import ca.bc.gov.open.jag.tco.oracledataapi.model.Dispute;
 
-public interface DisputeRepository extends CrudRepository<Dispute, Integer>{
+public interface DisputeRepository extends CrudRepository<Dispute, UUID>{
 
 }

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/service/DisputeService.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/service/DisputeService.java
@@ -2,6 +2,7 @@ package ca.bc.gov.open.jag.tco.oracledataapi.service;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -40,7 +41,7 @@ public class DisputeService {
 	 * @param id of the Dispute to be returned
 	 * @return
 	 */
-	public Dispute getDisputeById(Integer id) {
+	public Dispute getDisputeById(UUID id) {
 		return disputeRepository.findById(id).orElseThrow();
 	}
 
@@ -65,7 +66,7 @@ public class DisputeService {
 	 * @param {@link Dispute}
 	 * @return
 	 */
-	public Dispute update(Integer id, Dispute dispute) {
+	public Dispute update(UUID id, Dispute dispute) {
 		Dispute disputeToUpdate = disputeRepository.findById(id).orElseThrow();
 
 		BeanUtils.copyProperties(dispute, disputeToUpdate, "id", "ticketCounts");
@@ -84,7 +85,7 @@ public class DisputeService {
 	 *
 	 * @param id of the dispute to be deleted
 	 */
-	public void delete(Integer id) {
+	public void delete(UUID id) {
 		disputeRepository.deleteById(id);
 	}
 
@@ -95,7 +96,7 @@ public class DisputeService {
 	 * @param disputeStatus
 	 * @return the saved Dispute
 	 */
-	public Dispute setStatus(Integer id, DisputeStatus disputeStatus) {
+	public Dispute setStatus(UUID id, DisputeStatus disputeStatus) {
 		return setStatus(id, disputeStatus, null);
 	}
 
@@ -107,7 +108,7 @@ public class DisputeService {
 	 * @param rejectedReason the rejected reason if the status is REJECTED.
 	 * @return the saved Dispute
 	 */
-	public Dispute setStatus(Integer id, DisputeStatus disputeStatus, String rejectedReason) {
+	public Dispute setStatus(UUID id, DisputeStatus disputeStatus, String rejectedReason) {
 		if (disputeStatus == null) {
 			logger.error("Attempting to set Dispute status to null - bad method call.");
 			throw new NotAllowedException("Cannot set Dispute status to null");

--- a/src/backend/oracle-data-api/src/test/java/ca/bc/gov/open/jag/tco/oracledataapi/controller/v1_0/DisputeControllerTest.java
+++ b/src/backend/oracle-data-api/src/test/java/ca/bc/gov/open/jag/tco/oracledataapi/controller/v1_0/DisputeControllerTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.List;
+import java.util.UUID;
 
 import javax.validation.ConstraintViolationException;
 
@@ -33,7 +34,7 @@ class DisputeControllerTest extends BaseTestSuite {
 
 		// Create a single Dispute
 		Dispute dispute = RandomUtil.createDispute();
-		Integer disputeId = disputeController.saveDispute(dispute);
+		UUID disputeId = disputeController.saveDispute(dispute);
 
 		// Assert db contains the single created record
 		allDisputes = disputeController.getAllDisputes();
@@ -53,7 +54,7 @@ class DisputeControllerTest extends BaseTestSuite {
 	public void testRejectDispute() {
 		// Create a single Dispute
 		Dispute dispute = RandomUtil.createDispute();
-		Integer disputeId = disputeController.saveDispute(dispute);
+		UUID disputeId = disputeController.saveDispute(dispute);
 
 		// Retrieve it from the controller's endpoint
 		dispute = disputeController.getDispute(disputeId);
@@ -93,7 +94,7 @@ class DisputeControllerTest extends BaseTestSuite {
 	public void testSubmitDispute() {
 		// Create a single Dispute
 		Dispute dispute = RandomUtil.createDispute();
-		Integer disputeId = disputeController.saveDispute(dispute);
+		UUID disputeId = disputeController.saveDispute(dispute);
 
 		// Retrieve it from the controller's endpoint
 		dispute = disputeController.getDispute(disputeId);
@@ -113,7 +114,7 @@ class DisputeControllerTest extends BaseTestSuite {
 	public void testCancelDispute() {
 		// Create a single Dispute
 		Dispute dispute = RandomUtil.createDispute();
-		Integer disputeId = disputeController.saveDispute(dispute);
+		UUID disputeId = disputeController.saveDispute(dispute);
 
 		// Retrieve it from the controller's endpoint
 		dispute = disputeController.getDispute(disputeId);
@@ -137,7 +138,7 @@ class DisputeControllerTest extends BaseTestSuite {
 	public void testUpdateDispute() {
 		// Create a single Dispute
 		Dispute dispute = RandomUtil.createDispute();
-		Integer disputeId = disputeController.saveDispute(dispute);
+		UUID disputeId = disputeController.saveDispute(dispute);
 
 		// Retrieve it from the controller's endpoint
 		dispute = disputeController.getDispute(disputeId);

--- a/src/backend/oracle-data-api/src/test/java/ca/bc/gov/open/jag/tco/oracledataapi/service/DisputeServiceTest.java
+++ b/src/backend/oracle-data-api/src/test/java/ca/bc/gov/open/jag/tco/oracledataapi/service/DisputeServiceTest.java
@@ -2,6 +2,8 @@ package ca.bc.gov.open.jag.tco.oracledataapi.service;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import java.util.UUID;
+
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
@@ -20,14 +22,14 @@ class DisputeServiceTest extends BaseTestSuite {
 	@ParameterizedTest
 	@EnumSource(value = DisputeStatus.class, names = { "NEW", "PROCESSING" })
 	void testSetStatusToPROCESSING_200(DisputeStatus disputeStatus) {
-		Integer id = saveDispute(disputeStatus);
+		UUID id = saveDispute(disputeStatus);
 		disputeService.setStatus(id, DisputeStatus.PROCESSING);
 	}
 
 	@ParameterizedTest
 	@EnumSource(value = DisputeStatus.class, names = { "REJECTED", "CANCELLED" })
 	void testSetStatusToPROCESSING_405(DisputeStatus disputeStatus) {
-		Integer id = saveDispute(disputeStatus);
+		UUID id = saveDispute(disputeStatus);
 		assertThrows(NotAllowedException.class, () -> {
 			disputeService.setStatus(id, DisputeStatus.PROCESSING);
 		});
@@ -36,14 +38,14 @@ class DisputeServiceTest extends BaseTestSuite {
 	@ParameterizedTest
 	@EnumSource(value = DisputeStatus.class, names = { "NEW", "REJECTED", "CANCELLED" })
 	void testSetStatusToREJECTED_200(DisputeStatus disputeStatus) {
-		Integer id = saveDispute(disputeStatus);
+		UUID id = saveDispute(disputeStatus);
 		disputeService.setStatus(id, DisputeStatus.REJECTED);
 	}
 
 	@ParameterizedTest
 	@EnumSource(value = DisputeStatus.class, names = { "PROCESSING" })
 	void testSetStatusToREJECTED_405(DisputeStatus disputeStatus) {
-		Integer id = saveDispute(disputeStatus);
+		UUID id = saveDispute(disputeStatus);
 		assertThrows(NotAllowedException.class, () -> {
 			disputeService.setStatus(id, DisputeStatus.REJECTED);
 		});
@@ -52,14 +54,14 @@ class DisputeServiceTest extends BaseTestSuite {
 	@ParameterizedTest
 	@EnumSource(value = DisputeStatus.class, names = { "REJECTED", "PROCESSING" })
 	void testSetStatusToCANCELLED_200(DisputeStatus disputeStatus) {
-		Integer id = saveDispute(disputeStatus);
+		UUID id = saveDispute(disputeStatus);
 		disputeService.setStatus(id, DisputeStatus.CANCELLED);
 	}
 
 	@ParameterizedTest
 	@EnumSource(value = DisputeStatus.class, names = { "NEW", "CANCELLED" })
 	void testSetStatusToCANCELLED_405(DisputeStatus disputeStatus) {
-		Integer id = saveDispute(disputeStatus);
+		UUID id = saveDispute(disputeStatus);
 		assertThrows(NotAllowedException.class, () -> {
 			disputeService.setStatus(id, DisputeStatus.CANCELLED);
 		});
@@ -67,7 +69,7 @@ class DisputeServiceTest extends BaseTestSuite {
 
 	@Test
 	void testSetStatusToNEW_405() {
-		Integer id = saveDispute(DisputeStatus.NEW);
+		UUID id = saveDispute(DisputeStatus.NEW);
 		assertThrows(NotAllowedException.class, () -> {
 			disputeService.setStatus(id, DisputeStatus.NEW);
 		});
@@ -75,13 +77,13 @@ class DisputeServiceTest extends BaseTestSuite {
 
 	@Test
 	void testSetStatusToNULL_405() {
-		Integer id = saveDispute(null);
+		UUID id = saveDispute(null);
 		assertThrows(NotAllowedException.class, () -> {
 			disputeService.setStatus(id, null);
 		});
 	}
 
-	private Integer saveDispute(DisputeStatus disputeStatus) {
+	private UUID saveDispute(DisputeStatus disputeStatus) {
 		Dispute dispute = new Dispute();
 		dispute.setStatus(disputeStatus);
 


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- [TCVP-1281](https://justice.gov.bc.ca/jira/browse/TCVP-1281)
- Refactored Oracle Data API entity data models to use UUID instead of incremented Integer IDs.
- Updated Staff API controller and services to use GUIDs for ID related operations accordingly.
- Updated XUnit tests to use GUIDs.
- Regenerated OpenAPI spec of IOracleDataApi_v1_0Client.json
- Added email address field to the oracle-data-api dispute model and refactored message contracts and other related services to include email address field as well.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
