### PR TITLE
TCVP-1268 Added FilePersistence to staff-api

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,11 @@ services:
       RABBITMQ__USERNAME: ${RABBITMQ__USERNAME:-guest}
       RABBITMQ__PASSWORD: ${RABBITMQ__PASSWORD:-guest}
       REDIS__CONNECTIONSTRING: ${REDIS_CONNECTIONSTRING:-redis:6379,password=password}
+      TICKETSTORAGE: ${TICKETSTORAGE:-ObjectStore}
+      OBJECTSTORAGE__ENDPOINT: ${OBJECTSTORAGE__ENDPOINT:-minio:9000}
+      OBJECTSTORAGE__ACCESSKEY: ${OBJECTSTORAGE__ACCESSKEY:-username}
+      OBJECTSTORAGE__SECRETKEY: ${OBJECTSTORAGE__SECRETKEY:-password}
+      OBJECTSTORAGE__BUCKETNAME: ${OBJECTSTORAGE__ENDPOINT:-traffic-ticket-dev}
     ports:
       - "5000:8080"
     restart: always
@@ -193,7 +198,7 @@ services:
       MINIO_ROOT_PASSWORD: "password"
     command: server /data --console-address ":9001"
 
-  createbuckets:
+  minio-init:
     container_name: minio-init
     image: minio/mc
     depends_on:

--- a/src/backend/TrafficCourts/Citizen.Service/Configuration/Extensions.cs
+++ b/src/backend/TrafficCourts/Citizen.Service/Configuration/Extensions.cs
@@ -6,7 +6,7 @@ namespace TrafficCourts.Citizen.Service.Configuration;
 public static class Extensions
 {
     /// <summary>
-    /// Adds <see cref="IFilePersistenceService"/> that uses S3 Object Storage.s
+    /// Adds <see cref="IFilePersistenceService"/> that uses S3 Object Storage.
     /// </summary>
     /// <param name="builder"></param>
     /// <returns></returns>

--- a/src/backend/TrafficCourts/Citizen.Service/Controllers/TicketsController.cs
+++ b/src/backend/TrafficCourts/Citizen.Service/Controllers/TicketsController.cs
@@ -103,7 +103,7 @@ namespace TrafficCourts.Citizen.Service.Controllers
                 problemDetails.Status = (int)HttpStatusCode.InternalServerError;
                 problemDetails.Title = "Error invoking Azure Form Recognizer";
                 problemDetails.Instance = HttpContext?.Request?.Path;
-                problemDetails.Extensions.Add("errors", e.Message);
+                problemDetails.Extensions.Add("errors", new string[] { e.Message, e.InnerException?.Message });
 
                 return new ObjectResult(problemDetails);
             }

--- a/src/backend/TrafficCourts/Citizen.Service/Startup.cs
+++ b/src/backend/TrafficCourts/Citizen.Service/Startup.cs
@@ -2,18 +2,19 @@
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
 using NodaTime;
+using OpenTelemetry.Trace;
 using Serilog;
 using System.Configuration;
+using System.Reflection;
 using TrafficCourts.Citizen.Service.Configuration;
 using TrafficCourts.Citizen.Service.Services;
 using TrafficCourts.Citizen.Service.Validators;
+using TrafficCourts.Citizen.Service.Mappings;
+using TrafficCourts.Citizen.Service.Services.Impl;
 using TrafficCourts.Common;
 using TrafficCourts.Common.Configuration;
 using TrafficCourts.Messaging;
-using TrafficCourts.Citizen.Service.Services.Impl;
-using System.Reflection;
-using OpenTelemetry.Trace;
-using TrafficCourts.Citizen.Service.Mappings;
+using TicketStorageType = TrafficCourts.Citizen.Service.Configuration.TicketStorageType;
 
 namespace TrafficCourts.Citizen.Service;
 

