### PR TITLE
TCVP-1688 - Add JJ Dispute Remarks

### DIFF
--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/model/JJDispute.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/model/JJDispute.java
@@ -17,7 +17,6 @@ import javax.persistence.OneToOne;
 import javax.persistence.Table;
 import javax.persistence.Temporal;
 import javax.persistence.TemporalType;
-import javax.validation.constraints.Size;
 
 import com.fasterxml.jackson.annotation.JsonManagedReference;
 
@@ -165,12 +164,12 @@ public class JJDispute extends Auditable<String>{
 	private String timeToPayReason;
 	
 	/**
-	 * A note/free form text field that is for internal use of JJs.
+	 * All the remarks for this jj dispute that are for internal use of JJs.
 	 */
-	@Size(max = 500)
-	@Column(length = 500)
-	@Schema(nullable = true, maxLength = 500)
-	private String remarks;
+	@JsonManagedReference
+	@OneToMany(targetEntity = JJDisputeRemark.class, cascade = CascadeType.ALL, fetch = FetchType.LAZY, orphanRemoval = true, mappedBy = "jjDispute")
+	@Builder.Default
+	private List<JJDisputeRemark> remarks = new ArrayList<JJDisputeRemark>();
 	
 	@JsonManagedReference
 	@OneToOne(fetch = FetchType.LAZY, optional = true, cascade = CascadeType.ALL, orphanRemoval = true, mappedBy = "jjDispute")
@@ -188,6 +187,13 @@ public class JJDispute extends Auditable<String>{
 			disputedCount.setJjDispute(this);
 		}
 		this.jjDisputedCounts.addAll(disputedCounts);
+	}
+	
+	public void addRemarks(List<JJDisputeRemark> remarks) {
+		for (JJDisputeRemark remark : remarks) {
+			remark.setJjDispute(this);
+		}
+		this.remarks.addAll(remarks);
 	}
 
 }

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/model/JJDisputeRemark.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/model/JJDisputeRemark.java
@@ -1,0 +1,60 @@
+package ca.bc.gov.open.jag.tco.oracledataapi.model;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+import javax.validation.constraints.Size;
+
+import com.fasterxml.jackson.annotation.JsonBackReference;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+//mark class as an Entity
+/**
+ * @author 237563
+ * 
+ * Represents a note/comment on a JJ dispute that is for internal use of JJs.
+ *
+ */
+@Entity
+//defining class name as Table name
+@Table
+@Getter
+@Setter
+@NoArgsConstructor
+public class JJDisputeRemark extends Auditable<String> {
+
+	@Schema(description = "ID", accessMode = Schema.AccessMode.READ_ONLY)
+	@Id
+	@GeneratedValue
+    private Long id;
+	
+	/**
+	 * Name and surname of the JJ/Staff who adds the remark for the dispute.
+	 */
+	@Column
+    private String userFullName;
+	
+	/**
+	 * JJ's remark notes that will be added to the dispute.
+	 */
+	@Size(max = 500)
+	@Column(length = 500)
+	@Schema(maxLength = 500)
+	private String note;
+
+	@JsonBackReference
+	@ManyToOne(targetEntity=JJDispute.class, fetch = FetchType.LAZY)
+	@JoinColumn(name = "ticket_number")
+	@Schema(hidden = true)
+	private JJDispute jjDispute;
+
+}

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/service/JJDisputeService.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/service/JJDisputeService.java
@@ -107,13 +107,20 @@ public class JJDisputeService {
 			throw new NotAllowedException("Unknown status of a JJ Dispute record: %s", jjDisputeToUpdate.getStatus());
 		}
 
-		BeanUtils.copyProperties(jjDispute, jjDisputeToUpdate, "createdBy", "createdTs", "ticketNumber", "jjDisputedCounts");
+		BeanUtils.copyProperties(jjDispute, jjDisputeToUpdate, "createdBy", "createdTs", "ticketNumber", "jjDisputedCounts", "remarks");
 		// Remove all existing jj disputed counts that are associated to this jj dispute
 		if (jjDisputeToUpdate.getJjDisputedCounts() != null) {
 			jjDisputeToUpdate.getJjDisputedCounts().clear();
 		}
 		// Add updated ticket counts
 		jjDisputeToUpdate.addJJDisputedCounts(jjDispute.getJjDisputedCounts());
+		
+		// Remove all existing remarks that are associated to this jj dispute
+		if (jjDisputeToUpdate.getRemarks() != null) {
+			jjDisputeToUpdate.getRemarks().clear();
+		}
+		// Add updated remarks
+		jjDisputeToUpdate.addRemarks(jjDispute.getRemarks());
 
 		return jjDisputeRepository.save(jjDisputeToUpdate);
 	}

--- a/src/backend/oracle-data-api/src/test/java/ca/bc/gov/open/jag/tco/oracledataapi/controller/v1_0/JJDisputeControllerTest.java
+++ b/src/backend/oracle-data-api/src/test/java/ca/bc/gov/open/jag/tco/oracledataapi/controller/v1_0/JJDisputeControllerTest.java
@@ -84,18 +84,18 @@ class JJDisputeControllerTest extends BaseTestSuite {
 	public void testUpdateJJDispute() {
 		// Create a single JJ Dispute with a specified remark
 		JJDispute jjDispute = RandomUtil.createJJDispute();
-		jjDispute.setRemarks("This is a remark from a JJ");
+		jjDispute.setCourthouseLocation("Vancouver");
 		jjDisputeRepository.save(jjDispute);
 
 		// Create a new JJ Dispute with different remark value and update the existing JJ Dispute
 		JJDispute updatedJJDispute = RandomUtil.createJJDispute();
-		updatedJJDispute.setRemarks("This is another remark from another JJ");
+		updatedJJDispute.setCourthouseLocation("Victoria");
 		updatedJJDispute.setStatus(JJDisputeStatus.IN_PROGRESS);
 		jjDisputeController.updateJJDispute(jjDispute.getTicketNumber(), updatedJJDispute);
 
 		// Assert db contains only the updated JJ Dispute record.
 		jjDispute = jjDisputeController.getJJDispute(jjDispute.getTicketNumber());
-		assertEquals("This is another remark from another JJ", jjDispute.getRemarks());
+		assertEquals("Victoria", jjDispute.getCourthouseLocation());
 		assertEquals(JJDisputeStatus.IN_PROGRESS, jjDispute.getStatus());
 		List<JJDispute> allJJDisputes = jjDisputeController.getAllJJDisputes(null);
 		assertEquals(1, IterableUtils.size(allJJDisputes));


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- [TCVP-1688](https://justice.gov.bc.ca/jira/browse/TCVP-1688)
- Adds JJDisputeRemark model and JPA hibernate config to create table in H2 database.
- Adds functionality to store JJ Remarks in H2 database through the existing JJ Dispute update endpoint in Oracle Data API.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
