### PR TITLE
Adds unit test to read different section strings from statutes-test.csv

### DIFF
--- a/src/backend/TrafficCourts/Test/Arc.Dispute.Service/Data/statutes-test.csv
+++ b/src/backend/TrafficCourts/Test/Arc.Dispute.Service/Data/statutes-test.csv
@@ -1,0 +1,343 @@
+code,act,section,description
+11817,MVA,78,Allow unlicenced minor to drive
+11818,MVA,92.1,Failing to stop for peace officer
+11819,MVA,92.1(1),Fail to stop resulting in pursuit
+11821,MVA,217(1),No seat belt assembly in automobile for sale
+11822,MVA,217(3),Removal of seat belt assembly
+11809,MVA,64(b),Illegal use or no inspection of licence or permit
+11810,MVA,65,Refusing to Produce Licence
+11811,MVA,66,Transport animals in insecure manner on vehicle ex
+11812,MVA,68,Use of Ficticious Licence Plates
+11813,MVA,7.03,Exhaust muffler not in proper working condition
+11814,MVA,7.03(a),Exhaust muffler not in proper working condition
+11815,MVA,7.161,Worn tread on pneumatic tires
+11816,MVA,76,Liability of Owner for Violation of Act
+11804,MVA,63(a),Provide false information
+11805,MVA,63(b),Misuse of number plates
+11806,MVA,63(c),Allow another person to use dl
+11807,MVA,64,Use of Anothers Licence or Permit
+11808,MVA,64(a),Illegal use or no inspection of licence or permit
+11793,MVA,40(6),No manufacturer plate
+11794,MVA,40,No manufacturer plate
+11795,MVA,44,Misuse of demonstration plates
+11796,MVA,45,Pollution control devices on motor vehicles
+11797,MVA,45(3),Pollution control devices on motor vehicles
+11798,MVA,48,Disobey passenger restrictions mc
+11799,MVA,49,Passenger front of driver
+11800,MVA,50,Operating motorcycle
+11801,MVA,51,Letting vehicles for hire
+11802,MVA,54,Fail to notify superintendent of change serial eng
+11803,MVA,63,False Statements Misuse of Plates
+11786,MVA,32(2),No chauffeurs permit
+11787,MVA,33,Employing unlicenced driver
+11788,MVA,37,Note:  Section(s) Repealed Not In Force Spent
+11789,MVA,39(8),No transporter licence
+11790,MVA,39(9),No transporter licence
+11791,MVA,39,No transporter licence
+11792,MVA,39(3),No transporter licence
+11781,MVA,30(3),Fail to surrender duplicate Drivers licence
+11782,MVA,30,"Production of Licence and Liability Card, Duplicat"
+11783,MVA,30(1),Production of Drivers Licence and Liability Card
+11784,MVA,32(5),Chauffer Failing to have Permit in His Possession
+11785,MVA,32,Municipal Chauffer Permits
+11776,MVA,218,Motor Cycle Safety Helmets
+11321,MVA,151(3),Speeding
+11777,MVA,24(8),Drive Contrary to Restriction on Licence
+11778,MVA,24(3),Dual Drivers licences
+11779,MVA,25.02(ii),No valid inspection certificate displayed
+11780,MVA,25.02,No valid inspection certificate displayed
+11768,MVA,213(3),Tear down traffic control device
+11769,MVA,213(4),Signs
+11770,MVA,213(1)(a),Signs
+11771,MVA,213(1)(b),Erect sign against bylaws
+11772,MVA,216,Equipment of Motor Vehicles
+11773,MVA,216(1),Equipment of Motor Vehicles in Compliance with MVA
+11774,MVA,216(2)(a),Equipment of Motor Vehicles
+11775,MVA,216(2)(b),Equipment of Motor Vehicles
+11762,MVA,208(3),Explosives - no extinguishers
+11763,MVA,208,Transporting explosives
+11764,MVA,209(1),Fail to carry required warning devices
+11765,MVA,209,No warning devices
+11766,MVA,213(5),Signs
+11767,MVA,213,Signs
+11334,MVA,12(1)(b),Licence Plate Violations
+11335,MVA,12(1)(c),Licence Plate Violations
+11336,MVA,154,Fail to Keep Right
+11337,MVA,154(3),Fail to Keep Right
+11338,MVA,154(1),Fail to Keep Right
+11310,MVA,23,Fail to possess Drivers Licence Insurance
+11311,MVA,23(1),Fail to possess Drivers Licence Insurance
+11312,MVA,23(3)(b),Fail to possess Drivers Licence Insurance
+11313,MVA,94,Drive while Prohib Suspend
+11314,MVA,94(1),Drive While Prohib Suspend
+11315,MVA,150,Drive Too Slow
+11316,MVA,150(1),Drive Too Slow
+11317,MVA,151,Speeding
+11318,MVA,151(1),Speeding
+11319,MVA,151(10),Speeding
+11320,MVA,151(2),Speeding
+11956,MVA,7.05,Illegal windshield or window
+11957,MVA,7.05(1),Illegal windshield or window
+11369,MVA,192(2)(a),Unsecured Motor Vehicle
+11370,MVA,192(2)(b),Unsecured Motor Vehicle
+11383,MVA,187(c),Failing to stop at stop sign
+11389,MVA,61,Fail to Submit Accident Report
+11344,MVA,164,Follow Too Close
+11345,MVA,164(1),Follow Too Close
+11346,MVA,152,Speeding
+11347,MVA,152(1),Speeding
+11348,MVA,152(2),Speeding
+11349,MVA,153,Fail to Stop for School Bus
+11361,MVA,27,Fail to Notify Superintendent of Motor Vehicles
+11362,MVA,27(1),Address Change
+11363,MVA,27(2),Name Change
+11365,MVA,92,Fail to Stop for Peace Officer
+11366,MVA,92(1),Fail to Stop for Peace Officer
+11368,MVA,192,Unsecured Motor Vehicle
+11332,MVA,12,Licence Plate Violations
+11333,MVA,12(1)(a),Licence Plate Violations
+11322,MVA,151(7),Speeding
+11323,MVA,194,Reverse When Unsafe
+11294,MVA,149(1)(c),Drive Without Due Care
+11295,MVA,62(1),Fail to Remain
+11296,MVA,62,Fail to Remain
+11300,MVA,62(2),Fail to Remain
+11301,MVA,62(3),Fail to Remain
+11306,MVA,67,Fail to Stop for Police 
+11307,MVA,67(1),Fail to Stop for Police
+11308,MVA,67(2),Fail to Stop for Police
+11289,MVA,88,Drive While Prohibited
+11290,MVA,88(1),Drive While Prohibited
+11291,MVA,149,Drive Without Due Care
+11292,MVA,149(1)(a),Drive Without Due Care
+11293,MVA,149(1)(b),Drive Without Due Care
+11752,MVA,200,Drive Over Fire Hose
+11753,MVA,201,Driving on Sidewalk
+11754,MVA,204,Open Door While Unsafe
+11755,MVA,205(1),Depositing articles on highway
+11756,MVA,205(2),Depositing Articles on Highway
+11757,MVA,205(3),Depositing articles on highway
+11758,MVA,205,Depositing Articles on Highway
+11759,MVA,206,Operate motor vehicle with less than minimum clear
+11760,MVA,207,Drive motor vehicle with television set in illegal
+11761,MVA,208(2),Transporting explosives  - no sign
+11744,MVA,199,Follow fire truck too closely or park near fire tr
+11745,MVA,20(5)(b),Fail to register vehicle
+11746,MVA,20(5)(c),Fail to produce registration
+11747,MVA,20(5)(d),No proof fin responsibility
+11748,MVA,20(5)(e),Fail to register foreign motor vehicle
+11749,MVA,20,Registration of Foreign Motor Vehicles and Trailer
+11732,MVA,191,Manner of Parking
+11733,MVA,195(1),Operate motorcycle not on seat
+11734,MVA,195(2)(a),Improperly seated passenger
+11735,MVA,195(2)(b),Motorcycle passenger not lawfully seated
+11736,MVA,195(3),Permit unlawfully seated passenger
+11737,MVA,195(4),Operate motorcycle more than 2 abreast
+11738,MVA,195,Operate motorcycle not on seat
+11739,MVA,196(1)(a),Drive while control obstructed
+11740,MVA,196(1)(b),Obstructed View of Driver
+11741,MVA,196,Requirements for Moving Vehicle
+11742,MVA,197,Improper operation of vehicle - canyon defuke moun
+11743,MVA,198,Coasting down grade illegally
+11720,MVA,190(1)(n),Stopping where Sign Prohibiting
+11721,MVA,190(1)(o),Unlaw. stop park to obstruct sign
+11722,MVA,190(1)(a),Stopping or Parking on Sidewalk or Boulevard
+11723,MVA,190(1)(b),Block driveway
+11724,MVA,190(1)(c),Park in intersection
+11725,MVA,190(1)(d),Park near hydrant
+11726,MVA,190(1)(e),Park on crosswalk
+11727,MVA,190(1)(f),Park near crosswalk
+11728,MVA,190(1)(g),Park near traffic control device
+11729,MVA,190(1)(h),Park by exit
+11730,MVA,190(1)(i),Unlaw. stop park on rail crossing
+11574,MVA,187(a),Fail to Stop at Stop Sign
+11717,MVA,190(1)(k),Unlaw. stop park beside excavation
+11718,MVA,190(1)(l),Double parking
+11719,MVA,190(1)(m),Park on bridge or in tunnel
+11570,MVA,217,Seat Belt Violations
+11571,MVA,217(6),Permit passenger under 16 years without seat belt
+11572,MVA,217(4),Fail to wear seat belt
+11573,MVA,187,Failing to Stop at Stop Sign
+11606,MVA,117,Drive maintence construction vehicle no regards to
+11607,MVA,119(a),Fail to obey police direction
+11608,MVA,119(b),Fail to obey police direction
+11609,MVA,119(c),Fail to obey police direction
+11610,MVA,119,Fail to obey Police Direction
+11611,MVA,13(1),Failing to Notify Change of Address
+11612,MVA,13,Change of Address or Name
+11613,MVA,132(2)(c),Disobey green light ped
+11614,MVA,132(2),Fail to yield to pedestrian
+11615,MVA,132,Green Light
+11620,MVA,133(2)(a),Yellow light-no intersection
+11621,MVA,133(2)(b),Disobey yellow light ped.
+11622,MVA,133(2),Yellow light-no intersection
+11623,MVA,133,Yellow Light
+11631,MVA,134(3)(a),Pedestrian crossing against red light
+11632,MVA,135,Disobey green arrow
+11624,MVA,133(1)(a),"Yellow Light, intersection-no stop before intersec"
+11625,MVA,133(1)(b),Disobey yellow light
+11626,MVA,134,Red Light
+11627,MVA,134(3)(b),Fail to yield - left turn - red light
+11628,MVA,134(4)(a),Red Light-No Intersection
+11633,MVA,135(a),Fail to yield - on green arrow
+11634,MVA,135(b),Ped fail to yield to vehicle on green arrow
+11635,MVA,136(5)(a),Fail to yield at green flashing light
+11636,MVA,136,Flashing Lights
+11629,MVA,134(1),Red Light at Intersection
+11630,MVA,134(2),Fail to Yeild-Right Turn-Red Light
+11648,MVA,14,Notice of change made in motor vehicle
+11649,MVA,14(1),Fail to notify vehicle change
+11650,MVA,142,Unlawful alteration of traffic control device
+11637,MVA,136(3)(a),Yellow flashing light at intersection
+11638,MVA,136(4)(a),Yellow flashing light - no intersection
+11639,MVA,136(1)(a),Fail to Stop at Flashing Red Light
+11658,MVA,155(c),Change lanes without signal
+11659,MVA,160(2)(b),Pass on Right off Roadway
+11660,MVA,160,Pass on Right
+11642,MVA,137(3)(a),Disobey walk sign
+11643,MVA,137,Pedestrian controls
+11644,MVA,138(b),Disobey ped. controlled signal
+11645,MVA,138,Pedestrian disobey control signal
+11646,MVA,138(a),Pedestrian not in marked unmarked crosswalk
+11647,MVA,139,Failing to obey lane direction control signal
+11666,MVA,165,Driving on Divided Highway
+11667,MVA,168(a),Improper left turn - no interesction
+11668,MVA,168(b),Improper left turn - no intersection
+11651,MVA,145,Driving Over Speed Limit
+11652,MVA,146,Disobey Flagman
+11653,MVA,148,Drive over newly painted lines
+11654,MVA,152.1,Excessive Speeding
+11655,MVA,155,Driving on Laned Roadway
+11656,MVA,155(a),Unsafe lane change
+11657,MVA,155(b),Lane change solid line
+11673,MVA,178(1),Emerging Vehicle Fail to Stop
+11674,MVA,179,Approach of Emergency Vehicle
+11453,MVA,176,Fail to Yield on Left Turn
+11661,MVA,160(2)(a),Unsafe Pass on Right
+11662,MVA,162,Pass Without Clear View
+11663,MVA,163(a),Disobey traffic sign or signal
+11664,MVA,163(b),Disobey traffic sign or signal
+11665,MVA,163,Disobeying Traffic Sign or Signal
+11675,MVA,181(3),Pass vehicle yielding to pedestrian
+11676,MVA,181(4),Disobey school guard patrol
+11677,MVA,181,Rights of Way Between Vehicle and Pedestrian
+11678,MVA,181(1),Fail to Yeild to Pedestrian
+11679,MVA,181(2),Pedestrian Unsafely Walking on to Street
+11669,MVA,168(c),Improper left turn - no intersection
+11670,MVA,168,Turning Left Other than at Intersection
+11671,MVA,178(2),Failing to Yeild when Emerging from Alley
+11672,MVA,178,Emerging From Alleys
+11682,MVA,184(2),Pedestrian on wrong side of road
+20526,MVA,21,Registration of foreign motor vehicles and trailer
+11683,MVA,184(3),Pedestrian prohibited from solicit ride emp. bus.
+11684,MVA,184,Walking by pedestrian
+11685,MVA,185,Rights and Duties of Operator of Cycle
+11686,MVA,185(6)(a),Disobey duties of cyclist
+11698,MVA,185(2)(a),Riding Cycle on Sidewalk
+11699,MVA,186(6)(c),Not stop with part of vehicle on or over the railr
+11700,MVA,186,Railway Crossings
+11687,MVA,185(6)(b),Disobey duties of cyclist
+11688,MVA,185(7)(a),Careless cycling
+11689,MVA,185(4),Cycling while rider attached to vehicle
+11690,MVA,185(5),No Light when Dark
+11691,MVA,185(2)(b),Fail to ride cycle on right
+11680,MVA,182,Pedestrian fail to yield to vehicle
+11681,MVA,184(1),Pedestrian where prohibited
+11704,MVA,186(3),Drive past railway crossing gate
+11705,MVA,186(4)(a),Fail to Stop at Railway Crossing
+11706,MVA,186(4)(b),Fail to stop at railway crossing
+11707,MVA,186(2)(a),Failure to Stop at Railway Signal
+11708,MVA,186(2)(b),Fail to stop or leave safely at railway crossing
+11692,MVA,185(2)(c),Cycle two abreast
+11693,MVA,185(2)(d),Cycle without at least one hand on the handlebars
+11694,MVA,185(2)(e),Disobey duties of cyclist
+11695,MVA,185(2)(f),Ride on hwy prohib by sign
+11696,MVA,185(2)(g),Ride cycle where prohibited
+11697,MVA,185(3),Disobey duties of cyclist
+11709,MVA,188(2),Parking and Obstructing Passage of Traffic
+11710,MVA,188,Where Parking Prohibited
+11711,MVA,188(1),Leaving Vehicle Stopped or Parked on Roadway
+11712,MVA,190(2),Unlaw. stop park where prohibited
+11713,MVA,190,When Vehicle Stopping Prohibited
+11701,MVA,186(5),Commercial vehicle no stop at railway
+11702,MVA,186(6)(b),Not shift gears of vehicle while crossing railroad
+11703,MVA,186(2)(c),Fail to stop or leave safely at railway crossing
+11398,MVA,157(1)(a),Pass on Solid Double Line
+11399,MVA,157,Pass on Solid Double Line
+11400,MVA,77,Give Information False Information
+11401,MVA,77(1),Duty to give Information
+11402,MVA,77(1),Duty to Give Information
+15405,MVA,211(2)(d),Regulations
+15406,MVA,211(1)(h),Regulations
+15407,MVA,211(1)(g),Regulations
+15408,MVA,211(1)(f),Regulations
+15409,MVA,211(1)(e),Regulations
+15410,MVA,211(1)(k),Regulations
+15411,MVA,211(2),Regulations
+15412,MVA,211(1)(p),Regulations
+15413,MVA,211(1)(o),Regulations
+15414,MVA,211(1)(n),Regulations
+15416,MVA,211(1)(l),Regulations
+15417,MVA,211.1(1)(e),Specific powers to make regulations
+15418,MVA,211(1)(j),Regulations
+15420,MVA,211.1(1)(w),Specific powers to make regulations
+15421,MVA,215(1),Regulations
+15422,MVA,211.1(1)(bb),Specific powers to make regulations
+15423,MVA,214(7)(b),24 hr prohibition
+15424,MVA,211.1(1)(dd),Specific powers to make regulations
+15426,MVA,211(1)(i),Regulations
+15427,MVA,211(2)(a),Regulations
+15428,MVA,211.1(1)(c),Specific powers to make regulations
+15429,MVA,211.1(1)(r),Specific powers to make regulations
+15430,MVA,211.1(1)(s),Specific powers to make regulations
+15431,MVA,211.1(1)(t),Specific powers to make regulations
+15432,MVA,211.1(1)(u),Specific powers to make regulations
+15433,MVA,211.1(1)(v),Specific powers to make regulations
+15435,MVA,211.1(1)(j),Specific powers to make regulations
+15436,MVA,211.1(1)(i),Specific powers to make regulations
+15437,MVA,211.1(1)(h),Specific powers to make regulations
+15438,MVA,211.1(1)(g),Specific powers to make regulations
+15440,MVA,211.1(1)(p),Specific powers to make regulations
+15441,MVA,211.1(1)(l),Specific powers to make regulations
+15442,MVA,211.1(1)(k),Specific powers to make regulations
+15443,MVA,211.1(1)(j.2),Specific powers to make regulations
+15444,MVA,211.1(1)(f),Specific powers to make regulations
+15446,MVA,211.1(1)(q),Specific powers to make regulations
+15448,MVA,186(5)(e),Commercial vehicle no stop at railway
+15449,MVA,186(5)(d),Commercial vehicle no stop at railway
+15450,MVA,186(5)(c),Commercial vehicle no stop at railway
+15451,MVA,186(5)(b),Commercial vehicle no stop at railway
+15452,MVA,186(5)(a),Commercial vehicle no stop at railway
+15456,MVA,186(2),Fail to stop or leave safely at railway crossing
+15458,MVA,186(4),Fail to stop at railway crossing
+15459,MVA,185(4),Cycling while rider attached to vehicle
+15461,MVA,185(2)(g),Ride cycle where prohibited
+15467,MVA,186(5)(f),Commercial vehicle no stop at railway
+15470,MVA,185(6)(a),Disobey duties of cyclist
+15472,MVA,185(7)(b),Operating a Cycle With Undue Care and Attention
+15474,MVA,185(7),Operating a Cycle With Undue Care and Attention
+15475,MVA,185(6)(d),Duty of cyclist at accident
+15476,MVA,185(6)(c),Duty of cyclist at accident
+15477,MVA,185(6)(b),Disobey duties of cyclist
+15478,MVA,189(2)(b),Police may move parked vehicle
+15479,MVA,189(2)(a),Police may move parked vehicle
+15480,MVA,189(2),Police may move parked vehicle
+15481,MVA,189(1)(g),Police may move parked vehicle
+15483,MVA,189(3)(b),Police may move parked vehicle
+15486,MVA,185(8)(b),Rights and Duties of Operator of Cycle
+15487,MVA,185(8)(a),Rights and Duties of Operator of Cycle
+15490,MVA,190(1),When Vehicle Stopping Prohibited
+15492,MVA,189(4),Police may move parked vehicle
+15493,MVA,189(1)(d),Parked vehicle interferes with normal flow of traf
+15494,MVA,189(3)(a),Police may move parked vehicle
+15495,MVA,189(1)(e),Police may move parked vehicle
+15496,MVA,189(2)(c),Police may move parked vehicle
+15920,MVA,24.1(1)(b.1),"Refusal to issue a licence, permit etc."
+15921,MVA,45.2(1),No pollution control devices
+15922,MVA,45.2,No pollution control devices
+15923,MVA,45(4)(a),Pollution control devices on motor vehicles
+15924,MVA,45.1(a),No pollution control devices
+15925,MVA,45(4)(b),Pollution control devices on motor vehicles
+15926,MVA,45(4)(g),Pollution control devices on motor vehicles
+15927,MVA,45(4)(f),Pollution control devices on motor vehicles
+15928,MVA,45.1,No pollution control devices

