### PR TITLE
TCVP-1686 Create validateEmail API endpoint

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -148,7 +148,7 @@ services:
       CODETABLE_REFRESH_CRON: ${CODETABLE_REFRESH_CRON:-0 0/15 * * * *}
       H2_DATASOURCE: ${H2_DATASOURCE:-jdbc:h2:file:./data/h2-v2}
       SPRING_SLEUTH_ENABLED: ${SPRING_SLEUTH_ENABLED:-false}
-      JAVA_OPTS: ${JAVA_OPTS:--Dlogging.level.ca.bc.gov.open.jag.tco.oracledataapi=DEBUG}
+      JAVA_OPTS: ${JAVA_OPTS:--Dlogging.level.ca.bc.gov.open.jag.tco.oracledataapi=DEBUG -Dlogging.level.org.hibernate.SQL=DEBUG}
     depends_on:
       - redis
     ports:

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/controller/v1_0/DisputeController.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/controller/v1_0/DisputeController.java
@@ -160,6 +160,23 @@ public class DisputeController {
 		return new ResponseEntity<Dispute>(disputeService.setStatus(id, DisputeStatus.VALIDATED), HttpStatus.OK);
 	}
 
+	@Operation(summary = "Updates the emailVerification flag of a particular Dispute to true.")
+	@ApiResponses({
+		@ApiResponse(responseCode = "200", description = "Ok. Email verified."),
+		@ApiResponse(responseCode = "500", description = "Internal server error occured.")
+	})
+	@PutMapping("/dispute/{uuid}/email/validate")
+	public ResponseEntity<String> validateDisputeEmail(@PathVariable(name="uuid") @Parameter(description = "The emailVerificationToken of the Dispute to update.") String emailVerificationToken) {
+		logger.debug("PUT /dispute/{id}/email/validate called");
+		try {
+			disputeService.validateEmail(emailVerificationToken);
+		} catch (Exception e) {
+			logger.error("ERROR validating email for uuid {}", emailVerificationToken, e);
+			return ResponseEntity.internalServerError().body("ERROR validating email");
+		}
+		return ResponseEntity.ok().body("Email verified");
+	}
+
 	/**
 	 * PUT endpoint that updates the dispute detail, setting the status to CANCELLED.
 	 *

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/model/Dispute.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/model/Dispute.java
@@ -222,7 +222,7 @@ public class Dispute extends Auditable<String> {
 	/**
 	 * A unique string (the PK + GUID) for email verification.
 	 */
-	@Column(length = 56) // long (2^63 = 19 characters) + '-' + GUID (36 characters) = 56 characters.
+	@Column(length = 36) // GUID (36 characters)
 	private String emailVerificationToken;
 
 	@Column

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/service/DisputeService.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/service/DisputeService.java
@@ -3,6 +3,7 @@ package ca.bc.gov.open.jag.tco.oracledataapi.service;
 import java.security.Principal;
 import java.util.Date;
 import java.util.List;
+
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.time.DateUtils;
 import org.slf4j.Logger;
@@ -70,7 +71,7 @@ public class DisputeService {
 			for (ViolationTicketCount violationTicketCount : dispute.getViolationTicket().getViolationTicketCounts()) {
 				violationTicketCount.setViolationTicketCountId(null);
 			}
-		} 
+		}
 		disputeRepository.save(dispute);
 	}
 
@@ -91,7 +92,7 @@ public class DisputeService {
 		}
 		// Add updated ticket counts
 		disputeToUpdate.addDisputeCounts(dispute.getDisputeCounts());
-		
+
 		return disputeRepository.save(disputeToUpdate);
 	}
 
@@ -219,6 +220,18 @@ public class DisputeService {
 		}
 
 		logger.debug("Unassigned {} record(s)", count);
+	}
+
+	/**
+	 * Flips the Dispute.emailAddressVerified flag to true where Dispute.emailVerificationToken matches the given parameter
+	 * @param token the Dispute record to update
+	 */
+	public void validateEmail(String emailVerificationToken) {
+		List<Dispute> emailVerificationTokens = disputeRepository.findByEmailVerificationToken(emailVerificationToken);
+		for (Dispute dispute : emailVerificationTokens) {
+			dispute.setEmailAddressVerified(Boolean.TRUE);
+			disputeRepository.save(dispute);
+		}
 	}
 
 }

--- a/src/backend/oracle-data-api/src/test/java/ca/bc/gov/open/jag/tco/oracledataapi/service/DisputeServiceTest.java
+++ b/src/backend/oracle-data-api/src/test/java/ca/bc/gov/open/jag/tco/oracledataapi/service/DisputeServiceTest.java
@@ -105,13 +105,13 @@ class DisputeServiceTest extends BaseTestSuite {
 
 	@Test
 	void testEmailVerification() {
-		String emailVerificationToken = Long.valueOf(Long.MAX_VALUE).toString() + "-" + UUID.randomUUID();
+		String emailVerificationToken = UUID.randomUUID().toString();
 		Dispute dispute = new Dispute();
 		dispute.setEmailVerificationToken(emailVerificationToken);
 
 		assertNotNull(dispute.getEmailAddressVerified());
 		assertFalse(dispute.getEmailAddressVerified().booleanValue(), "emailAddressVerified should default to false");
-		assertEquals(56, emailVerificationToken.length(), "expect emailVerificationToken to have a max length of 56 characters");
+		assertEquals(36, emailVerificationToken.length(), "expect emailVerificationToken to have a max length of 36 characters");
 
 		// Try persisting and loading
 		Long id = disputeRepository.save(dispute).getDisputeId();


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

TCVP-1686

Created a new endpoint in the oracle-data-api project to update the Dispute.EmailAddressVerified flag based on an emailVerificationToken

PUT /api/v1.0/dispute/{uuid}/email/validate
Endpoint returns 200 or 500.

![image](https://user-images.githubusercontent.com/55215368/188751361-dd736179-ffe4-490b-b3e2-3c0e2bb6fab2.png)


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

mvn verify

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
