### PR TITLE
Remove UseHttpsRedirection middleware

### DIFF
--- a/src/backend/TrafficCourts/Staff.Service/Program.cs
+++ b/src/backend/TrafficCourts/Staff.Service/Program.cs
@@ -17,8 +17,6 @@ if (swagger.Enabled)
     app.UseSwaggerUI();
 }
 
-app.UseHttpsRedirection();
-
 app.UseAuthentication();
 app.UseAuthorization();
 

--- a/src/backend/TrafficCourts/Workflow.Service/Program.cs
+++ b/src/backend/TrafficCourts/Workflow.Service/Program.cs
@@ -18,8 +18,6 @@ if (swagger.Enabled)
     app.UseSwaggerUI();
 }
 
-app.UseHttpsRedirection();
-
 app.UseAuthorization();
 
 app.MapControllers();


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- removes Https Redirection middleware which attempts to redirect http to https traffic. With this middleware, the following warning is logged at startup "Failed to determine the https port for redirect." In our services, internal inter-pod traffic is not HTTPS. Any HTTPS is handled by proxies that perform edge TLS termination.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
