### PR TITLE
TCVP-1680 Integration with ORDS

### DIFF
--- a/.gitops/charts/traffic-court-dev-values.yaml
+++ b/.gitops/charts/traffic-court-dev-values.yaml
@@ -46,6 +46,7 @@ oracle-data-api:
     tag: "1.44.4"
     pullPolicy: Always
   env:
+    "ORDS_API_URL": "https://dev.jag.gov.bc.ca/ords/devj/occamords/occam/v1"
     "JAVA_OPTS": "-Dlogging.level.ca.bc.gov.open.jag.tco.oracledataapi=DEBUG -Dlogging.level.org.hibernate.SQL=DEBUG"
 
 staff-api:

--- a/.gitops/charts/traffic-court-online/values.yaml
+++ b/.gitops/charts/traffic-court-online/values.yaml
@@ -68,10 +68,9 @@ oracle-data-api:
     "REDIS_PORT": "6379"
     "UNASSIGN_DISPUTES_CRON": "0 0/5 * * * *"
     "UNASSIGN_DISPUTES_ENABLED": "true"
-    "ORDS_API_URL": "https://dev.jag.gov.bc.ca/ords/devj/occamords/occam/v1"
-    "ORDS_API_TIMEOUT": "2000"
+    "ORDS_API_TIMEOUT_MS": "2000"
     "ORDS_API_RETRY_COUNT": "3"
-    "ORDS_API_RETRY_DELAY": "5"
+    "ORDS_API_RETRY_DELAY_SEC": "5"
 
 staff-api:
   image:

--- a/.gitops/charts/traffic-court-online/values.yaml
+++ b/.gitops/charts/traffic-court-online/values.yaml
@@ -68,6 +68,10 @@ oracle-data-api:
     "REDIS_PORT": "6379"
     "UNASSIGN_DISPUTES_CRON": "0 0/5 * * * *"
     "UNASSIGN_DISPUTES_ENABLED": "true"
+    "ORDS_API_URL": "https://dev.jag.gov.bc.ca/ords/devj/occamords/occam/v1"
+    "ORDS_API_TIMEOUT": "2000"
+    "ORDS_API_RETRY_COUNT": "3"
+    "ORDS_API_RETRY_DELAY": "5"
 
 staff-api:
   image:

--- a/.gitops/charts/traffic-court-test-values.yaml
+++ b/.gitops/charts/traffic-court-test-values.yaml
@@ -46,6 +46,7 @@ oracle-data-api:
     tag: "1.44.4"
     pullPolicy: Always
   env:
+    "ORDS_API_URL": "https://dev.jag.gov.bc.ca/ords/devj/occamords/occam/v1"
     "JAVA_OPTS": "-Dlogging.level.ca.bc.gov.open.jag.tco.oracledataapi=DEBUG -Dlogging.level.org.hibernate.SQL=DEBUG"
 
 staff-api:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -148,9 +148,9 @@ services:
       CODETABLE_REFRESH_CRON: ${CODETABLE_REFRESH_CRON:-0 0/15 * * * *}
       H2_DATASOURCE: ${H2_DATASOURCE:-jdbc:h2:file:./data/h2-v2}
       ORDS_API_URL: ${ORDS_API_URL:-}
-      ORDS_API_TIMEOUT: ${ORDS_API_TIMEOUT:-2000}
+      ORDS_API_TIMEOUT_MS: ${ORDS_API_TIMEOUT_MS:-2000}
       ORDS_API_RETRY_COUNT: ${ORDS_API_RETRY_COUNT:-3}
-      ORDS_API_RETRY_DELAY: ${ORDS_API_RETRY_DELAY:-5}
+      ORDS_API_RETRY_DELAY_SEC: ${ORDS_API_RETRY_DELAY_SEC:-5}
       SPRING_SLEUTH_ENABLED: ${SPRING_SLEUTH_ENABLED:-false}
       JAVA_OPTS: ${JAVA_OPTS:--Dlogging.level.ca.bc.gov.open.jag.tco.oracledataapi=DEBUG -Dlogging.level.org.hibernate.SQL=DEBUG}
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -147,6 +147,10 @@ services:
       CODETABLE_REFRESH_ENABLED: ${CODETABLE_REFRESH_ENABLED:-true}
       CODETABLE_REFRESH_CRON: ${CODETABLE_REFRESH_CRON:-0 0/15 * * * *}
       H2_DATASOURCE: ${H2_DATASOURCE:-jdbc:h2:file:./data/h2-v2}
