### PR TITLE
add reference to pre-release serilog-sinks-periodicbatching 

### DIFF
--- a/src/backend/TrafficCourts/Common/TrafficCourts.Common.csproj
+++ b/src/backend/TrafficCourts/Common/TrafficCourts.Common.csproj
@@ -45,6 +45,7 @@
 		<PackageReference Include="Serilog.Exceptions" Version="8.4.0" />
 		<PackageReference Include="Serilog.Settings.Configuration" Version="3.4.0" />
 		<PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />
+		<PackageReference Include="Serilog.Sinks.PeriodicBatching" Version="3.1.0-dev-00796" />
 		<PackageReference Include="Serilog.Sinks.Seq" Version="5.2.0" />
 		<PackageReference Include="Serilog.Sinks.Splunk" Version="3.7.0" />
 		<PackageReference Include="SerilogAnalyzer" Version="0.15.0" />


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- Adds temporarily a reference to Serilog.Sinks.PeriodicBatching verison 3.1.0-dev-00796. In version 3.0 they changed and subsequently reverted making the PeriodicBatchingSink data type sealed. This sealing of the class broke Splunk and other periodic batching sinks. This dependency is a transitive dependency of Splunk.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [ ] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
