### PR TITLE
Feature TCVP-1364 update arc section parse method rebase

### DIFF
--- a/src/backend/TrafficCourts/Messaging/MessageContracts/DisputeApproved.cs
+++ b/src/backend/TrafficCourts/Messaging/MessageContracts/DisputeApproved.cs
@@ -27,7 +27,10 @@ namespace TrafficCourts.Messaging.MessageContracts
     public class ViolationTicketCount
     {
         public int Count { get; set; } = 0;
-        public string Section { get; set; } = String.Empty;
+        public string FullSection { get; set; } = String.Empty;
+        public string? Section { get; set; }
+        public string? Subsection { get; set; }
+        public string? Paragraph { get; set; }
         public string Act { get; set; } = String.Empty;
         public double? Amount { get; set; }
     }

--- a/src/backend/TrafficCourts/Staff.Service/Mappers/Mapper.cs
+++ b/src/backend/TrafficCourts/Staff.Service/Mappers/Mapper.cs
@@ -21,7 +21,10 @@ public class Mapper
             Messaging.MessageContracts.ViolationTicketCount ticketCount = new()
             {
                 Count = violationTicketCount.Count,
-                Section = violationTicketCount.FullSection,
+                FullSection = violationTicketCount.FullSection,
+                Section = violationTicketCount.Section,
+                Subsection = violationTicketCount.Subsection,
+                Paragraph = violationTicketCount.Paragraph,
                 Act = violationTicketCount.ActRegulation,
                 Amount = violationTicketCount.TicketedAmount
             };

--- a/src/backend/TrafficCourts/Test/Arc.Dispute.Service/Mappings/MappingTests.cs
+++ b/src/backend/TrafficCourts/Test/Arc.Dispute.Service/Mappings/MappingTests.cs
@@ -63,5 +63,22 @@ namespace TrafficCourts.Test.Arc.Dispute.Service.Mappings
                 }
             }  
         }
+
+        [Fact]
+        public void can_parse_full_section_with_valid_adnotated_ticket_and_full_section()
+        {
+            // Arrange
+            var fixture = new Fixture();
+            AdnotatedTicket at = fixture.Create<AdnotatedTicket>();
+            string fullSection = "127(1)(a)(ii)";
+
+            // Act
+            AdnotatedTicket? actual = CustomMap.ParseFullSection(at, fullSection);
+
+            // Assert
+            actual.Section.Equals("127");
+            actual.Subsection.Equals("1");
+            actual.Paragraph.Equals("a");
+        }
     }
 }

--- a/src/backend/TrafficCourts/TrafficCourts.Arc.Dispute.Service/Mappings/CustomMap.cs
+++ b/src/backend/TrafficCourts/TrafficCourts.Arc.Dispute.Service/Mappings/CustomMap.cs
@@ -31,10 +31,11 @@ namespace TrafficCourts.Arc.Dispute.Service.Mappings
                 {
                     adnotated = ParseFullSection(adnotated, ticket.FullSection);
                 }
-                adnotated.Act = ticket.Act;
+                adnotated.Act = ticket.Act != null ? ticket.Act : "MVA";
                 adnotated.OriginalAmount = ticket.Amount;
                 adnotated.Organization = source.IssuingOrganization;
                 adnotated.OrganizationLocation = source.IssuingLocation;
+                adnotated.ServiceDate = source.TicketIssuanceDate;
 
                 arcFileRecordList.Add(adnotated);
                 // Check if there are data required to encapsulate citizen dispute information
@@ -53,6 +54,7 @@ namespace TrafficCourts.Arc.Dispute.Service.Mappings
                     disputed.FileNumber = source.TicketFileNumber;
                     disputed.MvbClientNumber = source.DriversLicence;
                     // Mapping disputed ticket specific data
+                    disputed.ServiceDate = source.TicketIssuanceDate;
                     disputed.Name = source.CitizenName;
                     disputed.DisputeType = disputeCount.DisputeType != null ? disputeCount.DisputeType : "A"; //TODO: Find out what dispute type actually means
                     disputed.StreetAddress = source.StreetAddress != null ? source.StreetAddress : "";

