### PR TITLE
Bug/object storage error

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -195,6 +195,8 @@ services:
 
   #############################################################################################
   ###                           Minio                                                       ###
+  ###                                                                                       ###
+  ### MINIO_SITE_REGION - not sure if this is required, but matching what is in the client  ###
   #############################################################################################
   minio:
     container_name: minio
@@ -209,6 +211,7 @@ services:
     environment:
       MINIO_ROOT_USER: "username" 
       MINIO_ROOT_PASSWORD: "password"
+      MINIO_SITE_REGION: "BC"
     command: server /data --console-address ":9001"
 
   minio-init:

--- a/src/backend/TrafficCourts/Common/Features/FilePersistence/Extensions.cs
+++ b/src/backend/TrafficCourts/Common/Features/FilePersistence/Extensions.cs
@@ -62,9 +62,12 @@ namespace TrafficCourts.Common.Features.FilePersistence
             {
                 var configuration = serviceProvider.GetRequiredService<MinioClientConfiguration>();
 
+                // Have to specify a region, otherwise the library will attempt fetch the regions which DELL ECS does not support
+                // The region value of BC is arbitrary, just has to be non null or empty.
                 var client = new MinioClient()
                     .WithEndpoint(configuration.Endpoint)
-                    .WithCredentials(configuration.AccessKey, configuration.SecretKey);
+                    .WithCredentials(configuration.AccessKey, configuration.SecretKey)
+                    .WithRegion("BC"); 
 
                 if (configuration.Ssl)
                 {                    


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- configures the minio client with an arbitrary region to avoid trying to list regions
- add same arbitrary region to the docker compose container (not sure it is really required or not)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [ ] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
