### PR TITLE
Add rhel8 docker files for consistent base image

### DIFF
--- a/src/backend/TrafficCourts/TrafficCourts.Arc.Dispute.Service/Dockerfile.rhel8
+++ b/src/backend/TrafficCourts/TrafficCourts.Arc.Dispute.Service/Dockerfile.rhel8
@@ -1,0 +1,21 @@
+#See https://aka.ms/containerfastmode to understand how Visual Studio uses this Dockerfile to build your images for faster debugging.
+
+FROM registry.access.redhat.com/ubi8/dotnet-60-runtime AS base
+WORKDIR /opt/app-root/app
+EXPOSE 8080
+
+FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
+WORKDIR /src
+COPY ["TrafficCourts.Arc.Dispute.Service/TrafficCourts.Arc.Dispute.Service.csproj", "TrafficCourts.Arc.Dispute.Service/"]
+RUN dotnet restore "TrafficCourts.Arc.Dispute.Service/TrafficCourts.Arc.Dispute.Service.csproj"
+COPY . .
+WORKDIR "/src/TrafficCourts.Arc.Dispute.Service"
+RUN dotnet build "TrafficCourts.Arc.Dispute.Service.csproj" -c Release -o /app/build
+
+FROM build AS publish
+RUN dotnet publish "TrafficCourts.Arc.Dispute.Service.csproj" -c Release -o /app/publish
+
+FROM base AS final
+WORKDIR /opt/app-root/app
+COPY --from=publish /app/publish .
+ENTRYPOINT ["dotnet", "TrafficCourts.Arc.Dispute.Service.dll"]

--- a/src/backend/TrafficCourts/Workflow.Service/Dockerfile.rhel8
+++ b/src/backend/TrafficCourts/Workflow.Service/Dockerfile.rhel8
@@ -1,0 +1,24 @@
+#See https://aka.ms/containerfastmode to understand how Visual Studio uses this Dockerfile to build your images for faster debugging.
+
+FROM registry.access.redhat.com/ubi8/dotnet-60-runtime AS base
+WORKDIR /opt/app-root/app
+EXPOSE 8080
+
+
+FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
+WORKDIR /src
+COPY ["Workflow.Service/TrafficCourts.Workflow.Service.csproj", "Workflow.Service/"]
+COPY ["Common/TrafficCourts.Common.csproj", "Common/"]
+COPY ["Messaging/TrafficCourts.Messaging.csproj", "Messaging/"]
+RUN dotnet restore "Workflow.Service/TrafficCourts.Workflow.Service.csproj"
+COPY . .
+WORKDIR "/src/Workflow.Service"
+RUN dotnet build "TrafficCourts.Workflow.Service.csproj" -c Release -o /app/build
+
+FROM build AS publish
+RUN dotnet publish "TrafficCourts.Workflow.Service.csproj" -c Release -o /app/publish
+
+FROM base AS final
+WORKDIR /opt/app-root/app
+COPY --from=publish /app/publish .
+ENTRYPOINT ["dotnet", "TrafficCourts.Workflow.Service.dll"]


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- Adds ubi8/rhel8 docker files for using the ubi8 dotnet base image
- Builds are almost identical except for base image, export port and working directory

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [x] Yes - only for ubi8 builds
- [ ] No

If Yes: Has Docker been updated accordingly?

- [x] Yes
- [ ] No

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
