### PR TITLE
TCVP 1296 fix for citizen api create dispute endpoint

### DIFF
--- a/src/backend/TrafficCourts/Citizen.Service/Features/Disputes/Create.cs
+++ b/src/backend/TrafficCourts/Citizen.Service/Features/Disputes/Create.cs
@@ -23,17 +23,17 @@ namespace TrafficCourts.Citizen.Service.Features.Disputes
 
         public class Response
         {
-            public int Id { get; init; }
+            public Guid Id { get; init; }
             public Exception? Exception { get; init; }
 
-            public Response(int id)
+            public Response(Guid id)
             {
                 Id = id;
             }
 
             public Response(Exception exception)
             {
-                Id = -1;
+                Id = Guid.Empty;
                 Exception = exception;
             }
         }

--- a/src/backend/TrafficCourts/Common/Converters/Json/DateOnlyJsonConverter.cs
+++ b/src/backend/TrafficCourts/Common/Converters/Json/DateOnlyJsonConverter.cs
@@ -1,13 +1,16 @@
-﻿using System.Text.Json;
+﻿using System.Globalization;
+using System.Text.Json;
 using System.Text.Json.Serialization;
 
 namespace TrafficCourts.Common.Converters;
 
 public sealed class DateOnlyJsonConverter : JsonConverter<DateOnly>
 {
+    private const string DateFormat = "yyyy-MM-dd";
+
     public override DateOnly Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
     {
-        return DateOnly.Parse(reader.GetString()!);
+        return DateOnly.ParseExact(reader.GetString()!, DateFormat, CultureInfo.InvariantCulture);
     }
 
     public override void Write(Utf8JsonWriter writer, DateOnly value, JsonSerializerOptions options)

--- a/src/backend/TrafficCourts/Messaging/MessageContracts/DisputeSubmitted.cs
+++ b/src/backend/TrafficCourts/Messaging/MessageContracts/DisputeSubmitted.cs
@@ -8,6 +8,6 @@ namespace TrafficCourts.Messaging.MessageContracts
 {
     public interface DisputeSubmitted : IMessage
     {
-        int DisputeId { get; set; }
+        Guid DisputeId { get; set; }
     }
 }

--- a/src/backend/TrafficCourts/Test/Citizen.Service/Controllers/DisputesControllerTest.cs
+++ b/src/backend/TrafficCourts/Test/Citizen.Service/Controllers/DisputesControllerTest.cs
@@ -26,7 +26,7 @@ namespace TrafficCourts.Test.Citizen.Service.Controllers
             var mockLogger = new Mock<ILogger<DisputesController>>();
             var disputeController = new DisputesController(mockMediator.Object, mockLogger.Object);
             var request = new Create.Request(mockTicketDispute.Object);
-            var createResponse = new Create.Response(1);
+            var createResponse = new Create.Response(Guid.NewGuid());
             mockMediator
                 .Setup(_ => _.Send<Create.Response>(It.IsAny<Create.Request>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(createResponse);

--- a/src/backend/TrafficCourts/Workflow.Service/Consumers/SubmitDisputeConsumer.cs
+++ b/src/backend/TrafficCourts/Workflow.Service/Consumers/SubmitDisputeConsumer.cs
@@ -68,7 +68,7 @@ namespace TrafficCourts.Workflow.Service.Consumers
 
                 var disputeId = await _oracleDataApiService.CreateDisputeAsync(dispute);
 
-                if (disputeId != -1)
+                if (disputeId != Guid.Empty)
                 {
                     _logger.LogDebug("Dispute has been saved with {DisputeId}: ", disputeId);
 

--- a/src/backend/TrafficCourts/Workflow.Service/Services/IOracleDataApiService.cs
+++ b/src/backend/TrafficCourts/Workflow.Service/Services/IOracleDataApiService.cs
@@ -4,6 +4,6 @@ namespace TrafficCourts.Workflow.Service.Services
 {
     public interface IOracleDataApiService
     {
-        Task<int> CreateDisputeAsync(Dispute disputeToSubmit);
+        Task<Guid> CreateDisputeAsync(Dispute disputeToSubmit);
     }
 }

--- a/src/backend/TrafficCourts/Workflow.Service/Services/OracleDataApiService.cs
+++ b/src/backend/TrafficCourts/Workflow.Service/Services/OracleDataApiService.cs
@@ -18,7 +18,7 @@ namespace TrafficCourts.Workflow.Service.Services
             _oracleDataApiConfiguration = oracleDataApiConfiguration.Value;
         }
 
-        public async Task<int> CreateDisputeAsync(Dispute disputeToSubmit)
+        public async Task<Guid> CreateDisputeAsync(Dispute disputeToSubmit)
         {
             // Formatting all dispute class properties to camel case since oracle data api
             // accepts camel case only after serialization
@@ -31,17 +31,17 @@ namespace TrafficCourts.Workflow.Service.Services
 
             using (var httpClient = new HttpClient())
             {
-                var oracleDataApiBaseUri = $"http://{_oracleDataApiConfiguration.Host}:{_oracleDataApiConfiguration.Port}";
+                var oracleDataApiBaseUri = $"http://{_oracleDataApiConfiguration.Host}:{_oracleDataApiConfiguration.Port}/api/v1.0/";
                 httpClient.BaseAddress = new Uri(oracleDataApiBaseUri);
                 using (var response = await httpClient.PostAsync("dispute", disputeToSubmit, formatter))
                 {
                     if (response.IsSuccessStatusCode)
                     {
-                        var apiResponse = await response.Content.ReadAsAsync<int>();
+                        var apiResponse = await response.Content.ReadAsAsync<Guid>();
                         return apiResponse;
                     }
 
-                    return -1; 
+                    return Guid.Empty; 
                 }
             }
         }


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- [TCVP-1296](https://justice.gov.bc.ca/jira/browse/TCVP-1296)
- Fixed the issue that was preventing a dispute to be created through the citizen api create endpoint by updating DateOnlyJsonConverter.
- Updated message consumers and contracts to work with new guid type ids from oracle-data-api.
- Updated oracle data api base uri in workflow service to match most up to date api version.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
