### PR TITLE
Fixed issue with jwt auth not working in staff-api in Docker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,6 +54,8 @@ services:
       RABBITMQ__PORT: 5672
       RABBITMQ__USERNAME: ${RABBITMQ__USERNAME:-guest}
       RABBITMQ__PASSWORD: ${RABBITMQ__PASSWORD:-guest}
+      JWT__AUDIENCE: ${JWT__AUDIENCE:-tco-staff-portal}
+      JWT__AUTHORITY: ${JWT__AUTHORITY:-https://dev.oidc.gov.bc.ca/auth/realms/ezb8kej4/}
     ports:
       - "5005:8080"
     restart: always


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

Set default values to be able to authenticate with Keycloak when running the staff-api locally in Docker

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [x] Yes
- [ ] No

If Yes: Has Docker been updated accordingly?

- [x] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
