### PR TITLE
Add object destructuring to log.Trace statement to get object contents

### DIFF
--- a/src/backend/TrafficCourts/Workflow.Service/Consumers/DisputeSubmitConsumer.cs
+++ b/src/backend/TrafficCourts/Workflow.Service/Consumers/DisputeSubmitConsumer.cs
@@ -35,7 +35,7 @@ namespace TrafficCourts.Workflow.Service.Consumers
 
                 Dispute dispute = _mapper.Map<Dispute>(context.Message);
 
-                _logger.LogTrace("TRY CREATING DISPUTE: {Dispute}", dispute);
+                _logger.LogTrace("TRY CREATING DISPUTE: {@Dispute}", dispute);
 
                 var disputeId = await _oracleDataApiService.CreateDisputeAsync(dispute);
 


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- changes the logging of the dispute so it is destructured instead of logging the type name.

Note, Serilog may not use the same serializer as the Oracle Data API.
