### PR TITLE
Add dotnet monitor container if metrics enabled

### DIFF
--- a/.gitops/charts/traffic-court-online/charts/citizen-api/templates/deployment.yaml
+++ b/.gitops/charts/traffic-court-online/charts/citizen-api/templates/deployment.yaml
@@ -84,6 +84,10 @@ spec:
             value: "{{ .Values.jaeger.exporter.protocol }}"
           {{- end }}
           {{- end }}
+          {{- if .Values.metrics.enabled }}
+          - name: DOTNET_DiagnosticPorts
+            value: /diag/port.sock
+          {{- end }}
           {{- if .Values.swagger.enabled }}
           - name: Swagger__Enabled
             value: "true"
@@ -97,6 +101,40 @@ spec:
               protocol: TCP
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+          {{- if .Values.metrics.enabled }}
+          volumeMounts:
+          - mountPath: /diag
+            name: diagnostics
+          {{- end }}
+        {{- if .Values.metrics.enabled }}
+        - name: dotnet-monitor
+          image: mcr.microsoft.com/dotnet/monitor
+          # DO NOT use the --no-auth argument for deployments in production; this argument is used for demonstration
+          # purposes only in this example. Please continue reading after this example for further details.
+          args: [ "--no-auth" ]
+          env:
+          - name: DOTNETMONITOR_DiagnosticPort__ConnectionMode
+            value: Listen
+          - name: DOTNETMONITOR_DiagnosticPort__EndpointName
+            value: /diag/port.sock
+          - name: DOTNETMONITOR_Storage__DumpTempFolder
+            value: /diag/dumps
+          - name: DOTNETMONITOR_Urls
+            value: http://localhost:52323
+          imagePullPolicy: Always
+          ports:
+          - containerPort: 52325
+          volumeMounts:
+          - mountPath: /diag
+            name: diagnostics
+          resources:
+            requests:
+              cpu: 50m
+              memory: 32Mi
+            limits:
+              cpu: 250m
+              memory: 256Mi
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -108,5 +146,10 @@ spec:
       {{- with .Values.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.metrics.enabled }}
+      volumes:
+      - name: diagnostics
+        emptyDir: {}      
       {{- end }}
 {{- end }}

--- a/.gitops/charts/traffic-court-online/charts/citizen-api/values.yaml
+++ b/.gitops/charts/traffic-court-online/charts/citizen-api/values.yaml
@@ -82,8 +82,13 @@ affinity: {}
 
 ## @param enable prom scrape metrics
 ##
+## if you enable metrics be sure to add these podAnnotations
+##
+##     podAnnotations:
+##       prometheus.io/scrape: 'true'
+##       prometheus.io/port: "52325"    
 metrics:
-  enabled: true
+  enabled: false
 
 ## @param formRecognizer
 ## Todo: move formRecognizer.apiKey to secret
@@ -115,8 +120,8 @@ redis:
     serviceName: ""
 
 ## @param
-## Todo: move to secret
-##
+## objectStorage.accessKey The username used to access the bucket
+## objectStorage.secretKey The password used to access the bucket
 objectStorage:
   accessKey: ""
   bucketName: ""

--- a/.gitops/charts/traffic-court-online/charts/staff-api/templates/deployment.yaml
+++ b/.gitops/charts/traffic-court-online/charts/staff-api/templates/deployment.yaml
@@ -85,6 +85,10 @@ spec:
             value: "{{ .Values.jaeger.exporter.protocol }}"
           {{- end }}
           {{- end }}
+          {{- if .Values.metrics.enabled }}
+          - name: DOTNET_DiagnosticPorts
+            value: /diag/port.sock
+          {{- end }}
           {{- if .Values.swagger.enabled }}
           - name: Swagger__Enabled
             value: "true"
