### PR TITLE
allow ssh key to be provided in configuration/env variable

### DIFF
--- a/src/backend/TrafficCourts/Test/Arc.Dispute.Service/Configuration/SftpConnectionOptionsTests.cs
+++ b/src/backend/TrafficCourts/Test/Arc.Dispute.Service/Configuration/SftpConnectionOptionsTests.cs
@@ -1,0 +1,108 @@
+﻿using Renci.SshNet.Common;
+using System;
+using System.IO;
+using TrafficCourts.Arc.Dispute.Service.Configuration;
+using Xunit;
+
+namespace TrafficCourts.Test.Arc.Dispute.Service.Configuration
+{
+    public class SftpConnectionOptionsTests
+    {
+        [Theory]
+        [InlineData(1024)]
+        [InlineData(2048)]
+        [InlineData(4096)]
+        public void load_private_key_from_string(int keySize)
+        {
+            // arrange
+            var key = new SshKeyGenerator.SshKeyGenerator(keySize);
+
+            SftpConnectionOptions options = new SftpConnectionOptions
+            {
+                SshPrivateKey = key.ToPrivateKey()
+            };
+
+            var privateKey = options.GetPrivateKey();
+            Assert.NotNull(privateKey);
+        }
+
+        [Theory]
+        [InlineData(1024)]
+        [InlineData(2048)]
+        [InlineData(4096)]
+        public void load_private_key_from_file(int keySize)
+        {
+            string filename = Path.GetTempFileName();
+
+            try
+            {
+                var key = new SshKeyGenerator.SshKeyGenerator(keySize);
+                File.WriteAllText(filename, key.ToPrivateKey());
+
+                SftpConnectionOptions options = new()
+                {
+                    SshPrivateKeyPath = filename
+                };
+
+                var privateKey = options.GetPrivateKey();
+                Assert.NotNull(privateKey);
+            }
+            finally
+            {
+                TryDelete(filename);
+            }
+        }
+
+        [Fact]
+        public void GetPrivateKey_returns_null_if_keys_not_set()
+        {
+            SftpConnectionOptions options = new();
+            var privateKey = options.GetPrivateKey();
+            Assert.Null(privateKey);
+        }
+
+        [Fact]
+        public void GetPrivateKey_throws_if_SshPrivateKey_is_not_valid()
+        {
+            SftpConnectionOptions options = new SftpConnectionOptions
+            {
+                SshPrivateKey = Guid.NewGuid().ToString()
+            };
+
+            Assert.Throws<SshException>(() => options.GetPrivateKey());
+        }
+
+        [Fact]
+        public void GetPrivateKey_throws_if_SshPrivateKeyPath_is_not_valid()
+        {
+            string filename = Path.GetTempFileName();
+
+            try
+            {
+                File.WriteAllText(filename, Guid.NewGuid().ToString());
+
+                SftpConnectionOptions options = new SftpConnectionOptions
+                {
+                    SshPrivateKeyPath = filename
+                };
+
+                Assert.Throws<SshException>(() => options.GetPrivateKey());
+            }
+            finally
+            {
+                TryDelete(filename);
+            }
+        }
+
+        private void TryDelete(string filename)
+        {
+            try
+            {
+                File.Delete(filename);
+            }
+            catch (Exception)
+            {
+            }
+        }
+    }
+}

--- a/src/backend/TrafficCourts/Test/TrafficCourts.Test.csproj
+++ b/src/backend/TrafficCourts/Test/TrafficCourts.Test.csproj
@@ -18,6 +18,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
     <PackageReference Include="Moq" Version="4.17.2" />
     <PackageReference Include="NodaTime.Testing" Version="3.0.10" />
+    <PackageReference Include="SshKeyGenerator" Version="1.1.50" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- Allows the SSH key to be provided in environment variable as well as a file on disk
- key in variable will take precedence over file
- key in file will still work
- will still fall back to usename and password if no ssh key is available

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [ ] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