+      ORDS_API_URL: ${ORDS_API_URL:-}
+      ORDS_API_TIMEOUT: ${ORDS_API_TIMEOUT:-2000}
+      ORDS_API_RETRY_COUNT: ${ORDS_API_RETRY_COUNT:-3}
+      ORDS_API_RETRY_DELAY: ${ORDS_API_RETRY_DELAY:-5}
       SPRING_SLEUTH_ENABLED: ${SPRING_SLEUTH_ENABLED:-false}
       JAVA_OPTS: ${JAVA_OPTS:--Dlogging.level.ca.bc.gov.open.jag.tco.oracledataapi=DEBUG -Dlogging.level.org.hibernate.SQL=DEBUG}
     depends_on:

--- a/src/backend/README.md
+++ b/src/backend/README.md
@@ -50,6 +50,10 @@ Set the JDBC URL parameter to "jdbc:h2:file:./data/h2" to connect, username is "
 | REDIS_SENTINAL_NODES        | When redis is configured in a master-slave-sentinel configuration, a comma-separated list of host:port sentinal nodes. ie "redis-sentinel-1:26379,redis-sentinel-2:26380,redis-sentinel-3:26381"
 | SPLUNK_URL                  | 
 | SPLUNK_TOKEN                | 
+| ORDS_API_URL                | The URL to connect to ORDS. (Needs to be set in .env file to connect to ORDS successfully when running through docker-compose)
+| ORDS_API_TIMEOUT            | Connection timeout limit in MS.
+| ORDS_API_RETRY_COUNT        | The maximum number of retry attempts to allow.
+| ORDS_API_RETRY_DELAY        | The Duration of the fixed delays.
 | JAVA_OPTS	                  | JVM parameters to be passed to the container. ie, "-Dlogging.level.ca.bc.gov.open.jag.tco.oracledataapi=DEBUG"
 
 Note: Redis Standalone and Sentinel modes are mutually exclusive.  Either use host/port variables or master/nodes.

--- a/src/backend/TrafficCourts/Citizen.Service/Controllers/LookupController.cs
+++ b/src/backend/TrafficCourts/Citizen.Service/Controllers/LookupController.cs
@@ -21,7 +21,7 @@ public class LookupController : ControllerBase
     /// <summary> 
     /// Returns a list of Violation Ticket Statutes filtered by given section text (if provided).
     /// </summary>
-    /// <param name="section">Motor vehicle act Section text to query by, ie "13(1)(a)" returns "Motor Vehicle or Trailer without Licence" contravention, or blank for no filter.</param>
+    /// <param name="section">Motor vehicle act Section text to query by, ie "MVA 13(1)(a)" returns "Motor Vehicle or Trailer without Licence" contravention, or blank for no filter.</param>
     /// <param name="cancellationToken"></param>
     /// <returns></returns>
     [HttpGet]