--- a/src/backend/TrafficCourts/Common/Configuration/TicketStorageConfiguration.cs
+++ b/src/backend/TrafficCourts/Common/Configuration/TicketStorageConfiguration.cs
@@ -1,0 +1,14 @@
+﻿using TrafficCourts.Common.Configuration.Validation;
+
+namespace TrafficCourts.Common.Configuration;
+
+public class TicketStorageConfiguration : IValidatable
+{
+    public const string Section = "TicketStorage";
+
+    public TicketStorageType Type { get; set; } = TicketStorageType.InMemory;
+
+    public void Validate()
+    {
+    }
+}

--- a/src/backend/TrafficCourts/Common/Configuration/TicketStorageType.cs
+++ b/src/backend/TrafficCourts/Common/Configuration/TicketStorageType.cs
@@ -1,0 +1,7 @@
+﻿namespace TrafficCourts.Common.Configuration;
+
+public enum TicketStorageType
+{
+    InMemory,
+    ObjectStore
+}

--- a/src/backend/TrafficCourts/Common/Configuration/TicketStorageType.cs
+++ b/src/backend/TrafficCourts/Common/Configuration/TicketStorageType.cs
@@ -2,6 +2,6 @@
 
 public enum TicketStorageType
 {
-    InMemory,
-    ObjectStore
+    ObjectStore,
+    InMemory
 }

--- a/src/backend/TrafficCourts/Common/Features/FilePersistence/MinioFilePersistenceService.cs
+++ b/src/backend/TrafficCourts/Common/Features/FilePersistence/MinioFilePersistenceService.cs
@@ -115,8 +115,8 @@ public class MinioFilePersistenceService : FilePersistenceService
         }
         catch (MinioException exception)
         {
-            _logger.LogError(exception, "Failed up upload file");
-            throw new MinioFilePersistenceException("Failed up upload file", exception);
+            _logger.LogError(exception, "Failed to upload file to object storage");
+            throw new MinioFilePersistenceException("Failed to upload file to object storage", exception);
         }
     }
 }

