### PR TITLE
TCVP-1333 - Move e-mail send publishes to its own consumers

### DIFF
--- a/src/backend/TrafficCourts/Test/Workflow.Service/Consumers/DisputeApproveNotifyConsumerTests.cs
+++ b/src/backend/TrafficCourts/Test/Workflow.Service/Consumers/DisputeApproveNotifyConsumerTests.cs
@@ -1,0 +1,66 @@
+﻿using AutoMapper;
+using MassTransit;
+using MassTransit.Testing;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using TrafficCourts.Common.Features.Mail.Model;
+using TrafficCourts.Messaging.MessageContracts;
+using TrafficCourts.Workflow.Service.Consumers;
+using TrafficCourts.Workflow.Service.Features.Mail;
+using TrafficCourts.Workflow.Service.Services;
+using TrafficCourts.Workflow.Service.Configuration;
+using MailKit.Net.Smtp;
+using MimeKit;
+using MimeKit.Text;
+using Moq;
+using Xunit;
+
+namespace TrafficCourts.Test.Workflow.Service.Consumers
+{
+    public class DisputeApproveNotifyConsumerTests
+    {
+        private readonly Mock<ILogger<DisputeApprovedNotifyConsumer>> _mockLogger;
+
+        public DisputeApproveNotifyConsumerTests()
+        {
+            _mockLogger = new Mock<ILogger<DisputeApprovedNotifyConsumer>>();
+        }
+
+        private DisputeApprovedNotifyConsumer CreateConsumer()
+        {
+            return new DisputeApprovedNotifyConsumer(_mockLogger.Object);
+        }
+
+        [Fact]
+        public async Task DisputeApproveNotifyConsumerAsync_WithCorrectParams_ShouldReturnTaskComplete()
+        {
+            var consumer = CreateConsumer();
+            var harness = new InMemoryTestHarness();
+
+            var emailConsumer = harness.Consumer(() => consumer);
+ 
+            await harness.Start();
+
+            try
+            {
+                await harness.InputQueueSendEndpoint.Send<DisputeApproved>(new
+                {
+                    TicketFileNumber = "abc1234",
+                    Email = "test@test.com"
+                }, c => c.RequestId = NewId.NextGuid());
+
+                Assert.True(emailConsumer.Consumed.Select<DisputeApproved>().Any());
+            }
+            finally
+            {
+                await harness.Stop();
+            }
+
+        }
+
+    }
+}

--- a/src/backend/TrafficCourts/Test/Workflow.Service/Consumers/DisputeSubmitNotifyConsumerTests.cs
+++ b/src/backend/TrafficCourts/Test/Workflow.Service/Consumers/DisputeSubmitNotifyConsumerTests.cs
@@ -1,0 +1,68 @@
+﻿using AutoMapper;
+using MassTransit;
+using MassTransit.Testing;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using TrafficCourts.Common.Features.Mail.Model;
+using TrafficCourts.Messaging.MessageContracts;
+using TrafficCourts.Workflow.Service.Consumers;
+using TrafficCourts.Workflow.Service.Features.Mail;
+using TrafficCourts.Workflow.Service.Services;
+using TrafficCourts.Workflow.Service.Configuration;
+using MailKit.Net.Smtp;
+using MimeKit;
+using MimeKit.Text;
+using Moq;
+using Xunit;
+
+namespace TrafficCourts.Test.Workflow.Service.Consumers
+{
+    public class DisputeSubmitNotifyConsumerTests
+    {
+        private readonly Mock<ILogger<DisputeSubmitNotifyConsumer>> _mockLogger;
+        private readonly Mock<IMapper> _mockMapper;
+
+        public DisputeSubmitNotifyConsumerTests()
+        {
+            _mockLogger = new Mock<ILogger<DisputeSubmitNotifyConsumer>>();
+            _mockMapper = new Mock<IMapper>();
+        }
+
+        private DisputeSubmitNotifyConsumer CreateConsumer()
+        {
+            return new DisputeSubmitNotifyConsumer(_mockLogger.Object, _mockMapper.Object);
+        }
+
+        [Fact]
+        public async Task DisputeSubmitNotifyConsumerAsync_WithCorrectParams_ShouldReturnTaskComplete()
+        {
+            var consumer = CreateConsumer();
+            var harness = new InMemoryTestHarness();
+
+            var emailConsumer = harness.Consumer(() => consumer);
+ 
+            await harness.Start();
+
+            try
+            {
+                await harness.InputQueueSendEndpoint.Send<SubmitNoticeOfDispute>(new
+                {
+                    TicketNumber = "abc1234",
+                    EmailAddress = "test@test.com"
+                }, c => c.RequestId = NewId.NextGuid());
+
+                Assert.True(emailConsumer.Consumed.Select<SubmitNoticeOfDispute>().Any());
+            }
+            finally
+            {
+                await harness.Stop();
+            }
+
+        }
+
+    }
+}