@@ -98,6 +102,40 @@ spec:
               protocol: TCP
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+          {{- if .Values.metrics.enabled }}
+          volumeMounts:
+          - mountPath: /diag
+            name: diagnostics
+          {{- end }}
+        {{- if .Values.metrics.enabled }}
+        - name: dotnet-monitor
+          image: mcr.microsoft.com/dotnet/monitor
+          # DO NOT use the --no-auth argument for deployments in production; this argument is used for demonstration
+          # purposes only in this example. Please continue reading after this example for further details.
+          args: [ "--no-auth" ]
+          env:
+          - name: DOTNETMONITOR_DiagnosticPort__ConnectionMode
+            value: Listen
+          - name: DOTNETMONITOR_DiagnosticPort__EndpointName
+            value: /diag/port.sock
+          - name: DOTNETMONITOR_Storage__DumpTempFolder
+            value: /diag/dumps
+          - name: DOTNETMONITOR_Urls
+            value: http://localhost:52323
+          imagePullPolicy: Always
+          ports:
+          - containerPort: 52325
+          volumeMounts:
+          - mountPath: /diag
+            name: diagnostics
+          resources:
+            requests:
+              cpu: 50m
+              memory: 32Mi
+            limits:
+              cpu: 250m
+              memory: 256Mi
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -109,5 +147,10 @@ spec:
       {{- with .Values.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.metrics.enabled }}
+      volumes:
+      - name: diagnostics
+        emptyDir: {}      
       {{- end }}
 {{- end }}

--- a/.gitops/charts/traffic-court-online/charts/staff-api/values.yaml
+++ b/.gitops/charts/traffic-court-online/charts/staff-api/values.yaml
@@ -87,6 +87,16 @@ auth:
   audience:
   metadataAddress:
 
+## @param enable prom scrape metrics
+##
+## if you enable metrics be sure to add these podAnnotations
+##
+##     podAnnotations:
+##       prometheus.io/scrape: 'true'
+##       prometheus.io/port: "52325"    
+metrics:
+  enabled: false
+
 ## @param
 ## Todo: move rabbitmq.password to secret
 ##

--- a/.gitops/charts/traffic-court-online/charts/workflow-service/templates/deployment.yaml
+++ b/.gitops/charts/traffic-court-online/charts/workflow-service/templates/deployment.yaml
@@ -87,7 +87,10 @@ spec:
             value: "{{ .Values.jaeger.exporter.protocol }}"
           {{- end }}
           {{- end }}
-
+          {{- if .Values.metrics.enabled }}
+          - name: DOTNET_DiagnosticPorts
+            value: /diag/port.sock
+          {{- end }}
           name: {{ .Chart.Name }}
           image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
@@ -97,6 +100,40 @@ spec:
               protocol: TCP
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+          {{- if .Values.metrics.enabled }}
+          volumeMounts:
+          - mountPath: /diag
+            name: diagnostics
+          {{- end }}
+        {{- if .Values.metrics.enabled }}
+        - name: dotnet-monitor
+          image: mcr.microsoft.com/dotnet/monitor
+          # DO NOT use the --no-auth argument for deployments in production; this argument is used for demonstration
+          # purposes only in this example. Please continue reading after this example for further details.
+          args: [ "--no-auth" ]
+          env:
+          - name: DOTNETMONITOR_DiagnosticPort__ConnectionMode
+            value: Listen
+          - name: DOTNETMONITOR_DiagnosticPort__EndpointName
+            value: /diag/port.sock
+          - name: DOTNETMONITOR_Storage__DumpTempFolder
+            value: /diag/dumps
+          - name: DOTNETMONITOR_Urls
+            value: http://localhost:52323
+          imagePullPolicy: Always
+          ports:
+          - containerPort: 52325
+          volumeMounts:
+          - mountPath: /diag
+            name: diagnostics
+          resources:
+            requests:
+              cpu: 50m
+              memory: 32Mi
+            limits:
+              cpu: 250m
+              memory: 256Mi
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -108,5 +145,10 @@ spec:
       {{- with .Values.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.metrics.enabled }}
+      volumes:
+      - name: diagnostics
+        emptyDir: {}      
       {{- end }}
 {{- end }}

--- a/.gitops/charts/traffic-court-online/charts/workflow-service/values.yaml
+++ b/.gitops/charts/traffic-court-online/charts/workflow-service/values.yaml
@@ -82,6 +82,11 @@ affinity: {}
 
 ## @param enable prom scrape metrics
 ##
+## if you enable metrics be sure to add these podAnnotations
+##
+##     podAnnotations:
+##       prometheus.io/scrape: 'true'
+##       prometheus.io/port: "52325"    
 metrics:
   enabled: false
 


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- Adds exposing application metrics collection in the citizen-api
- other services will be added shortly outside of this PR

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [ ] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
