### PR TITLE
Moved splunk env vars to splunk.yml

### DIFF
--- a/.docker/docker-compose.splunk.yml
+++ b/.docker/docker-compose.splunk.yml
@@ -31,10 +31,9 @@ services:
       Serilog__WriteTo__0__Args:eventCollectorToken": "token"
     depends_on: [splunk]
 
-  ticket-search:
+  oracle-data-api:
     environment:
-      Serilog__Using__0: Serilog.Sinks.Splunk
-      Serilog__WriteTo__0__Name: EventCollector
-      Serilog__WriteTo__0__Args:splunkHost": "http://splunk:8088"
-      Serilog__WriteTo__0__Args:eventCollectorToken": "token"
+      SPLUNK_URL: ${SPLUNK_URL:-http://splunk:8088}
+      SPLUNK_TOKEN: ${SPLUNK_HEC_TOKEN:-token}
     depends_on: [splunk]
+    

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -133,8 +133,6 @@ services:
       args:
         - SKIP_TESTS=true
     environment:
-      SPLUNK_URL: ${SPLUNK_URL:-http://splunk:8088}
-      SPLUNK_TOKEN: ${SPLUNK_HEC_TOKEN:-token}
       REDIS_HOST: redis
       REDIS_PORT: 6379
       REDIS_PASSWORD: password


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- Fixed `docker-compose.splunk.yml` - still had references to ticket-search
- Moved splunk env vars from `docker-compose.yml` to `docker-compose.splunk.yml`

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

I confirmed logging works in splunk locally with 

```
docker-compose -f docker-compose.yml -f ./.docker/docker-compose.splunk.yml up -d --build oracle-data-api
```
## Does the change impact or break the Docker build?

- [x] Yes
- [ ] No

If Yes: Has Docker been updated accordingly?

- [x] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
