### PR TITLE
removed nginx resolver directive

### DIFF
--- a/.gitops/charts/traffic-court-online/charts/citizen-web/templates/configmap.yaml
+++ b/.gitops/charts/traffic-court-online/charts/citizen-web/templates/configmap.yaml
@@ -10,7 +10,6 @@ data:
 {{- end }}
   nginx-api-proxy-pass.conf: |-
     location /api {
-      resolver kube-dns.kube-system.svc.cluster.local;
       proxy_pass http://{{ .Release.Name }}-citizen-api.{{ .Values.global.namespace }}.svc.cluster.local:8080/api;
       client_max_body_size 10M;
     }

--- a/.gitops/charts/traffic-court-online/charts/staff-web/templates/configmap.yaml
+++ b/.gitops/charts/traffic-court-online/charts/staff-web/templates/configmap.yaml
@@ -8,7 +8,6 @@ data:
 {{ include "staff-web.tplvalues.render" ( dict "value" .Values.keycloakConfig "context" $ ) | indent 4 }}
   nginx-api-proxy-pass.conf: |-
     location /api {
-      resolver kube-dns.kube-system.svc.cluster.local;
       proxy_pass http://{{ .Release.Name }}-staff-api.{{ .Values.global.namespace }}.svc.cluster.local:8080/api;
       client_max_body_size 10M;
     }


### PR DESCRIPTION
kube-dns.kube-system.svc.cluster.local does not exist on openshift, so removed the `resolve` directive for now.