### PR TITLE
Fix passing JAVA_OPTS to oracle data api

### DIFF
--- a/.gitops/charts/traffic-court-dev-values.yaml
+++ b/.gitops/charts/traffic-court-dev-values.yaml
@@ -45,6 +45,8 @@ oracle-data-api:
   image:
     tag: "1.42.1"
     pullPolicy: Always
+  env:
+    "JAVA_OPTS": "-Dlogging.level.ca.bc.gov.open.jag.tco.oracledataapi=DEBUG -Dlogging.level.org.hibernate.SQL=DEBUG"
 
 staff-api:
   image:

--- a/.gitops/charts/traffic-court-online/values.yaml
+++ b/.gitops/charts/traffic-court-online/values.yaml
@@ -63,7 +63,6 @@ oracle-data-api:
     "CODETABLE_REFRESH_CRON": "0 0 * * * *"
     "CODETABLE_REFRESH_ENABLED": "true"
     "H2_DATASOURCE": "jdbc:h2:file:/data/h2"
-    "JAVA_OPTS": "-Dlogging.level.ca.bc.gov.open.jag.tco.oracledataapi=DEBUG -Dlogging.level.org.hibernate.SQL=DEBUG"
     "OTEL_EXPORTER_JAEGER_ENDPOINT": "http://jaeger-collector:14250"
     "REDIS_HOST": "redis-master"
     "REDIS_PORT": "6379"

--- a/.gitops/charts/traffic-court-test-values.yaml
+++ b/.gitops/charts/traffic-court-test-values.yaml
@@ -45,6 +45,8 @@ oracle-data-api:
   image:
     tag: "1.42.1"
     pullPolicy: Always
+  env:
+    "JAVA_OPTS": "-Dlogging.level.ca.bc.gov.open.jag.tco.oracledataapi=DEBUG -Dlogging.level.org.hibernate.SQL=DEBUG"
 
 staff-api:
   image:

--- a/src/backend/oracle-data-api/Dockerfile
+++ b/src/backend/oracle-data-api/Dockerfile
@@ -29,5 +29,6 @@ EXPOSE 8080
 COPY --from=build ./target/oracle-data-api.jar .
 COPY --from=build ./entrypoint.sh .
 RUN chgrp 0 entrypoint.sh && chmod a+rwx,o-rwx entrypoint.sh
-CMD ["./entrypoint.sh", "java", "-jar", "/app/oracle-data-api.jar"]
+# use CMD "shell form" so we can expand env vars
+CMD ./entrypoint.sh java $JAVA_OPTS -jar /app/oracle-data-api.jar
 #############################################################################################


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- changes Dockerfile for oracle-data-api to pass JAVA_OPTS as parameters to java executable
- moves the JAVA_OPTS settings to environment specific configuration as it is used for log levels

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [x] Yes
- [ ] No

If Yes: Has Docker been updated accordingly?

- [x] Yes
- [ ] No

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
