### PR TITLE
add missing semi-colon on include directive

### DIFF
--- a/src/frontend/citizen-portal/nginx.conf
+++ b/src/frontend/citizen-portal/nginx.conf
@@ -38,7 +38,7 @@ location /nginx_status {
 }
 
 # include the /api proxy_pass configuration
-include nginx-api-proxy-pass.conf
+include nginx-api-proxy-pass.conf;
 
 # Disables emitting nginx version in error messages and in the “Server” response header field.
 server_tokens off;

--- a/src/frontend/staff-portal/nginx.conf
+++ b/src/frontend/staff-portal/nginx.conf
@@ -38,7 +38,7 @@ location /nginx_status {
 }
 
 # include the /api proxy_pass configuration
-include nginx-api-proxy-pass.conf
+include nginx-api-proxy-pass.conf;
 
 # Disables emitting nginx version in error messages and in the “Server” response header field.
 server_tokens off;


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- adds missing semi-colon on include directives in nginx.conf

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
