### PR TITLE
TCVP-1741 impl unassignDispute

### DIFF
--- a/src/backend/oracle-data-api/pom.xml
+++ b/src/backend/oracle-data-api/pom.xml
@@ -301,6 +301,7 @@
                             <generatorName>java</generatorName>
                             <configOptions>
                                 <useTags>true</useTags>
+                                <useRuntimeException>true</useRuntimeException>
                             </configOptions>
                             <library>jersey2</library>
                             <apiPackage>${default-package}.api</apiPackage>

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/controller/v1_0/DisputeController.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/controller/v1_0/DisputeController.java
@@ -93,7 +93,8 @@ public class DisputeController {
 	@ApiResponses({
 		@ApiResponse(responseCode = "200", description = "Ok. Dispute record deleted."),
 		@ApiResponse(responseCode = "400", description = "Bad Request."),
-		@ApiResponse(responseCode = "404", description = "Dispute record not found. Delete failed.")
+		@ApiResponse(responseCode = "404", description = "Dispute record not found. Delete failed."),
+		@ApiResponse(responseCode = "500", description = "Internal Server Error. Delete failed.")
 	})
 	@DeleteMapping("/dispute/{id}")
 	public void deleteDispute(@PathVariable Long id) {
@@ -300,6 +301,10 @@ public class DisputeController {
 			summary = "An endpoint hook to trigger the Unassign Dispute job.",
 			description = "A Dispute can be assigned to a specific user that \"locks\" the record for others. This endpoing manually triggers the Unassign Dispute job that clears the assignment of all Disputes that were assigned for more than 1 hour."
 			)
+	@ApiResponses({
+		@ApiResponse(responseCode = "200", description = "Ok. Dispute record unassigned."),
+		@ApiResponse(responseCode = "500", description = "Internal Server Error. Unassigned failed.")
+	})
 	public void unassignDisputes() {
 		logger.debug("GET /disputes/unassign called");
 		disputeService.unassignDisputes();

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/repository/DisputeRepository.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/repository/DisputeRepository.java
@@ -72,4 +72,9 @@ public interface DisputeRepository {
 	 */
 	public Dispute saveAndFlush(Dispute entity);
 
+	/**
+	 * Unassigns all Disputes whose assignedTs is older than 1 hour ago, resetting the assignedTo and assignedTs fields.
+	 */
+	public void unassignDisputes(Date olderThan);
+
 }

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/repository/impl/h2/DisputeRepositoryImpl.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/repository/impl/h2/DisputeRepositoryImpl.java
@@ -1,8 +1,14 @@
 package ca.bc.gov.open.jag.tco.oracledataapi.repository.impl.h2;
 
+import java.util.Date;
+
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
 
 import ca.bc.gov.open.jag.tco.oracledataapi.model.Dispute;
 import ca.bc.gov.open.jag.tco.oracledataapi.repository.DisputeRepository;
@@ -10,4 +16,10 @@ import ca.bc.gov.open.jag.tco.oracledataapi.repository.DisputeRepository;
 @ConditionalOnProperty(name = "ords.enabled", havingValue = "false", matchIfMissing = true)
 @Qualifier("disputeRepository")
 public interface DisputeRepositoryImpl extends DisputeRepository, JpaRepository<Dispute, Long> {
+
+	@Override
+	@Modifying
+	@Query("update Dispute d set d.userAssignedTo = null, d.userAssignedTs = null where d.userAssignedTs < :olderThan")
+	@Transactional
+	public void unassignDisputes(@Param(value="olderThan") Date olderThan);
 }

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/service/DisputeService.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/service/DisputeService.java
@@ -217,22 +217,9 @@ public class DisputeService {
 
 	/**
 	 * Unassigns all Disputes whose assignedTs is older than 1 hour ago, resetting the assignedTo and assignedTs fields.
-	 * @return number of records modified.
 	 */
 	public void unassignDisputes() {
-		int count = 0;
-
-		// Find all Disputes with an assignedTs older than 1 hour ago.
-		Date hourAgo = DateUtils.addHours(new Date(), -1);
-		logger.debug("Unassigning all disputes older than {}", hourAgo.toInstant());
-		for (Dispute dispute : disputeRepository.findByUserAssignedTsBefore(hourAgo)) {
-			dispute.setUserAssignedTo(null);
-			dispute.setUserAssignedTs(null);
-			disputeRepository.saveAndFlush(dispute);
-			count++;
-		}
-
-		logger.debug("Unassigned {} record(s)", count);
+		disputeRepository.unassignDisputes(DateUtils.addHours(new Date(), -1));
 	}
 
 	/**

--- a/src/backend/oracle-data-api/src/main/resources/occm-openapi-spec.yaml
+++ b/src/backend/oracle-data-api/src/main/resources/occm-openapi-spec.yaml
@@ -152,7 +152,25 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DeleteResult'
+                $ref: '#/components/schemas/ResponseResult'
+      tags:
+        - Violation Ticket
+  /v1/unassignViolationTicket:
+    post:
+      parameters:
+        - name: assignedBeforeTs
+          in: query
+          description: ''
+          schema:
+            type: string
+            maxLength: 19
+      responses:
+        '200':
+          description: Ok
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResponseResult'
       tags:
         - Violation Ticket
 components:
@@ -270,7 +288,7 @@ components:
         currentTimestamp:
           type: string
           format: date-time
-    DeleteResult:
+    ResponseResult:
       type: object
       properties:
         status:

--- a/src/backend/oracle-data-api/src/test/java/ca/bc/gov/open/jag/tco/oracledataapi/service/impl/ords/DisputeServiceImplTest.java
+++ b/src/backend/oracle-data-api/src/test/java/ca/bc/gov/open/jag/tco/oracledataapi/service/impl/ords/DisputeServiceImplTest.java
@@ -3,10 +3,13 @@ package ca.bc.gov.open.jag.tco.oracledataapi.service.impl.ords;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import java.text.SimpleDateFormat;
+import java.util.Date;
 import java.util.NoSuchElementException;
 
 import javax.ws.rs.InternalServerErrorException;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.Mockito;
@@ -14,7 +17,7 @@ import org.mockito.Mockito;
 import ca.bc.gov.open.jag.tco.oracledataapi.BaseTestSuite;
 import ca.bc.gov.open.jag.tco.oracledataapi.api.ViolationTicketApi;
 import ca.bc.gov.open.jag.tco.oracledataapi.api.handler.ApiException;
-import ca.bc.gov.open.jag.tco.oracledataapi.api.model.DeleteResult;
+import ca.bc.gov.open.jag.tco.oracledataapi.api.model.ResponseResult;
 import ca.bc.gov.open.jag.tco.oracledataapi.repository.impl.ords.DisputeRepositoryImpl;
 
 
@@ -22,69 +25,158 @@ class DisputeServiceImplTest extends BaseTestSuite {
 
 	@Mock
 	private ViolationTicketApi violationTicketApi;
+	private DisputeRepositoryImpl repository;
+
+	@Override
+	@BeforeEach
+	public void beforeEach() {
+		repository = new DisputeRepositoryImpl(violationTicketApi);
+	}
 
 	@Test
-	public void testExpect200() throws ApiException {
+	public void testDeleteExpect200() throws ApiException {
 		Long disputeId = Long.valueOf(1);
-		DeleteResult _200 = new DeleteResult();
-		_200.setStatus("1");
+		ResponseResult response = new ResponseResult();
+		response.setStatus("1");
 
-		Mockito.when(violationTicketApi.v1DeleteViolationTicketDelete(disputeId)).thenReturn(_200);
-		DisputeRepositoryImpl repo = new DisputeRepositoryImpl(violationTicketApi);
+		Mockito.when(violationTicketApi.v1DeleteViolationTicketDelete(disputeId)).thenReturn(response);
+
 		assertDoesNotThrow(() -> {
-			repo.deleteById(disputeId);
+			repository.deleteById(disputeId);
 		});
 	}
 
 	@Test
-	public void testExpect400() throws ApiException {
+	public void testDeleteExpect400() throws ApiException {
 		Long disputeId = null;
 
-		DisputeRepositoryImpl repo = new DisputeRepositoryImpl(violationTicketApi);
 		assertThrows(IllegalArgumentException.class, () -> {
-			repo.deleteById(disputeId);
+			repository.deleteById(disputeId);
 		});
 	}
 
 	@Test
-	public void testExpect404() throws ApiException {
+	public void testDeleteExpect404() throws ApiException {
 		Long disputeId = Long.valueOf(1);
-		DeleteResult _404 = new DeleteResult();
-		_404.setStatus("0");
-		_404.setException("ORA-01403: no data found");
+		ResponseResult response = new ResponseResult();
+		response.setStatus("0");
+		response.setException("ORA-01403: no data found");
 
-		Mockito.when(violationTicketApi.v1DeleteViolationTicketDelete(disputeId)).thenReturn(_404);
-		DisputeRepositoryImpl repo = new DisputeRepositoryImpl(violationTicketApi);
+		Mockito.when(violationTicketApi.v1DeleteViolationTicketDelete(disputeId)).thenReturn(response);
+
 		assertThrows(NoSuchElementException.class, () -> {
-			repo.deleteById(disputeId);
+			repository.deleteById(disputeId);
 		});
 	}
 
 	@Test
-	public void testExpect500_noErrorMessage() throws ApiException {
+	public void testDeleteExpect500_noErrorMessage() throws ApiException {
 		Long disputeId = Long.valueOf(1);
-		DeleteResult _500 = new DeleteResult();
-		_500.setStatus("0"); // 0 status (meaning failure) and no message
+		ResponseResult response = new ResponseResult();
+		response.setStatus("0"); // 0 status (meaning failure) and no message
 
-		Mockito.when(violationTicketApi.v1DeleteViolationTicketDelete(disputeId)).thenReturn(_500);
-		DisputeRepositoryImpl repo = new DisputeRepositoryImpl(violationTicketApi);
+		Mockito.when(violationTicketApi.v1DeleteViolationTicketDelete(disputeId)).thenReturn(response);
+
 		assertThrows(InternalServerErrorException.class, () -> {
-			repo.deleteById(disputeId);
+			repository.deleteById(disputeId);
 		});
 	}
 
 	@Test
-	public void testExpect500_withErrorMessage() throws ApiException {
+	public void testDeleteExpect500_withErrorMessage() throws ApiException {
 		Long disputeId = Long.valueOf(1);
-		DeleteResult _500 = new DeleteResult();
-		_500.setStatus("0"); // 0 status (meaning failure) and no message
-		_500.setException("some failure cause");
+		ResponseResult response = new ResponseResult();
+		response.setStatus("0"); // 0 status (meaning failure) and no message
+		response.setException("some failure cause");
 
-		Mockito.when(violationTicketApi.v1DeleteViolationTicketDelete(disputeId)).thenReturn(_500);
-		DisputeRepositoryImpl repo = new DisputeRepositoryImpl(violationTicketApi);
+		Mockito.when(violationTicketApi.v1DeleteViolationTicketDelete(disputeId)).thenReturn(response);
+
 		assertThrows(InternalServerErrorException.class, () -> {
-			repo.deleteById(disputeId);
+			repository.deleteById(disputeId);
 		});
+	}
+
+	@Test
+	public void testDeleteExpect500_nullReponse() throws ApiException {
+		Long disputeId = Long.valueOf(1);
+
+		Mockito.when(violationTicketApi.v1DeleteViolationTicketDelete(disputeId)).thenReturn(null);
+
+		assertThrows(InternalServerErrorException.class, () -> {
+			repository.deleteById(disputeId);
+		});
+	}
+
+	@Test
+	public void testUnassignExpect200() throws Exception {
+		Date now = new Date();
+		String assignedBeforeTs = dateToString(now);
+		ResponseResult response = new ResponseResult();
+		response.setStatus("1");
+
+		Mockito.when(violationTicketApi.v1UnassignViolationTicketPost(assignedBeforeTs)).thenReturn(response);
+
+		assertDoesNotThrow(() -> {
+			repository.unassignDisputes(now);
+		});
+	}
+
+	@Test
+	public void testUnassignExpect500_nullReponse() throws Exception {
+		Date now = new Date();
+		String assignedBeforeTs = dateToString(now);
+
+		Mockito.when(violationTicketApi.v1UnassignViolationTicketPost(assignedBeforeTs)).thenReturn(null);
+
+		assertThrows(InternalServerErrorException.class, () -> {
+			repository.unassignDisputes(now);
+		});
+	}
+
+	@Test
+	public void testUnassignExpect500_withErrorMsg() throws Exception {
+		Date now = new Date();
+		String assignedBeforeTs = dateToString(now);
+		ResponseResult response = new ResponseResult();
+		response.setStatus("0"); // 0 status (meaning failure)
+		response.setException("some failure cause");
+
+		Mockito.when(violationTicketApi.v1UnassignViolationTicketPost(assignedBeforeTs)).thenReturn(response);
+
+		assertThrows(InternalServerErrorException.class, () -> {
+			repository.unassignDisputes(now);
+		});
+	}
+
+	@Test
+	public void testUnassignExpect500_noErrorMsg() throws Exception {
+		Date now = new Date();
+		String assignedBeforeTs = dateToString(now);
+		ResponseResult response = new ResponseResult();
+		response.setStatus("0"); // 0 status (meaning failure) and no message
+
+		Mockito.when(violationTicketApi.v1UnassignViolationTicketPost(assignedBeforeTs)).thenReturn(response);
+
+		assertThrows(InternalServerErrorException.class, () -> {
+			repository.unassignDisputes(now);
+		});
+	}
+
+	@Test
+	public void testUnassignExpect500_ApiException() throws Exception {
+		Date now = new Date();
+		String assignedBeforeTs = dateToString(now);
+
+		Mockito.when(violationTicketApi.v1UnassignViolationTicketPost(assignedBeforeTs)).thenThrow(ApiException.class);
+
+		assertThrows(ApiException.class, () -> {
+			repository.unassignDisputes(now);
+		});
+	}
+
+	private String dateToString(Date date) {
+		SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+		return dateFormat.format(date);
 	}
 
 }


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

TCVP-1741
- Implemented unassignDispute that calls ORDS. 
- Moved unassignDispute logic from DisputeService to DisputeRepository so it can be implemented differently by H2 or ORDS
- Changed ApiException so it extends RuntimeException so it can propagate up to controller
- Added junit tests


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

new junit tests,
mvn verify

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
