### PR TITLE
TCVP-1268 Default ticket storage to ObjectStore, not memory

### DIFF
--- a/src/backend/TrafficCourts/Common/Configuration/TicketStorageConfiguration.cs
+++ b/src/backend/TrafficCourts/Common/Configuration/TicketStorageConfiguration.cs
@@ -6,7 +6,7 @@ public class TicketStorageConfiguration : IValidatable
 {
     public const string Section = "TicketStorage";
 
-    public TicketStorageType Type { get; set; } = TicketStorageType.InMemory;
+    public TicketStorageType Type { get; set; } = TicketStorageType.ObjectStore;
 
     public void Validate()
     {


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

To simplify deployment configuration, defaulted the staff-api TicketStorageType to be ObjectStore instead of InMemory

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
