### PR TITLE
TCVP-1739 impl set Dispute status

### DIFF
--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/mapper/DisputeMapper.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/mapper/DisputeMapper.java
@@ -14,22 +14,24 @@ import org.mapstruct.factory.Mappers;
 import ca.bc.gov.open.jag.tco.oracledataapi.api.model.ViolationTicket;
 import ca.bc.gov.open.jag.tco.oracledataapi.model.Dispute;
 import ca.bc.gov.open.jag.tco.oracledataapi.model.DisputeCount;
+import ca.bc.gov.open.jag.tco.oracledataapi.model.DisputeStatus;
 import ca.bc.gov.open.jag.tco.oracledataapi.model.Plea;
 import ca.bc.gov.open.jag.tco.oracledataapi.model.ViolationTicketCount;
 import ca.bc.gov.open.jag.tco.oracledataapi.model.YesNo;
+import ca.bc.gov.open.jag.tco.oracledataapi.repository.impl.ords.DisputeRepositoryImpl;
 
 @Mapper
 public interface DisputeMapper {
-	
+
 	DisputeMapper INSTANCE = Mappers.getMapper(DisputeMapper.class);
-	
+
 	// Map dispute data from ORDS to Oracle Data API dispute model
-	@Mapping(source = "dispute.entDtm", target = "createdTs")
+	@Mapping(source = "dispute.entDtm", target = "createdTs", dateFormat = DisputeRepositoryImpl.DATE_TIME_FORMAT)
 	@Mapping(source = "dispute.entUserId", target = "createdBy")
-	@Mapping(source = "dispute.updDtm", target = "modifiedTs")
+	@Mapping(source = "dispute.updDtm", target = "modifiedTs", dateFormat = DisputeRepositoryImpl.DATE_TIME_FORMAT)
 	@Mapping(source = "dispute.updUserId", target = "modifiedBy")
 	@Mapping(source = "dispute.disputeId", target = "disputeId")
-	@Mapping(source = "dispute.disputeStatusTypeCd", target = "status")
+	@Mapping(source = "dispute.disputeStatusTypeCd", target = "status", qualifiedByName="mapDisputeStatus")
 	@Mapping(source = "dispute.courtAgenId", target = "courtLocation")
 	@Mapping(source = "dispute.issuedDt", target = "issuedDate")
 	@Mapping(source = "dispute.submittedDt", target = "submittedDate")
@@ -71,7 +73,7 @@ public interface DisputeMapper {
 	@Mapping(source = "dispute.disputantCommentTxt", target = "disputantComment")
 	@Mapping(source = "dispute.rejectedReasonTxt", target = "rejectedReason")
 	@Mapping(source = "dispute.userAssignedTo", target = "userAssignedTo")
-	@Mapping(source = "dispute.userAssignedDtm", target = "userAssignedTs")
+	@Mapping(source = "dispute.userAssignedDtm", target = "userAssignedTs", dateFormat = DisputeRepositoryImpl.DATE_TIME_FORMAT)
 	@Mapping(source = "dispute.disputantDetectOcrIssuesYn", target = "disputantDetectedOcrIssues")
 	@Mapping(source = "dispute.disputantOcrIssuesTxt", target = "disputantOcrIssues")
 	@Mapping(source = "dispute.systemDetectOcrIssuesYn", target = "systemDetectedOcrIssues")
@@ -111,8 +113,8 @@ public interface DisputeMapper {
 	// Map dispute counts data from ORDS to Oracle Data API dispute count model
 	@Mapping(source = "violationTicketCounts", target = "disputeCounts", qualifiedByName="mapCounts")
 	Dispute convertViolationTicketDtoToDispute (ViolationTicket violationTicketDto);
-	
-	
+
+
 	@Mapping(source = "entUserId", target = "createdBy")
 	@Mapping(source = "entDtm", target = "createdTs")
 	@Mapping(source = "updUserId", target = "modifiedBy")
@@ -127,10 +129,10 @@ public interface DisputeMapper {
 	@Mapping(source = "statSubParagraphTxt", target = "subparagraph")
 	@Mapping(source = "ticketedAmt", target = "ticketedAmount")
 	ViolationTicketCount convertViolationTicketCountDtoToViolationTicketCount (ca.bc.gov.open.jag.tco.oracledataapi.api.model.ViolationTicketCount violationTicketCountDto);
-	
+
 	/**
 	 * Custom mapping for mapping YesNo fields to Boolean value
-	 * 
+	 *
 	 * @param value
 	 * @return Boolean value of {@link YesNo} enum
 	 */
@@ -138,10 +140,21 @@ public interface DisputeMapper {
 	default Boolean mapYnToBoolean(YesNo value) {
 		return YesNo.Y.equals(value);
 	}
-	
+
+	@Named("mapDisputeStatus")
+	default DisputeStatus mapYnToBoolean(String statusShortCd) {
+		DisputeStatus[] values = DisputeStatus.values();
+		for (DisputeStatus disputeStatus : values) {
+			if (disputeStatus.toShortName().equals(statusShortCd)) {
+				return disputeStatus;
+			}
+		}
+		return null;
+	}
+
 	/**
 	 * Custom mapping for dispute counts
-	 * 
+	 *
 	 * @param violationTicketCounts
 	 * @return list of {@link DisputeCount}
 	 */
@@ -150,9 +163,9 @@ public interface DisputeMapper {
 		if ( violationTicketCounts == null || violationTicketCounts.isEmpty()) {
             return null;
         }
-		
+
 		List<DisputeCount> disputeCounts = new ArrayList<DisputeCount>();
-		
+
 		for (ca.bc.gov.open.jag.tco.oracledataapi.api.model.ViolationTicketCount violationTicketCount : violationTicketCounts) {
 			ca.bc.gov.open.jag.tco.oracledataapi.api.model.DisputeCount disputeCount = violationTicketCount.getDisputeCount();
 			if (disputeCount != null) {
@@ -196,8 +209,8 @@ public interface DisputeMapper {
 				dispute.setLawyerAddress(null);
 			} else {
 				dispute.setLawyerAddress(
-		        		addressLine1 == null ? "" : addressLine1 + " " + 
-		        		addressLine2 == null ? "" : addressLine2 + " " + 
+		        		addressLine1 == null ? "" : addressLine1 + " " +
+		        		addressLine2 == null ? "" : addressLine2 + " " +
 		        		addressLine3 == null ? "" : addressLine3);
 			}
 		}

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/model/DisputeStatus.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/model/DisputeStatus.java
@@ -4,9 +4,21 @@ package ca.bc.gov.open.jag.tco.oracledataapi.model;
  * An enumeration of available Statuses on a Dispute record.
  */
 public enum DisputeStatus {
-	NEW,
-	VALIDATED,
-	PROCESSING,
-	REJECTED,
-	CANCELLED
+
+	NEW("NEW"),
+	VALIDATED("VALD"),
+	PROCESSING("PROC"),
+	REJECTED("REJ"),
+	CANCELLED("CANC");
+
+	private String shortName;
+
+	private DisputeStatus(String shortName) {
+		this.shortName = shortName;
+	}
+
+	public String toShortName() {
+		return shortName;
+	}
+
 }

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/repository/DisputeRepository.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/repository/DisputeRepository.java
@@ -73,8 +73,28 @@ public interface DisputeRepository {
 	public Dispute saveAndFlush(Dispute entity);
 
 	/**
+	 * Assigns the given Dispute to the userName provided.
+	 * @param disputeId
+	 * @param userName
+	 */
+	public void assignDisputeToUser(Long disputeId, String userName);
+
+	/**
 	 * Unassigns all Disputes whose assignedTs is older than 1 hour ago, resetting the assignedTo and assignedTs fields.
 	 */
 	public void unassignDisputes(Date olderThan);
+
+	/**
+	 * Sets the status and rejectedReason fields on the given dispute.
+	 * @param disputeId
+	 * @param disputeStatus
+	 * @param rejectedReason
+	 */
+	public void setStatus(Long disputeId, DisputeStatus disputeStatus, String rejectedReason);
+
+	/**
+	 * Flushes all pending changes to the database and clears the session, if the underlying persistence layer needs it.
+	 */
+	void flushAndClear();
 
 }

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/repository/DisputeRepository.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/repository/DisputeRepository.java
@@ -19,9 +19,6 @@ public interface DisputeRepository {
     /** Fetch all records which do not have the specified status and older than the given date. */
     public Iterable<Dispute> findByStatusNotAndCreatedTsBefore(DisputeStatus excludeStatus, Date olderThan);
 
-	/** Fetch all records whose assignedTs has a timestamp older than the given date. */
-    public Iterable<Dispute> findByUserAssignedTsBefore(Date olderThan);
-
     /** Fetch all records that matches the emailVerificationToken. */
     public List<Dispute> findByEmailVerificationToken(String emailVerificationToken);
 

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/repository/impl/h2/DisputeRepositoryCustom.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/repository/impl/h2/DisputeRepositoryCustom.java
@@ -1,0 +1,10 @@
+package ca.bc.gov.open.jag.tco.oracledataapi.repository.impl.h2;
+
+public interface DisputeRepositoryCustom {
+
+	/**
+	 * Flushes all pending changes to the database.
+	 */
+	void flushAndClear();
+
+}

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/repository/impl/h2/DisputeRepositoryCustomImpl.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/repository/impl/h2/DisputeRepositoryCustomImpl.java
@@ -1,0 +1,19 @@
+package ca.bc.gov.open.jag.tco.oracledataapi.repository.impl.h2;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import javax.transaction.Transactional;
+
+public class DisputeRepositoryCustomImpl implements DisputeRepositoryCustom {
+
+	@PersistenceContext
+	private EntityManager entityManager;
+
+	@Override
+	@Transactional
+	public void flushAndClear() {
+		entityManager.flush();
+		entityManager.clear();
+	}
+
+}

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/repository/impl/h2/DisputeRepositoryImpl.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/repository/impl/h2/DisputeRepositoryImpl.java
@@ -11,15 +11,32 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.transaction.annotation.Transactional;
 
 import ca.bc.gov.open.jag.tco.oracledataapi.model.Dispute;
+import ca.bc.gov.open.jag.tco.oracledataapi.model.DisputeStatus;
 import ca.bc.gov.open.jag.tco.oracledataapi.repository.DisputeRepository;
 
 @ConditionalOnProperty(name = "ords.enabled", havingValue = "false", matchIfMissing = true)
 @Qualifier("disputeRepository")
-public interface DisputeRepositoryImpl extends DisputeRepository, JpaRepository<Dispute, Long> {
+public interface DisputeRepositoryImpl extends DisputeRepository, JpaRepository<Dispute, Long>, DisputeRepositoryCustom {
+
+	@Override
+	@Modifying
+	@Query("update Dispute d set d.userAssignedTo = :userName, d.userAssignedTs = CURRENT_TIMESTAMP() where d.disputeId = :disputeId")
+	@Transactional
+	public void assignDisputeToUser(@Param(value = "disputeId") Long disputeId, @Param(value = "userName") String userName);
 
 	@Override
 	@Modifying
 	@Query("update Dispute d set d.userAssignedTo = null, d.userAssignedTs = null where d.userAssignedTs < :olderThan")
 	@Transactional
 	public void unassignDisputes(@Param(value="olderThan") Date olderThan);
+
+	@Override
+	@Modifying
+	@Query("update Dispute d set d.status = :disputeStatus, d.rejectedReason = :rejectedReason where d.disputeId = :disputeId")
+	@Transactional
+	public void setStatus(
+			@Param(value = "disputeId") Long disputeId,
+			@Param(value = "disputeStatus") DisputeStatus disputeStatus,
+			@Param(value = "rejectedReason") String rejectedReason);
+
 }

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/repository/impl/ords/DisputeRepositoryImpl.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/repository/impl/ords/DisputeRepositoryImpl.java
@@ -5,6 +5,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Optional;
+import java.util.function.Supplier;
 
 import javax.ws.rs.InternalServerErrorException;
 
@@ -29,7 +30,9 @@ import ca.bc.gov.open.jag.tco.oracledataapi.repository.DisputeRepository;
 @Repository
 public class DisputeRepositoryImpl implements DisputeRepository {
 
-	Logger logger = LoggerFactory.getLogger(DisputeRepositoryImpl.class);
+	public static final String DATE_TIME_FORMAT = "yyyy-MM-dd HH:mm:ss";
+
+	private static Logger logger = LoggerFactory.getLogger(DisputeRepositoryImpl.class);
 
 	// Delegate, OpenAPI generated client
 	private final ViolationTicketApi violationTicketApi;
@@ -133,26 +136,46 @@ public class DisputeRepositoryImpl implements DisputeRepository {
 	}
 
 	@Override
+	public void assignDisputeToUser(Long disputeId, String userName) {
+		assertNoExceptions(() -> violationTicketApi.v1AssignViolationTicketPost(disputeId, userName));
+	}
+
+	@Override
 	public void unassignDisputes(Date olderThan) {
-		SimpleDateFormat simpleDateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+		SimpleDateFormat simpleDateFormat = new SimpleDateFormat(DATE_TIME_FORMAT);
 		String dateStr = simpleDateFormat.format(olderThan);
 
-		// Propagate any ApiException to caller
-		ResponseResult result = violationTicketApi.v1UnassignViolationTicketPost(dateStr);
+		assertNoExceptions(() -> violationTicketApi.v1UnassignViolationTicketPost(dateStr));
+	}
+
+	@Override
+	public void setStatus(Long disputeId, DisputeStatus disputeStatus, String rejectedReason) {
+		assertNoExceptions(() -> violationTicketApi.v1ViolationTicketStatusPost(disputeId, disputeStatus.toShortName(), rejectedReason));
+	}
+
+	@Override
+	public void flushAndClear() {
+		// no-op. Not needed for ORDS.
+	}
+
+	/**
+	 * A helper method that will throw an appropriate InternalServerErrorException based on the ResponseResult. Any RuntimeExceptions throw will propagate up to caller.
+	 */
+	private void assertNoExceptions(Supplier<ResponseResult> m) {
+		ResponseResult result = m.get();
 
 		if (result == null) {
-			// unknown if ORDS could unassign or not, missing response object.
+			// Missing response object.
 			throw new InternalServerErrorException("Invalid ResponseResult object");
 		}
 		else if (result.getException() != null) {
-			// ORDS could not unassign, error message in the response object.
+			// Exception in response exists
 			throw new InternalServerErrorException(result.getException());
 		}
 		else if (!"1".equals(result.getStatus())) {
-			// ORDS could not unassign, error message missing in the response object.
-			throw new InternalServerErrorException("Dispute unassign is not 1 (success)");
+			// Status is not 1 (success)
+			throw new InternalServerErrorException("Status is not 1 (success)");
 		}
-
 	}
 
 }

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/repository/impl/ords/DisputeRepositoryImpl.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/repository/impl/ords/DisputeRepositoryImpl.java
@@ -57,18 +57,13 @@ public class DisputeRepositoryImpl implements DisputeRepository {
 	}
 
 	@Override
-	public Iterable<Dispute> findByUserAssignedTsBefore(Date olderThan) {
-		throw new NotYetImplementedException();
-	}
-
-	@Override
 	public List<Dispute> findByEmailVerificationToken(String emailVerificationToken) {
 		throw new NotYetImplementedException();
 	}
 
 	@Override
 	public void deleteAll() {
-		throw new NotYetImplementedException();
+		// no-op. Not needed for ORDS.
 	}
 
 	@Override

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/service/DisputeService.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/service/DisputeService.java
@@ -181,9 +181,9 @@ public class DisputeService {
 			throw new NotAllowedException("Unknown status of a Dispute record: %s", dispute.getStatus());
 		}
 
-		dispute.setStatus(disputeStatus);
-		dispute.setRejectedReason(DisputeStatus.REJECTED.equals(disputeStatus) ? rejectedReason : null);
-		return disputeRepository.saveAndFlush(dispute);
+		disputeRepository.setStatus(id, disputeStatus, DisputeStatus.REJECTED.equals(disputeStatus) ? rejectedReason : null);
+		disputeRepository.flushAndClear();
+		return disputeRepository.findById(id).orElseThrow();
 	}
 
 	/**
@@ -203,9 +203,8 @@ public class DisputeService {
 
 		if (StringUtils.isBlank(dispute.getUserAssignedTo()) || dispute.getUserAssignedTo().equals(principal.getName())) {
 
-			dispute.setUserAssignedTo(principal.getName());
-			dispute.setUserAssignedTs(new Date());
-			disputeRepository.saveAndFlush(dispute);
+			disputeRepository.assignDisputeToUser(id, principal.getName());
+			disputeRepository.flushAndClear();
 
 			logger.debug("Dispute with id {} has been assigned to {}", id, principal.getName());
 

--- a/src/backend/oracle-data-api/src/main/resources/occm-openapi-spec.yaml
+++ b/src/backend/oracle-data-api/src/main/resources/occm-openapi-spec.yaml
@@ -142,10 +142,37 @@ paths:
       parameters:
         - name: disputeId
           in: query
+          required: true
           description: ''
           schema:
             type: integer
             format: int64
+      responses:
+        '200':
+          description: Ok
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResponseResult'
+      tags:
+        - Violation Ticket
+  /v1/assignViolationTicket:
+    post:
+      parameters:
+        - name: disputeId
+          in: query
+          required: true
+          description: ''
+          schema:
+            type: integer
+            format: int64
+        - name: userId
+          in: query
+          required: true
+          description: 'This is actually userName, not a user ID.'
+          schema:
+            type: string
+            maxLength: 30
       responses:
         '200':
           description: Ok
@@ -164,6 +191,36 @@ paths:
           schema:
             type: string
             maxLength: 19
+      responses:
+        '200':
+          description: Ok
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResponseResult'
+      tags:
+        - Violation Ticket
+  /v1/violationTicketStatus:
+    post:
+      parameters:
+        - name: disputeId
+          in: query
+          description: ''
+          schema:
+            type: integer
+            format: int64
+        - name: statusCd
+          in: query
+          description: ''
+          schema:
+            type: string
+            maxLength: 4
+        - name: rejectReason
+          in: query
+          description: ''
+          schema:
+            type: string
+            maxLength: 500
       responses:
         '200':
           description: Ok

--- a/src/backend/oracle-data-api/src/test/java/ca/bc/gov/open/jag/tco/oracledataapi/controller/v1_0/DisputeControllerTest.java
+++ b/src/backend/oracle-data-api/src/test/java/ca/bc/gov/open/jag/tco/oracledataapi/controller/v1_0/DisputeControllerTest.java
@@ -124,7 +124,7 @@ class DisputeControllerTest extends BaseTestSuite {
 		disputeController.submitDispute(disputeId, principal);
 
 		// Assert status is set, rejected reason is NOT set.
-		dispute = disputeController.getDispute(disputeId, principal).getBody();;
+		dispute = disputeController.getDispute(disputeId, principal).getBody();
 		assertEquals(DisputeStatus.PROCESSING, dispute.getStatus());
 		assertNull(dispute.getRejectedReason());
 	}
@@ -199,7 +199,7 @@ class DisputeControllerTest extends BaseTestSuite {
 		Iterable<Dispute> allDisputes = disputeController.getAllDisputes(null, null);
 		assertEquals(1, IterableUtils.size(allDisputes));
 	}
-	
+
 	@Test
 	@Transactional
 	public void testGetAllDisputesByStatusAndCreatedTs() throws ParseException {
@@ -211,11 +211,11 @@ class DisputeControllerTest extends BaseTestSuite {
 		Long disputeId = disputeController.saveDispute(dispute);
 		dispute.setModifiedTs(DateUtils.addDays(now, -1));
 		disputeController.updateDispute(disputeId, dispute, principal);
-		
+
 		Dispute dispute2 = RandomUtil.createDispute();
 		dispute2.setStatus(DisputeStatus.PROCESSING);
 		disputeController.saveDispute(dispute2);
-		
+
 		Dispute dispute3 = RandomUtil.createDispute();
 		dispute3.setStatus(DisputeStatus.CANCELLED);
 		disputeController.saveDispute(dispute3);
@@ -223,11 +223,11 @@ class DisputeControllerTest extends BaseTestSuite {
 		// Assert controller returns all the disputes that were saved if no parameters passed.
 		Iterable<Dispute> allDisputes = disputeController.getAllDisputes(null, null);
 		assertEquals(3, IterableUtils.size(allDisputes));
-		
+
 		// Assert controller returns all disputes which do not have the specified type.
 		List<Dispute> allDisputesWithStatusAndOlderThan = disputeController.getAllDisputes(null, DisputeStatus.CANCELLED);
 		assertEquals(2, IterableUtils.size(allDisputesWithStatusAndOlderThan));
-		
+
 		// Assert controller returns all disputes which do not have the specified type.
 		Iterable<Dispute> allDisputesWithStatus = disputeController.getAllDisputes(null, DisputeStatus.PROCESSING);
 		assertEquals(2, IterableUtils.size(allDisputesWithStatus));

--- a/src/backend/oracle-data-api/src/test/java/ca/bc/gov/open/jag/tco/oracledataapi/service/impl/ords/DisputeServiceImplTest.java
+++ b/src/backend/oracle-data-api/src/test/java/ca/bc/gov/open/jag/tco/oracledataapi/service/impl/ords/DisputeServiceImplTest.java
@@ -18,6 +18,7 @@ import ca.bc.gov.open.jag.tco.oracledataapi.BaseTestSuite;
 import ca.bc.gov.open.jag.tco.oracledataapi.api.ViolationTicketApi;
 import ca.bc.gov.open.jag.tco.oracledataapi.api.handler.ApiException;
 import ca.bc.gov.open.jag.tco.oracledataapi.api.model.ResponseResult;
+import ca.bc.gov.open.jag.tco.oracledataapi.model.DisputeStatus;
 import ca.bc.gov.open.jag.tco.oracledataapi.repository.impl.ords.DisputeRepositoryImpl;
 
 
@@ -31,6 +32,73 @@ class DisputeServiceImplTest extends BaseTestSuite {
 	@BeforeEach
 	public void beforeEach() {
 		repository = new DisputeRepositoryImpl(violationTicketApi);
+	}
+
+	@Test
+	public void testAssignExpect200() throws Exception {
+		Long disputeId = Long.valueOf(1);
+		String userName = "testUser";
+		ResponseResult response = new ResponseResult();
+		response.setStatus("1");
+
+		Mockito.when(violationTicketApi.v1AssignViolationTicketPost(disputeId, userName)).thenReturn(response);
+
+		assertDoesNotThrow(() -> {
+			repository.assignDisputeToUser(disputeId, userName);
+		});
+	}
+
+	@Test
+	public void testAssignExpect500_ApiException() throws Exception {
+		Long disputeId = Long.valueOf(1);
+		String userName = "testUser";
+
+		Mockito.when(violationTicketApi.v1AssignViolationTicketPost(disputeId, userName)).thenThrow(ApiException.class);
+
+		assertThrows(ApiException.class, () -> {
+			repository.assignDisputeToUser(disputeId, userName);
+		});
+	}
+
+	@Test
+	public void testAssignExpect500_noErrorMsg() throws Exception {
+		Long disputeId = Long.valueOf(1);
+		String userName = "testUser";
+		ResponseResult response = new ResponseResult();
+		response.setStatus("0"); // 0 status (meaning failure)
+
+		Mockito.when(violationTicketApi.v1AssignViolationTicketPost(disputeId, userName)).thenReturn(response);
+
+		assertThrows(InternalServerErrorException.class, () -> {
+			repository.assignDisputeToUser(disputeId, userName);
+		});
+	}
+
+	@Test
+	public void testAssignExpect500_nullResponse() throws Exception {
+		Long disputeId = Long.valueOf(1);
+		String userName = "testUser";
+
+		Mockito.when(violationTicketApi.v1AssignViolationTicketPost(disputeId, userName)).thenReturn(null);
+
+		assertThrows(InternalServerErrorException.class, () -> {
+			repository.assignDisputeToUser(disputeId, userName);
+		});
+	}
+
+	@Test
+	public void testAssignExpect500_withErrorMsg() throws Exception {
+		Long disputeId = Long.valueOf(1);
+		String userName = "testUser";
+		ResponseResult response = new ResponseResult();
+		response.setStatus("0"); // 0 status (meaning failure)
+		response.setException("some failure cause");
+
+		Mockito.when(violationTicketApi.v1AssignViolationTicketPost(disputeId, userName)).thenReturn(response);
+
+		assertThrows(InternalServerErrorException.class, () -> {
+			repository.assignDisputeToUser(disputeId, userName);
+		});
 	}
 
 	@Test
@@ -70,12 +138,34 @@ class DisputeServiceImplTest extends BaseTestSuite {
 	}
 
 	@Test
+	public void testDeleteExpect500_ApiException() throws Exception {
+		Long disputeId = Long.valueOf(1);
+
+		Mockito.when(violationTicketApi.v1DeleteViolationTicketDelete(disputeId)).thenThrow(ApiException.class);
+
+		assertThrows(ApiException.class, () -> {
+			repository.deleteById(disputeId);
+		});
+	}
+
+	@Test
 	public void testDeleteExpect500_noErrorMessage() throws ApiException {
 		Long disputeId = Long.valueOf(1);
 		ResponseResult response = new ResponseResult();
 		response.setStatus("0"); // 0 status (meaning failure) and no message
 
 		Mockito.when(violationTicketApi.v1DeleteViolationTicketDelete(disputeId)).thenReturn(response);
+
+		assertThrows(InternalServerErrorException.class, () -> {
+			repository.deleteById(disputeId);
+		});
+	}
+
+	@Test
+	public void testDeleteExpect500_nullReponse() throws ApiException {
+		Long disputeId = Long.valueOf(1);
+
+		Mockito.when(violationTicketApi.v1DeleteViolationTicketDelete(disputeId)).thenReturn(null);
 
 		assertThrows(InternalServerErrorException.class, () -> {
 			repository.deleteById(disputeId);
@@ -97,13 +187,74 @@ class DisputeServiceImplTest extends BaseTestSuite {
 	}
 
 	@Test
-	public void testDeleteExpect500_nullReponse() throws ApiException {
+	public void testSetStatusExpect200() throws Exception {
 		Long disputeId = Long.valueOf(1);
+		DisputeStatus disputeStatus = DisputeStatus.NEW;
+		String rejectedReason = "just because";
+		ResponseResult response = new ResponseResult();
+		response.setStatus("1");
 
-		Mockito.when(violationTicketApi.v1DeleteViolationTicketDelete(disputeId)).thenReturn(null);
+		Mockito.when(violationTicketApi.v1ViolationTicketStatusPost(disputeId, disputeStatus.toShortName(), rejectedReason)).thenReturn(response);
+
+		assertDoesNotThrow(() -> {
+			repository.setStatus(disputeId, disputeStatus, rejectedReason);
+		});
+	}
+
+	@Test
+	public void testSetStatusExpect500_ApiException() throws Exception {
+		Long disputeId = Long.valueOf(1);
+		DisputeStatus disputeStatus = DisputeStatus.NEW;
+		String rejectedReason = "just because";
+
+		Mockito.when(violationTicketApi.v1ViolationTicketStatusPost(disputeId, disputeStatus.toShortName(), rejectedReason)).thenThrow(ApiException.class);
+
+		assertThrows(ApiException.class, () -> {
+			repository.setStatus(disputeId, disputeStatus, rejectedReason);
+		});
+	}
+
+	@Test
+	public void testSetStatusExpect500_noErrorMsg() throws Exception {
+		Long disputeId = Long.valueOf(1);
+		DisputeStatus disputeStatus = DisputeStatus.NEW;
+		String rejectedReason = "just because";
+		ResponseResult response = new ResponseResult();
+		response.setStatus("0"); // 0 status (meaning failure) and no message
+
+		Mockito.when(violationTicketApi.v1ViolationTicketStatusPost(disputeId, disputeStatus.toShortName(), rejectedReason)).thenReturn(response);
 
 		assertThrows(InternalServerErrorException.class, () -> {
-			repository.deleteById(disputeId);
+			repository.setStatus(disputeId, disputeStatus, rejectedReason);
+		});
+	}
+
+	@Test
+	public void testSetStatusExpect500_nullReponse() throws Exception {
+		Long disputeId = Long.valueOf(1);
+		DisputeStatus disputeStatus = DisputeStatus.NEW;
+		String rejectedReason = "just because";
+
+		Mockito.when(violationTicketApi.v1ViolationTicketStatusPost(disputeId, disputeStatus.toShortName(), rejectedReason)).thenReturn(null);
+
+		assertThrows(InternalServerErrorException.class, () -> {
+			repository.setStatus(disputeId, disputeStatus, rejectedReason);
+		});
+	}
+
+	@Test
+	public void testSetStatusExpect500_withErrorMsg() throws Exception {
+		Long disputeId = Long.valueOf(1);
+		DisputeStatus disputeStatus = DisputeStatus.NEW;
+		String rejectedReason = "just because";
+		ResponseResult response = new ResponseResult();
+		response.setStatus("0"); // 0 status (meaning failure)
+		response.setException("some failure cause");
+
+		Mockito.when(violationTicketApi.v1ViolationTicketStatusPost(disputeId, disputeStatus.toShortName(), rejectedReason)).thenReturn(response);
+
+		assertThrows(InternalServerErrorException.class, () -> {
+			repository.setStatus(disputeId, disputeStatus, rejectedReason);
 		});
 	}
 
@@ -117,6 +268,32 @@ class DisputeServiceImplTest extends BaseTestSuite {
 		Mockito.when(violationTicketApi.v1UnassignViolationTicketPost(assignedBeforeTs)).thenReturn(response);
 
 		assertDoesNotThrow(() -> {
+			repository.unassignDisputes(now);
+		});
+	}
+
+	@Test
+	public void testUnassignExpect500_ApiException() throws Exception {
+		Date now = new Date();
+		String assignedBeforeTs = dateToString(now);
+
+		Mockito.when(violationTicketApi.v1UnassignViolationTicketPost(assignedBeforeTs)).thenThrow(ApiException.class);
+
+		assertThrows(ApiException.class, () -> {
+			repository.unassignDisputes(now);
+		});
+	}
+
+	@Test
+	public void testUnassignExpect500_noErrorMsg() throws Exception {
+		Date now = new Date();
+		String assignedBeforeTs = dateToString(now);
+		ResponseResult response = new ResponseResult();
+		response.setStatus("0"); // 0 status (meaning failure) and no message
+
+		Mockito.when(violationTicketApi.v1UnassignViolationTicketPost(assignedBeforeTs)).thenReturn(response);
+
+		assertThrows(InternalServerErrorException.class, () -> {
 			repository.unassignDisputes(now);
 		});
 	}
@@ -148,34 +325,8 @@ class DisputeServiceImplTest extends BaseTestSuite {
 		});
 	}
 
-	@Test
-	public void testUnassignExpect500_noErrorMsg() throws Exception {
-		Date now = new Date();
-		String assignedBeforeTs = dateToString(now);
-		ResponseResult response = new ResponseResult();
-		response.setStatus("0"); // 0 status (meaning failure) and no message
-
-		Mockito.when(violationTicketApi.v1UnassignViolationTicketPost(assignedBeforeTs)).thenReturn(response);
-
-		assertThrows(InternalServerErrorException.class, () -> {
-			repository.unassignDisputes(now);
-		});
-	}
-
-	@Test
-	public void testUnassignExpect500_ApiException() throws Exception {
-		Date now = new Date();
-		String assignedBeforeTs = dateToString(now);
-
-		Mockito.when(violationTicketApi.v1UnassignViolationTicketPost(assignedBeforeTs)).thenThrow(ApiException.class);
-
-		assertThrows(ApiException.class, () -> {
-			repository.unassignDisputes(now);
-		});
-	}
-
 	private String dateToString(Date date) {
-		SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+		SimpleDateFormat dateFormat = new SimpleDateFormat(DisputeRepositoryImpl.DATE_TIME_FORMAT);
 		return dateFormat.format(date);
 	}
 


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

TCVP-1739
- exposed ORDS endpoints assignViolationTicket and violationTicketStatus in OpenAPI spec
- Implemented DisputeRepository.setStatus() for ORDS
- Implemented DisputeRepository.assignDispute() for ORDS (I changed my mind with this. By calling this, only the 2 fields are updated, not everything else)
- enhanced DisputeStatus enum so it's compatible with ORDS (in ORDS, the enum values are 4 characters max)
- updated DisputeMapper to properly parse ORDS dateTime objects and the DisputeStatus enum
- added a DisputeRepository.flushAndClear() that can be called for H2 (so the objects get properly flushed and reloaded) and ignored for ORDS
- moved assignDispute and setStatus to repository so the implementation can get overridden by ORDS
- added a bunch of junit tests

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

new tests
mvn verify with code coverage

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
