### PR TITLE
Add Keycloak authorization classes

### DIFF
--- a/src/backend/TrafficCourts/Common/Authorization/KeycloakAuthorizationHandler.cs
+++ b/src/backend/TrafficCourts/Common/Authorization/KeycloakAuthorizationHandler.cs
@@ -1,0 +1,66 @@
+﻿using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Options;
+using System.Net.Http.Headers;
+
+namespace TrafficCourts.Common.Authorization;
+
+/// <summary>
+/// Authorization handler that handles Keycloak requirements.
+/// </summary>
+public class KeycloakAuthorizationHandler : AuthorizationHandler<KeycloakAuthorizationRequirement>
+{
+    private readonly IOptions<KeycloakAuthorizationOptions> _options;
+    private readonly IHttpContextAccessor _httpContextAccessor;
+
+    public KeycloakAuthorizationHandler(IOptions<KeycloakAuthorizationOptions> options, IHttpContextAccessor httpContextAccessor)
+    {
+        _options = options ?? throw new ArgumentNullException(nameof(options));
+        _httpContextAccessor = httpContextAccessor ?? throw new ArgumentNullException(nameof(httpContextAccessor));
+    }
+
+    /// <summary>
+    /// Makes a decision if authorization is allowed based on a specific requirement.
+    /// </summary>
+    /// <param name="context">The authorization context.</param>
+    /// <param name="requirement">The requirement to evaluate.</param>
+    protected override async Task HandleRequirementAsync(AuthorizationHandlerContext context, KeycloakAuthorizationRequirement requirement)
+    {
+        var httpContext = _httpContextAccessor.HttpContext;
+        if (httpContext == null)
+        {
+            context.Fail();
+            return;
+        }
+
+        var options = _options.Value;
+        var auth = await httpContext.AuthenticateAsync(options.RequiredScheme);
+        if (!auth.Succeeded)
+        {
+            context.Fail();
+            return;
+        }
+
+        var data = new Dictionary<string, string>
+        {
+            { "grant_type", "urn:ietf:params:oauth:grant-type:uma-ticket" },
+            { "response_mode", "decision" },
+            { "audience", options.Audience },
+            { "permission", requirement.PolicyName }
+        };
+
+        var client = new HttpClient(options.BackchannelHandler);
+        var token = await httpContext.GetTokenAsync(options.RequiredScheme, "access_token");
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+
+        var response = await client.PostAsync(options.TokenEndpoint, new FormUrlEncodedContent(data));
+        if (response.IsSuccessStatusCode)
+        {
+            context.Succeed(requirement);
+            return;
+        }
+
+        context.Fail();
+    }
+}

--- a/src/backend/TrafficCourts/Common/Authorization/KeycloakAuthorizationOptions.cs
+++ b/src/backend/TrafficCourts/Common/Authorization/KeycloakAuthorizationOptions.cs
@@ -1,0 +1,41 @@
+﻿using Microsoft.AspNetCore.Authentication.JwtBearer;
+
+namespace TrafficCourts.Common.Authorization;
+
+/// <summary>
+/// Defines options for Keycloak authorization
+/// </summary>
+public class KeycloakAuthorizationOptions
+{
+    /// <summary>
+    /// Gets or sets the required aithentication scheme that holds the token.
+    /// </summary>
+    /// <value>
+    /// The required scheme.
+    /// </value>
+    public string RequiredScheme { get; set; } = JwtBearerDefaults.AuthenticationScheme;
+
+    /// <summary>
+    /// Gets or sets the token endpoint.
+    /// </summary>
+    /// <value>
+    /// The token endpoint.
+    /// </value>
+    public string TokenEndpoint { get; set; }
+
+    /// <summary>
+    /// Gets or sets the backchannel handler.
+    /// </summary>
+    /// <value>
+    /// The backchannel handler.
+    /// </value>
+    public HttpMessageHandler BackchannelHandler { get; set; } = new HttpClientHandler();
+
+    /// <summary>
+    /// Gets or sets the audience.
+    /// </summary>
+    /// <value>
+    /// The audience.
+    /// </value>
+    public string Audience { get; set; }
+}

--- a/src/backend/TrafficCourts/Common/Authorization/KeycloakAuthorizationPolicyBuilderExtensions.cs
+++ b/src/backend/TrafficCourts/Common/Authorization/KeycloakAuthorizationPolicyBuilderExtensions.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.AspNetCore.Authorization;
+
+namespace TrafficCourts.Common.Authorization;
+
+public static class KeycloakAuthorizationPolicyBuilderExtensions
+{
+    /// <summary>
+    /// Adds a Keycloak requirement to the Requirements.
+    /// </summary>
+    /// <param name="builder">The builder.</param>
+    /// <param name="resource">The resource.</param>
+    /// <param name="scope">The scope.</param>
+    /// <returns></returns>
+    public static AuthorizationPolicyBuilder RequiresKeycloakEntitlement(this AuthorizationPolicyBuilder builder, string resource, string scope)
+    {
+        if (resource is null)
+        {
+            throw new ArgumentNullException(nameof(resource));
+        }
+
+        if (scope is null)
+        {
+            throw new ArgumentNullException(nameof(scope));
+        }
+
+        builder.AddRequirements(new KeycloakAuthorizationRequirement($"{resource}#{scope}"));
+        return builder;
+    }
+}

