### PR TITLE
TCVP-1376 Created an unassign Dispute cron job

### DIFF
--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/model/Dispute.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/model/Dispute.java
@@ -1,5 +1,7 @@
 package ca.bc.gov.open.jag.tco.oracledataapi.model;
 
+import static javax.persistence.TemporalType.TIMESTAMP;
+
 import java.sql.Date;
 import java.util.ArrayList;
 import java.util.List;
@@ -18,6 +20,7 @@ import javax.persistence.Lob;
 import javax.persistence.OneToMany;
 import javax.persistence.OneToOne;
 import javax.persistence.Table;
+import javax.persistence.Temporal;
 import javax.validation.constraints.Email;
 import javax.validation.constraints.Size;
 
@@ -88,13 +91,13 @@ public class Dispute extends Auditable<String> {
      */
     @Column
     private String givenNames;
-    
+
     /**
      * The disputant's birthdate.
      */
     @Column
     private Date birthdate;
-    
+
     /**
      * The drivers licence number. Note not all jurisdictions will use numeric drivers licence numbers.
      */
@@ -102,7 +105,7 @@ public class Dispute extends Auditable<String> {
     @Column(length = 20)
     @Schema(maxLength = 20)
     private String driversLicenceNumber;
-    
+
     /**
      * The province or state the drivers licence was issued by.
      */
@@ -213,20 +216,20 @@ public class Dispute extends Auditable<String> {
     @Column(length = 256)
     @Schema(nullable = true)
     private String rejectedReason;
-    
+
     /**
      * Identifier for whether the citizen has detected any issues with the OCR ticket result or not.
      */
     @Column
     private boolean disputantDetectedOcrIssues;
-    
+
     /**
      * The description of the issue with OCR ticket if the citizen has detected any.
      */
     @Column
     @Schema(nullable = true)
     private String disputantOcrIssuesDescription;
-    
+
     /**
      * Identifier for whether the system has detected any issues with the OCR ticket result or not.
      */
@@ -236,7 +239,7 @@ public class Dispute extends Auditable<String> {
     @Column
     @Schema(nullable = true)
     private String jjAssigned;
-    
+
     /**
 	 * All OCR Violation ticket data serialized into a JSON string.
 	 */
@@ -244,21 +247,22 @@ public class Dispute extends Auditable<String> {
 	@Lob
     @Schema(nullable = true)
     private String ocrViolationTicket;
-	
+
 	/**
 	 * The IDIR of the Staff whom the dispute is assigned to be reviewed on Staff Portal.
 	 */
 	@Column
 	@Schema(nullable = true)
 	private String assignedTo;
-	
+
 	/**
 	 * The date and time a dispute was assigned to a Staff to be reviewed.
 	 */
 	@Column
 	@Schema(nullable = true)
-	private Date assignedTs;
-    
+	@Temporal(TIMESTAMP)
+	private java.util.Date assignedTs;
+
     @JsonManagedReference
     @OneToOne(fetch = FetchType.LAZY, optional = true, cascade = CascadeType.ALL, orphanRemoval = true, mappedBy = "dispute")
     @Schema(nullable = true)

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/repository/DisputeRepository.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/repository/DisputeRepository.java
@@ -12,4 +12,7 @@ public interface DisputeRepository extends CrudRepository<Dispute, UUID> {
 	/** Fetch all records older than the given date. */
     public Iterable<Dispute> findByCreatedTsBefore(Date olderThan);
 
+	/** Fetch all records whose assignedTs has a timestamp older than the given date. */
+    public Iterable<Dispute> findByAssignedTsBefore(Date assignedTs);
+
 }

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/scheduled/CodeTableTasks.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/scheduled/CodeTableTasks.java
@@ -3,10 +3,7 @@ package ca.bc.gov.open.jag.tco.oracledataapi.scheduled;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.boot.context.event.ApplicationReadyEvent;
-import org.springframework.context.ApplicationListener;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
@@ -14,31 +11,20 @@ import ca.bc.gov.open.jag.tco.oracledataapi.service.LookupService;
 
 @Component
 @ConditionalOnProperty(
-        name = "codetable.refresh.enabled",
+        name = "cronjob.codetable.refresh.enabled",
         havingValue = "true",
         matchIfMissing = false)
-public class CodeTableTasks implements ApplicationListener<ApplicationReadyEvent>  {
+public class CodeTableTasks {
 
 	private Logger logger = LoggerFactory.getLogger(CodeTableTasks.class);
-
-	@Value("${codetable.refresh.atStartup}")
-	private boolean refreshAtStartup;
 
 	@Autowired
 	private LookupService lookupService;
 
-	@Scheduled(cron = "${codetable.refresh.cron}")
+	@Scheduled(cron = "${cronjob.codetable.refresh.cron}")
 	public void refresh() {
 		logger.debug("Scheduled 'codeTableRefresh' cron job called.");
 		lookupService.refresh();
-	}
-
-	@Override
-	public void onApplicationEvent(ApplicationReadyEvent event) {
-		if (refreshAtStartup) {
-			logger.debug("Refreshing code tables at startup.");
-			lookupService.refresh();
-		}
 	}
 
 }

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/scheduled/DisputeTasks.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/scheduled/DisputeTasks.java
@@ -1,0 +1,30 @@
+package ca.bc.gov.open.jag.tco.oracledataapi.scheduled;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import ca.bc.gov.open.jag.tco.oracledataapi.service.DisputeService;
+
+@Component
+@ConditionalOnProperty(
+        name = "cronjob.dispute.unassign.enabled",
+        havingValue = "true",
+        matchIfMissing = false)
+public class DisputeTasks {
+
+	private Logger logger = LoggerFactory.getLogger(DisputeTasks.class);
+
+	@Autowired
+	private DisputeService disputeService;
+
+	@Scheduled(cron = "${cronjob.dispute.unassign.cron}")
+	public void refresh() {
+		logger.debug("Scheduled 'unassignDisputes' cron job called.");
+		disputeService.unassignDisputes();
+	}
+
+}

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/scheduled/StartupTasks.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/scheduled/StartupTasks.java
@@ -1,0 +1,32 @@
+package ca.bc.gov.open.jag.tco.oracledataapi.scheduled;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.ApplicationListener;
+import org.springframework.stereotype.Component;
+
+import ca.bc.gov.open.jag.tco.oracledataapi.service.LookupService;
+
+@Component
+public class StartupTasks implements ApplicationListener<ApplicationReadyEvent> {
+
+	private Logger logger = LoggerFactory.getLogger(StartupTasks.class);
+
+	@Value("${codetable.refresh.atStartup}")
+	private boolean refreshAtStartup;
+
+	@Autowired
+	private LookupService lookupService;
+
+	@Override
+	public void onApplicationEvent(ApplicationReadyEvent event) {
+		if (refreshAtStartup) {
+			logger.debug("Refreshing code tables at startup.");
+			lookupService.refresh();
+		}
+	}
+
+}

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/service/DisputeService.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/service/DisputeService.java
@@ -4,6 +4,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.UUID;
 
+import org.apache.commons.lang3.time.DateUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.BeanUtils;
@@ -154,6 +155,18 @@ public class DisputeService {
 		dispute.setStatus(disputeStatus);
 		dispute.setRejectedReason(DisputeStatus.REJECTED.equals(disputeStatus) ? rejectedReason : null);
 		return disputeRepository.save(dispute);
+	}
+
+	/**
+	 * Unassigns all Disputes whose assignedTs is older than 1 hour ago, resetting the assignedTo and assignedTs fields.
+	 */
+	public void unassignDisputes() {
+		// Find all Disputes with an assignedTs older than 1 hour ago.
+		for (Dispute dispute : disputeRepository.findByAssignedTsBefore(DateUtils.addHours(new Date(), -1))) {
+			dispute.setAssignedTo(null);
+			dispute.setAssignedTs(null);
+			disputeRepository.save(dispute);
+		}
 	}
 
 }

--- a/src/backend/oracle-data-api/src/main/resources/application.yml
+++ b/src/backend/oracle-data-api/src/main/resources/application.yml
@@ -33,26 +33,40 @@ springdoc:
     # Configure swagger to list the most recent API version first
     groups-order: DESC
 
+
 codetable:
-  refresh:
-    # If enabled, this refresh will trigger a pull from JUSTIN to populate a cached copy of the lookup data in redis based on the cron schedule.
-    enabled: ${CODETABLE_REFRESH_ENABLED:false}
-    
-    # If true, will refresh code tables at startup.
+  refresh:    
+    # If true, will refresh code tables at startup. Codetables are cached in Redis for quick access and for high-availability
     atStartup: true
-     
-    # A cron-like expression (defaulting to once per day at 3am), extending the usual UN*X definition to include triggers on the second, minute, hour, day of month, month, and day of week. 
-    # 
-    # For example, "0 * * * * MON-FRI" means once per minute on weekdays(at the top of the minute - the 0th second). 
-    # 
-    # The fields read from left to right are interpreted as follows:
-    #  ┌───────────── second (0-59)
-    #  │ ┌───────────── minute (0 - 59)
-    #  │ │ ┌───────────── hour (0 - 23)
-    #  │ │ │ ┌───────────── day of the month (1 - 31)
-    #  │ │ │ │ ┌───────────── month (1 - 12) (or JAN-DEC)
-    #  │ │ │ │ │ ┌───────────── day of the week (0 - 7)
-    #  │ │ │ │ │ │          (0 or 7 is Sunday, or MON-SUN)
-    #  │ │ │ │ │ │
-    #  * * * * * *
-    cron: ${CODETABLE_REFRESH_CRON:0 0 3 * * *}
+      
+cronjob:
+  codetable:
+    refresh:
+      # If enabled, this refresh will trigger a pull from JUSTIN to populate a cached copy of the lookup data in redis based on the cron schedule.
+      enabled: ${CODETABLE_REFRESH_ENABLED:false}
+      
+      # If true, will refresh code tables at startup.
+      atStartup: true
+       
+      # A cron-like expression (defaulting to once per day at 3am), extending the usual UN*X definition to include triggers on the second, minute, hour, day of month, month, and day of week. 
+      # 
+      # For example, "0 * * * * MON-FRI" means once per minute on weekdays(at the top of the minute - the 0th second). 
+      # 
+      # The fields read from left to right are interpreted as follows:
+      #  ┌───────────── second (0-59)
+      #  │ ┌───────────── minute (0 - 59)
+      #  │ │ ┌───────────── hour (0 - 23)
+      #  │ │ │ ┌───────────── day of the month (1 - 31)
+      #  │ │ │ │ ┌───────────── month (1 - 12) (or JAN-DEC)
+      #  │ │ │ │ │ ┌───────────── day of the week (0 - 7)
+      #  │ │ │ │ │ │          (0 or 7 is Sunday, or MON-SUN)
+      #  │ │ │ │ │ │
+      #  * * * * * *
+      cron: ${CODETABLE_REFRESH_CRON:0 0 3 * * *}
+
+  dispute:
+    # If enabled, this unassign cronjob will clear the assignedTo and assignedTs fields on all Disputes whose assignedTs is older than 1 hour
+    unassign:
+      enabled: ${UNASSIGN_DISPUTES_ENABLED:true}
+      # A cron-like expression (defaulting to once every 5 minutes), extending the usual UN*X definition to include triggers on the second, minute, hour, day of month, month, and day of week.
+      cron: ${UNASSIGN_DISPUTES_CRON:0 */5 * * * *}


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

[TCVP-1369](https://justice.gov.bc.ca/jira/browse/TCVP-1369)

- Changed Dispute.assignedTs to be a timestamp object instead of a date object
- Created a cronjob that runs every 5 minutes to clear the assignedTo and assignedTs properties on all Disputes whose assignedTs is older than 1 hour.
- Cleaned up CodeTableTasks by pulling out startup tasks into it's own file.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
