### PR TITLE
Added fake-smtp server for development

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -126,6 +126,8 @@ services:
       RETRYCONFIGURATION__RETRYINTERVAL: ${RETRYCONFIGURATION__RETRYINTERVAL:-2}
       RETRYCONFIGURATION__CONCURRENCYLIMIT: ${RETRYCONFIGURATION__CONCURRENCYLIMIT:-2}
       ORACLEDATAAPI__BASEURL: ${ORACLEDATAAPI__BASEURL:-http://oracle-data-api:8080/}
+      SMTPCONFIGURATION__HOST: ${SMTPCONFIGURATION__HOST:-smtp-server}
+      SMTPCONFIGURATION__PORT: ${SMTPCONFIGURATION__PORT:-5025}
     ports:
       - "5020:8080"
     restart: always
@@ -264,6 +266,19 @@ services:
       - redis
     ports:
       - 8082:8081
+      
+  #############################################################################################
+  ###                                 Fake Email server                                     ###
+  #############################################################################################
+  smtp-server:
+    container_name: smtp-server
+    image: gessnerfl/fake-smtp-server
+    environment:
+      - "SERVER-PORT=5080"
+      - "SMTP_PORT=5025"
+    ports:
+      - "5080:5080"
+      - "5025:5025"
 
 volumes:
   data-rabbit:


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

Added a fake SMTP email server for local development.

docker-compose up -d now brings up an smtp-server container that catches all emails regardless of the receipient. This way developers can view sent emails in HTML to confirm the structure of the email.

http://localhost:5080/
![2022-09-20_154956](https://user-images.githubusercontent.com/55215368/191382877-20b3492c-5533-455d-b5af-6e5e05e9568f.png)


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [x] Yes
- [ ] No

If Yes: Has Docker been updated accordingly?

- [x] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
