### PR TITLE
Fixed the base URI to send request to ARC dispute service in Workflow Service

### DIFF
--- a/src/backend/TrafficCourts/Workflow.Service/Services/SubmitDisputeToArcService.cs
+++ b/src/backend/TrafficCourts/Workflow.Service/Services/SubmitDisputeToArcService.cs
@@ -29,7 +29,7 @@ namespace TrafficCourts.Workflow.Service.Services
             };
 
             using var httpClient = new HttpClient();
-            var arcBaseUri = $"https://{_arcApiConfiguration.Host}:{_arcApiConfiguration.Port}";
+            var arcBaseUri = $"http://{_arcApiConfiguration.Host}:{_arcApiConfiguration.Port}";
             httpClient.BaseAddress = new Uri(arcBaseUri);
 
             using var response = await httpClient.PostAsync("api/TcoDisputeTicket", approvedDispute, formatter);


### PR DESCRIPTION

# Description

This PR includes the following proposed change(s):

- Changed ARC dispute service base URI to start with http instead of https.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