--- a/src/backend/TrafficCourts/Test/Arc.Dispute.Service/Mappings/CsvDataAttribute.cs
+++ b/src/backend/TrafficCourts/Test/Arc.Dispute.Service/Mappings/CsvDataAttribute.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using Xunit.Sdk;
+
+namespace TrafficCourts.Test.Arc.Dispute.Service.Mappings
+{
+    /// <summary>
+    /// A custom data attribute to read data from CSV formatted file. Only parses strings and integers.
+    /// This method code has been taken from the following resource.
+    /// Resource: https://stackoverflow.com/questions/42727394/how-to-run-xunit-test-using-data-from-a-csv-file
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = false, Inherited = false)]
+    public class CsvDataAttribute : DataAttribute
+    {
+        private readonly string _fileName;
+        public CsvDataAttribute(string fileName)
+        {
+            _fileName = fileName;
+        }
+
+        public override IEnumerable<object[]> GetData(MethodInfo testMethod)
+        {
+            var pars = testMethod.GetParameters();
+            var parameterTypes = pars.Select(par => par.ParameterType).ToArray();
+            using (var csvFile = new StreamReader(_fileName))
+            {
+                csvFile.ReadLine(); // Headings Row. Comment out if not used
+                string line;
+                while ((line = csvFile.ReadLine()) != null)
+                {
+                    var row = line.Split(',');
+                    yield return ConvertParameters((object[])row, parameterTypes);
+                }
+            }
+        }
+
+        private static object[] ConvertParameters(IReadOnlyList<object> values, IReadOnlyList<Type> parameterTypes)
+        {
+            var result = new object[parameterTypes.Count];
+            for (var idx = 0; idx < parameterTypes.Count; idx++)
+            {
+                result[idx] = ConvertParameter(values[idx], parameterTypes[idx]);
+            }
+
+            return result;
+        }
+
+        private static object ConvertParameter(object parameter, Type parameterType)
+        {
+            return parameterType == typeof(int) ? Convert.ToInt32(parameter) : parameter;
+        }
+    }
+}

