### PR TITLE
TCVP-1423 add JJDispute model and endpoint for fetching all disputes filtered by jjAssigned

### DIFF
--- a/src/backend/TrafficCourts/Common/OpenAPIs/OracleDataAPI/v1_0/OracleDataApi.v1_0.json
+++ b/src/backend/TrafficCourts/Common/OpenAPIs/OracleDataAPI/v1_0/OracleDataApi.v1_0.json
@@ -32,12 +32,12 @@
             "description": "Not Found",
             "content": { "*/*": { "schema": { "type": "object" } } }
           },
-          "400": {
-            "description": "Bad Request",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
           "405": {
             "description": "Method Not Allowed",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "400": {
+            "description": "Bad Request",
             "content": { "*/*": { "schema": { "type": "object" } } }
           },
           "200": {
@@ -70,12 +70,12 @@
             "description": "Dispute record not found. Update failed.",
             "content": { "*/*": { "schema": { "type": "object" } } }
           },
-          "400": {
-            "description": "Bad Request.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
           "405": {
             "description": "Method Not Allowed",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "400": {
+            "description": "Bad Request.",
             "content": { "*/*": { "schema": { "type": "object" } } }
           },
           "409": {
@@ -107,12 +107,12 @@
             "description": "Not Found",
             "content": { "*/*": { "schema": { "type": "object" } } }
           },
-          "400": {
-            "description": "Bad Request",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
           "405": {
             "description": "Method Not Allowed",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "400": {
+            "description": "Bad Request",
             "content": { "*/*": { "schema": { "type": "object" } } }
           },
           "200": { "description": "OK" }
@@ -140,12 +140,12 @@
             "description": "Dispute record not found. Update failed.",
             "content": { "*/*": { "schema": { "type": "object" } } }
           },
-          "400": {
-            "description": "Bad Request.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
           "405": {
             "description": "A Dispute status can only be set to VALIDATED iff status is NEW. Update failed.",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "400": {
+            "description": "Bad Request.",
             "content": { "*/*": { "schema": { "type": "object" } } }
           },
           "200": {
@@ -180,12 +180,12 @@
             "description": "Dispute record not found. Update failed.",
             "content": { "*/*": { "schema": { "type": "object" } } }
           },
-          "400": {
-            "description": "Bad Request.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
           "405": {
             "description": "A Dispute status can only be set to PROCESSING iff status is NEW or REJECTED. Update failed.",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "400": {
+            "description": "Bad Request.",
             "content": { "*/*": { "schema": { "type": "object" } } }
           },
           "200": {
@@ -232,12 +232,12 @@
             "description": "Dispute record not found. Update failed.",
             "content": { "*/*": { "schema": { "type": "object" } } }
           },
-          "400": {
-            "description": "Bad Request.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
           "405": {
             "description": "A Dispute status can only be set to REJECTED iff status is NEW and the rejected reason must be <= 256 characters. Update failed.",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "400": {
+            "description": "Bad Request.",
             "content": { "*/*": { "schema": { "type": "object" } } }
           },
           "200": {
@@ -272,12 +272,12 @@
             "description": "Dispute record not found. Update failed.",
             "content": { "*/*": { "schema": { "type": "object" } } }
           },
-          "400": {
-            "description": "Bad Request.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
           "405": {
             "description": "A Dispute status can only be set to CANCELLED iff status is NEW, REJECTED or PROCESSING. Update failed.",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "400": {
+            "description": "Bad Request.",
             "content": { "*/*": { "schema": { "type": "object" } } }
           },
           "200": {
@@ -304,12 +304,12 @@
             "description": "Not Found",
             "content": { "*/*": { "schema": { "type": "object" } } }
           },
-          "400": {
-            "description": "Bad Request",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
           "405": {
             "description": "Method Not Allowed",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "400": {
+            "description": "Bad Request",
             "content": { "*/*": { "schema": { "type": "object" } } }
           },
           "200": {
@@ -359,12 +359,12 @@
             "description": "Not Found",
             "content": { "*/*": { "schema": { "type": "object" } } }
           },
-          "400": {
-            "description": "Bad Request",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
           "405": {
             "description": "Method Not Allowed",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "400": {
+            "description": "Bad Request",
             "content": { "*/*": { "schema": { "type": "object" } } }
           },
           "200": {
@@ -392,15 +392,55 @@
             "description": "Not Found",
             "content": { "*/*": { "schema": { "type": "object" } } }
           },
+          "405": {
+            "description": "Method Not Allowed",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
           "400": {
             "description": "Bad Request",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "200": { "description": "OK" }
+        }
+      }
+    },
+    "/api/v1.0/disputes/jj": {
+      "get": {
+        "tags": [ "dispute-controller" ],
+        "summary": "Returns all disputes that have the specified JJ assigned.",
+        "operationId": "getDisputesByJjAssigned",
+        "parameters": [
+          {
+            "name": "jjAssigned",
+            "in": "query",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "404": {
+            "description": "Not Found",
             "content": { "*/*": { "schema": { "type": "object" } } }
           },
           "405": {
             "description": "Method Not Allowed",
             "content": { "*/*": { "schema": { "type": "object" } } }
           },
-          "200": { "description": "OK" }
+          "400": {
+            "description": "Bad Request",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "array",
+                  "items": { "$ref": "#/components/schemas/Dispute" }
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -415,12 +455,12 @@
             "description": "Not Found",
             "content": { "*/*": { "schema": { "type": "object" } } }
           },
-          "400": {
-            "description": "Bad Request",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
           "405": {
             "description": "Method Not Allowed",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "400": {
+            "description": "Bad Request",
             "content": { "*/*": { "schema": { "type": "object" } } }
           },
           "200": { "description": "OK" }

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/controller/v1_0/DisputeController.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/controller/v1_0/DisputeController.java
@@ -251,5 +251,18 @@ public class DisputeController {
 		logger.debug("UnassignDisputes called");
 		disputeService.unassignDisputes();
 	}
+	
+	/**
+	 * GET endpoint that retrieves the disputes filtered by JJ assigned
+	 *
+	 * @param jjAssigned
+	 * @return list of all disputes filtered by JJ assigned
+	 */
+	@GetMapping("/disputes/jj")
+	@Operation(summary = "Returns all disputes that have the specified JJ assigned.")
+	public ResponseEntity<List<Dispute>> getDisputesByJjAssigned(@RequestParam String jjAssigned) {		
+		List<Dispute> allJjAssignedDisputes = disputeService.getAllDisputesByJjAssigned(jjAssigned);
+		return new ResponseEntity<List<Dispute>>(allJjAssignedDisputes, HttpStatus.OK);
+	}
 
 }

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/model/JJDispute.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/model/JJDispute.java
@@ -1,0 +1,94 @@
+package ca.bc.gov.open.jag.tco.oracledataapi.model;
+
+import java.util.Date;
+import java.util.UUID;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import javax.persistence.Temporal;
+import javax.persistence.TemporalType;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * @author 237563
+ * Represents a violation ticket dispute for JJ Workbench
+ *
+ */
+//mark class as an Entity
+@Entity
+//defining class name as Table name
+@Table
+@Getter
+@Setter
+@NoArgsConstructor
+public class JJDispute extends Auditable<String>{
+	
+	@Schema(description = "ID", accessMode = Schema.AccessMode.READ_ONLY)
+    @Id
+    @GeneratedValue
+    private UUID id;
+
+    /**
+     * The violation ticket number.
+     */
+    @Column
+    private String ticketNumber;
+    
+    /**
+     * The date and time the violation ticket was issued.
+     */
+    @Column
+    @Schema(nullable = true)
+    @Temporal(TemporalType.TIMESTAMP)
+    private Date violationDate;
+    
+    /**
+     * The given name and last name of the disputant.
+     */
+    @Column
+    @Schema(nullable = true)
+    private String disputantName;
+    
+    /**
+     * The enforcement officer associated to the disputed violation ticket.
+     */
+    @Column
+    @Schema(nullable = true)
+    private String enforcementOfficer;
+    
+    /**
+     * The police detachment location.
+     */
+    @Column
+    @Schema(nullable = true)
+    private String policeDetachment;
+
+    /**
+     * The provincial court hearing location named on the violation ticket.
+     */
+    @Column
+    @Schema(nullable = true)
+    private String courthouseLocation;
+    
+	/**
+	 * The ID of the Staff whom the dispute is assigned to be reviewed on JJ Workbench.
+	 */
+	@Column
+	@Schema(nullable = true)
+	private String jjAssignedTo;
+	
+	/**
+	 * The ID of the jj group whom the dispute is assigned to be listed on JJ Workbench.
+	 */
+	@Column
+	@Schema(nullable = true)
+	private String jjGroupAssignedTo;
+
+}

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/model/JJDispute.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/model/JJDispute.java
@@ -1,11 +1,8 @@
 package ca.bc.gov.open.jag.tco.oracledataapi.model;
 
 import java.util.Date;
-import java.util.UUID;
-
 import javax.persistence.Column;
 import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.Table;
 import javax.persistence.Temporal;
@@ -30,15 +27,10 @@ import lombok.Setter;
 @NoArgsConstructor
 public class JJDispute extends Auditable<String>{
 	
-	@Schema(description = "ID", accessMode = Schema.AccessMode.READ_ONLY)
-    @Id
-    @GeneratedValue
-    private UUID id;
-
     /**
-     * The violation ticket number.
+     * The violation ticket number as unique identifier.
      */
-    @Column
+    @Id
     private String ticketNumber;
     
     /**

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/repository/DisputeRepository.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/repository/DisputeRepository.java
@@ -1,6 +1,7 @@
 package ca.bc.gov.open.jag.tco.oracledataapi.repository;
 
 import java.util.Date;
+import java.util.List;
 import java.util.UUID;
 
 import org.springframework.data.repository.CrudRepository;
@@ -21,5 +22,8 @@ public interface DisputeRepository extends CrudRepository<Dispute, UUID> {
 
 	/** Fetch all records whose assignedTs has a timestamp older than the given date. */
     public Iterable<Dispute> findByAssignedTsBefore(Date olderThan);
+    
+    /** Fetch all records which have the specified jjAssigned. */
+    public List<Dispute> findByJjAssignedIgnoreCase(String jjAssigned);
 
 }

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/service/DisputeService.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/service/DisputeService.java
@@ -45,6 +45,16 @@ public class DisputeService {
 			return disputeRepository.findByStatusNotAndCreatedTsBefore(excludeStatus, olderThan);
 		}
 	}
+	
+	/**
+	 * Retrieves all {@link Dispute} records that are assigned to the provided JJ, delegating to CrudRepository
+	 * @param jjAssigned, will filter the result set to those having this jjAssigned.
+	 *
+	 * @return
+	 */
+	public List<Dispute> getAllDisputesByJjAssigned(String jjAssigned) {
+		return disputeRepository.findByJjAssignedIgnoreCase(jjAssigned);
+	}
 
 	/**
 	 * Retrieves a specific {@link Dispute} by using the method findById() of CrudRepository


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- [TCVP-1423](https://justice.gov.bc.ca/jira/browse/TCVP-1423)
- Added functionality to retrieve all disputes that can be filtered by specified jj assigned.
- Added a new JJDispute model class and schema for H2 db for storing/retrieving JJ Workbench related data.
- Updated open api client spec.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
