### PR TITLE
TCVP-1058 Added Validated Dispute status.

### DIFF
--- a/src/backend/TrafficCourts/Staff.Service/Controllers/DisputeController.cs
+++ b/src/backend/TrafficCourts/Staff.Service/Controllers/DisputeController.cs
@@ -196,6 +196,58 @@ public class DisputeController : TCOControllerBase<DisputeController>
     }
 
     /// <summary>
+    /// Updates the status of a particular Dispute record to VALIDATED.
+    /// </summary>
+    /// <param name="disputeId">Unique identifier for a specific Dispute record to validate.</param>
+    /// <param name="cancellationToken"></param>
+    /// <returns></returns>
+    /// <response code="200">The Dispute is updated.</response>
+    /// <response code="400">The request was not well formed. Check the parameters.</response>
+    /// <response code="401">Unauthenticated.</response>
+    /// <response code="403">Forbidden, wrong user roles.</response>
+    /// <response code="404">Dispute record not found. Update failed.</response>
+    /// <response code="405">A Dispute status can only be set to VALIDATED iff status is NEW. Update failed.</response>
+    /// <response code="500">There was a server error that prevented the update from completing successfully.</response>
+    [HttpPut("{disputeId}/validate")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status405MethodNotAllowed)]
+    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+    public async Task<IActionResult> ValidateDisputeAsync(Guid disputeId, CancellationToken cancellationToken)
+    {
+        _logger.LogDebug("Updating the Dispute status to VALIDATED");
+
+        try
+        {
+            await _disputeService.ValidateDisputeAsync(disputeId, cancellationToken);
+            return Ok();
+        }
+        catch (TrafficCourts.Staff.Service.OpenAPIs.OracleDataApi.v1_0.ApiException e) when (e.StatusCode == StatusCodes.Status400BadRequest)
+        {
+            return new HttpError(e.StatusCode, e.Message);
+        }
+        catch (TrafficCourts.Staff.Service.OpenAPIs.OracleDataApi.v1_0.ApiException e) when (e.StatusCode == StatusCodes.Status404NotFound)
+        {
+            return new HttpError(e.StatusCode, e.Message);
+        }
+        catch (TrafficCourts.Staff.Service.OpenAPIs.OracleDataApi.v1_0.ApiException e) when (e.StatusCode == StatusCodes.Status405MethodNotAllowed)
+        {
+            return new HttpError(e.StatusCode, e.Message);
+        }
+        catch (TrafficCourts.Staff.Service.OpenAPIs.OracleDataApi.v1_0.ApiException e)
+        {
+            _logger.LogError("Error updating Dispute status:", e);
+            return new HttpError(StatusCodes.Status500InternalServerError, e.Message);
+        }
+        catch (Exception e)
+        {
+            _logger.LogError("Error updating Dispute status:", e);
+            return new HttpError(StatusCodes.Status500InternalServerError, e.Message);
+        }
+    }
+
+    /// <summary>
     /// Updates the status of a particular Dispute record to CANCELLED.
     /// </summary>
     /// <param name="disputeId">Unique identifier for a specific Dispute record to cancel.</param>

