### PR TITLE
TCVP-1058 implemented business rule changes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -200,6 +200,7 @@ services:
   ###                           Minio                                                       ###
   #############################################################################################
   minio:
+    container_name: minio
     image: minio/minio
     ports:
       - 9000:9000
@@ -214,6 +215,7 @@ services:
     command: server /data --console-address ":9001"
 
   createbuckets:
+    container_name: minio-init
     image: minio/mc
     depends_on:
       - minio

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/controller/v1_0/DisputeController.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/controller/v1_0/DisputeController.java
@@ -99,7 +99,7 @@ public class DisputeController {
 		@ApiResponse(responseCode = "200", description = "Ok. Updated Dispute record returned."),
 		@ApiResponse(responseCode = "400", description = "Bad Request."),
 		@ApiResponse(responseCode = "404", description = "Dispute record not found. Update failed."),
-		@ApiResponse(responseCode = "405", description = "A Dispute status can only be set to REJECTED iff status is NEW, CANCELLED, or REJECTED and the rejected reason must be <= 256 characters. Update failed.")
+		@ApiResponse(responseCode = "405", description = "A Dispute status can only be set to REJECTED iff status is NEW and the rejected reason must be <= 256 characters. Update failed.")
 	})
 	@PutMapping("/dispute/{id}/reject")
 	public Dispute rejectDispute(@PathVariable UUID id, @Valid @RequestBody @NotBlank @Size(min=1, max=256) String rejectedReason) {
@@ -118,7 +118,7 @@ public class DisputeController {
 		@ApiResponse(responseCode = "200", description = "Ok. Updated Dispute record returned."),
 		@ApiResponse(responseCode = "400", description = "Bad Request."),
 		@ApiResponse(responseCode = "404", description = "Dispute record not found. Update failed."),
-		@ApiResponse(responseCode = "405", description = "A Dispute status can only be set to CANCELLED iff status is REJECTED or PROCESSING. Update failed.")
+		@ApiResponse(responseCode = "405", description = "A Dispute status can only be set to CANCELLED iff status is NEW, REJECTED or PROCESSING. Update failed.")
 	})
 	@PutMapping("/dispute/{id}/cancel")
 	public Dispute cancelDispute(@PathVariable UUID id) {
@@ -137,7 +137,7 @@ public class DisputeController {
 		@ApiResponse(responseCode = "200", description = "Ok. Updated Dispute record returned."),
 		@ApiResponse(responseCode = "400", description = "Bad Request."),
 		@ApiResponse(responseCode = "404", description = "Dispute record not found. Update failed."),
-		@ApiResponse(responseCode = "405", description = "A Dispute status can only be set to PROCESSING iff status is NEW or PROCESSING. Update failed.")
+		@ApiResponse(responseCode = "405", description = "A Dispute status can only be set to PROCESSING iff status is NEW or REJECTED. Update failed.")
 	})
 	@PutMapping("/dispute/{id}/submit")
 	public Dispute submitDispute(@PathVariable UUID id) {

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/service/DisputeService.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/service/DisputeService.java
@@ -117,22 +117,22 @@ public class DisputeService {
 		Dispute dispute = disputeRepository.findById(id).orElseThrow();
 
 		// TCVP-1058 - business rules
-		// - current status must be NEW,PROCESSING to change to PROCESSING
-		// - current status must be REJECTED,PROCESSING to change to CANCELLED
-		// - current status must be NEW,CANCELLED,REJECTED to change to REJECTED
+		// - current status must be NEW,REJECTED to change to PROCESSING
+		// - current status must be NEW to change to REJECTED
+		// - current status must be NEW,PROCESSING,REJECTED to change to CANCELLED
 		switch (disputeStatus) {
 		case PROCESSING:
-			if (!List.of(DisputeStatus.NEW, DisputeStatus.PROCESSING).contains(dispute.getStatus())) {
+			if (!List.of(DisputeStatus.NEW, DisputeStatus.REJECTED).contains(dispute.getStatus())) {
 				throw new NotAllowedException("Changing the status of a Dispute record from %s to %s is not permitted.", dispute.getStatus(), DisputeStatus.PROCESSING);
 			}
 			break;
 		case CANCELLED:
-			if (!List.of(DisputeStatus.REJECTED, DisputeStatus.PROCESSING).contains(dispute.getStatus())) {
+			if (!List.of(DisputeStatus.NEW, DisputeStatus.PROCESSING, DisputeStatus.REJECTED).contains(dispute.getStatus())) {
 				throw new NotAllowedException("Changing the status of a Dispute record from %s to %s is not permitted.", dispute.getStatus(), DisputeStatus.CANCELLED);
 			}
 			break;
 		case REJECTED:
-			if (!List.of(DisputeStatus.NEW, DisputeStatus.CANCELLED, DisputeStatus.REJECTED).contains(dispute.getStatus())) {
+			if (!List.of(DisputeStatus.NEW).contains(dispute.getStatus())) {
 				throw new NotAllowedException("Changing the status of a Dispute record from %s to %s is not permitted.", dispute.getStatus(), DisputeStatus.REJECTED);
 			}
 			break;

--- a/src/backend/oracle-data-api/src/test/java/ca/bc/gov/open/jag/tco/oracledataapi/controller/v1_0/DisputeControllerTest.java
+++ b/src/backend/oracle-data-api/src/test/java/ca/bc/gov/open/jag/tco/oracledataapi/controller/v1_0/DisputeControllerTest.java
@@ -7,10 +7,10 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import java.util.List;
 import java.util.UUID;
 
+import javax.transaction.Transactional;
 import javax.validation.ConstraintViolationException;
 
 import org.apache.commons.lang3.RandomStringUtils;
-import javax.transaction.Transactional;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -51,7 +51,7 @@ class DisputeControllerTest extends BaseTestSuite {
 	}
 
 	@Test
-	public void testRejectDispute() {
+	public void testRejectDisputeSuccess() {
 		// Create a single Dispute
 		Dispute dispute = RandomUtil.createDispute();
 		UUID disputeId = disputeController.saveDispute(dispute);
@@ -68,6 +68,18 @@ class DisputeControllerTest extends BaseTestSuite {
 		dispute = disputeController.getDispute(disputeId);
 		assertEquals(DisputeStatus.REJECTED, dispute.getStatus());
 		assertEquals("Just because", dispute.getRejectedReason());
+	}
+
+	@Test
+	public void testRejectDisputeFail() {
+		// Create a single Dispute
+		Dispute dispute = RandomUtil.createDispute();
+		UUID disputeId = disputeController.saveDispute(dispute);
+
+		// Retrieve it from the controller's endpoint
+		dispute = disputeController.getDispute(disputeId);
+		assertEquals(disputeId, dispute.getId());
+		assertEquals(DisputeStatus.NEW, dispute.getStatus());
 
 		// try using an empty reason (should fail with 405 error)
 		assertThrows(ConstraintViolationException.class, () -> {
@@ -132,7 +144,7 @@ class DisputeControllerTest extends BaseTestSuite {
 		assertEquals(DisputeStatus.CANCELLED, dispute.getStatus());
 		assertNull(dispute.getRejectedReason());
 	}
-	
+
 	@Test
 	@Transactional
 	public void testUpdateDispute() {

--- a/src/backend/oracle-data-api/src/test/java/ca/bc/gov/open/jag/tco/oracledataapi/service/DisputeServiceTest.java
+++ b/src/backend/oracle-data-api/src/test/java/ca/bc/gov/open/jag/tco/oracledataapi/service/DisputeServiceTest.java
@@ -20,14 +20,14 @@ class DisputeServiceTest extends BaseTestSuite {
 	private DisputeService disputeService;
 
 	@ParameterizedTest
-	@EnumSource(value = DisputeStatus.class, names = { "NEW", "PROCESSING" })
+	@EnumSource(value = DisputeStatus.class, names = { "NEW", "REJECTED" })
 	void testSetStatusToPROCESSING_200(DisputeStatus disputeStatus) {
 		UUID id = saveDispute(disputeStatus);
 		disputeService.setStatus(id, DisputeStatus.PROCESSING);
 	}
 
 	@ParameterizedTest
-	@EnumSource(value = DisputeStatus.class, names = { "REJECTED", "CANCELLED" })
+	@EnumSource(value = DisputeStatus.class, names = { "CANCELLED", "PROCESSING" })
 	void testSetStatusToPROCESSING_405(DisputeStatus disputeStatus) {
 		UUID id = saveDispute(disputeStatus);
 		assertThrows(NotAllowedException.class, () -> {
@@ -36,14 +36,14 @@ class DisputeServiceTest extends BaseTestSuite {
 	}
 
 	@ParameterizedTest
-	@EnumSource(value = DisputeStatus.class, names = { "NEW", "REJECTED", "CANCELLED" })
+	@EnumSource(value = DisputeStatus.class, names = { "NEW" })
 	void testSetStatusToREJECTED_200(DisputeStatus disputeStatus) {
 		UUID id = saveDispute(disputeStatus);
 		disputeService.setStatus(id, DisputeStatus.REJECTED);
 	}
 
 	@ParameterizedTest
-	@EnumSource(value = DisputeStatus.class, names = { "PROCESSING" })
+	@EnumSource(value = DisputeStatus.class, names = { "CANCELLED", "PROCESSING", "REJECTED" })
 	void testSetStatusToREJECTED_405(DisputeStatus disputeStatus) {
 		UUID id = saveDispute(disputeStatus);
 		assertThrows(NotAllowedException.class, () -> {
@@ -52,14 +52,14 @@ class DisputeServiceTest extends BaseTestSuite {
 	}
 
 	@ParameterizedTest
-	@EnumSource(value = DisputeStatus.class, names = { "REJECTED", "PROCESSING" })
+	@EnumSource(value = DisputeStatus.class, names = { "NEW", "PROCESSING", "REJECTED" })
 	void testSetStatusToCANCELLED_200(DisputeStatus disputeStatus) {
 		UUID id = saveDispute(disputeStatus);
 		disputeService.setStatus(id, DisputeStatus.CANCELLED);
 	}
 
 	@ParameterizedTest
-	@EnumSource(value = DisputeStatus.class, names = { "NEW", "CANCELLED" })
+	@EnumSource(value = DisputeStatus.class, names = { "CANCELLED" })
 	void testSetStatusToCANCELLED_405(DisputeStatus disputeStatus) {
 		UUID id = saveDispute(disputeStatus);
 		assertThrows(NotAllowedException.class, () -> {


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

[TCVP-1058](https://justice.gov.bc.ca/jira/browse/TCVP-1058)

Implemented a few requirement changes from business regarding when a Dispute is allowed to change state.  Now:
- a Dispute status can only be set to PROCESSING iff status is NEW or REJECTED
- a Dispute status can only be set to CANCELLED iff status is NEW, REJECTED or PROCESSING
- a Dispute status can only be set to REJECTED iff status is NEW

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Updated junit tests

ran `mvn verify`

## Does the change impact or break the Docker build?

- [x] Yes
- [ ] No

If Yes: Has Docker been updated accordingly?

- [x] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
