### PR TITLE
Adjust default memory requests to 256Mi, limits to 512Mi

### DIFF
--- a/.gitops/charts/traffic-court-online/charts/arc-dispute-api/values.yaml
+++ b/.gitops/charts/traffic-court-online/charts/arc-dispute-api/values.yaml
@@ -26,10 +26,10 @@ fullnameOverride: ""
 resources:
   limits:
     cpu: 100m
-    memory: 128Mi
+    memory: 512Mi
   requests:
     cpu: 100m
-    memory: 128Mi
+    memory: 256Mi
 
 ## Autoscaling configuration
 ## ref: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/

--- a/.gitops/charts/traffic-court-online/charts/citizen-api/values.yaml
+++ b/.gitops/charts/traffic-court-online/charts/citizen-api/values.yaml
@@ -26,10 +26,10 @@ fullnameOverride: ""
 resources:
   limits:
     cpu: 100m
-    memory: 128Mi
+    memory: 512Mi
   requests:
     cpu: 100m
-    memory: 128Mi
+    memory: 256Mi
 
 ## Autoscaling configuration
 ## ref: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/

--- a/.gitops/charts/traffic-court-online/charts/staff-api/values.yaml
+++ b/.gitops/charts/traffic-court-online/charts/staff-api/values.yaml
@@ -26,10 +26,10 @@ fullnameOverride: ""
 resources:
   limits:
     cpu: 100m
-    memory: 128Mi
+    memory: 512Mi
   requests:
     cpu: 100m
-    memory: 128Mi
+    memory: 256Mi
 
 ## Autoscaling configuration
 ## ref: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/

--- a/.gitops/charts/traffic-court-online/charts/workflow-service/values.yaml
+++ b/.gitops/charts/traffic-court-online/charts/workflow-service/values.yaml
@@ -26,10 +26,10 @@ fullnameOverride: ""
 resources:
   limits:
     cpu: 100m
-    memory: 128Mi
+    memory: 512Mi
   requests:
     cpu: 100m
-    memory: 128Mi
+    memory: 256Mi
 
 ## Autoscaling configuration
 ## ref: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- Adjusts default memory limits and request vaults for .net containers

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [ ] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
