### PR TITLE
Add ORDS proxy for development only

### DIFF
--- a/infrastructure/openshift/dev/ords-proxy.yaml
+++ b/infrastructure/openshift/dev/ords-proxy.yaml
@@ -1,0 +1,108 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: ords-proxy-configuration
+data:
+  nginx.conf: |
+    server {
+      listen 8080;
+      location / {
+        proxy_pass https://dev.jag.gov.bc.ca/ords/devj/occamords/occam/;
+      }
+      error_page   500 502 503 504  /50x.html;
+      location = /50x.html {
+          root   /usr/share/nginx/html;
+      }
+      error_log stderr warn;
+    }
+---
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: ords-proxy
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: traffic-court-online
+      app.kubernetes.io/name: ords-proxy
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/instance: traffic-court-online
+        app.kubernetes.io/name: ords-proxy
+    spec:
+      containers:
+        - resources:
+            limits:
+              cpu: 150m
+              memory: 512Mi
+            requests:
+              cpu: 100m
+              memory: 256Mi
+          name: ords-proxy
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          image: nginx:latest
+          imagePullPolicy: Always
+          volumeMounts:
+            - name: configuration
+              readOnly: true
+              mountPath: /etc/nginx/conf.d/default.conf
+              subPath: nginx.conf
+            - name: cache
+              mountPath: /var/cache/nginx
+            - name: varrun
+              mountPath: /var/run
+      volumes:
+        - name: configuration
+          configMap:
+            name: ords-proxy-configuration
+            items:
+              - key: nginx.conf
+                path: nginx.conf
+            defaultMode: 420
+        - name: cache
+          emptyDir: {}              
+        - name: varrun
+          emptyDir: {}
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: ords-proxy
+  labels:
+    app.kubernetes.io/instance: traffic-court-online
+    app.kubernetes.io/name: ords-proxy
+spec:
+  ports:
+    - name: http
+      protocol: TCP
+      port: 8080
+      targetPort: http
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/instance: traffic-court-online
+    app.kubernetes.io/name: ords-proxy
+---
+kind: Route
+apiVersion: route.openshift.io/v1
+metadata:
+  name: ords
+  labels:
+    app.kubernetes.io/instance: traffic-court-online
+    app.kubernetes.io/name: ords-proxy
+  annotations:
+    openshift.io/host.generated: 'true'
+    # replace with developer's ip address list, see TCVP-1682
+    # haproxy.router.openshift.io/ip_whitelist: 127.0.0.1 
+spec:
+  to:
+    kind: Service
+    name: ords-proxy
+    weight: 100
+  port:
+    targetPort: http
+  wildcardPolicy: None


### PR DESCRIPTION
Adds the required manifests for creating objects to allow proxy to ORDS endpoints in Dev only. Dev IP addresses added to allow list as per values provided. See https://justice.gov.bc.ca/jira/projects/TCVP/issues/TCVP-1682