### PR TITLE
TCVP-1268 bug fix to better parse the ocrViolationTicket

### DIFF
--- a/src/backend/TrafficCourts/Staff.Service/Services/DisputeService.cs
+++ b/src/backend/TrafficCourts/Staff.Service/Services/DisputeService.cs
@@ -79,8 +79,8 @@ public class DisputeService : IDisputeService
             try
             {
                 // deserialize json string to a dictionary
-                var keys = JsonConvert.DeserializeObject<Dictionary<string, string>>(dispute.OcrViolationTicket);
-                string? imageFilename = keys?["ImageFilename"];
+                var keys = JsonConvert.DeserializeObject<Dictionary<string, object>>(dispute.OcrViolationTicket);
+                string? imageFilename = (string?)(keys?["ImageFilename"]);
 
                 return imageFilename;
             }


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

TCVP-1268

Fixed a bug where the service could not parse the ocrViolationTicket json string to retrieve the image filename that is in the object store.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

dotnet test

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
