### PR TITLE
Move Field, BoundingBox and Point types from nested under OcrViolationTicket

### DIFF
--- a/src/backend/TrafficCourts/Citizen.Service/Services/Impl/FormRecognizerService.cs
+++ b/src/backend/TrafficCourts/Citizen.Service/Services/Impl/FormRecognizerService.cs
@@ -90,7 +90,7 @@ public class FormRecognizerService : IFormRecognizerService
 
         foreach (var fieldLabel in _fieldLabels)
         {
-            OcrViolationTicket.Field field = new();
+            Field field = new();
             field.TagName = fieldLabel.Key;
             field.JsonName = fieldLabel.Value;
 
@@ -102,11 +102,11 @@ public class FormRecognizerService : IFormRecognizerService
                 field.Type = Enum.GetName(extractedField.ValueType);
                 foreach (BoundingRegion region in extractedField.BoundingRegions)
                 {
-                    OcrViolationTicket.BoundingBox boundingBox = new();
-                    boundingBox.Points.Add(new OcrViolationTicket.Point(region.BoundingBox[0].X, region.BoundingBox[0].Y));
-                    boundingBox.Points.Add(new OcrViolationTicket.Point(region.BoundingBox[1].X, region.BoundingBox[1].Y));
-                    boundingBox.Points.Add(new OcrViolationTicket.Point(region.BoundingBox[2].X, region.BoundingBox[2].Y));
-                    boundingBox.Points.Add(new OcrViolationTicket.Point(region.BoundingBox[3].X, region.BoundingBox[3].Y));
+                    Models.Tickets.BoundingBox boundingBox = new();
+                    boundingBox.Points.Add(new Point(region.BoundingBox[0].X, region.BoundingBox[0].Y));
+                    boundingBox.Points.Add(new Point(region.BoundingBox[1].X, region.BoundingBox[1].Y));
+                    boundingBox.Points.Add(new Point(region.BoundingBox[2].X, region.BoundingBox[2].Y));
+                    boundingBox.Points.Add(new Point(region.BoundingBox[3].X, region.BoundingBox[3].Y));
                     field.BoundingBoxes.Add(boundingBox);
                 }
             }

