### PR TITLE
TCVP-1395 add status filter for fetching all disputes

### DIFF
--- a/src/backend/TrafficCourts/Staff.Service/Controllers/DisputeController.cs
+++ b/src/backend/TrafficCourts/Staff.Service/Controllers/DisputeController.cs
@@ -23,8 +23,10 @@ public class DisputeController : TCOControllerBase<DisputeController>
     }
 
     /// <summary>
-    /// Returns all Disputes from the Oracle Data API.
+    /// Returns all Disputes from the Oracle Data API based on a specified type to exclude and older than date.
     /// </summary>
+    /// <param name="olderThan"></param>
+    /// <param name="status"></param>
     /// <param name="cancellationToken"></param>
     /// <response code="200">The Disputes were found.</response>
     /// <response code="401">Unauthenticated.</response>
@@ -34,13 +36,13 @@ public class DisputeController : TCOControllerBase<DisputeController>
     [HttpGet("disputes")]
     [ProducesResponseType(typeof(IList<Dispute>), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    public async Task<IActionResult> GetDisputesAsync(CancellationToken cancellationToken)
+    public async Task<IActionResult> GetDisputesAsync(DateTimeOffset? olderThan, Status? status, CancellationToken cancellationToken)
     {
         _logger.LogDebug("Retrieving all Disputes from oracle-data-api");
 
         try
         {
-            ICollection<Dispute> disputes = await _disputeService.GetAllDisputesAsync(cancellationToken);
+            ICollection<Dispute> disputes = await _disputeService.GetAllDisputesAsync(olderThan, status, cancellationToken);
             return Ok(disputes);
         }
         catch (Exception e)

--- a/src/backend/TrafficCourts/Staff.Service/Controllers/DisputeController.cs
+++ b/src/backend/TrafficCourts/Staff.Service/Controllers/DisputeController.cs
@@ -23,10 +23,9 @@ public class DisputeController : TCOControllerBase<DisputeController>
     }
 
     /// <summary>
-    /// Returns all Disputes from the Oracle Data API based on a specified type to exclude and older than date.
+    /// Returns all Disputes from the Oracle Data API with optional exclusion parameter to exclude disputes having specified status from the result.
     /// </summary>
-    /// <param name="olderThan"></param>
-    /// <param name="status"></param>
+    /// <param name="excludeStatus"></param>
     /// <param name="cancellationToken"></param>
     /// <response code="200">The Disputes were found.</response>
     /// <response code="401">Unauthenticated.</response>
@@ -36,13 +35,13 @@ public class DisputeController : TCOControllerBase<DisputeController>
     [HttpGet("disputes")]
     [ProducesResponseType(typeof(IList<Dispute>), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    public async Task<IActionResult> GetDisputesAsync(DateTimeOffset? olderThan, Status? status, CancellationToken cancellationToken)
+    public async Task<IActionResult> GetDisputesAsync(ExcludeStatus? excludeStatus, CancellationToken cancellationToken)
     {
         _logger.LogDebug("Retrieving all Disputes from oracle-data-api");
 
         try
         {
-            ICollection<Dispute> disputes = await _disputeService.GetAllDisputesAsync(olderThan, status, cancellationToken);
+            ICollection<Dispute> disputes = await _disputeService.GetAllDisputesAsync(excludeStatus, cancellationToken);
             return Ok(disputes);
         }
         catch (Exception e)

--- a/src/backend/TrafficCourts/Staff.Service/OpenAPIs/OracleDataAPI/v1_0/OracleDataApi.v1_0.json
+++ b/src/backend/TrafficCourts/Staff.Service/OpenAPIs/OracleDataAPI/v1_0/OracleDataApi.v1_0.json
@@ -343,7 +343,7 @@
             "example": "2022-03-15"
           },
           {
-            "name": "status",
+            "name": "excludeStatus",
             "in": "query",
             "description": "If specified, will retrieve records which do not have the specified status",
             "required": false,

--- a/src/backend/TrafficCourts/Staff.Service/OpenAPIs/OracleDataAPI/v1_0/OracleDataApi.v1_0.json
+++ b/src/backend/TrafficCourts/Staff.Service/OpenAPIs/OracleDataAPI/v1_0/OracleDataApi.v1_0.json
@@ -341,6 +341,17 @@
               "format": "date-time"
             },
             "example": "2022-03-15"
+          },
+          {
+            "name": "status",
+            "in": "query",
+            "description": "If specified, will retrieve records which do not have the specified status",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": [ "NEW", "VALIDATED", "PROCESSING", "REJECTED", "CANCELLED" ]
+            },
+            "example": "CANCELLED"
           }
         ],
         "responses": {
@@ -825,6 +836,11 @@
             "readOnly": true
           },
           "paragraph": {
+            "type": "string",
+            "nullable": true,
+            "readOnly": true
+          },
+          "subparagraph": {
             "type": "string",
             "nullable": true,
             "readOnly": true

--- a/src/backend/TrafficCourts/Staff.Service/Services/DisputeService.cs
+++ b/src/backend/TrafficCourts/Staff.Service/Services/DisputeService.cs
@@ -67,9 +67,9 @@ public class DisputeService : IDisputeService
         return client;
     }
 
-    public async Task<ICollection<Dispute>> GetAllDisputesAsync(CancellationToken cancellationToken)
+    public async Task<ICollection<Dispute>> GetAllDisputesAsync(DateTimeOffset? olderThan, Status? status, CancellationToken cancellationToken)
     {
-        return await GetOracleDataApi().GetAllDisputesAsync(null, cancellationToken);
+        return await GetOracleDataApi().GetAllDisputesAsync(olderThan, status, cancellationToken);
     }
 
     public async Task<Guid> SaveDisputeAsync(Dispute dispute, CancellationToken cancellationToken)

--- a/src/backend/TrafficCourts/Staff.Service/Services/DisputeService.cs
+++ b/src/backend/TrafficCourts/Staff.Service/Services/DisputeService.cs
@@ -67,9 +67,9 @@ public class DisputeService : IDisputeService
         return client;
     }
 