--- a/src/backend/TrafficCourts/Test/Workflow.Service/Features/Mail/SendEmailConsumerTests.cs
+++ b/src/backend/TrafficCourts/Test/Workflow.Service/Features/Mail/SendEmailConsumerTests.cs
@@ -1,40 +1,33 @@
-﻿using MassTransit;
+﻿using MailKit.Net.Smtp;
+using MassTransit;
 using MassTransit.Testing;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using System;
+using MimeKit;
+using Moq;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using TrafficCourts.Common.Features.Mail.Model;
 using TrafficCourts.Messaging.MessageContracts;
+using TrafficCourts.Workflow.Service.Configuration;
 using TrafficCourts.Workflow.Service.Features.Mail;
 using TrafficCourts.Workflow.Service.Services;
-using TrafficCourts.Workflow.Service.Configuration;
-using MailKit.Net.Smtp;
-using MimeKit;
-using MimeKit.Text;
-using Moq;
 using Xunit;
 
 namespace TrafficCourts.Test.Workflow.Service.Features.Mail
 {
     public class SendEmailConsumerTests
     {
-        private readonly Mock<ILogger<SendEmailConsumer>> _mockLogger;
         private readonly Mock<ILogger<EmailSenderService>> _mockSenderLogger;
         private readonly Mock<ISmtpClient> _mockSmtpClient;
         private readonly Mock<ISmtpClientFactory> _mockSmtpClientFactory;
-        private readonly Mock<IEmailSenderService> _mockEmailSenderService;
 
         public SendEmailConsumerTests()
         {
-
-            _mockLogger = new Mock<ILogger<SendEmailConsumer>>();
             _mockSenderLogger = new Mock<ILogger<EmailSenderService>>();
             _mockSmtpClientFactory = new Mock<ISmtpClientFactory>();
             _mockSmtpClient = new Mock<ISmtpClient>();
-            _mockEmailSenderService = new Mock<IEmailSenderService>();
         }
 
         private EmailSenderService CreateService()
@@ -55,9 +48,7 @@ namespace TrafficCourts.Test.Workflow.Service.Features.Mail
 
         private SendEmailConsumer CreateConsumer(EmailSenderService senderService)
         {
-            return new SendEmailConsumer(
-                _mockLogger.Object,
-                senderService);
+            return new SendEmailConsumer(senderService);
         }
 
         // Tests:
@@ -129,7 +120,6 @@ namespace TrafficCourts.Test.Workflow.Service.Features.Mail
             {
                 await harness.Stop();
             }
-
         }
 
         // Test retrieve mail template found
@@ -180,7 +170,6 @@ namespace TrafficCourts.Test.Workflow.Service.Features.Mail
             {
                 await harness.Stop();
             }
-
         }
 
         [Fact]
@@ -224,7 +213,6 @@ namespace TrafficCourts.Test.Workflow.Service.Features.Mail
             {
                 await harness.Stop();
             }
-
         }
     }
 }

--- a/src/backend/TrafficCourts/Workflow.Service/Configuration/EmailConfiguration.cs
+++ b/src/backend/TrafficCourts/Workflow.Service/Configuration/EmailConfiguration.cs
@@ -1,10 +1,14 @@
-﻿namespace TrafficCourts.Workflow.Service.Configuration
+﻿using TrafficCourts.Common.Configuration.Validation;
+
+namespace TrafficCourts.Workflow.Service.Configuration
 {
     /// <summary>
     /// Represents the email sending configuration
     /// </summary>
-    public class EmailConfiguration
+    public class EmailConfiguration : IValidatable
     {
+        public const string Section = "EmailConfiguration";
+
         private IList<string>? _allowed;
 
         /// <summary>
@@ -26,21 +30,35 @@
             {
                 if (_allowed is null)
                 {
-                    string allowList = AllowList;
-                    if (string.IsNullOrEmpty(allowList))
-                    {
-                        _allowed = Array.Empty<string>();
-                    }
-                    else
-                    {
-                        _allowed = allowList.Split(",")
-                            .Select(_ => _.Trim())
-                            .ToList();
-                    }
+                    _allowed = SplitAllowList();
                 }
 
                 return _allowed;
             }
+        }
+
+        public void Validate()
+        {
+            if (string.IsNullOrEmpty(Sender)) throw new SettingsValidationException(Section, nameof(Sender), "is required");
+
+            if (!string.IsNullOrEmpty(AllowList))
+            {
+                var allowed = SplitAllowList();
+                if (allowed.Any(_ => !_.StartsWith("@"))) throw new SettingsValidationException(Section, nameof(AllowList), "values must start with @");
+            }
+        }
+
+
+        private IList<string> SplitAllowList()
+        {
+            if (string.IsNullOrEmpty(AllowList))
+            {
+                return Array.Empty<string>();
+            }
+
+            return AllowList.Split(",")
+                .Select(_ => _.Trim())
+                .ToList();
         }
     }
 }

--- a/src/backend/TrafficCourts/Workflow.Service/Consumers/DisputeSubmitConsumer.cs
+++ b/src/backend/TrafficCourts/Workflow.Service/Consumers/DisputeSubmitConsumer.cs
@@ -3,7 +3,6 @@ using MassTransit;
 using TrafficCourts.Messaging.MessageContracts;
 using TrafficCourts.Workflow.Service.Models;
 using TrafficCourts.Workflow.Service.Services;
