### PR TITLE
TCVP-1591 Change encoding when writing to ARC file

### DIFF
--- a/src/backend/TrafficCourts/TrafficCourts.Arc.Dispute.Service/Services/ArcFileService.cs
+++ b/src/backend/TrafficCourts/TrafficCourts.Arc.Dispute.Service/Services/ArcFileService.cs
@@ -59,7 +59,7 @@ public class ArcFileService : IArcFileService
 
         // Write ARC data into the memory stream that will be uploaded as a file
         var stream = _memoryStreamManager.GetStream();
-        var fileWriter = new StreamWriter(stream, Encoding.UTF8);
+        var fileWriter = new StreamWriter(stream, Encoding.ASCII);
         var writer = selector.GetWriter(fileWriter, new FixedLengthOptions { RecordSeparator = NewLineRecordSeparator });
 
         await writer.WriteAllAsync(arcFileData);

--- a/src/backend/TrafficCourts/TrafficCourts.Arc.Dispute.Service/Services/ArcFileService.cs
+++ b/src/backend/TrafficCourts/TrafficCourts.Arc.Dispute.Service/Services/ArcFileService.cs
@@ -59,6 +59,8 @@ public class ArcFileService : IArcFileService
 
         // Write ARC data into the memory stream that will be uploaded as a file
         var stream = _memoryStreamManager.GetStream();
+        // Encoding with ASCII instead of UTF-8 which prevents final ARC file from being initialized with a
+        // Byte Order Mark (BOM) Character which can cause issues with other systems processing the file.
         var fileWriter = new StreamWriter(stream, Encoding.ASCII);
         var writer = selector.GetWriter(fileWriter, new FixedLengthOptions { RecordSeparator = NewLineRecordSeparator });
 


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- [TCVP-1591](https://justice.gov.bc.ca/jira/browse/TCVP-1591)
- Fixes a bug that prevents ARC file to be processed by other systems due to the encoding type of the final file being initialized with a Byte Order Mark (BOM) Character.
- Updated ARC file encoding to ASCII instead of UTF8 prior to streaming/writing in data.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Tested running ARC Dispute API locally and sending a request for creating an ARC file. Opened created ARC file in SFTP location via Notepad++ and confirmed the encoding is UTF-8 only.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
