### PR TITLE
TCVP-1703 added length on a description column

### DIFF
--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/model/Dispute.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/model/Dispute.java
@@ -232,7 +232,8 @@ public class Dispute extends Auditable<String> {
 	/**
 	 * The description of the issue with OCR ticket if the citizen has detected any.
 	 */
-	@Column
+	@Size(max = 255)
+	@Column(length = 255)
 	@Schema(nullable = true)
 	private String disputantOcrIssuesDescription;
 


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

Small PR to add a specific length on a description column instead of leaving it as default.  This way the validator will engage.

The column is currently 255 (the default in H2), but can be expanded later when the Oracle datamodel is defined.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

mvn verify

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
