### PR TITLE
Renamed email validate endpoint to verify

### DIFF
--- a/src/backend/TrafficCourts/Citizen.Service/Controllers/DisputesController.cs
+++ b/src/backend/TrafficCourts/Citizen.Service/Controllers/DisputesController.cs
@@ -73,26 +73,28 @@ public class DisputesController : ControllerBase
     [ProducesResponseType((int)HttpStatusCode.BadRequest)]
     public async Task<IActionResult> ResendEmailAsync(Guid uuid, CancellationToken cancellationToken)
     {
+        // FIXME: this is wrong. The "Host" in this case resolves to the citizen-api. This should be the hostname of citizen-web (not api) in any of the environments (local, dev, test, or prod).
         string host = HttpContext.Request.Host.Value;
+
         EmailVerificationSend emailVerificationSend = new(uuid, host);
         await _bus.Publish(emailVerificationSend, cancellationToken);
         return Accepted();
     }
 
     /// <summary>
-    /// An endpoint for validating an email sent to a Disputant.
+    /// An endpoint for verifying an email sent to a Disputant.
     /// </summary>
     /// <param name="uuid"></param>
     /// <param name="cancellationToken"></param>
     /// <returns>
-    /// <response code="202">Validate email acknowledged.</response>
+    /// <response code="202">Verify email acknowledged.</response>
     /// <response code="400">The uuid doesn't appear to be a valid UUID.</response>
     /// <response code="500">There was a internal server error when triggering a received email message.</response>
     /// </returns>
-    [HttpPut("/api/disputes/email/{uuid}/validate")]
+    [HttpPut("/api/disputes/email/{uuid}/verify")]
     [ProducesResponseType((int)HttpStatusCode.Accepted)]
     [ProducesResponseType((int)HttpStatusCode.BadRequest)]
-    public async Task<IActionResult> ValidateEmailAsync(Guid uuid, CancellationToken cancellationToken)
+    public async Task<IActionResult> VerifyEmailAsync(Guid uuid, CancellationToken cancellationToken)
     {
         EmailVerificationReceived emailVerificationReceived = new(uuid);
         await _bus.Publish(emailVerificationReceived, cancellationToken);

--- a/src/backend/TrafficCourts/Citizen.Service/Features/Disputes/Create.cs
+++ b/src/backend/TrafficCourts/Citizen.Service/Features/Disputes/Create.cs
@@ -158,6 +158,8 @@ namespace TrafficCourts.Citizen.Service.Features.Disputes
                     if (!string.IsNullOrEmpty(submitNoticeOfDispute.EmailAddress))
                     {
                         submitNoticeOfDispute.EmailVerificationToken = Guid.NewGuid().ToString();
+                        
+                        // FIXME: this is wrong. The "Host" in this case resolves to the citizen-api. This should be the hostname of citizen-web (not api) in any of the environments (local, dev, test, or prod).
                         submitNoticeOfDispute.Host = request.Host;
                     }
 

--- a/src/backend/TrafficCourts/Common/Features/Mail/Model/MailTemplateCollection.cs
+++ b/src/backend/TrafficCourts/Common/Features/Mail/Model/MailTemplateCollection.cs
@@ -56,7 +56,7 @@ namespace TrafficCourts.Common.Features.Mail.Model
                 Sender = "DoNotReply@tickets.gov.bc.ca",
                 SubjectTemplate = "Verify your email for traffic violation ticket <ticketid>.",
                 HtmlContentTemplate = "In order to confirm submission of your intent to dispute traffic violation ticket <ticketid> click on the following link." +
-                    "<br/><br/><a href='http://<baseref>/email?uuid=<emailverificationtoken>'>http://<baseref>/email?uuid=<emailverificationtoken></a>" +
+                    "<br/><br/><a href='http://<baseref>/verifiyEmail?uuid=<emailverificationtoken>'>http://<baseref>/email?uuid=<emailverificationtoken></a>" +
                     "<br/><br/>If you need more help, contact the Violation Ticket Centre toll free 1-877-661-8026, open weekdays 9am to 4pm."
             }
         };

--- a/src/backend/TrafficCourts/Common/OpenAPIs/OracleDataAPI/v1_0/OracleDataApi.v1_0.json
+++ b/src/backend/TrafficCourts/Common/OpenAPIs/OracleDataAPI/v1_0/OracleDataApi.v1_0.json
@@ -334,11 +334,11 @@
         }
       }
     },