--- a/src/backend/TrafficCourts/Citizen.Service/Validators/Rules/CountSectionRule.cs
+++ b/src/backend/TrafficCourts/Citizen.Service/Validators/Rules/CountSectionRule.cs
@@ -21,7 +21,7 @@ public class CountSectionRule : ValidationRule
     {
         if (!String.IsNullOrEmpty(Field.Value))
         {
-            Field.Value = Regex.Replace(Field.Value, @"\s+", ""); // remove whitespace
+            Field.Value = Field.Value.Trim(); // remove whitespace only from beginning and end
             Field.Value = Regex.Replace(Field.Value, @"^\$$", ""); // remove $ if it's the only character.
             if (!String.IsNullOrEmpty(Field.Value))
             {

--- a/src/backend/TrafficCourts/Common/Features/Lookups/StatuteLookupService.cs
+++ b/src/backend/TrafficCourts/Common/Features/Lookups/StatuteLookupService.cs
@@ -16,7 +16,7 @@ namespace TrafficCourts.Common.Features.Lookups
         {
             var values = await GetListAsync();
 
-            var sections = values.Where(_ => _.Section == section).ToList();
+            var sections = values.Where(_ => _.StatCode == section).ToList();
             if (sections.Count == 0)
             {
                 return null;

--- a/src/backend/TrafficCourts/Common/Features/Lookups/StatuteLookupService.cs
+++ b/src/backend/TrafficCourts/Common/Features/Lookups/StatuteLookupService.cs
@@ -16,7 +16,7 @@ namespace TrafficCourts.Common.Features.Lookups
         {
             var values = await GetListAsync();
 
-            var sections = values.Where(_ => _.StatCode == section).ToList();
+            var sections = values.Where(_ => _.Code == section).ToList();
             if (sections.Count == 0)
             {
                 return null;

--- a/src/backend/TrafficCourts/Common/Models/Statute.cs
+++ b/src/backend/TrafficCourts/Common/Models/Statute.cs
@@ -1,4 +1,13 @@
 ﻿namespace TrafficCourts.Common.Models;
 
-public record Statute(string StatId, string ActCd, string StatSectionTxt, string StatSubSectionTxt,
-    string StatParagraphTxt, string StatSubParagraphTxt, string StatCode, string StatShortDescriptionTxt, string StatDescriptionTxt);
+public record Statute(
+    string Id, 
+    string ActCode, 
+    string SectionText, 
+    string SubsectionText,
+    string ParagraphText, 
+    string SubparagraphText, 
+    string Code, 
+    string ShortDescriptionText, 
+    string DescriptionText
+);

--- a/src/backend/TrafficCourts/Common/Models/Statute.cs
+++ b/src/backend/TrafficCourts/Common/Models/Statute.cs
@@ -1,3 +1,4 @@
 ﻿namespace TrafficCourts.Common.Models;
 
-public record Statute(decimal Code, string Act, string Section, string Description);
+public record Statute(string StatId, string ActCd, string StatSectionTxt, string StatSubSectionTxt,
+    string StatParagraphTxt, string StatSubParagraphTxt, string StatCode, string StatShortDescriptionTxt, string StatDescriptionTxt);

--- a/src/backend/TrafficCourts/Test/Citizen.Service/Validators/Rules/CountSectionRuleTest.cs
+++ b/src/backend/TrafficCourts/Test/Citizen.Service/Validators/Rules/CountSectionRuleTest.cs
@@ -13,11 +13,10 @@ namespace TrafficCourts.Test.Citizen.Service.Validators.Rules;
 public class CountSectionRuleTest
 {
     [Theory]
-    [InlineData("24(1)", true)]
+    [InlineData("MVA 100(1) ai", true)]
     [InlineData("23(1)", false)]
-    [InlineData("24(1) ", true)]
-    [InlineData(" 24(1)", true)]
-    [InlineData("24 (1)", true)]
+    [InlineData("MVA 100(1) ai ", true)]
+    [InlineData(" MVA 100(1) ai", true)]
     [InlineData("224(1)", false)]
     [InlineData("", true)] 
     [InlineData("$", true)] // treat as blank (must have pulled this character from the adjacent Ticket Amount field).
@@ -25,8 +24,8 @@ public class CountSectionRuleTest
     {
         // Given
         var lookupService = new Mock<IStatuteLookupService>();
-        var expected = new Statute((decimal) 18886, "MVA", "24(1)", "drive without licence");
-        lookupService.Setup(_ => _.GetBySectionAsync("24(1)")).Returns(Task.FromResult(expected));
+        var expected = new Statute("19588", "MVA", "100", "1", "a", "i", "MVA 100(1) ai", "Fail to stop/police pursuit", "Fail to stop/police pursuit");
+        lookupService.Setup(_ => _.GetBySectionAsync("MVA 100(1) ai")).Returns(Task.FromResult(expected));
 
         Field field = new();
         field.TagName = Count1Section;

--- a/src/backend/oracle-data-api/pom.xml
+++ b/src/backend/oracle-data-api/pom.xml
@@ -19,6 +19,8 @@
 		<log4j2.version>2.17.1</log4j2.version>
 		<release.train.version>2021.0.3</release.train.version>
   		<spring-cloud-sleuth-otel.version>1.1.0-M7</spring-cloud-sleuth-otel.version>
+  		<org.mapstruct.version>1.5.2.Final</org.mapstruct.version>
+  		<org.projectlombok.version>1.18.24</org.projectlombok.version>
 	</properties>
 	
 	<dependencyManagement>
@@ -147,6 +149,13 @@
 	    	<groupId>io.opentelemetry</groupId>
 	    	<artifactId>opentelemetry-exporter-jaeger</artifactId>
 	  	</dependency>
+	  	
+	  	<!-- Mapstruct dependencies -->
+	  	<dependency>
+	         <groupId>org.mapstruct</groupId>
+	         <artifactId>mapstruct</artifactId>
+	         <version>${org.mapstruct.version}</version>
+	     </dependency>
 	</dependencies>
 
 	<build>
@@ -187,6 +196,35 @@
 						</goals>
 					</execution>
 				</executions>
+			</plugin>
+			
+			<!-- Needed for compiling Mapstruct with Lombok -->
+			<plugin>
+			    <groupId>org.apache.maven.plugins</groupId>
+			    <artifactId>maven-compiler-plugin</artifactId>
+			    <configuration>
+			        <source>${java.version}</source>
+			        <target>${java.version}</target>
+			        <annotationProcessorPaths>
+			            <path>
+			                <groupId>org.projectlombok</groupId>
+			                <artifactId>lombok</artifactId>
+			                <version>${org.projectlombok.version}</version>
+			            </path>
+			            <!-- This is needed when using Lombok 1.18.16 and above -->
+			            <path>
+			                <groupId>org.projectlombok</groupId>
+			                <artifactId>lombok-mapstruct-binding</artifactId>
+			                <version>0.2.0</version>
+			            </path>
+			            <!-- Mapstruct should follow the lombok path(s) -->
+			            <path>
+			                <groupId>org.mapstruct</groupId>
+			                <artifactId>mapstruct-processor</artifactId>
+			                <version>${org.mapstruct.version}</version>
+			            </path>
+			        </annotationProcessorPaths>
+			    </configuration>
 			</plugin>
 		</plugins>
 	</build>

--- a/src/backend/oracle-data-api/pom.xml
+++ b/src/backend/oracle-data-api/pom.xml
@@ -72,6 +72,15 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-security</artifactId>
 		</dependency>
+		<dependency>
+		    <groupId>org.springframework.boot</groupId>
+		    <artifactId>spring-boot-starter-webflux</artifactId>
+		</dependency>
+		<dependency>
+	  		<groupId>org.springframework.boot</groupId>
+	  		<artifactId>spring-boot-configuration-processor</artifactId>
+	  		<optional>true</optional>
+	  	</dependency>
 
 		<!-- Redis dependencies -->
 		<dependency>

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/config/ConfigProperties.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/config/ConfigProperties.java
@@ -1,0 +1,34 @@
+package ca.bc.gov.open.jag.tco.oracledataapi.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * Externalized configuration for easy access to properties
+ * 
+ * @author 237563
+ *
+ */
+@Component
+@ConfigurationProperties
+@Getter
+@Setter
+public class ConfigProperties {
+	
+	// ORDS Service properties
+	@Value("${ords.rest-api.url}")
+    private String ordsRestApiUrl;
+    
+    @Value("${ords.rest-api.timeout}")
+    private int ordsRestApiTimeout;
+    
+    @Value("${ords.rest-api.retry.count}")
+    private long ordsRestApiRetryCount;
+    
+    @Value("${ords.rest-api.retry.delay}")
+    private long ordsRestApiRetryDelay;
+}

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/config/WebClientConfiguration.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/config/WebClientConfiguration.java
@@ -1,0 +1,75 @@
+package ca.bc.gov.open.jag.tco.oracledataapi.config;
+
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
+import org.springframework.web.reactive.function.client.ExchangeFilterFunction;
+import org.springframework.web.reactive.function.client.ExchangeStrategies;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import ca.bc.gov.open.jag.tco.oracledataapi.error.OracleDataApiException;
+import io.netty.channel.ChannelOption;
+import io.netty.handler.timeout.ReadTimeoutHandler;
+import io.netty.handler.timeout.WriteTimeoutHandler;
+import reactor.netty.http.client.HttpClient;
+import reactor.util.retry.Retry;
+
+@Configuration
+public class WebClientConfiguration {
+	
+	private final Logger logger = LoggerFactory.getLogger(WebClientConfiguration.class);
+	
+	@Autowired
+    ConfigProperties properties;
+	
+	@Bean
+    public WebClient ordsWebClient() {
+        final var httpClient = HttpClient
+                .create()
+                .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, properties.getOrdsRestApiTimeout())
+                .doOnConnected(connection -> {
+                    connection.addHandlerLast(new ReadTimeoutHandler(properties.getOrdsRestApiTimeout(), TimeUnit.MILLISECONDS));
+                    connection.addHandlerLast(new WriteTimeoutHandler(properties.getOrdsRestApiTimeout(), TimeUnit.MILLISECONDS));
+                });
+        
+        final int size = 16 * 1024 * 1024;
+        final ExchangeStrategies strategies = ExchangeStrategies.builder()
+            .codecs(codecs -> codecs.defaultCodecs().maxInMemorySize(size))
+            .build();
+
+        return WebClient.builder()
+                .baseUrl(properties.getOrdsRestApiUrl())
+                .clientConnector(new ReactorClientHttpConnector(httpClient))
+                .defaultHeader(HttpHeaders.CONTENT_TYPE, "application/json")
+                .exchangeStrategies(strategies)
+                .filter(retryFilter())
+                .build();
+    }
+	
+	
+	/**
+	 * Connection retry configuration
+	 * 
+	 * @return {@link ExchangeFilterFunction}
+	 */
+	private ExchangeFilterFunction retryFilter() {
+		return (request, next) ->
+			next.exchange(request)
+	        	.retryWhen(
+		            Retry.fixedDelay(properties.getOrdsRestApiRetryCount(), Duration.ofSeconds(properties.getOrdsRestApiRetryDelay()))
+		            .doAfterRetry(retrySignal -> {
+	                    logger.info("Retried " + retrySignal.totalRetries());
+	                })
+		            .onRetryExhaustedThrow((retryBackoffSpec, retrySignal) ->
+	                new OracleDataApiException(
+	                    "ORDS API failed to respond, after max attempts of: "
+	                    + retrySignal.totalRetries())));
+	}
+}

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/dto/StatuteDTO.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/dto/StatuteDTO.java
@@ -1,0 +1,29 @@
+package ca.bc.gov.open.jag.tco.oracledataapi.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+public class StatuteDTO {
+	
+	private String id;
+
+	private String actCode;
+
+	private String sectionText;
+
+	private String subsectionText;
+	
+	private String paragraphText;
+	
+	private String subparagraphText;
+	
+	private String code;
+	
+	private String shortDescriptionText;
+	
+	private String descriptionText;
+}

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/error/OracleDataApiException.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/error/OracleDataApiException.java
@@ -1,0 +1,20 @@
+package ca.bc.gov.open.jag.tco.oracledataapi.error;
+
+/**
+ * Generic Exception for Oracle Data API
+ * 
+ * @author 237563
+ *
+ */
+public class OracleDataApiException extends RuntimeException{
+
+	private static final long serialVersionUID = 1L;
+	
+	public OracleDataApiException(String message) {
+		super(message);
+	}
+
+	public OracleDataApiException(String message, Throwable cause) {
+		super(message, cause);
+	}
+}

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/mapper/StatuteMapper.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/mapper/StatuteMapper.java
@@ -1,0 +1,28 @@
+package ca.bc.gov.open.jag.tco.oracledataapi.mapper;
+
+import java.util.List;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.factory.Mappers;
+
+import ca.bc.gov.open.jag.tco.oracledataapi.dto.StatuteDTO;
+import ca.bc.gov.open.jag.tco.oracledataapi.model.Statute;
+
+@Mapper
+public interface StatuteMapper {
+	
+	StatuteMapper INSTANCE = Mappers.getMapper(StatuteMapper.class);
+	
+	@Mapping(source = "statId", target = "id")
+	@Mapping(source = "actCd", target = "actCode")
+	@Mapping(source = "statSectionTxt", target = "sectionText")
+	@Mapping(source = "statSubSectionTxt", target = "subsectionText")
+	@Mapping(source = "statParagraphTxt", target = "paragraphText")
+	@Mapping(source = "statSubParagraphTxt", target = "subparagraphText")
+	@Mapping(source = "statCode", target = "code")
+	@Mapping(source = "statShortDescriptionTxt", target = "shortDescriptionText")
+	@Mapping(source = "statDescriptionTxt", target = "descriptionText")
+	StatuteDTO convertStatute(Statute statute);
+	List<StatuteDTO> convertStatutes(List<Statute> statuteList);
+}

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/model/GetStatutesListServiceResponse.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/model/GetStatutesListServiceResponse.java
@@ -1,0 +1,23 @@
+package ca.bc.gov.open.jag.tco.oracledataapi.model;
+
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * Holds response from ORDS Get Statutes List
+ * 
+ * @author 237563
+ *
+ */
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public final class GetStatutesListServiceResponse {
+	
+	private List<Statute> statuteCodeValues = null;
+}

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/model/Statute.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/model/Statute.java
@@ -1,9 +1,6 @@
 package ca.bc.gov.open.jag.tco.oracledataapi.model;
 
-import org.springframework.data.annotation.Id;
-
-import com.opencsv.bean.CsvBindByPosition;
-
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -14,19 +11,25 @@ import lombok.Setter;
 @Getter
 @Setter
 @NoArgsConstructor
+@AllArgsConstructor
 public class Statute {
 
-	@Id
-	@CsvBindByPosition(position = 0)
-	private Integer code;
+	private String statId;
 
-	@CsvBindByPosition(position = 1)
-	private String act;
+	private String actCd;
 
-	@CsvBindByPosition(position = 2)
-	private String section;
+	private String statSectionTxt;
 
-	@CsvBindByPosition(position = 3)
-	private String description;
+	private String statSubSectionTxt;
+	
+	private String statParagraphTxt;
+	
+	private String statSubParagraphTxt;
+	
+	private String statCode;
+	
+	private String statShortDescriptionTxt;
+	
+	private String statDescriptionTxt;
 
 }

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/service/LookupService.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/service/LookupService.java
@@ -9,6 +9,8 @@ import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
 
+import ca.bc.gov.open.jag.tco.oracledataapi.dto.StatuteDTO;
+import ca.bc.gov.open.jag.tco.oracledataapi.mapper.StatuteMapper;
 import ca.bc.gov.open.jag.tco.oracledataapi.model.GetStatutesListServiceResponse;
 import ca.bc.gov.open.jag.tco.oracledataapi.model.Statute;
 import io.swagger.v3.core.util.Json;
@@ -32,7 +34,9 @@ public class LookupService {
 		log.debug("Refreshing code tables in redis.");
 
 		try {
-			List<Statute> statutes = getAllStatutes();
+			// Get all statutes from the ORDS webclient service and convert them to DTO using Mapstruct
+			List<StatuteDTO> statutes = StatuteMapper.INSTANCE.convertStatutes(getAllStatutes());
+			
 			String json = Json.pretty(statutes);
 
 			// replace the Statutes key with a new json-serialized version of the statutes list.

--- a/src/backend/oracle-data-api/src/main/resources/application.yml
+++ b/src/backend/oracle-data-api/src/main/resources/application.yml
@@ -98,3 +98,14 @@ cronjob:
       enabled: ${UNASSIGN_DISPUTES_ENABLED:false}
       # A cron-like expression (defaulting to once every 5 minutes), extending the usual UN*X definition to include triggers on the second, minute, hour, day of month, month, and day of week.
       cron: ${UNASSIGN_JJDISPUTES_CRON:0 */5 * * * *}
+
+# ORDS CLIENT properties
+ords:
+  rest-api:
+    url: ${ORDS_API_URL:localhost}
+    timeout: ${ORDS_API_TIMEOUT:2000}
+    retry:
+      # The maximum number of retry attempts to allow
+      count: ${ORDS_API_RETRY_COUNT:3}
+      # The Duration of the fixed delays
+      delay: ${ORDS_API_RETRY_DELAY:5}

--- a/src/backend/oracle-data-api/src/main/resources/application.yml
+++ b/src/backend/oracle-data-api/src/main/resources/application.yml
@@ -103,9 +103,10 @@ cronjob:
 ords:
   rest-api:
     url: ${ORDS_API_URL:localhost}
-    timeout: ${ORDS_API_TIMEOUT:2000}
+    # The connection timeout limit in miliseconds
+    timeout: ${ORDS_API_TIMEOUT_MS:2000}
     retry:
       # The maximum number of retry attempts to allow
       count: ${ORDS_API_RETRY_COUNT:3}
       # The Duration of the fixed delays
-      delay: ${ORDS_API_RETRY_DELAY:5}
+      delay: ${ORDS_API_RETRY_DELAY_SEC:5}

--- a/src/backend/oracle-data-api/src/test/java/ca/bc/gov/open/jag/tco/oracledataapi/service/LookupServiceTest.java
+++ b/src/backend/oracle-data-api/src/test/java/ca/bc/gov/open/jag/tco/oracledataapi/service/LookupServiceTest.java
@@ -1,0 +1,63 @@
+package ca.bc.gov.open.jag.tco.oracledataapi.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import ca.bc.gov.open.jag.tco.oracledataapi.BaseTestSuite;
+import ca.bc.gov.open.jag.tco.oracledataapi.model.GetStatutesListServiceResponse;
+import ca.bc.gov.open.jag.tco.oracledataapi.model.Statute;
+import reactor.core.publisher.Mono;
+
+public class LookupServiceTest extends BaseTestSuite {
+	
+	@MockBean 
+	WebClient webClient;
+	
+	@SuppressWarnings("rawtypes")
+	@Mock 
+	WebClient.RequestHeadersUriSpec requestHeadersUriMock;
+	@SuppressWarnings("rawtypes")
+	@Mock 
+	WebClient.RequestHeadersSpec requestHeadersMock;
+	@Mock 
+	WebClient.ResponseSpec responseMock;
+	
+	@Autowired
+	LookupService service;
+
+	@SuppressWarnings("unchecked")
+	@Test
+    public void testGetAllStatutes() {
+		
+		GetStatutesListServiceResponse statutesListServiceResponse = new GetStatutesListServiceResponse();
+		
+		List<Statute> statutes = new ArrayList<>();
+		
+		Statute statute = new Statute("20153", "MVA", "10", "1", null, null, "MVA 10(1) ", "Special licence for tractors, etc.", null);
+		
+		statutes.add(statute);
+		
+		statutesListServiceResponse.setStatuteCodeValues(statutes);
+		
+		when(this.webClient.get()).thenReturn(this.requestHeadersUriMock);
+        when(this.requestHeadersUriMock.uri("/statutes")).thenReturn(this.requestHeadersMock);
+        when(this.requestHeadersMock.retrieve()).thenReturn(this.responseMock);
+        when(this.responseMock.bodyToMono(GetStatutesListServiceResponse.class)).thenReturn(Mono.just(statutesListServiceResponse));
+        
+        var result = service.getAllStatutes();
+        
+        assertThat(result).isNotNull();
+        assertThat(result.size() > 0);
+        assertThat("20153".equals(result.get(0).getStatId()));
+        assertThat(result).usingRecursiveComparison().isEqualTo(statutes);
+	}
+}

--- a/src/backend/oracle-data-api/src/test/resources/application.yml
+++ b/src/backend/oracle-data-api/src/test/resources/application.yml
@@ -12,3 +12,14 @@ spring:
   sql:
     init:
       mode: never
+      
+# ORDS CLIENT properties
+ords:
+  rest-api:
+    url: localhost
+    timeout: 2000
+    retry:
+      # The maximum number of retry attempts to allow
+      count: 3
+      # The Duration of the fixed delays
+      delay: 5


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- [TCVP-1680](https://justice.gov.bc.ca/jira/browse/TCVP-1680)
- Added Spring WebClient configuration with timeout and retry in order to perform communications with ORDS.
- Added functionality to get statutes from the ORDS statutes endpoint to save into Redis.
- Updated docker-compose and helm chart with the new ORDS connection related environment variables.
- Updated 'Statute' object in Common project to match the json returned from ORDS and saved in Redis. Also, updated StatuteLookupService's section based query as well.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Ran all existing and new unit tests. Ran the project locally and sent a GET request to the "/api/v1.0/codetable/refresh" to trigger refreshing statutes from the ORDS endpoint and verified that the results has been saved to Redis successfully. 

## Does the change impact or break the Docker build?

- [x] Yes
- [ ] No

If Yes: Has Docker been updated accordingly?

- [x] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