--- a/src/backend/TrafficCourts/Common/StreamExtensions.cs
+++ b/src/backend/TrafficCourts/Common/StreamExtensions.cs
@@ -1,16 +1,18 @@
-﻿using System;
-using System.Buffers;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Buffers;
 using Winista.Mime;
 
 namespace System.IO;
 
 public static class StreamExtensions
 {
-
+    /// <summary>
+    /// Scans the first 1K of a data stream looking for the MimeType.
+    /// 
+    /// Logic copied from TrafficCourts.Common.Features.FilePersistence.FilePersistenceService#GetMimeTypeAsync(Stream data) 
+    /// since that method is protected and not accessible.
+    /// </summary>
+    /// <param name="data">A stream to scan for a MimeType</param>
+    /// <returns></returns>
     public static async Task<MimeType> GetMimeTypeAsync(this Stream data)
     {
         ArgumentNullException.ThrowIfNull(data);

--- a/src/backend/TrafficCourts/Common/StreamExtensions.cs
+++ b/src/backend/TrafficCourts/Common/StreamExtensions.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Buffers;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Winista.Mime;
+
+namespace System.IO;
+
+public static class StreamExtensions
+{
+
+    public static async Task<MimeType> GetMimeTypeAsync(this Stream data)
+    {
+        ArgumentNullException.ThrowIfNull(data);
+
+        var pool = ArrayPool<byte>.Shared;
+        // get a buffer to read the first 1K of the file stream
+        // any of our images should be at least 1KB be.
+        var buffer = pool.Rent(1024);
+
+        try
+        {
+            int count = await data.ReadAsync(buffer, 0, buffer.Length);
+            var mimeTypes = new MimeTypes();
+            MimeType mimeType = mimeTypes.GetMimeType(buffer);
+            return mimeType;
+        }
+        finally
+        {
+            data.Seek(0L, SeekOrigin.Begin); // reset the memory stream to the beginning
+            pool.Return(buffer);
+        }
+    }
+
+}

--- a/src/backend/TrafficCourts/Staff.Service/Models/ViolationTicket.cs
+++ b/src/backend/TrafficCourts/Staff.Service/Models/ViolationTicket.cs
@@ -1,0 +1,13 @@
+﻿namespace TrafficCourts.Staff.Service.OpenAPIs.OracleDataApi.v1_0;
+
+/// <summary>
+/// An extension of the ViolationTicket object to include a ViolationTicketImage object.
+/// </summary>
+public partial class ViolationTicket
+{
+    /// <summary>
+    /// A non-persistent object (not in the Oracle database model) that wraps an uploaded image (the actual byte[])
+    /// of the object store image reference in the ocrViolationTicket json property.
+    /// </summary>
+    public ViolationTicketImage? ViolationTicketImage { get; set; }
+}

--- a/src/backend/TrafficCourts/Staff.Service/Models/ViolationTicketImage.cs
+++ b/src/backend/TrafficCourts/Staff.Service/Models/ViolationTicketImage.cs
@@ -1,0 +1,25 @@
+﻿using Winista.Mime;
+
+namespace TrafficCourts.Staff.Service.OpenAPIs.OracleDataApi.v1_0;
+
+/// <summary>
+/// A class that contains the byte[] data (raw image) that is retrieved from the object store.
+/// </summary>
+public class ViolationTicketImage
+{
+    public ViolationTicketImage(byte[] Image, MimeType MimeType)
+    {
+        this.Image = Image;
+        this.MimeType = MimeType;
+    }
+
+    /// <summary>
+    /// The byte[] of the ViolationTicket image.
+    /// </summary>
+    public byte[] Image { get; set; }
+
+    /// <summary>
+    /// The MimeType of the image.
+    /// </summary>
+    public MimeType MimeType { get; set; }
+}

--- a/src/backend/TrafficCourts/Staff.Service/Models/ViolationTicketImage.cs
+++ b/src/backend/TrafficCourts/Staff.Service/Models/ViolationTicketImage.cs
@@ -9,6 +9,8 @@ public class ViolationTicketImage
 {
     public ViolationTicketImage(byte[] Image, MimeType MimeType)
     {
+        ArgumentNullException.ThrowIfNull(Image);
+        ArgumentNullException.ThrowIfNull(MimeType);
         this.Image = Image;
         this.MimeType = MimeType;
     }

--- a/src/backend/TrafficCourts/Staff.Service/Services/DisputeService.cs
+++ b/src/backend/TrafficCourts/Staff.Service/Services/DisputeService.cs
@@ -1,9 +1,12 @@
 ﻿using MassTransit;
-using Microsoft.Extensions.Options;
+using Newtonsoft.Json;
+using TrafficCourts.Common.Features.FilePersistence;
 using TrafficCourts.Messaging.MessageContracts;
 using TrafficCourts.Staff.Service.Configuration;
 using TrafficCourts.Staff.Service.Mappers;
 using TrafficCourts.Staff.Service.OpenAPIs.OracleDataApi.v1_0;
+using Winista.Mime;
+using ViolationTicket = TrafficCourts.Staff.Service.OpenAPIs.OracleDataApi.v1_0.ViolationTicket;
 
 namespace TrafficCourts.Staff.Service.Services;
 
@@ -15,11 +18,17 @@ public class DisputeService : IDisputeService
     private readonly OracleDataApiConfiguration _oracleDataApiConfiguration;
     private readonly ILogger<DisputeService> _logger;
     private readonly IBus _bus;
+    private readonly IFilePersistenceService _filePersistenceService;
 
-    public DisputeService(OracleDataApiConfiguration oracleDataApiConfiguration, IBus bus, ILogger<DisputeService> logger)
+    public DisputeService(
+        OracleDataApiConfiguration oracleDataApiConfiguration,
+        IBus bus,
+        IFilePersistenceService filePersistenceService,
+        ILogger<DisputeService> logger)
     {
         _oracleDataApiConfiguration = oracleDataApiConfiguration ?? throw new ArgumentNullException(nameof(oracleDataApiConfiguration));
         _bus = bus ?? throw new ArgumentNullException(nameof(bus));
+        _filePersistenceService = filePersistenceService ?? throw new ArgumentNullException(nameof(filePersistenceService));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
@@ -46,7 +55,69 @@ public class DisputeService : IDisputeService
 
     public async Task<Dispute> GetDisputeAsync(Guid disputeId, CancellationToken cancellationToken)
     {
-        return await GetOracleDataApi().GetDisputeAsync(disputeId, cancellationToken);
+        Dispute dispute = await GetOracleDataApi().GetDisputeAsync(disputeId, cancellationToken);
+
+        // If OcrViolationTicket != null, then this Violation Ticket was scanned using the Azure OCR Form Recognizer at one point.
+        // If so, retrieve the image from object storage and return it as well.
+
+        // Get the object store reference of the image (iff this is a scanned ViolationTicket)
+        string? imageFilename = GetViolationTicketImageFilename(dispute);
+        dispute.ViolationTicket.ViolationTicketImage = await GetViolationTicketImageAsync(imageFilename, cancellationToken);
+
+        return dispute;
+    }
+
+    /// <summary>
+    /// Extracts the path to the image located in the object store from the dispute record, or null if not filename could be found.
+    /// </summary>
+    /// <param name="dispute"></param>
+    /// <returns></returns>
+    public string? GetViolationTicketImageFilename(Dispute dispute)
+    {
+        ViolationTicket violationTicket = dispute.ViolationTicket;
+        if (violationTicket.OcrViolationTicket is not null)
+        {
+            try
+            {
+                // deserialize json string to a dictionary
+                var keys = JsonConvert.DeserializeObject<Dictionary<string, string>>(violationTicket.OcrViolationTicket);
+                string? imageFilename = keys?["ImageFilename"];
+
+                return imageFilename;
+            }
+            catch (Exception ex)
+            {
+                // Should never reach here, but if so then it means the ocr json data is invalid or not parseable by .NET
+                // For now, just log the error and return null to mean no image could be found so the GetDispute(id) endpoint doesn't break.
+                _logger.LogError("Could not extract object store file reference from json data.", ex);
+            }
+        }
+        return null;
+    }
+
+    /// <summary>
+    /// Retrieves a image from the object store with the given imageFilename.
+    /// </summary>
+    /// <param name="imageFilename"></param>
+    /// <param name="cancellationToken"></param>
+    /// <returns></returns>
+    private async Task<ViolationTicketImage?> GetViolationTicketImageAsync(string? imageFilename, CancellationToken cancellationToken)
+    {
+        if (!String.IsNullOrEmpty(imageFilename))
+        {
+            try
+            {
+                MemoryStream stream = await _filePersistenceService.GetFileAsync(imageFilename, cancellationToken);
+                MimeType mimeType = await stream.GetMimeTypeAsync();
+                return new ViolationTicketImage(stream.ToArray(), mimeType);
+            }
+            catch (Exception e)
+            {
+                _logger.LogError("Could not retrieve image from object storage", e);
+                throw;
+            }
+        }
+        return null;
     }
 
     public async Task<Dispute> UpdateDisputeAsync(Guid disputeId, Dispute dispute, System.Threading.CancellationToken cancellationToken)

--- a/src/backend/TrafficCourts/Staff.Service/Startup.cs
+++ b/src/backend/TrafficCourts/Staff.Service/Startup.cs
@@ -3,6 +3,7 @@ using Microsoft.OpenApi.Models;
 using System.Reflection;
 using System.Text.Json.Serialization;
 using TrafficCourts.Common.Configuration;
+using TrafficCourts.Common.Features.FilePersistence;
 using TrafficCourts.Messaging;
 using TrafficCourts.Staff.Service.Authentication;
 using TrafficCourts.Staff.Service.Configuration;
@@ -32,6 +33,8 @@ public static class Startup
         builder.Services.Configure<RouteOptions>(options => options.LowercaseUrls = true);
 
         builder.Services.AddAuthentication(builder.Configuration);
+
+        builder.Services.AddFilePersistence(builder.Configuration);
 
         // Add DisputeService
         builder.Services.ConfigureValidatableSetting<OracleDataApiConfiguration>(builder.Configuration.GetRequiredSection(OracleDataApiConfiguration.Section));

--- a/src/backend/TrafficCourts/Staff.Service/TrafficCourts.Staff.Service.csproj
+++ b/src/backend/TrafficCourts/Staff.Service/TrafficCourts.Staff.Service.csproj
@@ -29,6 +29,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="2.2.0" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.15.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="NSwag.ApiDescription.Client" Version="13.0.5">

--- a/src/backend/TrafficCourts/TrafficCourts.Staff.Service.Test/Services/DisputeServiceTest.cs
+++ b/src/backend/TrafficCourts/TrafficCourts.Staff.Service.Test/Services/DisputeServiceTest.cs
@@ -1,0 +1,40 @@
+﻿using MassTransit;
+using Microsoft.Extensions.Logging;
+using Moq;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using TrafficCourts.Common.Features.FilePersistence;
+using TrafficCourts.Staff.Service.Configuration;
+using TrafficCourts.Staff.Service.OpenAPIs.OracleDataApi.v1_0;
+using TrafficCourts.Staff.Service.Services;
+using Xunit;
+
+namespace TrafficCourts.Staff.Service.Test.Services;
+
+public class DisputeServiceTest
+{
+
+    [Theory]
+    [InlineData("{\"ImageFilename\":\"2022-05-09/5d6811cbae4f4dd297151a27ab9f0707.xwd\",\"GlobalConfidence\":0.88}", "2022-05-09/5d6811cbae4f4dd297151a27ab9f0707.xwd")]
+    [InlineData("{\"BadProperty\":\"2022-05-09/5d6811cbae4f4dd297151a27ab9f0707.xwd\",\"GlobalConfidence\":0.88}", null)]
+    [InlineData("", null)]
+    [InlineData(null, null)]
+    public void TestGetViolationTicketImageFilename(string json, string? expectedFilename)
+    {
+        //Given
+        DisputeService service = new(new OracleDataApiConfiguration(), new Mock<IBus>().Object, new Mock<IFilePersistenceService>().Object, new Mock<ILogger<DisputeService>>().Object);
+        Dispute dispute = new();
+        dispute.Id = Guid.NewGuid();
+        dispute.ViolationTicket = new();
+        dispute.ViolationTicket.OcrViolationTicket = json;
+
+        //When
+        string? filename = service.GetViolationTicketImageFilename(dispute);
+
+        //Then
+        Assert.Equal(expectedFilename, filename);
+    }
+}


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

[TCVP-1268](https://justice.gov.bc.ca/jira/browse/TCVP-1268)

Per the JIRA requirements, modified the `/api/dispute/{id}` staff-api endpoint by extending the returned `Dispute `object to include the raw byte[] (raw image) of the uploaded violation ticket image that is located in the object store.

- Created a FilePersistenceExtension in Common to wire up Minio, an object store (copied from Citizen Service configuration)
- Configured the StaffApi to use the new common file persistence extension
- Extended ViolationTicket to included a new ViolationTicketImage object that holds the byte[] of the actual image
- Enhanced the GetDisputeAsync service call to pull the raw image from Minio and store it in the returned ViolationTicket 
- Added xUnit test

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

dotnet test

## Does the change impact or break the Docker build?

- [x] Yes
- [ ] No

If Yes: Has Docker been updated accordingly?

- [x] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