--- a/src/backend/TrafficCourts/Test/Arc.Dispute.Service/Mappings/MappingTests.cs
+++ b/src/backend/TrafficCourts/Test/Arc.Dispute.Service/Mappings/MappingTests.cs
@@ -64,21 +64,34 @@ namespace TrafficCourts.Test.Arc.Dispute.Service.Mappings
             }  
         }
 
-        [Fact]
-        public void can_parse_full_section_with_valid_adnotated_ticket_and_full_section()
+        [Theory]
+        [CsvData(@"../../../Arc.Dispute.Service/Data/statutes-test.csv")]
+        public void can_parse_full_section_with_valid_adnotated_ticket_and_full_section(int code, string act, string section, string description)
         {
             // Arrange
-            var fixture = new Fixture();
-            AdnotatedTicket at = fixture.Create<AdnotatedTicket>();
-            string fullSection = "127(1)(a)(ii)";
+            //var fixture = new Fixture();
+            AdnotatedTicket at = new();
+            string fullSection = section;
 
             // Act
             AdnotatedTicket? actual = CustomMap.ParseFullSection(at, fullSection);
 
             // Assert
-            actual.Section.Equals("127");
-            actual.Subsection.Equals("1");
-            actual.Paragraph.Equals("a");
+            string result;
+            if (!string.IsNullOrEmpty(actual.Paragraph))
+            {
+                result = actual.Section + "(" + actual.Subsection + ")" + "(" + actual.Paragraph + ")";
+            }
+            else if(!string.IsNullOrEmpty(actual.Subsection))
+            {
+                result = actual.Section + "(" + actual.Subsection + ")";
+            }
+            else
+            {
+                result = actual.Section;
+            }
+            
+            Assert.Equal(fullSection, result);
         }
     }
 }