--- a/src/backend/TrafficCourts/Citizen.Service/Validators/Rules/CheckboxIsValidRule.cs
+++ b/src/backend/TrafficCourts/Citizen.Service/Validators/Rules/CheckboxIsValidRule.cs
@@ -4,7 +4,7 @@ namespace TrafficCourts.Citizen.Service.Validators.Rules;
 
 public class CheckboxIsValidRule : ValidationRule
 {
-    public CheckboxIsValidRule(OcrViolationTicket.Field field) : base(field)
+    public CheckboxIsValidRule(Field field) : base(field)
     {
     }
 

--- a/src/backend/TrafficCourts/Citizen.Service/Validators/Rules/DriversLicenceValidRule.cs
+++ b/src/backend/TrafficCourts/Citizen.Service/Validators/Rules/DriversLicenceValidRule.cs
@@ -12,7 +12,7 @@ public class DriversLicenceValidRule : ValidationRule
 
     private readonly OcrViolationTicket _violationTicket;
 
-    public DriversLicenceValidRule(OcrViolationTicket.Field field, OcrViolationTicket violationTicket) : base(field)
+    public DriversLicenceValidRule(Field field, OcrViolationTicket violationTicket) : base(field)
     {
         this._violationTicket = violationTicket;
     }
@@ -24,7 +24,7 @@ public class DriversLicenceValidRule : ValidationRule
         // - if Driver's Licence province/state != BC flag for staff review
         // - if Driver's Licence province/state is blank flag for staff review
         // - if Driver's Licence Number is blank flag for staff review
-        OcrViolationTicket.Field province = _violationTicket.Fields[OcrViolationTicket.DriverLicenceProvince];
+        Field province = _violationTicket.Fields[OcrViolationTicket.DriverLicenceProvince];
         bool provMatches = true;
         if (province.Value is not null && !Regex.IsMatch(province.Value, DriverLicenceProvinceRegex))
         {

--- a/src/backend/TrafficCourts/Citizen.Service/Validators/Rules/FieldIsRequiredRule.cs
+++ b/src/backend/TrafficCourts/Citizen.Service/Validators/Rules/FieldIsRequiredRule.cs
@@ -7,7 +7,7 @@ public class FieldIsRequiredRule : ValidationRule
 {
 
     /// <summary>Validates a field is not blank.</summary>
-    public FieldIsRequiredRule(OcrViolationTicket.Field field) : base(field)
+    public FieldIsRequiredRule(Field field) : base(field)
     {
     }
 

--- a/src/backend/TrafficCourts/Citizen.Service/Validators/Rules/FieldMatchesRegexRule.cs
+++ b/src/backend/TrafficCourts/Citizen.Service/Validators/Rules/FieldMatchesRegexRule.cs
@@ -8,7 +8,7 @@ public class FieldMatchesRegexRule : ValidationRule
     private readonly string _pattern;
     private readonly string _reason;
 
-    public FieldMatchesRegexRule(Field field, string pattern, string reason) : base(field)
+    public FieldMatchesRegexRule(Models.Tickets.Field field, string pattern, string reason) : base(field)
     {
         this._pattern = pattern;
         this._reason = reason;

--- a/src/backend/TrafficCourts/Citizen.Service/Validators/Rules/OnlyMVAIsSelectedRule.cs
+++ b/src/backend/TrafficCourts/Citizen.Service/Validators/Rules/OnlyMVAIsSelectedRule.cs
@@ -10,7 +10,7 @@ public class OnlyMVAIsSelectedRule : ValidationRule
 {
     private readonly OcrViolationTicket _violationTicket;
 
-    public OnlyMVAIsSelectedRule(OcrViolationTicket.Field field, OcrViolationTicket violationTicket) : base(field)
+    public OnlyMVAIsSelectedRule(Field field, OcrViolationTicket violationTicket) : base(field)
     {
         this._violationTicket = violationTicket;
     }

--- a/src/backend/TrafficCourts/Citizen.Service/Validators/Rules/TicketAmountValidRule.cs
+++ b/src/backend/TrafficCourts/Citizen.Service/Validators/Rules/TicketAmountValidRule.cs
@@ -8,7 +8,7 @@ public class TicketAmountValidRule : ValidationRule
 {
 
     /// <summary>Validates a Ticket Amount field - should be a parsable currency field, ie. '$120.00' or simply '120'.</summary>
-    public TicketAmountValidRule(OcrViolationTicket.Field field) : base(field)
+    public TicketAmountValidRule(Field field) : base(field)
     {
     }
 

--- a/src/backend/TrafficCourts/Citizen.Service/Validators/Rules/ValidationRule.cs
+++ b/src/backend/TrafficCourts/Citizen.Service/Validators/Rules/ValidationRule.cs
@@ -5,12 +5,12 @@ namespace TrafficCourts.Citizen.Service.Validators.Rules;
 public abstract class ValidationRule
 {
 
-    public ValidationRule(Field field)
+    public ValidationRule(Models.Tickets.Field field)
     {
         Field = field;
     }
 
-    public Field Field { get; }
+    public Models.Tickets.Field Field { get; }
 
     public bool IsValid()
     {

--- a/src/backend/TrafficCourts/Test/Citizen.Service/Validators/Rules/FieldMatchesRegexRuleTest.cs
+++ b/src/backend/TrafficCourts/Test/Citizen.Service/Validators/Rules/FieldMatchesRegexRuleTest.cs
@@ -1,3 +1,4 @@
+using TrafficCourts.Citizen.Service.Models.Tickets;
 using TrafficCourts.Citizen.Service.Validators.Rules;
 using Xunit;
 using static TrafficCourts.Citizen.Service.Models.Tickets.OcrViolationTicket;


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- Moves nested types out of OcrViolationTicket
- Fixes error with rendering swagger ui

![image](https://user-images.githubusercontent.com/1844480/165647653-766551c7-9f35-45d7-8687-5bd74cf3340f.png)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [ ] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