--- a/src/backend/TrafficCourts/Common/Authorization/KeycloakAuthorizationPolicyProvider.cs
+++ b/src/backend/TrafficCourts/Common/Authorization/KeycloakAuthorizationPolicyProvider.cs
@@ -1,0 +1,40 @@
+﻿using Microsoft.AspNetCore.Authorization;
+using Microsoft.Extensions.Options;
+
+namespace TrafficCourts.Common.Authorization;
+
+public class KeycloakAuthorizationPolicyProvider : IAuthorizationPolicyProvider
+{
+    private readonly IOptions<KeycloakAuthorizationOptions> _options;
+    private readonly IOptions<AuthorizationOptions> _authorizationOptions;
+    private readonly DefaultAuthorizationPolicyProvider _fallbackPolicyProvider;
+
+    public KeycloakAuthorizationPolicyProvider(IOptions<KeycloakAuthorizationOptions> options, IOptions<AuthorizationOptions> authorizationOptions)
+    {
+        _options = options ?? throw new ArgumentNullException(nameof(options));
+        _authorizationOptions = authorizationOptions ?? throw new ArgumentNullException(nameof(authorizationOptions));
+        _fallbackPolicyProvider = new DefaultAuthorizationPolicyProvider(_authorizationOptions);
+    }
+
+    public Task<AuthorizationPolicy> GetDefaultPolicyAsync() => _fallbackPolicyProvider.GetDefaultPolicyAsync();
+
+    public Task<AuthorizationPolicy?> GetFallbackPolicyAsync() => _fallbackPolicyProvider.GetFallbackPolicyAsync();
+
+    public Task<AuthorizationPolicy?> GetPolicyAsync(string policyName)
+    {
+        if (_authorizationOptions.Value.GetPolicy(policyName) is not null)
+        {
+            return _fallbackPolicyProvider.GetPolicyAsync(policyName);
+        }
+
+        var builder = new AuthorizationPolicyBuilder();
+        builder.AuthenticationSchemes.Add(_options.Value.RequiredScheme);
+        builder.AddRequirements(new KeycloakAuthorizationRequirement(policyName));
+
+        AuthorizationPolicy? policy = builder.Build();
+
+#pragma warning disable CS8619 // Nullability of reference types in value doesn't match target type.
+        return Task.FromResult(policy);
+#pragma warning restore CS8619 // Nullability of reference types in value doesn't match target type.
+    }
+}

--- a/src/backend/TrafficCourts/Common/Authorization/KeycloakAuthorizationRequirement.cs
+++ b/src/backend/TrafficCourts/Common/Authorization/KeycloakAuthorizationRequirement.cs
@@ -1,0 +1,22 @@
+﻿using Microsoft.AspNetCore.Authorization;
+
+namespace TrafficCourts.Common.Authorization;
+
+public class KeycloakAuthorizationRequirement : IAuthorizationRequirement
+{
+    /// Initializes a new instance of the <see cref="KeycloakRequirement"/> class.
+    /// </summary>
+    /// <param name="policyName">Name of the policy.</param>
+    public KeycloakAuthorizationRequirement(string policyName)
+    {
+        PolicyName = policyName ?? throw new ArgumentNullException(nameof(policyName));
+    }
+
+    /// <summary>
+    /// Gets the name of the policy.
+    /// </summary>
+    /// <value>
+    /// The name of the policy.
+    /// </value>
+    public string PolicyName { get; }
+}

--- a/src/backend/TrafficCourts/Common/Authorization/KeycloakAuthorizationServiceCollectionExtensions.cs
+++ b/src/backend/TrafficCourts/Common/Authorization/KeycloakAuthorizationServiceCollectionExtensions.cs
@@ -1,0 +1,22 @@
+﻿using Microsoft.AspNetCore.Authorization;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace TrafficCourts.Common.Authorization;
+
+public static class KeycloakAuthorizationServiceCollectionExtensions
+{
+    /// <summary>
+    /// Add keycloak authorization components.
+    /// </summary>
+    /// <param name="services">The services.</param>
+    /// <param name="configure">The configure.</param>
+    /// <returns></returns>
+    public static IServiceCollection AddKeycloakAuthorization(this IServiceCollection services, Action<KeycloakAuthorizationOptions> configure)
+    {
+        services.Configure(configure);
+        services.AddHttpContextAccessor();
+        services.AddSingleton<IAuthorizationHandler, KeycloakAuthorizationHandler>();
+
+        return services;
+    }
+}

--- a/src/backend/TrafficCourts/Common/TrafficCourts.Common.csproj
+++ b/src/backend/TrafficCourts/Common/TrafficCourts.Common.csproj
@@ -8,6 +8,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="MediatR" Version="10.0.1" />
+		<PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="6.0.3" />
 		<PackageReference Include="Microsoft.Extensions.ApiDescription.Client" Version="6.0.5">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- Adds ASP.NET Core authorization logic based on [thinktecture-labs/webinar-keycloak](https://github.com/thinktecture-labs/webinar-keycloak) example
- Does not add new authorization logic yet to other APIs.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
