### PR TITLE
TCVP-1423 fetch filtered jj disputes

### DIFF
--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/controller/v1_0/JJDisputeController.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/controller/v1_0/JJDisputeController.java
@@ -1,0 +1,44 @@
+package ca.bc.gov.open.jag.tco.oracledataapi.controller.v1_0;
+
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import ca.bc.gov.open.jag.tco.oracledataapi.model.JJDispute;
+import ca.bc.gov.open.jag.tco.oracledataapi.service.JJDisputeService;
+import io.swagger.v3.oas.annotations.Parameter;
+
+@RestController(value = "JJDisputeControllerV1_0")
+@RequestMapping("/api/v1.0/jj")
+public class JJDisputeController {
+
+	@Autowired
+	private JJDisputeService jjDisputeService;
+
+	private Logger logger = LoggerFactory.getLogger(JJDisputeController.class);
+	
+	/**
+	 * GET endpoint that retrieves all the jj disputes optionally filtered by jjGroupAssignedTo and/or jjAssignedTo from the database
+	 * @param jjGroupAssignedTo if specified, will filter the result set to those assigned to the specified jj group.
+	 * @param jjAssignedTo if specified, will filter the result set to those assigned to the specified jj staff.
+	 * @return list of all jj disputes
+	 */
+	@GetMapping("/disputes")
+	public List<JJDispute> getAllJJDisputes(
+			@RequestParam(required = false)
+			@Parameter(description = "If specified, will retrieve the records which are assigned to the specified jj group")
+			String jjGroupAssignedTo,
+			@RequestParam(required = false)
+			@Parameter(description = "If specified, will retrieve the records which are assigned to the specified jj staff")
+			String jjAssignedTo) {
+		logger.debug("getAllJJDisputes called");
+		
+		return jjDisputeService.getAllJJDisputes(jjGroupAssignedTo, jjAssignedTo);
+	}
+}

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/repository/JJDisputeRepository.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/repository/JJDisputeRepository.java
@@ -1,0 +1,19 @@
+package ca.bc.gov.open.jag.tco.oracledataapi.repository;
+
+import java.util.List;
+
+import org.springframework.data.repository.CrudRepository;
+
+import ca.bc.gov.open.jag.tco.oracledataapi.model.JJDispute;
+
+public interface JJDisputeRepository extends CrudRepository<JJDispute, String>{
+
+	/** Fetch all records which have the specified jjAssigned. */
+    public List<JJDispute> findByJjAssignedToIgnoreCase(String jjAssigned);
+    
+    /** Fetch all records which have the specified jjGroupAssigned. */
+    public List<JJDispute> findByJjGroupAssignedToIgnoreCase(String jjGroupAssigned);
+    
+    /** Fetch all records which have the specified jjGroupAssigned. */
+    public List<JJDispute> findByJjGroupAssignedToIgnoreCaseAndJjAssignedToIgnoreCase(String jjGroupAssigned, String jjAssigned);
+}

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/service/JJDisputeService.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/service/JJDisputeService.java
@@ -1,0 +1,38 @@
+package ca.bc.gov.open.jag.tco.oracledataapi.service;
+
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import ca.bc.gov.open.jag.tco.oracledataapi.model.JJDispute;
+import ca.bc.gov.open.jag.tco.oracledataapi.repository.JJDisputeRepository;
+
+@Service
+public class JJDisputeService {
+	
+	private Logger logger = LoggerFactory.getLogger(DisputeService.class);
+
+	@Autowired
+	JJDisputeRepository jjDisputeRepository;
+
+	/**
+	 * Retrieves all {@link JJDispute} records, delegating to CrudRepository
+	 * @param jjGroupAssignedTo if specified, will filter the result set to those assigned to the specified jj group.
+	 * @param jjAssignedTo if specified, will filter the result set to those assigned to the specified jj staff.
+	 * @return
+	 */
+	public List<JJDispute> getAllJJDisputes(String jjGroupAssignedTo, String jjAssignedTo) {
+		if (jjGroupAssignedTo == null && jjAssignedTo == null) {
+			return (List<JJDispute>) jjDisputeRepository.findAll();
+		} else if (jjGroupAssignedTo == null) {
+			return jjDisputeRepository.findByJjAssignedToIgnoreCase(jjAssignedTo);
+		} else if (jjAssignedTo == null) {
+			return jjDisputeRepository.findByJjGroupAssignedToIgnoreCase(jjGroupAssignedTo);
+		} else {
+			return jjDisputeRepository.findByJjGroupAssignedToIgnoreCaseAndJjAssignedToIgnoreCase(jjGroupAssignedTo, jjAssignedTo);
+		}
+	}
+}

