### PR TITLE
TCVP-1629 / ARC File - Add Two Spaces After File Number

### DIFF
--- a/src/backend/TrafficCourts/Test/Arc.Dispute.Service/Mappings/MappingTests.cs
+++ b/src/backend/TrafficCourts/Test/Arc.Dispute.Service/Mappings/MappingTests.cs
@@ -46,7 +46,7 @@ namespace TrafficCourts.Test.Arc.Dispute.Service.Mappings
                 var actualTimestamp = actualRec.TransactionDate;
                 var actualHM = new DateTime(actualTimestamp.Year, actualTimestamp.Month, actualTimestamp.Day, actualTimestamp.Hour, actualTimestamp.Minute, 0);
                 Assert.Equal(expectedHM, actualHM);
-                Assert.Equal(tcoDisputeTicket.TicketFileNumber + " 01".ToUpper(), actualRec.FileNumber);
+                Assert.Equal(tcoDisputeTicket.TicketFileNumber.ToUpper() + "  01", actualRec.FileNumber);
                 Assert.Equal(expectedMvbClientNumber, actualRec.MvbClientNumber);
 
                 if (actualRec is AdnotatedTicket)

--- a/src/backend/TrafficCourts/TrafficCourts.Arc.Dispute.Service/Mappings/DisputeTicketToArcFileRecordListConverter.cs
+++ b/src/backend/TrafficCourts/TrafficCourts.Arc.Dispute.Service/Mappings/DisputeTicketToArcFileRecordListConverter.cs
@@ -85,7 +85,7 @@ namespace TrafficCourts.Arc.Dispute.Service.Mappings
                         EffectiveDate = source.TicketIssuanceDate,
                         // There has to be two spaces between the 10th character and the "01" at the end for ARC to process the file properly
                         FileNumber = source.TicketFileNumber.ToUpper() + "  01",
-                        MvbClientNumber = source.DriversLicence.ToUpper(),
+                        MvbClientNumber = DriversLicence.WithCheckDigit(source.DriversLicence),
 
                         // Mapping disputed ticket specific data
                         ServiceDate = source.TicketIssuanceDate,

--- a/src/backend/TrafficCourts/TrafficCourts.Arc.Dispute.Service/Mappings/DisputeTicketToArcFileRecordListConverter.cs
+++ b/src/backend/TrafficCourts/TrafficCourts.Arc.Dispute.Service/Mappings/DisputeTicketToArcFileRecordListConverter.cs
@@ -27,7 +27,8 @@ namespace TrafficCourts.Arc.Dispute.Service.Mappings
                 adnotated.TransactionDate = DateTime.Now.AddMinutes(addedMinutes);
                 adnotated.TransactionTime = DateTime.Now.AddMinutes(addedMinutes);
                 adnotated.EffectiveDate = source.TicketIssuanceDate;
-                adnotated.FileNumber = source.TicketFileNumber + " 01".ToUpper();
+                // There has to be two spaces between the 10th character and the "01" at the end for ARC to process the file properly
+                adnotated.FileNumber = source.TicketFileNumber.ToUpper() + "  01";
                 adnotated.MvbClientNumber = DriversLicence.WithCheckDigit(source.DriversLicence);
                 
                 // Map adnotated ticket specific data
@@ -82,7 +83,8 @@ namespace TrafficCourts.Arc.Dispute.Service.Mappings
                         TransactionDate = DateTime.Now.AddMinutes(addedMinutes),
                         TransactionTime = DateTime.Now.AddMinutes(addedMinutes),
                         EffectiveDate = source.TicketIssuanceDate,
-                        FileNumber = source.TicketFileNumber.ToUpper() + " 01",
+                        // There has to be two spaces between the 10th character and the "01" at the end for ARC to process the file properly
+                        FileNumber = source.TicketFileNumber.ToUpper() + "  01",
                         MvbClientNumber = source.DriversLicence.ToUpper(),
 
                         // Mapping disputed ticket specific data


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- [TCVP-1629](https://justice.gov.bc.ca/jira/browse/TCVP-1629)
- Fixes a bug with ARC file output by adding two spaces after file number (between the 10th character and the "01" at the end) instead of one.
- Fixes a bug with the checksum digit was not applied to the disputed type ticket rows.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Ran ARC API locally and sent a request to create a new ARC data file. Then checked the content of the file to see whether there are two space after the File Number or not. The output file content was correct.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
