### PR TITLE
Remove token validation parameters that broke auth

### DIFF
--- a/src/backend/TrafficCourts/Staff.Service/Authentication/Authentication.cs
+++ b/src/backend/TrafficCourts/Staff.Service/Authentication/Authentication.cs
@@ -20,8 +20,9 @@ public static class AuthenticationExtensions
             {
                 configuration.Bind(_jwtBearerOptionsSection, options);
 
-                options.TokenValidationParameters.NameClaimType = "preferred_username";
-                options.TokenValidationParameters.RoleClaimType = _roleClaimType;
+                // removed until full authorization is enabled, otherwise this will case 403
+                //options.TokenValidationParameters.NameClaimType = "preferred_username";
+                //options.TokenValidationParameters.RoleClaimType = _roleClaimType;
 
                 options.Events = new JwtBearerEvents
                 {


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- removes the token validation parameters to avoid breaking incomplete keycloak config
- resolves issue getting 403 error accessing staff api

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change
