### PR TITLE
TCVP-1301 Add audit fields to Oracle data model objects

### DIFF
--- a/src/backend/TrafficCourts/Staff.Service/OpenAPIs/OracleDataAPI/v1_0/OracleDataApi.v1_0.json
+++ b/src/backend/TrafficCourts/Staff.Service/OpenAPIs/OracleDataAPI/v1_0/OracleDataApi.v1_0.json
@@ -273,6 +273,19 @@
       "get": {
         "tags": [ "dispute-controller" ],
         "operationId": "getAllDisputes",
+        "parameters": [
+          {
+            "name": "olderThan",
+            "in": "query",
+            "description": "If specified, will retrieve records older than this date (specified by yyyy-MM-dd)",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "example": "2022-03-15"
+          }
+        ],
         "responses": {
           "405": {
             "description": "Method Not Allowed",
@@ -329,6 +342,16 @@
       "Dispute": {
         "type": "object",
         "properties": {
+          "createdBy": { "type": "string" },
+          "createdTs": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "modifiedBy": { "type": "string" },
+          "modifiedTs": {
+            "type": "string",
+            "format": "date-time"
+          },
           "id": {
             "type": "string",
             "description": "ID",
@@ -462,6 +485,16 @@
       "DisputedCount": {
         "type": "object",
         "properties": {
+          "createdBy": { "type": "string" },
+          "createdTs": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "modifiedBy": { "type": "string" },
+          "modifiedTs": {
+            "type": "string",
+            "format": "date-time"
+          },
           "id": {
             "type": "string",
             "description": "ID",
@@ -486,6 +519,16 @@
       "LegalRepresentation": {
         "type": "object",
         "properties": {
+          "createdBy": { "type": "string" },
+          "createdTs": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "modifiedBy": { "type": "string" },
+          "modifiedTs": {
+            "type": "string",
+            "format": "date-time"
+          },
           "id": {
             "type": "string",
             "description": "ID",
@@ -503,6 +546,16 @@
       "ViolationTicket": {
         "type": "object",
         "properties": {
+          "createdBy": { "type": "string" },
+          "createdTs": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "modifiedBy": { "type": "string" },
+          "modifiedTs": {
+            "type": "string",
+            "format": "date-time"
+          },
           "id": {
             "type": "string",
             "description": "ID",
@@ -661,6 +714,16 @@
       "ViolationTicketCount": {
         "type": "object",
         "properties": {
+          "createdBy": { "type": "string" },
+          "createdTs": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "modifiedBy": { "type": "string" },
+          "modifiedTs": {
+            "type": "string",
+            "format": "date-time"
+          },
           "id": {
             "type": "string",
             "description": "ID",

--- a/src/backend/TrafficCourts/Staff.Service/Services/DisputeService.cs
+++ b/src/backend/TrafficCourts/Staff.Service/Services/DisputeService.cs
@@ -45,7 +45,7 @@ public class DisputeService : IDisputeService
 
     public async Task<ICollection<Dispute>> GetAllDisputesAsync(CancellationToken cancellationToken)
     {
-        return await GetOracleDataApi().GetAllDisputesAsync(cancellationToken);
+        return await GetOracleDataApi().GetAllDisputesAsync(null, cancellationToken);
     }
 
     public async Task<Guid> SaveDisputeAsync(Dispute dispute, CancellationToken cancellationToken)

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/OracleDataApiApplication.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/OracleDataApiApplication.java
@@ -5,10 +5,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableScheduling
+@EnableJpaAuditing(auditorAwareRef="auditorAware")
 public class OracleDataApiApplication {
 
 	private static Logger logger = LoggerFactory.getLogger(OracleDataApiApplication.class);

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/config/AuditConfig.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/config/AuditConfig.java
@@ -1,0 +1,15 @@
+package ca.bc.gov.open.jag.tco.oracledataapi.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.domain.AuditorAware;
+
+@Configuration
+public class AuditConfig {
+
+	@Bean
+	public AuditorAware<String> auditorAware() {
+		return new SpringSecurityAuditorAware();
+	}
+
+}

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/config/SpringSecurityAuditorAware.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/config/SpringSecurityAuditorAware.java
@@ -1,0 +1,21 @@
+package ca.bc.gov.open.jag.tco.oracledataapi.config;
+
+import java.util.Optional;
+
+import org.springframework.data.domain.AuditorAware;
+
+/**
+ * A class to extract the current user of the application. This data is used to auto-populate the createBy and modifiedBy audit fields on entity
+ * records.
+ */
+public class SpringSecurityAuditorAware implements AuditorAware<String> {
+
+	@Override
+	public Optional<String> getCurrentAuditor() {
+		// Just return a string representing the System default username for now
+		// We could get the username from Keycloak, (i.e.
+		// https://github.com/bcgov/jag-ai-reviewer/blob/main/src/backend/ai-reviewer-api/src/main/java/ca/bc/gov/open/jag/aireviewerapi/core/SecurityUtils.java)
+		return Optional.ofNullable("System").filter(s -> !s.isEmpty());
+	}
+
+}

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/controller/v1_0/DisputeController.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/controller/v1_0/DisputeController.java
@@ -1,7 +1,6 @@
 package ca.bc.gov.open.jag.tco.oracledataapi.controller.v1_0;
 
 import java.util.Date;
-import java.util.List;
 import java.util.UUID;
 
 import javax.validation.Valid;
@@ -11,6 +10,7 @@ import javax.validation.constraints.Size;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -19,6 +19,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import ca.bc.gov.open.jag.tco.oracledataapi.model.Dispute;
@@ -26,6 +27,7 @@ import ca.bc.gov.open.jag.tco.oracledataapi.model.DisputeStatus;
 import ca.bc.gov.open.jag.tco.oracledataapi.service.DisputeService;
 import ca.bc.gov.open.jag.tco.oracledataapi.service.LookupService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 
@@ -44,13 +46,16 @@ public class DisputeController {
 
 	/**
 	 * GET endpoint that retrieves all the dispute detail from the database
-	 *
+	 * @param olderThan if specified, will filter the result set to those older than this date.
 	 * @return list of all dispute tickets
 	 */
 	@GetMapping("/disputes")
-	public List<Dispute> getAllDisputes() {
-		log.debug("Retrieve all disputes endpoint is called." + new Date());
-		return disputeService.getAllDisputes();
+	public Iterable<Dispute> getAllDisputes(
+			@RequestParam(required = false)
+			@DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+			@Parameter(description = "If specified, will retrieve records older than this date (specified by yyyy-MM-dd)", example = "2022-03-15")
+			Date olderThan) {
+		return disputeService.getAllDisputes(olderThan);
 	}
 
 	/**

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/controller/v1_0/DisputeController.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/controller/v1_0/DisputeController.java
@@ -1,12 +1,14 @@
 package ca.bc.gov.open.jag.tco.oracledataapi.controller.v1_0;
 
 import java.util.Date;
+import java.util.List;
 import java.util.UUID;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.Size;
 
+import org.apache.commons.collections4.IterableUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -50,12 +52,14 @@ public class DisputeController {
 	 * @return list of all dispute tickets
 	 */
 	@GetMapping("/disputes")
-	public Iterable<Dispute> getAllDisputes(
+	public List<Dispute> getAllDisputes(
 			@RequestParam(required = false)
 			@DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
 			@Parameter(description = "If specified, will retrieve records older than this date (specified by yyyy-MM-dd)", example = "2022-03-15")
 			Date olderThan) {
-		return disputeService.getAllDisputes(olderThan);
+		Iterable<Dispute> allDisputes = disputeService.getAllDisputes(olderThan);
+		// Swagger doesn't seem to know what an Iterable<Dispute> object is.  Convert to an actual instantiated list to return a collection.
+		return IterableUtils.toList(allDisputes);
 	}
 
 	/**

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/model/Auditable.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/model/Auditable.java
@@ -1,0 +1,48 @@
+package ca.bc.gov.open.jag.tco.oracledataapi.model;
+
+import static javax.persistence.TemporalType.TIMESTAMP;
+
+import java.util.Date;
+
+import javax.persistence.EntityListeners;
+import javax.persistence.MappedSuperclass;
+import javax.persistence.Temporal;
+
+import org.springframework.data.annotation.CreatedBy;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedBy;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * An abstract Auditable class that auto-populates <code>createdBy</code>, <code>createdTs</code>, <code>modifiedBy</code>, and
+ * <code>modifiedTs</code> fields. Classes need only to extend this class to add auditing fields to a model object.
+ */
+@MappedSuperclass
+@Getter
+@Setter
+@EntityListeners(AuditingEntityListener.class)
+public abstract class Auditable<U> {
+
+	/** The username of the individual (or system) who created this record. */
+	@CreatedBy
+	private U createdBy;
+
+	/** The timestamp this record was created. */
+	@CreatedDate
+	@Temporal(TIMESTAMP)
+	private Date createdTs;
+
+	/** The username of the individual (or system) who modified this record. */
+	@LastModifiedBy
+	private U modifiedBy;
+
+	/** The timestamp this record was last modified. */
+	@LastModifiedDate
+	@Temporal(TIMESTAMP)
+	private Date modifiedTs;
+
+}

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/model/Dispute.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/model/Dispute.java
@@ -41,7 +41,7 @@ import lombok.Setter;
 @Getter
 @Setter
 @NoArgsConstructor
-public class Dispute {
+public class Dispute extends Auditable<String> {
 
 	@Schema(description = "ID", accessMode = Schema.AccessMode.READ_ONLY)
     @Id
@@ -71,7 +71,7 @@ public class Dispute {
     @Column
     @Schema(nullable = true)
     private Date issuedDate;
-    
+
     /**
      * The date and time the citizen was submitted the notice of dispute.
      */
@@ -122,7 +122,7 @@ public class Dispute {
     @Column
     @Schema(nullable = true)
     private String address;
-    
+
     /**
      * The mailing address city of the disputant.
      */
@@ -150,14 +150,14 @@ public class Dispute {
     @Column
     @Schema(nullable = true)
     private String homePhoneNumber;
-    
+
     /**
      * The disputant's work phone number.
      */
     @Column
     @Schema(nullable = true)
     private String workPhoneNumber;
-    
+
     /**
      * The disputant's email address.
      */
@@ -165,11 +165,11 @@ public class Dispute {
     @Email(regexp = ".+@.+\\..+")
     @Schema(nullable = true)
     private String emailAddress;
-    
+
     @Column
     @Schema(nullable = true)
     private Date filingDate;
-    
+
     @JsonManagedReference
     @OneToMany(targetEntity=DisputedCount.class, cascade = CascadeType.ALL, fetch = FetchType.LAZY, orphanRemoval = true)
     @JoinColumn(name="dispute_id")
@@ -180,7 +180,7 @@ public class Dispute {
      */
     @Column
     private boolean representedByLawyer;
-    
+
     @JsonManagedReference
     @OneToOne(fetch = FetchType.LAZY, optional = true, cascade = CascadeType.ALL, orphanRemoval = true, mappedBy = "dispute")
     @Schema(nullable = true)
@@ -199,14 +199,14 @@ public class Dispute {
     @Column
     @Schema(nullable = true)
     private Integer numberOfWitness;
-    
+
     /**
      * Reason indicating why the fine reduction requested for the ticket.
      */
     @Column(length = 256)
     @Schema(nullable = true)
     private String fineReductionReason;
-    
+
     /**
      * Reason indicating why the disputant needs more time in order to make payment for the ticket.
      */
@@ -220,7 +220,7 @@ public class Dispute {
     @Column(length = 256)
     @Schema(nullable = true)
     private String rejectedReason;
-    
+
     @Column
     private boolean disputantDetectedOcrIssues;
     
@@ -230,7 +230,7 @@ public class Dispute {
     
     @Column
     private boolean systemDetectedOcrIssues;
-    
+
     @Column
     @Schema(nullable = true)
     private String jjAssigned;
@@ -247,14 +247,14 @@ public class Dispute {
     @OneToOne(fetch = FetchType.LAZY, optional = true, cascade = CascadeType.ALL, orphanRemoval = true, mappedBy = "dispute")
     @Schema(nullable = true)
     private ViolationTicket violationTicket;
-    
-    public void addDisputedCounts(List<DisputedCount> disputedCounts) { 		
-    	for (DisputedCount disputedCount : disputedCounts) { 			
-    		disputedCount.setDispute(this); 		
-    	} 		
-    	this.disputedCounts.addAll(disputedCounts); 	
+
+    public void addDisputedCounts(List<DisputedCount> disputedCounts) {
+    	for (DisputedCount disputedCount : disputedCounts) {
+    		disputedCount.setDispute(this);
+    	}
+    	this.disputedCounts.addAll(disputedCounts);
     }
-    
+
     public void setLegalRepresentation(LegalRepresentation legal) {
         if (legal == null) {
             if (this.legalRepresentation != null) {
@@ -266,7 +266,7 @@ public class Dispute {
         }
         this.legalRepresentation = legal;
     }
-    
+
     public void setViolationTicket(ViolationTicket ticket) {
         if (ticket == null) {
             if (this.violationTicket != null) {

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/model/DisputedCount.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/model/DisputedCount.java
@@ -13,6 +13,7 @@ import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
 
 import com.fasterxml.jackson.annotation.JsonBackReference;
+
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -25,7 +26,7 @@ import lombok.Setter;
 @Getter
 @Setter
 @NoArgsConstructor
-public class DisputedCount {
+public class DisputedCount extends Auditable<String> {
 
 	@Schema(description = "ID", accessMode = Schema.AccessMode.READ_ONLY)
 	@Id
@@ -37,7 +38,7 @@ public class DisputedCount {
 	 */
 	@Column
 	private Plea plea;
-	
+
 	/**
 	 * The count number.
 	 */
@@ -56,13 +57,13 @@ public class DisputedCount {
 	 */
 	@Column
 	private boolean requestReduction;
-	
+
 	/**
 	 * Does the want to appear in court?
 	 */
 	@Column
 	private boolean appearInCourt;
-	
+
 	@JsonBackReference
 	@ManyToOne(targetEntity=Dispute.class, fetch = FetchType.LAZY)
 	@Schema(hidden = true)

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/model/LegalRepresentation.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/model/LegalRepresentation.java
@@ -25,8 +25,8 @@ import lombok.Setter;
 @Getter
 @Setter
 @NoArgsConstructor
-public class LegalRepresentation {
-	
+public class LegalRepresentation extends Auditable<String> {
+
 	@Schema(description = "ID", accessMode = Schema.AccessMode.READ_ONLY)
     @Id
     @GeneratedValue
@@ -68,5 +68,5 @@ public class LegalRepresentation {
 	@JoinColumn(name = "dispute_id", referencedColumnName = "id")
 	@Schema(hidden = true)
 	private Dispute dispute;
-	
+
 }

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/model/ViolationTicket.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/model/ViolationTicket.java
@@ -28,7 +28,7 @@ import lombok.Setter;
 /**
  * @author 237563
  * Represents the data contained on a BC violation ticket
- * 
+ *
  */
 //mark class as an Entity
 @Entity
@@ -37,8 +37,8 @@ import lombok.Setter;
 @Getter
 @Setter
 @NoArgsConstructor
-public class ViolationTicket {
-	
+public class ViolationTicket extends Auditable<String> {
+
 	@Schema(description = "ID", accessMode = Schema.AccessMode.READ_ONLY)
     @Id
     @GeneratedValue
@@ -50,7 +50,7 @@ public class ViolationTicket {
     @Column
     @Schema(nullable = true)
     private String ticketNumber;
-    
+
     /**
      * The surname or corporate name.
      */
@@ -64,14 +64,14 @@ public class ViolationTicket {
     @Column
     @Schema(nullable = true)
     private String givenNames;
-    
+
     /**
      * The person issued the ticket has been identified as a young person.
      */
     @Column
     @Schema(nullable = true)
     private Boolean isYoungPerson;
-    
+
     /**
      * The drivers licence number. Note not all jurisdictions will use numeric drivers licence numbers.
      */
@@ -86,35 +86,35 @@ public class ViolationTicket {
     @Column
     @Schema(nullable = true)
     private String driversLicenceProvince;
-    
+
     /**
      * The year the drivers licence was produced.
      */
     @Column
     @Schema(nullable = true)
     private Integer driversLicenceProducedYear;
-    
+
     /**
      * The year the drivers licence expires.
      */
     @Column
     @Schema(nullable = true)
     private Integer driversLicenceExpiryYear;
-    
+
     /**
      * The birthdate of the individual the violation ticket was issued to.
      */
     @Column
     @Schema(nullable = true)
     private Date birthdate;
-    
+
     /**
      * The address of the individual the violation ticket was issued to.
      */
     @Column
     @Schema(nullable = true)
     private String address;
-    
+
     /**
      * The city of the individual the violation ticket was issued to.
      */
@@ -135,144 +135,144 @@ public class ViolationTicket {
     @Column
     @Schema(nullable = true)
     private String postalCode;
-    
+
     /**
      * The address represents a change of address. The address on the violation would be different from the address on the drivers licence or provided identification.
      */
     @Column
     @Schema(nullable = true)
     private Boolean isChangeOfAddress;
-    
+
     /**
      * The enforcement officer says that he or she has reasonable grounds to believe, and does believe, that the above named as the vehicle driver.
      */
     @Column
     @Schema(nullable = true)
     private Boolean isDriver;
-    
+
     /**
      * The enforcement officer says that he or she has reasonable grounds to believe, and does believe, that the above named as the cyclist.
      */
     @Column
     @Schema(nullable = true)
     private Boolean isCyclist;
-    
+
     /**
      * The enforcement officer says that he or she has reasonable grounds to believe, and does believe, that the above named as the vehicle owner.
      */
     @Column
     @Schema(nullable = true)
     private Boolean isOwner;
-    
+
     /**
      * The enforcement officer says that he or she has reasonable grounds to believe, and does believe, that the above named as a pedestrain.
      */
     @Column
     @Schema(nullable = true)
     private Boolean isPedestrian;
-    
+
     /**
      * The enforcement officer says that he or she has reasonable grounds to believe, and does believe, that the above named as a passenger.
      */
     @Column
     @Schema(nullable = true)
     private Boolean isPassenger;
-    
+
     /**
      * The enforcement officer says that he or she has reasonable grounds to believe, and does believe, that the above named as a other designation.
      */
     @Column
     @Schema(nullable = true)
     private Boolean isOther;
-    
+
     /**
      * If TrafficCourts.Models.ViolationTicket.IssuedToOther is true, the other designation description.
      */
     @Column
     @Schema(nullable = true)
     private String otherDescription;
-    
+
     /**
      * The date and time the violation ticket was issue. Time must only be hours and minutes.
      */
     @Column
     @Schema(nullable = true)
     private Date issuedDate;
-    
+
     /**
      * The violation ticket was issued on this road or highway.
      */
     @Column
     @Schema(nullable = true)
     private String issuedOnRoadOrHighway;
-    
+
     @Column
     @Schema(nullable = true)
     private String issuedAtOrNearCity;
-    
+
     /**
      * The violation ticket was issued for offence under the Motor Vehicle Act (MVA).
      */
     @Column
     @Schema(nullable = true)
     private Boolean isMvaOffence;
-    
+
     /**
      * The violation ticket was issued for offence under the Wildlife Act (WLA).
      */
     @Column
     @Schema(nullable = true)
     private Boolean isWlaOffence;
-    
+
     /**
      * The violation ticket was issued for offence under the Liquor Control and Licencing Act (LCA).
      */
     @Column
     @Schema(nullable = true)
     private Boolean isLcaOffence;
-    
+
     /**
      * The violation ticket was issued for offence under the Motor Carrier Act (MCA).
      */
     @Column
     @Schema(nullable = true)
     private Boolean isMcaOffence;
-    
+
     /**
      * The violation ticket was issued for offence under the Firearm Act (FAA).
      */
     @Column
     @Schema(nullable = true)
     private Boolean isFaaOffence;
-    
+
     /**
      * The violation ticket was issued for offence under the Transit Conduct and Safety Regs (TCR).
      */
     @Column
     @Schema(nullable = true)
     private Boolean isTcrOffence;
-    
+
     /**
      * The violation ticket was issued for offence under the Commercial Transport Act (CTA).
      */
     @Column
     @Schema(nullable = true)
     private Boolean isCtaOffence;
-    
+
     /**
      * The violation ticket was issued for other.
      */
     @Column
     @Schema(nullable = true)
     private Boolean isOtherOffence;
-    
+
     /**
      * The violation ticket was issued for other.
      */
     @Column
     @Schema(nullable = true)
     private String otherOffenceDescription;
-    
+
     /**
      * Issuing organization.
      */
@@ -284,11 +284,11 @@ public class ViolationTicket {
     @OneToMany(targetEntity=ViolationTicketCount.class, cascade = CascadeType.ALL, fetch = FetchType.LAZY, orphanRemoval = true)
     @JoinColumn(name="violation_ticket_id")
     private List<ViolationTicketCount> violationTicketCounts = new ArrayList<ViolationTicketCount>();
-    
+
     @JsonBackReference
 	@OneToOne
 	@JoinColumn(name = "dispute_id", referencedColumnName = "id")
 	@Schema(hidden = true)
 	private Dispute dispute;
-    
+
 }

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/model/ViolationTicketCount.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/model/ViolationTicketCount.java
@@ -32,27 +32,27 @@ import lombok.Setter;
 @Getter
 @Setter
 @NoArgsConstructor
-public class ViolationTicketCount {
-	
+public class ViolationTicketCount extends Auditable<String> {
+
 	@Schema(description = "ID", accessMode = Schema.AccessMode.READ_ONLY)
 	@Id
 	@GeneratedValue
     private UUID id;
-	
+
 	/**
 	 * The count number.
 	 */
 	@Column
 	@Min(1) @Max(3)
 	private int count;
-	
+
 	/**
 	 * The description of the offence.
 	 */
 	@Column
 	@Schema(nullable = true)
     private String description;
-	
+
 	/**
 	 * The act or regulation code the violation occurred against. For example, MVA, WLA, TCR, etc
 	 */
@@ -66,28 +66,28 @@ public class ViolationTicketCount {
 	@Column
 	@Schema(nullable = true)
     private String fullSection;
-	
+
 	/**
 	 * The section part of the full section. For example, "127"
 	 */
 	@Column
 	@Schema(nullable = true, accessMode = Schema.AccessMode.READ_ONLY)
     private String section;
-	
+
 	/**
 	 * The subsection part of the full section. For example, "(1)"
 	 */
 	@Column
 	@Schema(nullable = true, accessMode = Schema.AccessMode.READ_ONLY)
     private String subsection;
-	
+
 	/**
 	 * The paragraph part of the full section. For example, "(a)"
 	 */
 	@Column
 	@Schema(nullable = true, accessMode = Schema.AccessMode.READ_ONLY)
     private String paragraph;
-	
+
 	/**
 	 * The ticketed amount.
 	 */
@@ -101,17 +101,17 @@ public class ViolationTicketCount {
 	@Column
 	@Schema(nullable = true)
     private Boolean isAct;
-	
+
 	/**
 	 * The count is flagged as an offence to a regulation. Cannot be true, if is_act is true.
 	 */
 	@Column
 	@Schema(nullable = true)
     private Boolean isRegulation;
-	
+
 	@JsonBackReference
 	@ManyToOne(targetEntity=ViolationTicket.class, fetch = FetchType.LAZY)
 	@Schema(hidden = true)
 	private ViolationTicket violationTicket;
-	
+
 }

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/repository/DisputeRepository.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/repository/DisputeRepository.java
@@ -1,11 +1,15 @@
 package ca.bc.gov.open.jag.tco.oracledataapi.repository;
 
+import java.util.Date;
 import java.util.UUID;
 
 import org.springframework.data.repository.CrudRepository;
 
 import ca.bc.gov.open.jag.tco.oracledataapi.model.Dispute;
 
-public interface DisputeRepository extends CrudRepository<Dispute, UUID>{
+public interface DisputeRepository extends CrudRepository<Dispute, UUID> {
+
+	/** Fetch all records older than the given date. */
+    public Iterable<Dispute> findByCreatedTsBefore(Date olderThan);
 
 }

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/service/DisputeService.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/service/DisputeService.java
@@ -1,6 +1,6 @@
 package ca.bc.gov.open.jag.tco.oracledataapi.service;
 
-import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
 import java.util.UUID;
 
@@ -26,13 +26,17 @@ public class DisputeService {
 
 	/**
 	 * Retrieves all {@link Dispute} records, delegating to CrudRepository
+	 * @param olderThan if specified, will filter the result set to those older than this date.
 	 *
 	 * @return
 	 */
-	public List<Dispute> getAllDisputes() {
-		List<Dispute> disputes = new ArrayList<Dispute>();
-		disputeRepository.findAll().forEach(dispute -> disputes.add(dispute));
-		return disputes;
+	public Iterable<Dispute> getAllDisputes(Date olderThan) {
+		if (olderThan == null) {
+			return disputeRepository.findAll();
+		}
+		else {
+			return disputeRepository.findByCreatedTsBefore(olderThan);
+		}
 	}
 
 	/**

--- a/src/backend/oracle-data-api/src/main/resources/application.yml
+++ b/src/backend/oracle-data-api/src/main/resources/application.yml
@@ -13,7 +13,7 @@ spring:
   datasource:
     driverClassName: org.h2.Driver
     password: ''
-    url: jdbc:h2:mem:dispute_data
+    url: jdbc:h2:mem:testdb
     username: sa
   h2:
     console:

--- a/src/backend/oracle-data-api/src/test/java/ca/bc/gov/open/jag/tco/oracledataapi/controller/v1_0/DisputeControllerTest.java
+++ b/src/backend/oracle-data-api/src/test/java/ca/bc/gov/open/jag/tco/oracledataapi/controller/v1_0/DisputeControllerTest.java
@@ -10,6 +10,7 @@ import java.util.UUID;
 import javax.transaction.Transactional;
 import javax.validation.ConstraintViolationException;
 
+import org.apache.commons.collections4.IterableUtils;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -29,7 +30,7 @@ class DisputeControllerTest extends BaseTestSuite {
 	@Test
 	public void testSaveDispute() {
 		// Assert db is empty and clean
-		List<Dispute> allDisputes = disputeController.getAllDisputes();
+		List<Dispute> allDisputes = IterableUtils.toList(disputeController.getAllDisputes(null));
 		assertEquals(0, allDisputes.size());
 
 		// Create a single Dispute
@@ -37,7 +38,7 @@ class DisputeControllerTest extends BaseTestSuite {
 		UUID disputeId = disputeController.saveDispute(dispute);
 
 		// Assert db contains the single created record
-		allDisputes = disputeController.getAllDisputes();
+		allDisputes = IterableUtils.toList(disputeController.getAllDisputes(null));
 		assertEquals(1, allDisputes.size());
 		assertEquals(disputeId, allDisputes.get(0).getId());
 		assertEquals(dispute.getSurname(), allDisputes.get(0).getSurname());
@@ -46,7 +47,7 @@ class DisputeControllerTest extends BaseTestSuite {
 		disputeController.deleteDispute(disputeId);
 
 		// Assert db contains is empty again
-		allDisputes = disputeController.getAllDisputes();
+		allDisputes = IterableUtils.toList(disputeController.getAllDisputes(null));
 		assertEquals(0, allDisputes.size());
 	}
 
@@ -166,8 +167,8 @@ class DisputeControllerTest extends BaseTestSuite {
 		dispute = disputeController.getDispute(disputeId);
 		assertEquals("Doe", dispute.getSurname());
 		assertEquals("John", dispute.getGivenNames());
-		List<Dispute> allDisputes = disputeController.getAllDisputes();
-		assertEquals(1, allDisputes.size());
+		Iterable<Dispute> allDisputes = disputeController.getAllDisputes(null);
+		assertEquals(1, IterableUtils.size(allDisputes));
 	}
 
 }


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

[TCVP-1301](https://justice.gov.bc.ca/jira/browse/TCVP-1301)

In preparation for TCVP-1301, this PR adds audit fields to the Oracle data model objects, 
ie.
```
{
        "createdBy": "System",
        "createdTs": "2022-05-09T20:55:10.139+00:00",
        "modifiedBy": "System",
        "modifiedTs": "2022-05-09T20:55:10.139+00:00",
...
}
```

The **...Ts** fields are automatically populated when doing an INSERT (both createdTS and modifiedTS) or an UPDATE (only modifiedTS).
The **...By** fields are currently statically set to "System" until a way is found to provide a username to the oracle-data-api

The audit fields are added to these objects:
- Dispute
- DisputedCount
- LegalRepresentation
- ViolationTicket
- ViolationTicketCount

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Manual inserts or edits to a Dispute populate audit fields.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
