### PR TITLE
Added JUnit CI to oracle-data-api project

### DIFF
--- a/.github/workflows/pr-oracle-api.yml
+++ b/.github/workflows/pr-oracle-api.yml
@@ -1,0 +1,23 @@
+name: Oracle Data API CI
+
+on:
+  pull_request:
+    paths:
+      - 'src/backend/oracle-data-api/**'
+      - '.github/workflows/pr-oracle-api.yml'
+
+jobs:
+  test:
+    name: Junit Tests
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./src/backend/oracle-data-api
+    steps:
+      - uses: actions/checkout@v1
+      - name: Set up JDK 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.11
+      - name: Maven Verify
+        run: mvn -B clean verify


### PR DESCRIPTION
Added continuous integration (CI) to oracle-data-api Java project.

This workflow will run all the JUnit tests on every PR with changes to the /src/backend/oracle-data-api folder.