### PR TITLE
Fix startup using wrong class name after rename

### DIFF
--- a/src/backend/TrafficCourts/Workflow.Service/Startup.cs
+++ b/src/backend/TrafficCourts/Workflow.Service/Startup.cs
@@ -41,13 +41,8 @@ public static class Startup
         builder.Services.AddTransient<IEmailSenderService, EmailSenderService>();
 
         void AddConsumers(IBusRegistrationConfigurator cfg)
-        {
-            // TODO: use cfg.AddConsumers(params Type[] types) or cfg.AddConsumers(params Assembly[] assemblies)
-            cfg.AddConsumer<SubmitDisputeConsumer>();
-            cfg.AddConsumer<DisputeSubmitNotifyConsumer>();
-            cfg.AddConsumer<DisputeApprovedConsumer>();
-            cfg.AddConsumer<DisputeApprovedNotifyConsumer>();
-            cfg.AddConsumer<SendEmailConsumer>();
+        {            
+            cfg.AddConsumers(typeof(Startup).Assembly); // add all the consumers in this assembly
         }
 
         builder.Services.AddMassTransit(builder.Configuration, logger, AddConsumers);


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- geez.. how did I miss this. 
- fixes reference class that does not exit

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [ ] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
