### PR TITLE
Updated data.sql to fix Staff API JJDispute endpoints

### DIFF
--- a/src/backend/oracle-data-api/src/main/resources/data.sql
+++ b/src/backend/oracle-data-api/src/main/resources/data.sql
@@ -2,9 +2,9 @@ DELETE FROM JJDISPUTE;
 
 INSERT INTO JJDISPUTE (TICKET_NUMBER, CREATED_BY, CREATED_TS, MODIFIED_BY, MODIFIED_TS, COURTHOUSE_LOCATION, 
 	DISPUTANT_NAME, ENFORCEMENT_OFFICER, JJ_ASSIGNED_TO, JJ_GROUP_ASSIGNED_TO, POLICE_DETACHMENT, VIOLATION_DATE) VALUES
-  ('1000001', 'System', LOCALTIMESTAMP, NULL, NULL, 'Victoria', 'John Doe', 'Steven Allan', 'JJ1', 'JJGroup1', 'West Shore', LOCALTIMESTAMP),
-  ('1000002', 'System', LOCALTIMESTAMP, NULL, NULL, 'Vancouver', 'Jane Doe', 'Alison Kerr', 'JJ2', 'JJGroup2', 'Valemount', DATEADD('DAY',-1, CURRENT_DATE)),
-  ('1000003', 'System', LOCALTIMESTAMP, NULL, NULL, 'Vancouver', 'Simon Young', 'Adrian Peake', NULL, 'JJGroup2', 'University', DATEADD('DAY',-2, CURRENT_DATE)),
-  ('1000004', 'System', LOCALTIMESTAMP, NULL, NULL, 'Whistler', 'Matt Vaughan', 'Steven Allan', 'JJ3', 'JJGroup1', 'Whistler', DATEADD('DAY',-3, CURRENT_DATE)),
-  ('1000005', 'System', LOCALTIMESTAMP, NULL, NULL, 'Squamish', 'Gavin Glover', 'Harry Reid', 'JJ3', 'JJGroup3', 'Ladysmith', DATEADD('DAY',-4, CURRENT_DATE)),
-  ('1000006', 'System', LOCALTIMESTAMP, NULL, NULL, 'Squamish', 'Gavin Glover', 'Harry Reid', NULL, NULL, 'Ladysmith', DATEADD('DAY',-5, CURRENT_DATE));
+  ('1000001', 'System', LOCALTIMESTAMP, 'System', LOCALTIMESTAMP, 'Victoria', 'John Doe', 'Steven Allan', 'JJ1', 'JJGroup1', 'West Shore', LOCALTIMESTAMP),
+  ('1000002', 'System', LOCALTIMESTAMP, 'System', LOCALTIMESTAMP, 'Vancouver', 'Jane Doe', 'Alison Kerr', 'JJ2', 'JJGroup2', 'Valemount', DATEADD('DAY',-1, CURRENT_DATE)),
+  ('1000003', 'System', LOCALTIMESTAMP, 'System', LOCALTIMESTAMP, 'Vancouver', 'Simon Young', 'Adrian Peake', NULL, 'JJGroup2', 'University', DATEADD('DAY',-2, CURRENT_DATE)),
+  ('1000004', 'System', LOCALTIMESTAMP, 'System', LOCALTIMESTAMP, 'Whistler', 'Matt Vaughan', 'Steven Allan', 'JJ3', 'JJGroup1', 'Whistler', DATEADD('DAY',-3, CURRENT_DATE)),
+  ('1000005', 'System', LOCALTIMESTAMP, 'System', LOCALTIMESTAMP, 'Squamish', 'Gavin Glover', 'Harry Reid', 'JJ3', 'JJGroup3', 'Ladysmith', DATEADD('DAY',-4, CURRENT_DATE)),
+  ('1000006', 'System', LOCALTIMESTAMP, 'System', LOCALTIMESTAMP, 'Squamish', 'Gavin Glover', 'Harry Reid', NULL, NULL, 'Ladysmith', DATEADD('DAY',-5, CURRENT_DATE));


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- Staff API OpenAPI spec expects MODIFIED_BY and MODIFIED_TS fields to be not NULL so it returns a serialization error when fetching the jj disputes with the auto populated data.
- Updated data.sql to populate MODIFIED_BY and MODIFIED_TS fields of JJDISPUTE table on startup so Staff API JJ Dispute endpoints work properly.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
