### PR TITLE
TCVP-1673 add email verified flag

### DIFF
--- a/src/backend/oracle-data-api/.gitignore
+++ b/src/backend/oracle-data-api/.gitignore
@@ -31,3 +31,5 @@ build/
 
 ### VS Code ###
 .vscode/
+
+/data

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/model/BooleanConverter.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/model/BooleanConverter.java
@@ -1,0 +1,34 @@
+package ca.bc.gov.open.jag.tco.oracledataapi.model;
+
+import javax.persistence.AttributeConverter;
+import javax.persistence.Converter;
+
+/**
+ * This class maps <i>Boolean</i> to <code>'Y'</code> or <code>'N'</code> characters (or null if Boolean is null).<br/>
+ * <br/>
+ * Note: autoApply is set to <code>true</code> here, meaning this is affects *all* Boolean when serialized/deserialized from the database
+ */
+@Converter(autoApply = true)
+public class BooleanConverter implements AttributeConverter<Boolean, Character> {
+
+	@Override
+	public Character convertToDatabaseColumn(Boolean attribute) {
+		if (attribute != null) {
+			if (attribute) {
+				return 'Y';
+			} else {
+				return 'N';
+			}
+		}
+		return null;
+	}
+
+	@Override
+	public Boolean convertToEntityAttribute(Character dbData) {
+		if (dbData != null) {
+			return dbData.equals('Y');
+		}
+		return null;
+	}
+
+}

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/model/Dispute.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/model/Dispute.java
@@ -47,21 +47,21 @@ public class Dispute extends Auditable<String> {
 	@Id
 	@GeneratedValue
 	private Long disputeId;
-	
+
 	 /**
      * The violation ticket number.
      */
     @Column(length = 50)
     @Schema(nullable = false)
     private String ticketNumber;
-	
+
 	/**
      * Court location.
      */
     @Column(length = 150)
     @Schema(nullable = true)
     private String courtLocation;
-    
+
     /**
 	 * The date and time the violation ticket was issue. Time must only be hours and
 	 * minutes.
@@ -91,21 +91,21 @@ public class Dispute extends Auditable<String> {
 	@Column(length = 30)
 	@Schema(nullable = true)
 	private String disputantGivenName1;
-	
+
 	/**
 	 * Second given name of the disputant
 	 */
 	@Column(length = 30)
 	@Schema(nullable = true)
 	private String disputantGivenName2;
-	
+
 	/**
 	 * Third given name of the disputant
 	 */
 	@Column(length = 30)
 	@Schema(nullable = true)
 	private String disputantGivenName3;
-	
+
 	/**
 	 * The disputant's birthdate.
 	 */
@@ -113,7 +113,7 @@ public class Dispute extends Auditable<String> {
 	@Schema(nullable = true)
 	@Temporal(TemporalType.DATE)
 	private Date disputantBirthdate;
-	
+
 	/**
 	 * The drivers licence number. Note not all jurisdictions will use numeric
 	 * drivers licence numbers.
@@ -122,21 +122,21 @@ public class Dispute extends Auditable<String> {
 	@Column(length = 30)
 	@Schema(maxLength = 30, nullable = true)
 	private String driversLicenceNumber;
-	
+
 	/**
 	 * Name of the organization of the disputant
 	 */
 	@Column(length = 150)
 	@Schema(nullable = true)
 	private String disputantOrganization;
-	
+
 	/**
 	 * Disputant client ID
 	 */
 	@Column(length = 30)
 	@Schema(nullable = true, accessMode = Schema.AccessMode.READ_ONLY)
 	private String disputantClientId;
-	
+
 	/**
 	 * The province or state the drivers licence was issued by.
 	 */
@@ -144,7 +144,7 @@ public class Dispute extends Auditable<String> {
 	@Column(length = 30)
 	@Schema(maxLength = 30, nullable = true)
 	private String driversLicenceProvince;
-	
+
 	@Enumerated(EnumType.STRING)
 	private DisputeStatus status;
 
@@ -191,7 +191,7 @@ public class Dispute extends Auditable<String> {
 	@Column(length = 10)
 	@Schema(maxLength = 10)
 	private String postalCode;
-	
+
 	/**
 	 * The disputant's home phone number.
 	 */
@@ -213,6 +213,18 @@ public class Dispute extends Auditable<String> {
 	@Schema(nullable = true)
 	private String emailAddress;
 
+	/**
+	 * Indicates whether the disputant's email address is verified or not.
+	 */
+	@Column
+	private Boolean emailAddressVerified = Boolean.FALSE;
+
+	/**
+	 * A unique string (the PK + GUID) for email verification.
+	 */
+	@Column(length = 56) // long (2^63 = 19 characters) + '-' + GUID (36 characters) = 56 characters.
+	private String emailVerificationToken;
+
 	@Column
 	@Schema(nullable = true)
 	@Temporal(TemporalType.TIMESTAMP)
@@ -227,81 +239,81 @@ public class Dispute extends Auditable<String> {
 	@Enumerated(EnumType.STRING)
 	@Schema(nullable = true)
     private YesNo representedByLawyer;
-	
+
 	/**
 	 * Name of the law firm that will represent the disputant at the hearing.
 	 */
 	@Column(length = 200)
 	@Schema(nullable = true)
 	private String lawFirmName;
-	
+
 	/**
 	 * Surname of the lawyer
 	 */
 	@Column(length = 30)
 	@Schema(nullable = true)
 	private String lawyerSurname;
-	
+
 	/**
 	 * First given name of the lawyer
 	 */
 	@Column(length = 30)
 	@Schema(nullable = true)
 	private String lawyerGivenName1;
-	
+
 	/**
 	 * Second given name of the lawyer
 	 */
 	@Column(length = 30)
 	@Schema(nullable = true)
 	private String lawyerGivenName2;
-	
+
 	/**
 	 * Third given name of the lawyer
 	 */
 	@Column(length = 30)
 	@Schema(nullable = true)
 	private String lawyerGivenName3;
-	
-	
+
+
 	/**
 	 * Address of the lawyer who will represent the disputant at the hearing.
 	 */
 	@Column(length = 200)
 	@Schema(nullable = true)
 	private String lawyerAddress;
-	
+
 	/**
 	 * Phone number of the lawyer who will represent the disputant at the hearing.
 	 */
 	@Column(length = 20)
 	@Schema(nullable = true)
 	private String lawyerPhoneNumber;
-		
+
 	/**
 	 * Email address of the lawyer who will represent the disputant at the hearing.
 	 */
 	@Column
 	@Schema(nullable = true)
 	private String lawyerEmail;
-	
+
 	// End of Legal Representation Section
-	
+
 	/**
 	 * Officer Pin
 	 */
 	@Column(length = 10)
 	@Schema(nullable = true)
 	private String officerPin;
-	
+
 	/**
 	 * Detachment location
 	 */
 	@Column(length = 150)
 	@Schema(nullable = true)
 	private String detachmentLocation;
-	
-	
+
+
 	/**
 	 * The disputant requires spoken language interpreter. The language name is
 	 * indicated in this field.
@@ -309,14 +321,14 @@ public class Dispute extends Auditable<String> {
 	@Column
 	@Schema(nullable = true)
 	private String interpreterLanguage;
-	
+
 	/**
 	 * Indicates that whether an interpreter is required by the disputant or not
 	 */
 	@Schema(nullable = true)
 	@Enumerated(EnumType.STRING)
     private YesNo interpreterRequired;
-	
+
 	/**
 	 * Number of witness that the disputant intends to call.
 	 */
@@ -338,14 +350,14 @@ public class Dispute extends Auditable<String> {
 	@Column(length = 500)
 	@Schema(nullable = true)
 	private String timeToPayReason;
-	
+
 	/**
 	 * Disputant comment
 	 */
 	@Column(length = 4000)
 	@Schema(nullable = true)
 	private String disputantComment;
-	
+
 	/**
 	 * A note or reason indicating why this Dispute has a status of REJECTED. This
 	 * field is blank for other status types.
@@ -353,7 +365,7 @@ public class Dispute extends Auditable<String> {
 	@Column(length = 500)
 	@Schema(nullable = true)
 	private String rejectedReason;
-	
+
 	/**
 	 * The IDIR of the Staff whom the dispute is assigned to be reviewed on Staff
 	 * Portal.
@@ -408,18 +420,18 @@ public class Dispute extends Auditable<String> {
 	@Schema(nullable = true)
 	@JoinColumn(name = "dispute_id", referencedColumnName="disputeId")
 	private ViolationTicket violationTicket;
-	
+
 	@JsonBackReference
 	@ManyToOne(targetEntity=DisputeStatusType.class, fetch = FetchType.LAZY)
 	@Schema(hidden = true)
 	@JoinColumn(name = "dispute_status_type_cd", referencedColumnName="disputeStatusTypeCode")
 	private DisputeStatusType disputeStatusType;
-	
+
     @JsonManagedReference(value="dispute_count_reference")
     @OneToMany(targetEntity=DisputeCount.class, cascade = CascadeType.ALL, fetch = FetchType.LAZY, orphanRemoval = true)
     @JoinColumn(name="dispute_id", referencedColumnName="disputeId")
     private List<DisputeCount> disputeCounts = new ArrayList<DisputeCount>();
-    
+
 	public void setViolationTicket(ViolationTicket ticket) {
 		if (ticket == null) {
 			if (this.violationTicket != null) {
@@ -430,7 +442,7 @@ public class Dispute extends Auditable<String> {
 		}
 		this.violationTicket = ticket;
 	}
-	
+
 	public void addDisputeCounts(List<DisputeCount> disputeCounts) {
 		for (DisputeCount disputeCount : disputeCounts) {
 			disputeCount.setDispute(this);

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/repository/DisputeRepository.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/repository/DisputeRepository.java
@@ -2,6 +2,7 @@ package ca.bc.gov.open.jag.tco.oracledataapi.repository;
 
 import java.util.Date;
 import java.util.List;
+
 import org.springframework.data.repository.CrudRepository;
 
 import ca.bc.gov.open.jag.tco.oracledataapi.model.Dispute;
@@ -20,4 +21,8 @@ public interface DisputeRepository extends CrudRepository<Dispute, Long> {
 
 	/** Fetch all records whose assignedTs has a timestamp older than the given date. */
     public Iterable<Dispute> findByUserAssignedTsBefore(Date olderThan);
+
+    /** Fetch all records that matches the emailVerificationToken. */
+    public List<Dispute> findByEmailVerificationToken(String emailVerificationToken);
+
 }

--- a/src/backend/oracle-data-api/src/test/java/ca/bc/gov/open/jag/tco/oracledataapi/service/DisputeServiceTest.java
+++ b/src/backend/oracle-data-api/src/test/java/ca/bc/gov/open/jag/tco/oracledataapi/service/DisputeServiceTest.java
@@ -1,6 +1,12 @@
 package ca.bc.gov.open.jag.tco.oracledataapi.service;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.List;
+import java.util.UUID;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -11,7 +17,6 @@ import ca.bc.gov.open.jag.tco.oracledataapi.BaseTestSuite;
 import ca.bc.gov.open.jag.tco.oracledataapi.error.NotAllowedException;
 import ca.bc.gov.open.jag.tco.oracledataapi.model.Dispute;
 import ca.bc.gov.open.jag.tco.oracledataapi.model.DisputeStatus;
-import ca.bc.gov.open.jag.tco.oracledataapi.model.DisputeStatusType;
 
 class DisputeServiceTest extends BaseTestSuite {
 
@@ -96,6 +101,26 @@ class DisputeServiceTest extends BaseTestSuite {
 		assertThrows(NotAllowedException.class, () -> {
 			disputeService.setStatus(id, null);
 		});
+	}
+
+	@Test
+	void testEmailVerification() {
+		String emailVerificationToken = Long.valueOf(Long.MAX_VALUE).toString() + "-" + UUID.randomUUID();
+		Dispute dispute = new Dispute();
+		dispute.setEmailVerificationToken(emailVerificationToken);
+
+		assertNotNull(dispute.getEmailAddressVerified());
+		assertFalse(dispute.getEmailAddressVerified().booleanValue(), "emailAddressVerified should default to false");
+		assertEquals(56, emailVerificationToken.length(), "expect emailVerificationToken to have a max length of 56 characters");
+
+		// Try persisting and loading
+		Long id = disputeRepository.save(dispute).getDisputeId();
+		List<Dispute> findBy = disputeRepository.findByEmailVerificationToken(emailVerificationToken);
+		assertEquals(1, findBy.size());
+		assertEquals(id, findBy.get(0).getDisputeId());
+
+		Dispute disputeDb = findBy.get(0);
+		assertEquals(emailVerificationToken, disputeDb.getEmailVerificationToken());
 	}
 
 	private Long saveDispute(DisputeStatus disputeStatus) {


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

TCVP-1673

Added `emailAddressVerified `and `emailVerificationToken `to Dispute
Added service to retrieve Dispute by `emailVerificationToken`
Added a converter that maps Boolean datatype to 'Y' 'N' characters
Added junit test.

Note: at the moment, these database fields are unused. Next task is to write API endpoints to update these values.
Also, the OpenAPI definition is not yet updated in staff-api (that will be done when the staff-api is updated with new api endpoints)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

mvn verify

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
