### PR TITLE
change oracle data api to use recreate strategy instead of rolling

### DIFF
--- a/.gitops/charts/traffic-court-online/charts/oracle-data-api/templates/deployment.yaml
+++ b/.gitops/charts/traffic-court-online/charts/oracle-data-api/templates/deployment.yaml
@@ -12,6 +12,8 @@ spec:
   selector:
     matchLabels:
       {{- include "oracle-data-api.selectorLabels" . | nindent 6 }}
+  strategy:
+    type: Recreate
   template:
     metadata:
       {{- with .Values.podAnnotations }}


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- Sets oracle data api service to use recreate instead of rolling due to single PVC.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [ ] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