--- a/src/backend/TrafficCourts/TrafficCourts.Arc.Dispute.Service/Models/ArcFileRecord.cs
+++ b/src/backend/TrafficCourts/TrafficCourts.Arc.Dispute.Service/Models/ArcFileRecord.cs
@@ -5,14 +5,12 @@
         public int LockoutFlag { get; set; }
         public DateTime TransactionDate { get; set; }
         public DateTime TransactionTime { get; set; }
-        public int TransactionLocation { get; set; }
-        public string TransactionType { get; set; } = String.Empty;
+        public int TransactionLocation { get; } = 20254;
         public DateTime EffectiveDate { get; set; }
-        public string Owner { get; set; } = String.Empty;
+        public string Owner { get; } = "00001";
         public string FileNumber { get; set; } = String.Empty;
         public string CountNumber { get; set; } = String.Empty;
-        public string ReceivableType { get; set; } = String.Empty;
-        public int TransactionNumber { get; set; }
+        public string ReceivableType { get; } = "M";
         public string MvbClientNumber { get; set; } = String.Empty;
         public string UpdateFlag { get; set; } = String.Empty;
         public string Filler { get; set; } = String.Empty;
@@ -21,6 +19,8 @@
 
     public class AdnotatedTicket : ArcFileRecord
     {
+        public string TransactionType { get; } = "EV";
+        public int TransactionNumber { get; } = 100;
         public string Name { get; set; } = String.Empty;
         public string Section { get; set; } = String.Empty;
         public string Subsection { get; set; } = String.Empty;
@@ -35,6 +35,8 @@
 
     public class DisputedTicket : ArcFileRecord
     {
+        public string TransactionType { get; } = "ED";
+        public int TransactionNumber { get; } = 200;
         public DateTime ServiceDate { get; set; }
         public string Name { get; set; } = String.Empty;
         public string DisputeType { get; set; } = String.Empty;

--- a/src/backend/TrafficCourts/TrafficCourts.Arc.Dispute.Service/Models/TcoDisputeTicket.cs
+++ b/src/backend/TrafficCourts/TrafficCourts.Arc.Dispute.Service/Models/TcoDisputeTicket.cs
@@ -38,11 +38,10 @@ namespace TrafficCourts.Arc.Dispute.Service.Models
         [JsonRequired]
         public int Count { get; set; } = 0;
         [JsonRequired]
-        public string Section { get; set; } = String.Empty;
-        [JsonRequired]
-        public string Subsection { get; set; } = String.Empty;
-        [JsonRequired]
-        public string Paragraph { get; set; } = String.Empty;
+        public string FullSection { get; set; } = String.Empty;
+        public string? Section { get; set; }
+        public string? Subsection { get; set; }
+        public string? Paragraph { get; set; }
         [JsonRequired]
         public string Act { get; set; } = String.Empty;
         [JsonRequired]

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/model/ViolationTicketCount.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/model/ViolationTicketCount.java
@@ -87,6 +87,13 @@ public class ViolationTicketCount extends Auditable<String> {
 	@Column
 	@Schema(nullable = true, accessMode = Schema.AccessMode.READ_ONLY)
     private String paragraph;
+	
+	/**
+	 * The subparagraph part of the full section. For example, "(ii)"
+	 */
+	@Column
+	@Schema(nullable = true, accessMode = Schema.AccessMode.READ_ONLY)
+    private String subparagraph;
 
 	/**
 	 * The ticketed amount.


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- [TCVP-1364](https://justice.gov.bc.ca/jira/browse/TCVP-1364)
- Added functionality to parse full section of statutes into 3 groups required for ARC if 3 fields are not passed separately. 
For example: If the full section field is passed as "127(1)(a)(ii)", it would be parsed out and split into the following 3 groups and the last part (subparagraph) will be ignored:
Section: 127
Subsection: 1
Paragraph: a
- Added 'subparagraph' field to the Oracle data model.
- Added some default field values that are required to be represented on each record of ARC file.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
