### PR TITLE
TCVP-1627 Add a minute difference between each transaction time of EV and ED

### DIFF
--- a/src/backend/TrafficCourts/Test/Arc.Dispute.Service/Mappings/MappingTests.cs
+++ b/src/backend/TrafficCourts/Test/Arc.Dispute.Service/Mappings/MappingTests.cs
@@ -40,7 +40,12 @@ namespace TrafficCourts.Test.Arc.Dispute.Service.Mappings
 
             foreach (var actualRec in actual)
             {
-                Assert.Equal(tcoDisputeTicket.TicketIssuanceDate, actualRec.TransactionDate);
+                var expectedTimestamp = DateTime.Now;
+                var expectedHM = new DateTime(expectedTimestamp.Year, expectedTimestamp.Month, expectedTimestamp.Day, expectedTimestamp.Hour, expectedTimestamp.Minute, 0);
+
+                var actualTimestamp = actualRec.TransactionDate;
+                var actualHM = new DateTime(actualTimestamp.Year, actualTimestamp.Month, actualTimestamp.Day, actualTimestamp.Hour, actualTimestamp.Minute, 0);
+                Assert.Equal(expectedHM, actualHM);
                 Assert.Equal(tcoDisputeTicket.TicketFileNumber + " 01".ToUpper(), actualRec.FileNumber);
                 Assert.Equal(expectedMvbClientNumber, actualRec.MvbClientNumber);
 

--- a/src/backend/TrafficCourts/TrafficCourts.Arc.Dispute.Service/Mappings/DisputeTicketToArcFileRecordListConverter.cs
+++ b/src/backend/TrafficCourts/TrafficCourts.Arc.Dispute.Service/Mappings/DisputeTicketToArcFileRecordListConverter.cs
@@ -15,13 +15,17 @@ namespace TrafficCourts.Arc.Dispute.Service.Mappings
 
             List<ArcFileRecord> arcFileRecordList = new();
 
+            // Additional minutes between the transaction times since each transaction timestamp for EV and ED must be unique for ARC to process
+            double addedMinutes = 0;
+
             foreach (TicketCount ticket in source.TicketDetails)
             {
+
                 AdnotatedTicket adnotated = new();
 
                 // Adnotated ticket's Master File Data mapping
-                adnotated.TransactionDate = source.TicketIssuanceDate;
-                adnotated.TransactionTime = source.TicketIssuanceDate;
+                adnotated.TransactionDate = DateTime.Now.AddMinutes(addedMinutes);
+                adnotated.TransactionTime = DateTime.Now.AddMinutes(addedMinutes);
                 adnotated.EffectiveDate = source.TicketIssuanceDate;
                 adnotated.FileNumber = source.TicketFileNumber + " 01".ToUpper();
                 adnotated.MvbClientNumber = DriversLicence.WithCheckDigit(source.DriversLicence);
@@ -70,11 +74,13 @@ namespace TrafficCourts.Arc.Dispute.Service.Mappings
                         continue;
                     }
 
+                    addedMinutes++;
+
                     DisputedTicket disputed = new()
                     {
                         // Dispited ticket's Master File Data mapping
-                        TransactionDate = source.TicketIssuanceDate,
-                        TransactionTime = source.TicketIssuanceDate,
+                        TransactionDate = DateTime.Now.AddMinutes(addedMinutes),
+                        TransactionTime = DateTime.Now.AddMinutes(addedMinutes),
                         EffectiveDate = source.TicketIssuanceDate,
                         FileNumber = source.TicketFileNumber.ToUpper() + " 01",
                         MvbClientNumber = source.DriversLicence.ToUpper(),
@@ -90,7 +96,9 @@ namespace TrafficCourts.Arc.Dispute.Service.Mappings
                     };
 
                     arcFileRecordList.Add(disputed);
-                }              
+                }
+
+                addedMinutes++;
             }
             return arcFileRecordList;
         }


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- [TCVP-1627](https://justice.gov.bc.ca/jira/browse/TCVP-1627)
- Added a minute between the transaction times since each transaction timestamp for EV and ED must be unique for ARC to process.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Ran ARC API locally and sent a request to create a new ARC data file. Then checked the content of the file to see whether all transaction times are 1 minute apart. They all looked accurate.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