--- a/src/backend/TrafficCourts/TrafficCourts.Arc.Dispute.Service/Mappings/CustomMap.cs
+++ b/src/backend/TrafficCourts/TrafficCourts.Arc.Dispute.Service/Mappings/CustomMap.cs
@@ -80,12 +80,27 @@ namespace TrafficCourts.Arc.Dispute.Service.Mappings
             ArgumentNullException.ThrowIfNull(fullSection);
 
             var sectionArray = fullSection.Split(new string[] { "(", ")" }, StringSplitOptions.RemoveEmptyEntries);
+            var count = sectionArray.Length;
 
-            if (sectionArray.Length > 0)
+            if (count > 0)
             {
-                ticket.Section = sectionArray[0];
-                ticket.Subsection = sectionArray[1];
-                ticket.Paragraph = sectionArray[2];
+                switch (count)
+                {
+                    case 1:
+                        ticket.Section = sectionArray[0];
+                        break;
+                    case 2:
+                        ticket.Section = sectionArray[0];
+                        ticket.Subsection = sectionArray[1];
+                        break;
+                    case int _ when count > 2:
+                        ticket.Section = sectionArray[0];
+                        ticket.Subsection = sectionArray[1];
+                        ticket.Paragraph = sectionArray[2];
+                        break;
+                    default:
+                        break;
+                }
             }
 
             return ticket;


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- Added unit test to read different section strings from statutes-test.csv file to verify can parse all.
- Improved the method to parse section data to split out into 3 groups.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
