### PR TITLE
TCVP-1595 OpenShift cronjobs to cleanup Form Recognizer data

### DIFF
--- a/.docker/docker-compose-ocr.yml
+++ b/.docker/docker-compose-ocr.yml
@@ -20,8 +20,26 @@ services:
       - form-rec-layout
       - form-rec-custom-api
       - form-rec-custom-supervised
+      - form-rec-cron
     ports:
       - "5200:5200"
+
+  form-rec-cron:
+    container_name: azure-cognitive-service-custom-cron
+    image: alpine:3.14
+    entrypoint: >
+      /bin/sh -c "
+      LC_ALL=C find /shared/formrecognizer/.__custom__.virtualdir/.__requests__.virtualdir/.__default__.virtualdir -mmin +60 -delete;
+      LC_ALL=C find /logs -mtime +30 -delete;
+      exit 0;
+      "
+    volumes:
+      - type: bind
+        source: ./tools/form-recognizer/shared
+        target: /shared
+      - type: bind
+        source: ./tools/form-recognizer/logs
+        target: /logs
 
   form-rec-layout:
     container_name: azure-cognitive-service-custom-layout

--- a/.gitops/azure/azure-custom-cron-logs.yml
+++ b/.gitops/azure/azure-custom-cron-logs.yml
@@ -1,0 +1,27 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: azure-cognitive-service-cleanup-logs
+  namespace: 0198bb-dev
+spec:
+  schedule: '@daily'
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          volumes:
+            - name: forms-recognizer-logs
+              persistentVolumeClaim:
+                claimName: forms-recognizer-logs
+          containers:
+            - name: azure-cognitive-service-cleanup-logs
+              image: alpine:3.14
+              args:
+                - /bin/sh
+                - '-c'
+                - "LC_ALL=C find /logs -mtime +30 -delete;"
+              volumeMounts:
+                - name: forms-recognizer-logs
+                  mountPath: /logs
+          restartPolicy: OnFailure

--- a/.gitops/azure/azure-custom-cron-requests.yml
+++ b/.gitops/azure/azure-custom-cron-requests.yml
@@ -1,0 +1,27 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: azure-cognitive-service-cleanup-requests
+  namespace: 0198bb-dev
+spec:
+  schedule: '@hourly'
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          volumes:
+            - name: forms-recognizer-shared
+              persistentVolumeClaim:
+                claimName: forms-recognizer-shared
+          containers:
+            - name: azure-cognitive-service-cleanup-requests
+              image: alpine:3.14
+              args:
+                - /bin/sh
+                - '-c'
+                - "LC_ALL=C find /shared/formrecognizer/.__custom__.virtualdir/.__requests__.virtualdir/.__default__.virtualdir -mmin +60 -delete;"
+              volumeMounts:
+                - name: forms-recognizer-shared
+                  mountPath: /shared
+          restartPolicy: OnFailure


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

TCVP-1595

Added 2 OpenShift configuration files to create cronjobs to cleanup Form Recognizer data.

Job1: Run daily, remove old log files over 1 month old
Job2: Run hourly, remove old Form Recognizer OCR ticket images and results that are over 1 hour old.

To deploy these jobs:
oc apply -f azure-custom-cron-logs.yml
oc apply -f azure-custom-cron-requests.yml

Added a new container to docker-compose to test this functionality.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Deployed to DEV and confirmed the data is properly cleared out.

## Does the change impact or break the Docker build?

- [x] Yes
- [ ] No

If Yes: Has Docker been updated accordingly?

- [x] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
