### PR TITLE
TCVP-933 Added new ocr validation rule

### DIFF
--- a/src/backend/TrafficCourts/Citizen.Service/Validators/FormRecognizerValidator.cs
+++ b/src/backend/TrafficCourts/Citizen.Service/Validators/FormRecognizerValidator.cs
@@ -40,6 +40,7 @@ public class FormRecognizerValidator : IFormRecognizerValidator
         // - Ticket number must start with 'A', another alphabetic character, and then 8 digits
         // - In "Did commit offence(s) indicated, under the following act or its regulations" section, only 'MVA' is selected.
         // - If the Violation Date is less than 30 days
+        // - Count ACT/REGs must be MVA as text - all 3 counts must be MVA at this time.
         List<ValidationRule> rules = new();
         rules.Add(new FieldMatchesRegexRule(violationTicket.Fields[OcrViolationTicket.ViolationTicketTitle], _ticketTitleRegex, ValidationMessages.TicketTitleInvalid));
         rules.Add(new FieldMatchesRegexRule(violationTicket.Fields[OcrViolationTicket.ViolationTicketNumber], _violationTicketNumberRegex, ValidationMessages.TicketNumberInvalid));
@@ -52,6 +53,9 @@ public class FormRecognizerValidator : IFormRecognizerValidator
         rules.Add(new CheckboxIsValidRule(violationTicket.Fields[OcrViolationTicket.OffenceIsTCR]));
         rules.Add(new CheckboxIsValidRule(violationTicket.Fields[OcrViolationTicket.OffenceIsOther]));
         rules.Add(new OnlyMVAIsSelectedRule(violationTicket.Fields[OcrViolationTicket.OffenceIsMCA], violationTicket));
+        rules.Add(new CountActRegMustBeMVA(violationTicket.Fields[OcrViolationTicket.Count1ActRegs], 1));
+        rules.Add(new CountActRegMustBeMVA(violationTicket.Fields[OcrViolationTicket.Count2ActRegs], 2));
+        rules.Add(new CountActRegMustBeMVA(violationTicket.Fields[OcrViolationTicket.Count3ActRegs], 3));
         rules.Add(new ViolationDateLT30Rule(violationTicket.Fields[OcrViolationTicket.ViolationDate]));
 
         // Run each rule and aggregate the results

--- a/src/backend/TrafficCourts/Citizen.Service/Validators/Rules/CountActRegMustBeMVA.cs
+++ b/src/backend/TrafficCourts/Citizen.Service/Validators/Rules/CountActRegMustBeMVA.cs
@@ -1,0 +1,26 @@
+using TrafficCourts.Citizen.Service.Models.Tickets;
+
+namespace TrafficCourts.Citizen.Service.Validators.Rules;
+
+/// <summary>
+/// For all 3 counts, the ACT/REGs section must be "MVA" or blank.
+/// </summary>
+public class CountActRegMustBeMVA : ValidationRule
+{
+
+    private int _countNum;
+
+    public CountActRegMustBeMVA(Field field, int countNum) : base(field)
+    {
+        _countNum = countNum;
+    }
+
+    public override void Run()
+    {
+        string? countAct = this.Field.Value;
+        if (countAct is not null && !"MVA".Equals(countAct.Replace("\\s+", "").ToUpper()))
+        {
+            AddValidationError(String.Format(ValidationMessages.MVAMustBeCountValue, countAct, _countNum));
+        }
+    }
+}

--- a/src/backend/TrafficCourts/Citizen.Service/Validators/ValidationMessages.cs
+++ b/src/backend/TrafficCourts/Citizen.Service/Validators/ValidationMessages.cs
@@ -10,6 +10,7 @@ public static class ValidationMessages
     public static readonly string CheckboxInvalid = @"Checkbox '{0}' has an unknown value '{1}'. Expecting 'selected' or 'unselected'.";
     public static readonly string CurrencyInvalid = @"Amount '{0}' is not a valid currency value.";
     public static readonly string MVAMustBeSelectedError = @"MVA must be selected under the 'Did commit the offence(s) indicated' section.";
+    public static readonly string MVAMustBeCountValue = @"TCO only supports counts with MVA as the ACT/REG at this time. Read '{0}' for count {1}.";
     public static readonly string OnlyMVAMustBeSelectedError = @"MVA must be the only selected ACT under the 'Did commit the offence(s) indicated' section.";
     public static readonly string ViolationDateInvalid = @"Violation Date must be a valid date. Read '{0}'.";
     public static readonly string ViolationDateFutureInvalid = @"Violation Date must not be in the future. Read '{0}'.";

--- a/src/backend/TrafficCourts/Test/Citizen.Service/Validators/Rules/CountActRegMustBeMVATest.cs
+++ b/src/backend/TrafficCourts/Test/Citizen.Service/Validators/Rules/CountActRegMustBeMVATest.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using TrafficCourts.Citizen.Service.Models.Tickets;
+using TrafficCourts.Citizen.Service.Validators.Rules;
+using Xunit;
+
+namespace TrafficCourts.Test.Citizen.Service.Validators.Rules;
+
+public class CountActRegMustBeMVATest
+{
+
+    [Theory]
+    [InlineData("MVA", true)]
+    [InlineData("CTA", false)]
+    [InlineData("", false)]
+    public void TestACTREGsFields(string countAct, bool expectValid)
+    {
+        // Given
+        Field field = new(countAct);
+        OcrViolationTicket violationTicket = new();
+        violationTicket.Fields.Add(OcrViolationTicket.Count1ActRegs, field);
+        CountActRegMustBeMVA rule = new(field, 1);
+
+        // When
+        rule.Run();
+
+        // Then.
+        if (expectValid)
+        {
+            Assert.Empty(rule.Field.ValidationErrors);
+        }
+        else
+        {
+            Assert.NotEmpty(rule.Field.ValidationErrors);
+        }
+
+    }
+}


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

[TCVP-933](https://justice.gov.bc.ca/jira/browse/TCVP-933)

Added a new OCR Validation rule per a new business rule requirement to the citizen-api.
Now, the ACT/REGs section of all 3 counts must be the text "MVA".  The entire ticket is considered invalid otherwise.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

New tests
dotnet test

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