-    "/api/v1.0/dispute/email/{uuid}/validate": {
+    "/api/v1.0/dispute/email/{uuid}/verify": {
       "put": {
         "tags": [ "dispute-controller" ],
         "summary": "Updates the emailVerification flag of a particular Dispute to true.",
-        "operationId": "validateDisputeEmail",
+        "operationId": "verifyDisputeEmail",
         "parameters": [
           {
             "name": "uuid",

--- a/src/backend/TrafficCourts/Common/OpenAPIs/OracleDataAPI/v1_0/OracleDataApiClient.cs
+++ b/src/backend/TrafficCourts/Common/OpenAPIs/OracleDataAPI/v1_0/OracleDataApiClient.cs
@@ -136,7 +136,7 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
         /// <param name="uuid">The emailVerificationToken of the Dispute to update.</param>
         /// <returns>Ok. Email verified.</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
-        System.Threading.Tasks.Task ValidateDisputeEmailAsync(string uuid);
+        System.Threading.Tasks.Task VerifyDisputeEmailAsync(string uuid);
 
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <summary>
@@ -145,7 +145,7 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
         /// <param name="uuid">The emailVerificationToken of the Dispute to update.</param>
         /// <returns>Ok. Email verified.</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
-        System.Threading.Tasks.Task ValidateDisputeEmailAsync(string uuid, System.Threading.CancellationToken cancellationToken);
+        System.Threading.Tasks.Task VerifyDisputeEmailAsync(string uuid, System.Threading.CancellationToken cancellationToken);
 
         /// <param name="ticketNumber">Ticket number to retrieve related emails.</param>
         /// <returns>OK</returns>
@@ -1269,9 +1269,9 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
         /// <param name="uuid">The emailVerificationToken of the Dispute to update.</param>
         /// <returns>Ok. Email verified.</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
-        public virtual System.Threading.Tasks.Task ValidateDisputeEmailAsync(string uuid)
+        public virtual System.Threading.Tasks.Task VerifyDisputeEmailAsync(string uuid)
         {
-            return ValidateDisputeEmailAsync(uuid, System.Threading.CancellationToken.None);
+            return VerifyDisputeEmailAsync(uuid, System.Threading.CancellationToken.None);
         }
 
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
@@ -1281,13 +1281,13 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
         /// <param name="uuid">The emailVerificationToken of the Dispute to update.</param>
         /// <returns>Ok. Email verified.</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
-        public virtual async System.Threading.Tasks.Task ValidateDisputeEmailAsync(string uuid, System.Threading.CancellationToken cancellationToken)
+        public virtual async System.Threading.Tasks.Task VerifyDisputeEmailAsync(string uuid, System.Threading.CancellationToken cancellationToken)
         {
             if (uuid == null)
                 throw new System.ArgumentNullException("uuid");
 
             var urlBuilder_ = new System.Text.StringBuilder();
-            urlBuilder_.Append("api/v1.0/dispute/email/{uuid}/validate");
+            urlBuilder_.Append("api/v1.0/dispute/email/{uuid}/verify");
             urlBuilder_.Replace("{uuid}", System.Uri.EscapeDataString(ConvertToString(uuid, System.Globalization.CultureInfo.InvariantCulture)));
 
             var client_ = _httpClient;

--- a/src/backend/TrafficCourts/Staff.Service/Controllers/DisputeController.cs
+++ b/src/backend/TrafficCourts/Staff.Service/Controllers/DisputeController.cs
@@ -366,6 +366,7 @@ public class DisputeController : VTCControllerBase<DisputeController>
     public async Task<IActionResult> ResendEmailAsync(long disputeId, CancellationToken cancellationToken)
     {
         _logger.LogDebug("Resending Email Verification");
+        // FIXME: this is wrong. The "Host" in this case resolves to the staff-api. This should be the hostname of citizen-web in any of the environments (local, dev, test, or prod).
         string host = this.HttpContext.Request.Host.Value;
 
         try

--- a/src/backend/TrafficCourts/Staff.Service/Mappers/Mapper.cs
+++ b/src/backend/TrafficCourts/Staff.Service/Mappers/Mapper.cs
@@ -61,10 +61,10 @@ public class Mapper
         return disputeRejected;
     }
 
-    public static EmailVerificationSend ToEmailSendValidation(Guid uuid, string host)
+    public static EmailVerificationSend ToEmailVerification(Guid uuid, string host)
     {
-        EmailVerificationSend emailSendValidation = new(uuid, host);
-        return emailSendValidation;
+        EmailVerificationSend emailVerificationSend = new(uuid, host);
+        return emailVerificationSend;
     }
 
     public static DisputeCancelled ToDisputeCancelled(Dispute dispute)

--- a/src/backend/TrafficCourts/Staff.Service/Services/DisputeService.cs
+++ b/src/backend/TrafficCourts/Staff.Service/Services/DisputeService.cs
@@ -241,7 +241,7 @@ public class DisputeService : IDisputeService
         Dispute dispute = await GetOracleDataApi().GetDisputeAsync(disputeId, cancellationToken);
 
         // Publish submit event (consumer(s) will generate email, etc)
-        EmailVerificationSend emailVerificationSentEvent = Mapper.ToEmailSendValidation(new Guid(dispute.EmailVerificationToken), host);
+        EmailVerificationSend emailVerificationSentEvent = Mapper.ToEmailVerification(new Guid(dispute.EmailVerificationToken), host);
         await _bus.Publish(emailVerificationSentEvent, cancellationToken);
 
         SendEmail emailVerificationEmail = Mapper.ToResendEmailVerification(dispute, host);

--- a/src/backend/TrafficCourts/Workflow.Service/Consumers/EmailVerificationReceivedConsumer.cs
+++ b/src/backend/TrafficCourts/Workflow.Service/Consumers/EmailVerificationReceivedConsumer.cs
@@ -40,7 +40,7 @@ public class EmailVerificationReceivedConsumer : IConsumer<EmailVerificationRece
             string token = message.EmailVerificationToken.ToString();
             Dispute dispute = await _oracleDataApiService.GetDisputeByEmailVerificationTokenAsync(token);
 
-            await _oracleDataApiService.ValidateDisputeEmailAsync(token);
+            await _oracleDataApiService.VerifyDisputeEmailAsync(token);
 
             // TCVP-1529 Send NoticeOfDisputeConfirmationEmail *after* validating Disputant's email
             SendEmail email = _emailSenderService.ToConfirmationEmail(dispute);

--- a/src/backend/TrafficCourts/Workflow.Service/Services/IOracleDataApiService.cs
+++ b/src/backend/TrafficCourts/Workflow.Service/Services/IOracleDataApiService.cs
@@ -6,7 +6,7 @@ namespace TrafficCourts.Workflow.Service.Services
     {
         Task<long> CreateDisputeAsync(Dispute disputeToSubmit);
         Task<Dispute> GetDisputeByEmailVerificationTokenAsync(string emailVerificationToken);
-        Task ValidateDisputeEmailAsync(string emailVerificationToken);
+        Task VerifyDisputeEmailAsync(string emailVerificationToken);
         Task<long> CreateEmailHistoryAsync(EmailHistory emailHistory);
     }
 }

--- a/src/backend/TrafficCourts/Workflow.Service/Services/OracleDataApiService.cs
+++ b/src/backend/TrafficCourts/Workflow.Service/Services/OracleDataApiService.cs
@@ -33,8 +33,8 @@ public class OracleDataApiService : IOracleDataApiService
         return await _oracleDataApiClient.GetDisputeByEmailVerificationTokenAsync(emailVerificationToken);
     }
 
-    public async Task ValidateDisputeEmailAsync(string emailVerificationToken)
+    public async Task VerifyDisputeEmailAsync(string emailVerificationToken)
     {
-        await _oracleDataApiClient.ValidateDisputeEmailAsync(emailVerificationToken);
+        await _oracleDataApiClient.VerifyDisputeEmailAsync(emailVerificationToken);
     }
 }

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/controller/v1_0/DisputeController.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/controller/v1_0/DisputeController.java
@@ -187,11 +187,11 @@ public class DisputeController {
 		@ApiResponse(responseCode = "200", description = "Ok. Email verified."),
 		@ApiResponse(responseCode = "500", description = "Internal server error occured.")
 	})
-	@PutMapping("/dispute/email/{uuid}/validate")
-	public ResponseEntity<Void> validateDisputeEmail(@PathVariable(name="uuid") @Parameter(description = "The emailVerificationToken of the Dispute to update.") String emailVerificationToken) {
-		logger.debug("PUT /dispute/email/{uuid}/validate called");
+	@PutMapping("/dispute/email/{uuid}/verify")
+	public ResponseEntity<Void> verifyDisputeEmail(@PathVariable(name="uuid") @Parameter(description = "The emailVerificationToken of the Dispute to update.") String emailVerificationToken) {
+		logger.debug("PUT /dispute/email/{uuid}/verify called");
 		try {
-			disputeService.validateEmail(emailVerificationToken);
+			disputeService.verifyEmail(emailVerificationToken);
 		} catch (Exception e) {
 			logger.error("ERROR validating email for uuid {}", emailVerificationToken, e);
 			return ResponseEntity.internalServerError().build();

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/service/DisputeService.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/service/DisputeService.java
@@ -239,7 +239,7 @@ public class DisputeService {
 	 * Flips the Dispute.emailAddressVerified flag to true where Dispute.emailVerificationToken matches the given parameter
 	 * @param token the Dispute record to update
 	 */
-	public void validateEmail(String emailVerificationToken) {
+	public void verifyEmail(String emailVerificationToken) {
 		List<Dispute> emailVerificationTokens = disputeRepository.findByEmailVerificationToken(emailVerificationToken);
 		for (Dispute dispute : emailVerificationTokens) {
 			dispute.setEmailAddressVerified(Boolean.TRUE);


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

Refactoring to cleanup naming convention. EmailValidation should be EmailVerification in the context of verifying one's email.

Updated citizen-api endpoint
/api/disputes/email/{uuid}/validate

Updated oracle-data-api endpoint
/dispute/email/{uuid}/validate

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