-    public async Task<ICollection<Dispute>> GetAllDisputesAsync(DateTimeOffset? olderThan, Status? status, CancellationToken cancellationToken)
+    public async Task<ICollection<Dispute>> GetAllDisputesAsync(ExcludeStatus? excludeStatus, CancellationToken cancellationToken)
     {
-        return await GetOracleDataApi().GetAllDisputesAsync(olderThan, status, cancellationToken);
+        return await GetOracleDataApi().GetAllDisputesAsync(null, excludeStatus, cancellationToken);
     }
 
     public async Task<Guid> SaveDisputeAsync(Dispute dispute, CancellationToken cancellationToken)

--- a/src/backend/TrafficCourts/Staff.Service/Services/IDisputeService.cs
+++ b/src/backend/TrafficCourts/Staff.Service/Services/IDisputeService.cs
@@ -4,13 +4,12 @@ namespace TrafficCourts.Staff.Service.Services;
 
 public interface IDisputeService
 {
-    /// <summary>Returns all the existing disputes from the database.</summary>
-    /// <param name="olderThan"></param>
-    /// <param name="status"></param>
+    /// <summary>Returns all the existing disputes from the database with optional exclusion parameter to exclude disputes having specified status from the result.</summary>
+    /// <param name="excludeStatus"></param>
     /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
     /// <returns>A collection of Dispute objects</returns>
     /// <exception cref="ApiException">A server side error occurred.</exception>
-    Task<ICollection<Dispute>> GetAllDisputesAsync(DateTimeOffset? olderThan, Status? status, CancellationToken cancellationToken);
+    Task<ICollection<Dispute>> GetAllDisputesAsync(ExcludeStatus? excludeStatus, CancellationToken cancellationToken);
 
     /// <summary>Saves new dispute in the oracle database.</summary>
     /// <param name="dispute"></param>

--- a/src/backend/TrafficCourts/Staff.Service/Services/IDisputeService.cs
+++ b/src/backend/TrafficCourts/Staff.Service/Services/IDisputeService.cs
@@ -5,10 +5,12 @@ namespace TrafficCourts.Staff.Service.Services;
 public interface IDisputeService
 {
     /// <summary>Returns all the existing disputes from the database.</summary>
+    /// <param name="olderThan"></param>
+    /// <param name="status"></param>
     /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
     /// <returns>A collection of Dispute objects</returns>
     /// <exception cref="ApiException">A server side error occurred.</exception>
-    Task<ICollection<Dispute>> GetAllDisputesAsync(CancellationToken cancellationToken);
+    Task<ICollection<Dispute>> GetAllDisputesAsync(DateTimeOffset? olderThan, Status? status, CancellationToken cancellationToken);
 
     /// <summary>Saves new dispute in the oracle database.</summary>
     /// <param name="dispute"></param>

--- a/src/backend/TrafficCourts/TrafficCourts.Staff.Service.Test/Controllers/DisputeControllerTest.cs
+++ b/src/backend/TrafficCourts/TrafficCourts.Staff.Service.Test/Controllers/DisputeControllerTest.cs
@@ -28,13 +28,13 @@ public class DisputeControllerTest
         List<Dispute> disputes = new() { dispute1, dispute2 };
         var disputeService = new Mock<IDisputeService>();
         disputeService
-            .Setup(_ => _.GetAllDisputesAsync(null, null, It.IsAny<CancellationToken>()))
+            .Setup(_ => _.GetAllDisputesAsync(null, It.IsAny<CancellationToken>()))
             .ReturnsAsync(disputes);
         var mockLogger = new Mock<ILogger<DisputeController>>();
         DisputeController disputeController = new(disputeService.Object, mockLogger.Object);
 
         // Act
-        IActionResult? result = await disputeController.GetDisputesAsync(null, null, CancellationToken.None);
+        IActionResult? result = await disputeController.GetDisputesAsync(null, CancellationToken.None);
 
         // Assert
         var okResult = Assert.IsType<OkObjectResult>(result);

--- a/src/backend/TrafficCourts/TrafficCourts.Staff.Service.Test/Controllers/DisputeControllerTest.cs
+++ b/src/backend/TrafficCourts/TrafficCourts.Staff.Service.Test/Controllers/DisputeControllerTest.cs
@@ -28,13 +28,13 @@ public class DisputeControllerTest
         List<Dispute> disputes = new() { dispute1, dispute2 };
         var disputeService = new Mock<IDisputeService>();
         disputeService
-            .Setup(_ => _.GetAllDisputesAsync(It.IsAny<CancellationToken>()))
+            .Setup(_ => _.GetAllDisputesAsync(null, null, It.IsAny<CancellationToken>()))
             .ReturnsAsync(disputes);
         var mockLogger = new Mock<ILogger<DisputeController>>();
         DisputeController disputeController = new(disputeService.Object, mockLogger.Object);
 
         // Act
-        IActionResult? result = await disputeController.GetDisputesAsync(CancellationToken.None);
+        IActionResult? result = await disputeController.GetDisputesAsync(null, null, CancellationToken.None);
 
         // Assert
         var okResult = Assert.IsType<OkObjectResult>(result);

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/controller/v1_0/DisputeController.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/controller/v1_0/DisputeController.java
@@ -62,8 +62,8 @@ public class DisputeController {
 			Date olderThan,
 			@RequestParam(required = false)
 			@Parameter(description = "If specified, will retrieve records which do not have the specified status", example = "CANCELLED")
-			DisputeStatus status) {
-		Iterable<Dispute> allDisputes = disputeService.getAllDisputes(olderThan, status);
+			DisputeStatus excludeStatus) {
+		Iterable<Dispute> allDisputes = disputeService.getAllDisputes(olderThan, excludeStatus);
 		// Swagger doesn't seem to know what an Iterable<Dispute> object is. Convert to an actual instantiated list to return a collection.
 		return IterableUtils.toList(allDisputes);
 	}

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/controller/v1_0/DisputeController.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/controller/v1_0/DisputeController.java
@@ -59,8 +59,11 @@ public class DisputeController {
 			@RequestParam(required = false)
 			@DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
 			@Parameter(description = "If specified, will retrieve records older than this date (specified by yyyy-MM-dd)", example = "2022-03-15")
-			Date olderThan) {
-		Iterable<Dispute> allDisputes = disputeService.getAllDisputes(olderThan);
+			Date olderThan,
+			@RequestParam(required = false)
+			@Parameter(description = "If specified, will retrieve records which do not have the specified status", example = "CANCELLED")
+			DisputeStatus status) {
+		Iterable<Dispute> allDisputes = disputeService.getAllDisputes(olderThan, status);
 		// Swagger doesn't seem to know what an Iterable<Dispute> object is. Convert to an actual instantiated list to return a collection.
 		return IterableUtils.toList(allDisputes);
 	}

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/repository/DisputeRepository.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/repository/DisputeRepository.java
@@ -13,10 +13,10 @@ public interface DisputeRepository extends CrudRepository<Dispute, UUID> {
     public Iterable<Dispute> findByCreatedTsBefore(Date olderThan);
     
     /** Fetch all records which do not have the specified status. */
-    public Iterable<Dispute> findByStatusNot(DisputeStatus status);
+    public Iterable<Dispute> findByStatusNot(DisputeStatus excludeStatus);
     
     /** Fetch all records which do not have the specified status and older than the given date. */
-    public Iterable<Dispute> findByStatusNotAndCreatedTsBefore(DisputeStatus status, Date olderThan);
+    public Iterable<Dispute> findByStatusNotAndCreatedTsBefore(DisputeStatus excludeStatus, Date olderThan);
 
 	/** Fetch all records whose assignedTs has a timestamp older than the given date. */
     public Iterable<Dispute> findByAssignedTsBefore(Date assignedTs);

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/repository/DisputeRepository.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/repository/DisputeRepository.java
@@ -4,13 +4,19 @@ import java.util.Date;
 import java.util.UUID;
 
 import org.springframework.data.repository.CrudRepository;
-
 import ca.bc.gov.open.jag.tco.oracledataapi.model.Dispute;
+import ca.bc.gov.open.jag.tco.oracledataapi.model.DisputeStatus;
 
 public interface DisputeRepository extends CrudRepository<Dispute, UUID> {
 
 	/** Fetch all records older than the given date. */
     public Iterable<Dispute> findByCreatedTsBefore(Date olderThan);
+    
+    /** Fetch all records which do not have the specified status. */
+    public Iterable<Dispute> findByStatusNot(DisputeStatus status);
+    
+    /** Fetch all records which do not have the specified status and older than the given date. */
+    public Iterable<Dispute> findByStatusNotAndCreatedTsBefore(DisputeStatus status, Date olderThan);
 
 	/** Fetch all records whose assignedTs has a timestamp older than the given date. */
     public Iterable<Dispute> findByAssignedTsBefore(Date assignedTs);

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/service/DisputeService.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/service/DisputeService.java
@@ -33,15 +33,15 @@ public class DisputeService {
 	 *
 	 * @return
 	 */
-	public Iterable<Dispute> getAllDisputes(Date olderThan, DisputeStatus status) {
-		if (olderThan == null && status == null) {
+	public Iterable<Dispute> getAllDisputes(Date olderThan, DisputeStatus excludeStatus) {
+		if (olderThan == null && excludeStatus == null) {
 			return disputeRepository.findAll();
 		} else if (olderThan == null) {
-			return disputeRepository.findByStatusNot(status);
-		} else if (status == null) {
+			return disputeRepository.findByStatusNot(excludeStatus);
+		} else if (excludeStatus == null) {
 			return disputeRepository.findByCreatedTsBefore(olderThan);
 		} else {
-			return disputeRepository.findByStatusNotAndCreatedTsBefore(status, olderThan);
+			return disputeRepository.findByStatusNotAndCreatedTsBefore(excludeStatus, olderThan);
 		}
 	}
 

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/service/DisputeService.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/service/DisputeService.java
@@ -33,12 +33,15 @@ public class DisputeService {
 	 *
 	 * @return
 	 */
-	public Iterable<Dispute> getAllDisputes(Date olderThan) {
-		if (olderThan == null) {
+	public Iterable<Dispute> getAllDisputes(Date olderThan, DisputeStatus status) {
+		if (olderThan == null && status == null) {
 			return disputeRepository.findAll();
-		}
-		else {
+		} else if (olderThan == null) {
+			return disputeRepository.findByStatusNot(status);
+		} else if (status == null) {
 			return disputeRepository.findByCreatedTsBefore(olderThan);
+		} else {
+			return disputeRepository.findByStatusNotAndCreatedTsBefore(status, olderThan);
 		}
 	}
 


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- [TCVP-1395](https://justice.gov.bc.ca/jira/browse/TCVP-1395)
- Added functionality to fetch all disputes by filtering them through specifying a status type to exclude the disputes having the specified status from the returned result set.
- Added ability to combine status filter with older than date filter.
- Updated Staff API get all disputes endpoint to get optional parameters to filter by status and older than date.
- Regenerated OpenAPI spec of IOracleDataApi_v1_0Client.json

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
