### PR TITLE
Configured docker-compose files to disable jaeger exporting for oracle-data-api by default

### DIFF
--- a/.docker/docker-compose.jaeger.yml
+++ b/.docker/docker-compose.jaeger.yml
@@ -28,5 +28,6 @@ services:
   oracle-data-api:
     environment:
       OTEL_EXPORTER_JAEGER_ENDPOINT: ${OTEL_EXPORTER_JAEGER_ENDPOINT:-http://jaeger:14250}
+      SPRING_SLEUTH_ENABLED: ${SPRING_SLEUTH_ENABLED:-true}
     depends_on: [jaeger]
 

--- a/.gitops/charts/traffic-court-online/charts/oracle-data-api/templates/deployment.yaml
+++ b/.gitops/charts/traffic-court-online/charts/oracle-data-api/templates/deployment.yaml
@@ -41,6 +41,8 @@ spec:
           {{- end }}
           {{- if .Values.jaeger.enabled }}
           # OpenTelemetry Jaeger
+          - name: SPRING_SLEUTH_ENABLED
+            value: true
           - name: OTEL_EXPORTER_JAEGER_ENDPOINT
             value: "{{ required "jaeger.exporter.endpoint is required" .Values.jaeger.exporter.endpoint }}"
           {{- end }}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -142,6 +142,7 @@ services:
       CODETABLE_REFRESH_ENABLED: ${CODETABLE_REFRESH_ENABLED:-true}
       CODETABLE_REFRESH_CRON: ${CODETABLE_REFRESH_CRON:-0 * * * * *}
       H2_DATASOURCE: ${H2_DATASOURCE:-jdbc:h2:file:./data/h2}
+      SPRING_SLEUTH_ENABLED: ${SPRING_SLEUTH_ENABLED:-false}
       JAVA_OPTS: ${JAVA_OPTS:--Dlogging.level.ca.bc.gov.open.jag.tco.oracledataapi=DEBUG}
     depends_on:
       - redis

--- a/src/backend/oracle-data-api/src/main/resources/application.yml
+++ b/src/backend/oracle-data-api/src/main/resources/application.yml
@@ -6,7 +6,8 @@ spring:
     name: oracle-data-api
 
   sleuth:
-    otel:
+    enabled: ${SPRING_SLEUTH_ENABLED:false}
+    otel:   
       config:
         trace-id-ratio-based: 1.0
       exporter:


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- Added env variables to docker-compose and docker-compose.jaeger files to disable exporting to jaeger by default for local development in order to prevent error messages in the logs.
- Configured docker-compose.jaeger to enable jaeger trace exporting by default.
- Updated helm chart to add spring sleuth enabled parameter and value.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [x] Yes
- [ ] No

If Yes: Has Docker been updated accordingly?

- [x] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