--- a/src/backend/oracle-data-api/src/main/resources/application.yml
+++ b/src/backend/oracle-data-api/src/main/resources/application.yml
@@ -20,7 +20,10 @@ spring:
     sentinel:
       master: ${REDIS_SENTINAL_MASTER:}
       nodes: ${REDIS_SENTINAL_NODES:}
-
+  
+  sql:
+    init:
+      mode: always
   datasource:
     driverClassName: org.h2.Driver
     password: ''
@@ -32,6 +35,7 @@ spring:
       settings:
         web-allow-others: true
   jpa:
+    defer-datasource-initialization: true
     database-platform: org.hibernate.dialect.H2Dialect
     hibernate:
       ddl-auto: update

--- a/src/backend/oracle-data-api/src/main/resources/data.sql
+++ b/src/backend/oracle-data-api/src/main/resources/data.sql
@@ -1,0 +1,10 @@
+DELETE FROM JJDISPUTE;
+
+INSERT INTO JJDISPUTE (TICKET_NUMBER, CREATED_BY, CREATED_TS, MODIFIED_BY, MODIFIED_TS, COURTHOUSE_LOCATION, 
+	DISPUTANT_NAME, ENFORCEMENT_OFFICER, JJ_ASSIGNED_TO, JJ_GROUP_ASSIGNED_TO, POLICE_DETACHMENT, VIOLATION_DATE) VALUES
+  ('1000001', 'System', LOCALTIMESTAMP, NULL, NULL, 'Victoria', 'John Doe', 'Steven Allan', 'JJ1', 'JJGroup1', 'West Shore', LOCALTIMESTAMP),
+  ('1000002', 'System', LOCALTIMESTAMP, NULL, NULL, 'Vancouver', 'Jane Doe', 'Alison Kerr', 'JJ2', 'JJGroup2', 'Valemount', DATEADD('DAY',-1, CURRENT_DATE)),
+  ('1000003', 'System', LOCALTIMESTAMP, NULL, NULL, 'Vancouver', 'Simon Young', 'Adrian Peake', NULL, 'JJGroup2', 'University', DATEADD('DAY',-2, CURRENT_DATE)),
+  ('1000004', 'System', LOCALTIMESTAMP, NULL, NULL, 'Whistler', 'Matt Vaughan', 'Steven Allan', 'JJ3', 'JJGroup1', 'Whistler', DATEADD('DAY',-3, CURRENT_DATE)),
+  ('1000005', 'System', LOCALTIMESTAMP, NULL, NULL, 'Squamish', 'Gavin Glover', 'Harry Reid', 'JJ3', 'JJGroup3', 'Ladysmith', DATEADD('DAY',-4, CURRENT_DATE)),
+  ('1000006', 'System', LOCALTIMESTAMP, NULL, NULL, 'Squamish', 'Gavin Glover', 'Harry Reid', NULL, NULL, 'Ladysmith', DATEADD('DAY',-5, CURRENT_DATE));

--- a/src/backend/oracle-data-api/src/test/resources/application.yml
+++ b/src/backend/oracle-data-api/src/test/resources/application.yml
@@ -5,3 +5,8 @@ codetable:
 logging:
   level:
     ca.bc.gov.open.jag.tco.oracledataapi: DEBUG
+    
+spring:
+  sql:
+    init:
+      mode: never


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- [TCVP-1423](https://justice.gov.bc.ca/jira/browse/TCVP-1423)
- Added a new controller, service and repository for JJ Disputes in order to provide functionality to fetch all JJ Disputes by optionally filtering them based on the specified JJ staff and/or JJ group assigned.
- Created a data.sql script to auto populate the JJDispute table in H2 database on startup.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