-using ViolationTicketCount = TrafficCourts.Workflow.Service.Models.ViolationTicket;
 
 namespace TrafficCourts.Workflow.Service.Consumers
 {

--- a/src/backend/TrafficCourts/Workflow.Service/Features/Mail/SendEmailConsumer.cs
+++ b/src/backend/TrafficCourts/Workflow.Service/Features/Mail/SendEmailConsumer.cs
@@ -1,6 +1,5 @@
 ﻿using MassTransit;
 using TrafficCourts.Messaging.MessageContracts;
-using TrafficCourts.Workflow.Service.Models;
 using TrafficCourts.Workflow.Service.Services;
 
 namespace TrafficCourts.Workflow.Service.Features.Mail
@@ -10,13 +9,11 @@ namespace TrafficCourts.Workflow.Service.Features.Mail
     /// </summary>
     public class SendEmailConsumer : IConsumer<SendEmail>
     {
-        private readonly ILogger<SendEmailConsumer> _logger;
         private readonly IEmailSenderService _emailSenderService;
 
-        public SendEmailConsumer(ILogger<SendEmailConsumer> logger, IEmailSenderService emailSenderService)
+        public SendEmailConsumer(IEmailSenderService emailSenderService)
         {
-            _logger = logger;
-            _emailSenderService = emailSenderService;
+            _emailSenderService = emailSenderService ?? throw new ArgumentNullException(nameof(emailSenderService));
         }
 
         public async Task Consume(ConsumeContext<SendEmail> context)

--- a/src/backend/TrafficCourts/Workflow.Service/Services/EmailSenderService.cs
+++ b/src/backend/TrafficCourts/Workflow.Service/Services/EmailSenderService.cs
@@ -14,7 +14,7 @@ namespace TrafficCourts.Workflow.Service.Services
 
         public EmailSenderService(ILogger<EmailSenderService> logger, IOptions<EmailConfiguration> emailConfiguration, ISmtpClientFactory stmpClientFactory)
         {
-            _logger = logger;
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
             _emailConfiguration = emailConfiguration.Value;
             _smptClientFactory = stmpClientFactory;
         }

--- a/src/backend/TrafficCourts/Workflow.Service/Startup.cs
+++ b/src/backend/TrafficCourts/Workflow.Service/Startup.cs
@@ -43,7 +43,7 @@ public static class Startup
         void AddConsumers(IBusRegistrationConfigurator cfg)
         {
             // TODO: use cfg.AddConsumers(params Type[] types) or cfg.AddConsumers(params Assembly[] assemblies)
-            cfg.AddConsumer<SubmitDisputeConsumer>();
+            cfg.AddConsumer<DisputeSubmitConsumer>();
             cfg.AddConsumer<DisputeSubmitNotifyConsumer>();
             cfg.AddConsumer<DisputeApprovedConsumer>();
             cfg.AddConsumer<DisputeApprovedNotifyConsumer>();

--- a/src/backend/TrafficCourts/Workflow.Service/Startup.cs
+++ b/src/backend/TrafficCourts/Workflow.Service/Startup.cs
@@ -32,7 +32,7 @@ public static class Startup
 
         builder.Services.Configure<ArcApiConfiguration>(builder.Configuration.GetRequiredSection("ArcApiConfiguration"));
         builder.Services.Configure<OracleDataApiConfiguration>(builder.Configuration.GetRequiredSection(OracleDataApiConfiguration.Section));
-        builder.Services.Configure<EmailConfiguration>(builder.Configuration.GetRequiredSection("EmailConfiguration"));
+        builder.Services.ConfigureValidatableSetting<EmailConfiguration>(builder.Configuration.GetSection(EmailConfiguration.Section));
         builder.Services.ConfigureValidatableSetting<SmtpConfiguration>(builder.Configuration.GetRequiredSection(SmtpConfiguration.Section));
 
         builder.Services.AddTransient<IOracleDataApiService, OracleDataApiService>();

--- a/src/backend/TrafficCourts/Workflow.Service/Startup.cs
+++ b/src/backend/TrafficCourts/Workflow.Service/Startup.cs
@@ -42,12 +42,7 @@ public static class Startup
 
         void AddConsumers(IBusRegistrationConfigurator cfg)
         {
-            // TODO: use cfg.AddConsumers(params Type[] types) or cfg.AddConsumers(params Assembly[] assemblies)
-            cfg.AddConsumer<DisputeSubmitConsumer>();
-            cfg.AddConsumer<DisputeSubmitNotifyConsumer>();
-            cfg.AddConsumer<DisputeApprovedConsumer>();
-            cfg.AddConsumer<DisputeApprovedNotifyConsumer>();
-            cfg.AddConsumer<SendEmailConsumer>();
+            cfg.AddConsumers(typeof(Startup).Assembly); // add all the consumers in this assembly
         }
 
         builder.Services.AddMassTransit(builder.Configuration, logger, AddConsumers);


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- TCVP-1333 - have the e-mail notification as its own consumer, for submit and approval of disputes

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Unit testing to verify calls work.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