--- a/src/backend/TrafficCourts/Staff.Service/OpenAPIs/OracleDataAPI/v1_0/OracleDataApi.v1_0.json
+++ b/src/backend/TrafficCourts/Staff.Service/OpenAPIs/OracleDataAPI/v1_0/OracleDataApi.v1_0.json
@@ -28,16 +28,16 @@
           }
         ],
         "responses": {
-          "405": {
-            "description": "Method Not Allowed",
+          "404": {
+            "description": "Not Found",
             "content": { "*/*": { "schema": { "type": "object" } } }
           },
           "400": {
             "description": "Bad Request",
             "content": { "*/*": { "schema": { "type": "object" } } }
           },
-          "404": {
-            "description": "Not Found",
+          "405": {
+            "description": "Method Not Allowed",
             "content": { "*/*": { "schema": { "type": "object" } } }
           },
           "200": {
@@ -66,17 +66,21 @@
           "required": true
         },
         "responses": {
-          "405": {
-            "description": "Method Not Allowed",
+          "404": {
+            "description": "Dispute record not found. Update failed.",
             "content": { "*/*": { "schema": { "type": "object" } } }
           },
           "400": {
             "description": "Bad Request.",
             "content": { "*/*": { "schema": { "type": "object" } } }
           },
-          "404": {
-            "description": "Dispute record not found. Update failed.",
+          "405": {
+            "description": "Method Not Allowed",
             "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "409": {
+            "description": "The Dispute has already been assigned to a different user. Dispute cannot be modified until assigned time expires.",
+            "content": { "*/*": { "schema": { "$ref": "#/components/schemas/Dispute" } } }
           },
           "200": {
             "description": "Ok",
@@ -99,19 +103,59 @@
           }
         ],
         "responses": {
-          "405": {
-            "description": "Method Not Allowed",
+          "404": {
+            "description": "Not Found",
             "content": { "*/*": { "schema": { "type": "object" } } }
           },
           "400": {
             "description": "Bad Request",
             "content": { "*/*": { "schema": { "type": "object" } } }
           },
-          "404": {
-            "description": "Not Found",
+          "405": {
+            "description": "Method Not Allowed",
             "content": { "*/*": { "schema": { "type": "object" } } }
           },
           "200": { "description": "OK" }
+        }
+      }
+    },
+    "/api/v1.0/dispute/{id}/validate": {
+      "put": {
+        "tags": [ "dispute-controller" ],
+        "summary": "Updates the status of a particular Dispute record to VALIDATED.",
+        "operationId": "validateDispute",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "404": {
+            "description": "Dispute record not found. Update failed.",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "400": {
+            "description": "Bad Request.",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "405": {
+            "description": "A Dispute status can only be set to VALIDATED iff status is NEW. Update failed.",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "200": {
+            "description": "Ok. Updated Dispute record returned.",
+            "content": { "*/*": { "schema": { "$ref": "#/components/schemas/Dispute" } } }
+          },
+          "409": {
+            "description": "The Dispute has already been assigned to a different user. Dispute cannot be modified until assigned time expires.",
+            "content": { "*/*": { "schema": { "$ref": "#/components/schemas/Dispute" } } }
+          }
         }
       }
     },
@@ -132,20 +176,24 @@
           }
         ],
         "responses": {
-          "405": {
-            "description": "A Dispute status can only be set to PROCESSING iff status is NEW or REJECTED. Update failed.",
+          "404": {
+            "description": "Dispute record not found. Update failed.",
             "content": { "*/*": { "schema": { "type": "object" } } }
           },
           "400": {
             "description": "Bad Request.",
             "content": { "*/*": { "schema": { "type": "object" } } }
           },
-          "404": {
-            "description": "Dispute record not found. Update failed.",
+          "405": {
+            "description": "A Dispute status can only be set to PROCESSING iff status is NEW or REJECTED. Update failed.",
             "content": { "*/*": { "schema": { "type": "object" } } }
           },
           "200": {
             "description": "Ok. Updated Dispute record returned.",
+            "content": { "*/*": { "schema": { "$ref": "#/components/schemas/Dispute" } } }
+          },
+          "409": {
+            "description": "The Dispute has already been assigned to a different user. Dispute cannot be modified until assigned time expires.",
             "content": { "*/*": { "schema": { "$ref": "#/components/schemas/Dispute" } } }
           }
         }
@@ -180,20 +228,24 @@
           "required": true
         },
         "responses": {
-          "405": {
-            "description": "A Dispute status can only be set to REJECTED iff status is NEW and the rejected reason must be <= 256 characters. Update failed.",
+          "404": {
+            "description": "Dispute record not found. Update failed.",
             "content": { "*/*": { "schema": { "type": "object" } } }
           },
           "400": {
             "description": "Bad Request.",
             "content": { "*/*": { "schema": { "type": "object" } } }
           },
-          "404": {
-            "description": "Dispute record not found. Update failed.",
+          "405": {
+            "description": "A Dispute status can only be set to REJECTED iff status is NEW and the rejected reason must be <= 256 characters. Update failed.",
             "content": { "*/*": { "schema": { "type": "object" } } }
           },
           "200": {
             "description": "Ok. Updated Dispute record returned.",
+            "content": { "*/*": { "schema": { "$ref": "#/components/schemas/Dispute" } } }
+          },
+          "409": {
+            "description": "The Dispute has already been assigned to a different user. Dispute cannot be modified until assigned time expires.",
             "content": { "*/*": { "schema": { "$ref": "#/components/schemas/Dispute" } } }
           }
         }
@@ -216,20 +268,24 @@
           }
         ],
         "responses": {
-          "405": {
-            "description": "A Dispute status can only be set to CANCELLED iff status is NEW, REJECTED or PROCESSING. Update failed.",
+          "404": {
+            "description": "Dispute record not found. Update failed.",
             "content": { "*/*": { "schema": { "type": "object" } } }
           },
           "400": {
             "description": "Bad Request.",
             "content": { "*/*": { "schema": { "type": "object" } } }
           },
-          "404": {
-            "description": "Dispute record not found. Update failed.",
+          "405": {
+            "description": "A Dispute status can only be set to CANCELLED iff status is NEW, REJECTED or PROCESSING. Update failed.",
             "content": { "*/*": { "schema": { "type": "object" } } }
           },
           "200": {
             "description": "Ok. Updated Dispute record returned.",
+            "content": { "*/*": { "schema": { "$ref": "#/components/schemas/Dispute" } } }
+          },
+          "409": {
+            "description": "The Dispute has already been assigned to a different user. Dispute cannot be modified until assigned time expires.",
             "content": { "*/*": { "schema": { "$ref": "#/components/schemas/Dispute" } } }
           }
         }
@@ -244,16 +300,16 @@
           "required": true
         },
         "responses": {
-          "405": {
-            "description": "Method Not Allowed",
+          "404": {
+            "description": "Not Found",
             "content": { "*/*": { "schema": { "type": "object" } } }
           },
           "400": {
             "description": "Bad Request",
             "content": { "*/*": { "schema": { "type": "object" } } }
           },
-          "404": {
-            "description": "Not Found",
+          "405": {
+            "description": "Method Not Allowed",
             "content": { "*/*": { "schema": { "type": "object" } } }
           },
           "200": {
@@ -288,16 +344,16 @@
           }
         ],
         "responses": {
-          "405": {
-            "description": "Method Not Allowed",
+          "404": {
+            "description": "Not Found",
             "content": { "*/*": { "schema": { "type": "object" } } }
           },
           "400": {
             "description": "Bad Request",
             "content": { "*/*": { "schema": { "type": "object" } } }
           },
-          "404": {
-            "description": "Not Found",
+          "405": {
+            "description": "Method Not Allowed",
             "content": { "*/*": { "schema": { "type": "object" } } }
           },
           "200": {
@@ -321,16 +377,16 @@
         "description": "A Dispute can be assigned to a specific user that \"locks\" the record for others. This endpoing manually triggers the Unassign Dispute job that clears the assignment of all Disputes that were assigned for more than 1 hour.",
         "operationId": "unassignDisputes",
         "responses": {
-          "405": {
-            "description": "Method Not Allowed",
+          "404": {
+            "description": "Not Found",
             "content": { "*/*": { "schema": { "type": "object" } } }
           },
           "400": {
             "description": "Bad Request",
             "content": { "*/*": { "schema": { "type": "object" } } }
           },
-          "404": {
-            "description": "Not Found",
+          "405": {
+            "description": "Method Not Allowed",
             "content": { "*/*": { "schema": { "type": "object" } } }
           },
           "200": { "description": "OK" }
@@ -344,16 +400,16 @@
         "description": "The codetables in redis are cached copies of data pulled from Oracle to ensure TCO remains stable. This data is periodically refreshed, but can be forced by hitting this endpoint.",
         "operationId": "codeTableRefresh",
         "responses": {
-          "405": {
-            "description": "Method Not Allowed",
+          "404": {
+            "description": "Not Found",
             "content": { "*/*": { "schema": { "type": "object" } } }
           },
           "400": {
             "description": "Bad Request",
             "content": { "*/*": { "schema": { "type": "object" } } }
           },
-          "404": {
-            "description": "Not Found",
+          "405": {
+            "description": "Method Not Allowed",
             "content": { "*/*": { "schema": { "type": "object" } } }
           },
           "200": { "description": "OK" }
@@ -384,7 +440,7 @@
           },
           "status": {
             "type": "string",
-            "enum": [ "NEW", "PROCESSING", "REJECTED", "CANCELLED" ]
+            "enum": [ "NEW", "VALIDATED", "PROCESSING", "REJECTED", "CANCELLED" ]
           },
           "ticketNumber": { "type": "string" },
           "provincialCourtHearingLocation": {

--- a/src/backend/TrafficCourts/Staff.Service/Services/DisputeService.cs
+++ b/src/backend/TrafficCourts/Staff.Service/Services/DisputeService.cs
@@ -124,6 +124,13 @@ public class DisputeService : IDisputeService
         return await GetOracleDataApi().UpdateDisputeAsync(disputeId, dispute, cancellationToken);
     }
 
+    public async Task ValidateDisputeAsync(Guid disputeId, CancellationToken cancellationToken)
+    {
+        _logger.LogDebug("Dispute status setting to validated");
+
+        await GetOracleDataApi().ValidateDisputeAsync(disputeId, cancellationToken);
+    }
+
     public async Task CancelDisputeAsync(Guid disputeId, CancellationToken cancellationToken)
     {
         _logger.LogDebug("Dispute cancelled");
@@ -150,7 +157,6 @@ public class DisputeService : IDisputeService
 
         SendEmail rejectSendEmail = Mapper.ToRejectSendEmail(dispute);
         await _bus.Publish(rejectSendEmail, cancellationToken);
-
     }
 
     public async Task SubmitDisputeAsync(Guid disputeId, CancellationToken cancellationToken)

--- a/src/backend/TrafficCourts/Staff.Service/Services/IDisputeService.cs
+++ b/src/backend/TrafficCourts/Staff.Service/Services/IDisputeService.cs
@@ -32,6 +32,13 @@ public interface IDisputeService
     /// <exception cref="ApiException">A server side error occurred.</exception>
     Task<Dispute> UpdateDisputeAsync(Guid id, Dispute dispute, System.Threading.CancellationToken cancellationToken);
 
+    /// <summary>Updates the status of a particular Dispute record to VALIDATED.</summary>
+    /// <param name="id">Unique identifier of a Dispute record to validate.</param>
+    /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+    /// <returns></returns>
+    /// <exception cref="ApiException">A server side error occurred.</exception>
+    Task ValidateDisputeAsync(Guid id, CancellationToken cancellationToken);
+
     /// <summary>Updates the status of a particular Dispute record to CANCELLED.</summary>
     /// <param name="id">Unique identifier of a Dispute record to cancel.</param>
     /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>

--- a/src/backend/TrafficCourts/TrafficCourts.Staff.Service.Test/Controllers/DisputeControllerTest.cs
+++ b/src/backend/TrafficCourts/TrafficCourts.Staff.Service.Test/Controllers/DisputeControllerTest.cs
@@ -188,4 +188,27 @@ public class DisputeControllerTest
         var notFoundResult = Assert.IsType<HttpError>(result);
         Assert.Equal(StatusCodes.Status404NotFound, notFoundResult.StatusCode);
     }
+
+    [Fact]
+    public async void TestValidateDispute200Result()
+    {
+        // Mock the OracleDataApi to update a specific Dispute with id (1), confirm controller updates and returns the dispute.
+
+        // Arrange
+        Dispute dispute = new();
+        Guid id = Guid.NewGuid();
+        dispute.Id = id;
+        var disputeService = new Mock<IDisputeService>();
+        disputeService
+            .Setup(_ => _.ValidateDisputeAsync(It.Is<Guid>(v => v == id), It.IsAny<CancellationToken>()))
+            .Verifiable();
+        var mockLogger = new Mock<ILogger<DisputeController>>();
+        DisputeController disputeController = new(disputeService.Object, mockLogger.Object);
+
+        // Act
+        await disputeController.ValidateDisputeAsync(id, CancellationToken.None);
+
+        // Assert
+        disputeService.VerifyAll();
+    }
 }

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/controller/v1_0/DisputeController.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/controller/v1_0/DisputeController.java
@@ -117,7 +117,7 @@ public class DisputeController {
 		@ApiResponse(responseCode = "400", description = "Bad Request."),
 		@ApiResponse(responseCode = "404", description = "Dispute record not found. Update failed."),
 		@ApiResponse(responseCode = "405", description = "A Dispute status can only be set to REJECTED iff status is NEW and the rejected reason must be <= 256 characters. Update failed."),
-		@ApiResponse(responseCode = "409", description = "The Dispute has already been assigned to a user. Dispute cannot be modified until assigned time expires.")
+		@ApiResponse(responseCode = "409", description = "The Dispute has already been assigned to a different user. Dispute cannot be modified until assigned time expires.")
 	})
 	@PutMapping("/dispute/{id}/reject")
 	public ResponseEntity<Dispute> rejectDispute(@PathVariable UUID id, @Valid @RequestBody @NotBlank @Size(min = 1, max = 256) String rejectedReason,
@@ -126,6 +126,30 @@ public class DisputeController {
 			return new ResponseEntity<>(null, HttpStatus.CONFLICT);
 		}
 		return new ResponseEntity<Dispute>(disputeService.setStatus(id, DisputeStatus.REJECTED, rejectedReason), HttpStatus.OK);
+	}
+
+	/**
+	 * PUT endpoint that updates the dispute detail, setting the status to VALIDATED.
+	 *
+	 * @param dispute to be updated
+	 * @param id of the saved {@link Dispute} to update
+	 * @param principal the logged-in user
+	 * @return {@link Dispute}
+	 */
+	@Operation(summary = "Updates the status of a particular Dispute record to VALIDATED.")
+	@ApiResponses({
+		@ApiResponse(responseCode = "200", description = "Ok. Updated Dispute record returned."),
+		@ApiResponse(responseCode = "400", description = "Bad Request."),
+		@ApiResponse(responseCode = "404", description = "Dispute record not found. Update failed."),
+		@ApiResponse(responseCode = "405", description = "A Dispute status can only be set to VALIDATED iff status is NEW. Update failed."),
+		@ApiResponse(responseCode = "409", description = "The Dispute has already been assigned to a different user. Dispute cannot be modified until assigned time expires.")
+	})
+	@PutMapping("/dispute/{id}/validate")
+	public ResponseEntity<Dispute> validateDispute(@PathVariable UUID id, Principal principal) {
+		if (!disputeService.assignDisputeToUser(id, principal)) {
+			return new ResponseEntity<>(null, HttpStatus.CONFLICT);
+		}
+		return new ResponseEntity<Dispute>(disputeService.setStatus(id, DisputeStatus.VALIDATED), HttpStatus.OK);
 	}
 
 	/**
@@ -142,7 +166,7 @@ public class DisputeController {
 		@ApiResponse(responseCode = "400", description = "Bad Request."),
 		@ApiResponse(responseCode = "404", description = "Dispute record not found. Update failed."),
 		@ApiResponse(responseCode = "405", description = "A Dispute status can only be set to CANCELLED iff status is NEW, REJECTED or PROCESSING. Update failed."),
-		@ApiResponse(responseCode = "409", description = "The Dispute has already been assigned to a user. Dispute cannot be modified until assigned time expires.")
+		@ApiResponse(responseCode = "409", description = "The Dispute has already been assigned to a different user. Dispute cannot be modified until assigned time expires.")
 	})
 	@PutMapping("/dispute/{id}/cancel")
 	public ResponseEntity<Dispute> cancelDispute(@PathVariable UUID id, Principal principal) {
@@ -166,7 +190,7 @@ public class DisputeController {
 		@ApiResponse(responseCode = "400", description = "Bad Request."),
 		@ApiResponse(responseCode = "404", description = "Dispute record not found. Update failed."),
 		@ApiResponse(responseCode = "405", description = "A Dispute status can only be set to PROCESSING iff status is NEW or REJECTED. Update failed."),
-		@ApiResponse(responseCode = "409", description = "The Dispute has already been assigned to a user. Dispute cannot be modified until assigned time expires.")
+		@ApiResponse(responseCode = "409", description = "The Dispute has already been assigned to a different user. Dispute cannot be modified until assigned time expires.")
 	})
 	@PutMapping("/dispute/{id}/submit")
 	public ResponseEntity<Dispute> submitDispute(@PathVariable UUID id, Principal principal) {
@@ -189,7 +213,7 @@ public class DisputeController {
 		@ApiResponse(responseCode = "200", description = "Ok"),
 		@ApiResponse(responseCode = "400", description = "Bad Request."),
 		@ApiResponse(responseCode = "404", description = "Dispute record not found. Update failed."),
-		@ApiResponse(responseCode = "409", description = "The Dispute has already been assigned to a user. Dispute cannot be modified until assigned time expires.")
+		@ApiResponse(responseCode = "409", description = "The Dispute has already been assigned to a different user. Dispute cannot be modified until assigned time expires.")
 	})
 	@PutMapping("/dispute/{id}")
 	public ResponseEntity<Dispute> updateDispute(@PathVariable UUID id, @RequestBody Dispute dispute, Principal principal) {

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/model/DisputeStatus.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/model/DisputeStatus.java
@@ -5,6 +5,7 @@ package ca.bc.gov.open.jag.tco.oracledataapi.model;
  */
 public enum DisputeStatus {
 	NEW,
+	VALIDATED,
 	PROCESSING,
 	REJECTED,
 	CANCELLED

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/service/DisputeService.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/service/DisputeService.java
@@ -129,18 +129,23 @@ public class DisputeService {
 		// - current status must be NEW,PROCESSING,REJECTED to change to CANCELLED
 		switch (disputeStatus) {
 		case PROCESSING:
-			if (!List.of(DisputeStatus.NEW, DisputeStatus.REJECTED).contains(dispute.getStatus())) {
+			if (!List.of(DisputeStatus.NEW, DisputeStatus.REJECTED, DisputeStatus.VALIDATED).contains(dispute.getStatus())) {
 				throw new NotAllowedException("Changing the status of a Dispute record from %s to %s is not permitted.", dispute.getStatus(), DisputeStatus.PROCESSING);
 			}
 			break;
 		case CANCELLED:
-			if (!List.of(DisputeStatus.NEW, DisputeStatus.PROCESSING, DisputeStatus.REJECTED).contains(dispute.getStatus())) {
+			if (!List.of(DisputeStatus.NEW, DisputeStatus.PROCESSING, DisputeStatus.REJECTED, DisputeStatus.VALIDATED).contains(dispute.getStatus())) {
 				throw new NotAllowedException("Changing the status of a Dispute record from %s to %s is not permitted.", dispute.getStatus(), DisputeStatus.CANCELLED);
 			}
 			break;
 		case REJECTED:
 			if (!List.of(DisputeStatus.NEW).contains(dispute.getStatus())) {
 				throw new NotAllowedException("Changing the status of a Dispute record from %s to %s is not permitted.", dispute.getStatus(), DisputeStatus.REJECTED);
+			}
+			break;
+		case VALIDATED:
+			if (!List.of(DisputeStatus.NEW).contains(dispute.getStatus())) {
+				throw new NotAllowedException("Changing the status of a Dispute record from %s to %s is not permitted.", dispute.getStatus(), DisputeStatus.VALIDATED);
 			}
 			break;
 		case NEW:

--- a/src/backend/oracle-data-api/src/test/java/ca/bc/gov/open/jag/tco/oracledataapi/controller/v1_0/DisputeControllerTest.java
+++ b/src/backend/oracle-data-api/src/test/java/ca/bc/gov/open/jag/tco/oracledataapi/controller/v1_0/DisputeControllerTest.java
@@ -152,6 +152,27 @@ class DisputeControllerTest extends BaseTestSuite {
 	}
 
 	@Test
+	public void testValidateDispute() {
+		// Create a single Dispute
+		Dispute dispute = RandomUtil.createDispute();
+		UUID disputeId = disputeController.saveDispute(dispute);
+		Principal principal = getPrincipal("testUser");
+
+		// Retrieve it from the controller's endpoint
+		dispute = disputeController.getDispute(disputeId, principal).getBody();
+		assertEquals(disputeId, dispute.getId());
+		assertEquals(DisputeStatus.NEW, dispute.getStatus());
+
+		// Set the status to VALIDATED
+		disputeController.validateDispute(disputeId, principal);
+
+		// Assert status is set, rejected reason is NOT set.
+		dispute = disputeController.getDispute(disputeId, principal).getBody();
+		assertEquals(DisputeStatus.VALIDATED, dispute.getStatus());
+		assertNull(dispute.getRejectedReason());
+	}
+
+	@Test
 	@Transactional
 	public void testUpdateDispute() {
 		// Create a single Dispute

--- a/src/backend/oracle-data-api/src/test/java/ca/bc/gov/open/jag/tco/oracledataapi/service/DisputeServiceTest.java
+++ b/src/backend/oracle-data-api/src/test/java/ca/bc/gov/open/jag/tco/oracledataapi/service/DisputeServiceTest.java
@@ -20,7 +20,7 @@ class DisputeServiceTest extends BaseTestSuite {
 	private DisputeService disputeService;
 
 	@ParameterizedTest
-	@EnumSource(value = DisputeStatus.class, names = { "NEW", "REJECTED" })
+	@EnumSource(value = DisputeStatus.class, names = { "NEW", "REJECTED", "VALIDATED" })
 	void testSetStatusToPROCESSING_200(DisputeStatus disputeStatus) {
 		UUID id = saveDispute(disputeStatus);
 		disputeService.setStatus(id, DisputeStatus.PROCESSING);
@@ -37,13 +37,29 @@ class DisputeServiceTest extends BaseTestSuite {
 
 	@ParameterizedTest
 	@EnumSource(value = DisputeStatus.class, names = { "NEW" })
+	void testSetStatusToVALIDATED_200(DisputeStatus disputeStatus) {
+		UUID id = saveDispute(disputeStatus);
+		disputeService.setStatus(id, DisputeStatus.VALIDATED);
+	}
+
+	@ParameterizedTest
+	@EnumSource(value = DisputeStatus.class, names = { "CANCELLED", "PROCESSING", "VALIDATED" })
+	void testSetStatusToVALIDATED_405(DisputeStatus disputeStatus) {
+		UUID id = saveDispute(disputeStatus);
+		assertThrows(NotAllowedException.class, () -> {
+			disputeService.setStatus(id, DisputeStatus.VALIDATED);
+		});
+	}
+
+	@ParameterizedTest
+	@EnumSource(value = DisputeStatus.class, names = { "NEW" })
 	void testSetStatusToREJECTED_200(DisputeStatus disputeStatus) {
 		UUID id = saveDispute(disputeStatus);
 		disputeService.setStatus(id, DisputeStatus.REJECTED);
 	}
 
 	@ParameterizedTest
-	@EnumSource(value = DisputeStatus.class, names = { "CANCELLED", "PROCESSING", "REJECTED" })
+	@EnumSource(value = DisputeStatus.class, names = { "CANCELLED", "PROCESSING", "REJECTED", "VALIDATED" })
 	void testSetStatusToREJECTED_405(DisputeStatus disputeStatus) {
 		UUID id = saveDispute(disputeStatus);
 		assertThrows(NotAllowedException.class, () -> {
@@ -52,7 +68,7 @@ class DisputeServiceTest extends BaseTestSuite {
 	}
 
 	@ParameterizedTest
-	@EnumSource(value = DisputeStatus.class, names = { "NEW", "PROCESSING", "REJECTED" })
+	@EnumSource(value = DisputeStatus.class, names = { "NEW", "PROCESSING", "REJECTED", "VALIDATED" })
 	void testSetStatusToCANCELLED_200(DisputeStatus disputeStatus) {
 		UUID id = saveDispute(disputeStatus);
 		disputeService.setStatus(id, DisputeStatus.CANCELLED);


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

[TCVP-1058](https://justice.gov.bc.ca/jira/browse/TCVP-1058)

Added a new Dispute status of VALIDATED.  A NEW Dispute can be opened by a staff on the staff-portal. After staff has vetted and approved field values on an OCR Violation Ticket, the staff can click a Validate button which moves the Dispute to the VALIDATED state, which in turn can move to the PROCESSING state when they click Submit.

This PR adds VALIDATED as a new possible state to the oracle-data-api project.
- added a new /dispute/{id}/validate endpoint to oracle-data-api
- regenerated openapi spec for staff-api
- added a new /dispute/{id}/validate endpoint to staff-api

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

mvn verify
dotnet test

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
