### PR TITLE
add optional sleep at start of container start

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh      text eol=lf

--- a/src/backend/TrafficCourts/entrypoint.sh
+++ b/src/backend/TrafficCourts/entrypoint.sh
@@ -8,6 +8,13 @@ set -euo pipefail
 
 # shellcheck disable=SC1091
 
+# if the first two parameters are a sleep command,
+# execute the sleep and remove the parameters
+if [[ "$1" = "sleep" ]] ; then
+  sleep $2
+  shift 2
+fi
+
 VAULT_SECRETS_DIR=/vault/secrets
 
 if [ -d ${VAULT_SECRETS_DIR} ]; then

--- a/src/backend/oracle-data-api/entrypoint.sh
+++ b/src/backend/oracle-data-api/entrypoint.sh
@@ -8,6 +8,13 @@ set -euo pipefail
 
 # shellcheck disable=SC1091
 
+# if the first two parameters are a sleep command,
+# execute the sleep and remove the parameters
+if [[ "$1" = "sleep" ]] ; then
+  sleep $2
+  shift 2
+fi
+
 VAULT_SECRETS_DIR=/vault/secrets
 
 if [ -d ${VAULT_SECRETS_DIR} ]; then


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- allow adding a "sleep x" before the main entry point starts for troubleshooting
