### PR TITLE
TCVP-1737 integrate update dispute ords

### DIFF
--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/repository/DisputeRepository.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/repository/DisputeRepository.java
@@ -12,26 +12,26 @@ import ca.bc.gov.open.jag.tco.oracledataapi.model.DisputeStatus;
 public interface DisputeRepository {
 
 	/** Fetch all records older than the given date. */
-    public List<Dispute> findByCreatedTsBefore(Date olderThan);
+	public List<Dispute> findByCreatedTsBefore(Date olderThan);
 
-    /** Fetch all records which do not have the specified status. */
-    public List<Dispute> findByStatusNot(DisputeStatus excludeStatus);
+	/** Fetch all records which do not have the specified status. */
+	public List<Dispute> findByStatusNot(DisputeStatus excludeStatus);
 
-    /** Fetch all records which do not have the specified status and older than the given date. */
-    public List<Dispute> findByStatusNotAndCreatedTsBefore(DisputeStatus excludeStatus, Date olderThan);
+	/** Fetch all records which do not have the specified status and older than the given date. */
+	public List<Dispute> findByStatusNotAndCreatedTsBefore(DisputeStatus excludeStatus, Date olderThan);
 
-    /** Fetch all records that matches the emailVerificationToken. */
+	/** Fetch all records that matches the emailVerificationToken. */
 	@Deprecated
-    public List<Dispute> findByEmailVerificationToken(String emailVerificationToken);
+	public List<Dispute> findByEmailVerificationToken(String emailVerificationToken);
 
-    /** Fetch all records that matches the noticeOfDisputeId. */
+	/** Fetch all records that matches the noticeOfDisputeId. */
 	public List<Dispute> findByNoticeOfDisputeId(String noticeOfDisputeId);
 
 	/** Fetch all records that match by Dispute.ticketNumber and the time portion of the Dispute.issuedTs. */
 	public List<DisputeResult> findByTicketNumberAndTime(String ticketNumber, Date issuedTime);
 
 	/** Deletes all entities managed by the repository. */
-    public void deleteAll();
+	public void deleteAll();
 
 	/**
 	 * Deletes the entity with the given id.
@@ -101,5 +101,13 @@ public interface DisputeRepository {
 	 * Flushes all pending changes to the database and clears the session, if the underlying persistence layer needs it.
 	 */
 	void flushAndClear();
+
+	/**
+	 * Updates the given dispute entity.
+	 *
+	 * @param dispute entity to be updated. Must not be {@literal null}.
+	 * @return the updated entity
+	 */
+	public Dispute update(Dispute dispute);
 
 }

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/repository/impl/h2/DisputeRepositoryCustom.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/repository/impl/h2/DisputeRepositoryCustom.java
@@ -1,5 +1,7 @@
 package ca.bc.gov.open.jag.tco.oracledataapi.repository.impl.h2;
 
+import ca.bc.gov.open.jag.tco.oracledataapi.model.Dispute;
+
 public interface DisputeRepositoryCustom {
 
 	/**
@@ -7,4 +9,11 @@ public interface DisputeRepositoryCustom {
 	 */
 	void flushAndClear();
 
+	/**
+	 * Updates the given dispute entity in the database.
+	 *
+	 * @param dispute entity to be updated. Must not be {@literal null}.
+	 * @return the updated entity
+	 */
+	Dispute update(Dispute dispute);
 }

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/repository/impl/h2/DisputeRepositoryCustomImpl.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/repository/impl/h2/DisputeRepositoryCustomImpl.java
@@ -27,17 +27,24 @@ public class DisputeRepositoryCustomImpl implements DisputeRepositoryCustom {
 	@Override
 	public Dispute update(Dispute dispute) {
 		Session session = entityManager.unwrap(Session.class);
-		List<ViolationTicketCount> mergedTicketCounts = dispute.getViolationTicket().getViolationTicketCounts();
-		for (ViolationTicketCount violationTicketCount : mergedTicketCounts) {
-			ViolationTicketCount mergedCount = (ViolationTicketCount) session.merge(violationTicketCount);
-			mergedCount.setViolationTicket(dispute.getViolationTicket());
+		ViolationTicket mergedTicket = null;
+
+		if (dispute.getViolationTicket() != null && dispute.getViolationTicket().getViolationTicketCounts() != null) {
+			List<ViolationTicketCount> mergedTicketCounts = dispute.getViolationTicket().getViolationTicketCounts();
+			for (ViolationTicketCount violationTicketCount : mergedTicketCounts) {
+				ViolationTicketCount mergedCount = (ViolationTicketCount) session.merge(violationTicketCount);
+				mergedCount.setViolationTicket(dispute.getViolationTicket());
+			}
+			mergedTicket = (ViolationTicket) session.merge(dispute.getViolationTicket());
+		} else if (dispute.getViolationTicket() != null) {
+			mergedTicket = (ViolationTicket) session.merge(dispute.getViolationTicket());
 		}
-		ViolationTicket mergedTicket = (ViolationTicket) session.merge(dispute.getViolationTicket());
+
 		dispute.setViolationTicket(mergedTicket);
 		Dispute managedDispute = (Dispute) session.merge(dispute);
 		session.saveOrUpdate(managedDispute);
 		entityManager.flush();
-		// We need to refresh the state of the instance from the database in order to return the fully updated object after persistance
+		// We need to refresh the state of the instance from the database in order to return the fully updated object after persistence
 		entityManager.refresh(dispute);
 		return dispute;
 	}

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/repository/impl/ords/DisputeRepositoryImpl.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/repository/impl/ords/DisputeRepositoryImpl.java
@@ -205,6 +205,27 @@ public class DisputeRepositoryImpl implements DisputeRepository {
 	}
 
 	@Override
+	public Dispute update(Dispute dispute) {
+		if (dispute == null) {
+			throw new IllegalArgumentException("Dispute body is null.");
+		}
+
+		ViolationTicket violationTicket = ViolationTicketMapper.INSTANCE.convertDisputeToViolationTicketDto(dispute);
+		try {
+			ResponseResult result = assertNoExceptions(() -> violationTicketApi.v1UpdateViolationTicketPut(violationTicket));
+			if (result.getDisputeId() != null) {
+				logger.debug("Successfully updated the dispute through ORDS with dispute id {}", result.getDisputeId());
+				return findById(Long.valueOf(result.getDisputeId()).longValue()).orElse(null);
+			}
+		} catch (ApiException e) {
+			logger.error("ERROR updating Dispute through ORDS with dispute data: {}", violationTicket.toString(), e);
+			throw new InternalServerErrorException(e);
+		}
+
+		return null;
+	}
+
+	@Override
 	public void flushAndClear() {
 		// no-op. Not needed for ORDS.
 	}

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/service/DisputeService.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/service/DisputeService.java
@@ -23,6 +23,7 @@ import ca.bc.gov.open.jag.tco.oracledataapi.model.Dispute;
 import ca.bc.gov.open.jag.tco.oracledataapi.model.DisputeCount;
 import ca.bc.gov.open.jag.tco.oracledataapi.model.DisputeResult;
 import ca.bc.gov.open.jag.tco.oracledataapi.model.DisputeStatus;
+import ca.bc.gov.open.jag.tco.oracledataapi.model.ViolationTicket;
 import ca.bc.gov.open.jag.tco.oracledataapi.model.ViolationTicketCount;
 import ca.bc.gov.open.jag.tco.oracledataapi.repository.DisputeRepository;
 
@@ -35,7 +36,7 @@ public class DisputeService {
 	DisputeRepository disputeRepository;
 
 	@PersistenceContext
-    private EntityManager entityManager;
+	private EntityManager entityManager;
 
 	/**
 	 * Retrieves all {@link Dispute} records, delegating to CrudRepository
@@ -95,18 +96,43 @@ public class DisputeService {
 	@Transactional
 	public Dispute update(Long id, Dispute dispute) {
 		Dispute disputeToUpdate = disputeRepository.findById(id).orElseThrow();
+		List<DisputeCount> disputeCountsToUpdate = disputeToUpdate.getDisputeCounts();
+		ViolationTicket violationTicketToUpdate = disputeToUpdate.getViolationTicket();
+		List<ViolationTicketCount> violationTicketCountsToUpdate = disputeToUpdate.getViolationTicket().getViolationTicketCounts();
 
-		BeanUtils.copyProperties(dispute, disputeToUpdate, "createdBy", "createdTs", "disputeId", "disputeCounts");
-		// Remove all existing dispute counts that are associated to this dispute
-		if (disputeToUpdate.getDisputeCounts() != null) {
-			disputeToUpdate.getDisputeCounts().clear();
+		BeanUtils.copyProperties(dispute, disputeToUpdate, "createdBy", "createdTs", "disputeId", "disputeCounts", "violationTicket");
+		// Copy all new dispute counts data to be saved from the request to disputeCountsToUpdate ignoring the disputeCountId, creation audit fields
+		if (dispute.getDisputeCounts() != null && disputeCountsToUpdate != null) {
+			if (dispute.getDisputeCounts().size() == disputeCountsToUpdate.size()) {
+				for (int i = 0; i < dispute.getDisputeCounts().size(); i++) {
+					BeanUtils.copyProperties(dispute.getDisputeCounts().get(i), disputeCountsToUpdate.get(i), "createdBy", "createdTs", "disputeCountId");
+				}
+			}
+			// TODO - determine what to do if the disputeCount list sizes don't match
 		}
-		// Add updated ticket counts
-		disputeToUpdate.addDisputeCounts(dispute.getDisputeCounts());
 
-		Dispute updatedDispute = disputeRepository.saveAndFlush(disputeToUpdate);
-		// We need to refresh the state of the instance from the database in order to return the fully updated object after persistance
-		entityManager.refresh(updatedDispute);
+		if (dispute.getViolationTicket() != null) {
+			BeanUtils.copyProperties(dispute.getViolationTicket(), violationTicketToUpdate, "createdBy", "createdTs", "violationTicketId", "violationTicketCounts");
+
+			if (dispute.getViolationTicket().getViolationTicketCounts() != null && violationTicketCountsToUpdate != null) {
+				int violationTicketCountSize = dispute.getViolationTicket().getViolationTicketCounts().size();
+				if (violationTicketCountSize == violationTicketCountsToUpdate.size()) {
+					for (int i = 0; i < violationTicketCountSize; i++) {
+						BeanUtils.copyProperties(dispute.getViolationTicket().getViolationTicketCounts().get(i), violationTicketCountsToUpdate.get(i), "createdBy", "createdTs", "violationTicketCountId");
+					}
+				}
+				// TODO - determine what to do if the violationTicketCount list sizes don't match
+			}
+		}
+
+		// Add updated ticket counts
+		disputeToUpdate.addDisputeCounts(disputeCountsToUpdate);
+		// Add updated violation ticket counts to parent violation ticket
+		violationTicketToUpdate.setViolationTicketCounts(violationTicketCountsToUpdate);
+		// Add updated violation ticket
+		disputeToUpdate.setViolationTicket(violationTicketToUpdate);
+
+		Dispute updatedDispute = disputeRepository.update(disputeToUpdate);
 
 		return updatedDispute;
 	}

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/service/DisputeService.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/service/DisputeService.java
@@ -96,9 +96,18 @@ public class DisputeService {
 	@Transactional
 	public Dispute update(Long id, Dispute dispute) {
 		Dispute disputeToUpdate = disputeRepository.findById(id).orElseThrow();
-		List<DisputeCount> disputeCountsToUpdate = disputeToUpdate.getDisputeCounts();
-		ViolationTicket violationTicketToUpdate = disputeToUpdate.getViolationTicket();
-		List<ViolationTicketCount> violationTicketCountsToUpdate = disputeToUpdate.getViolationTicket().getViolationTicketCounts();
+		List<DisputeCount> disputeCountsToUpdate = null;
+		if (disputeToUpdate.getDisputeCounts() != null) {
+			disputeCountsToUpdate = disputeToUpdate.getDisputeCounts();
+		}
+		ViolationTicket violationTicketToUpdate = null;
+		List<ViolationTicketCount> violationTicketCountsToUpdate = null;
+		if (disputeToUpdate.getViolationTicket() != null) {
+			violationTicketToUpdate = disputeToUpdate.getViolationTicket();
+			if (disputeToUpdate.getViolationTicket().getViolationTicketCounts() != null) {
+				violationTicketCountsToUpdate = disputeToUpdate.getViolationTicket().getViolationTicketCounts();
+			}
+		}
 
 		BeanUtils.copyProperties(dispute, disputeToUpdate, "createdBy", "createdTs", "disputeId", "disputeCounts", "violationTicket");
 		// Copy all new dispute counts data to be saved from the request to disputeCountsToUpdate ignoring the disputeCountId, creation audit fields
@@ -127,8 +136,11 @@ public class DisputeService {
 
 		// Add updated ticket counts
 		disputeToUpdate.addDisputeCounts(disputeCountsToUpdate);
-		// Add updated violation ticket counts to parent violation ticket
-		violationTicketToUpdate.setViolationTicketCounts(violationTicketCountsToUpdate);
+
+		if (violationTicketToUpdate != null && violationTicketCountsToUpdate != null) {
+			// Add updated violation ticket counts to parent violation ticket
+			violationTicketToUpdate.setViolationTicketCounts(violationTicketCountsToUpdate);
+		}
 		// Add updated violation ticket
 		disputeToUpdate.setViolationTicket(violationTicketToUpdate);
 

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/service/DisputeService.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/service/DisputeService.java
@@ -116,8 +116,11 @@ public class DisputeService {
 				for (int i = 0; i < dispute.getDisputeCounts().size(); i++) {
 					BeanUtils.copyProperties(dispute.getDisputeCounts().get(i), disputeCountsToUpdate.get(i), "createdBy", "createdTs", "disputeCountId");
 				}
+				logger.warn("Unexpected number of disputeCounts: " + dispute.getDisputeCounts().size() +
+						" received from the request whereas updatable number of disputeCounts from database is: " + disputeCountsToUpdate.size() +
+						". This should not happen with current dispute update use case unless something has been changed");
+				// TODO - determine what to do if the disputeCount list sizes don't match
 			}
-			// TODO - determine what to do if the disputeCount list sizes don't match
 		}
 
 		if (dispute.getViolationTicket() != null) {
@@ -130,6 +133,9 @@ public class DisputeService {
 						BeanUtils.copyProperties(dispute.getViolationTicket().getViolationTicketCounts().get(i), violationTicketCountsToUpdate.get(i), "createdBy", "createdTs", "violationTicketCountId");
 					}
 				}
+				logger.warn("Unexpected number of violationTicketCounts: " + violationTicketCountSize +
+						" received from the request whereas updatable number of violationTicketCounts from database is: " + violationTicketCountsToUpdate.size() +
+						". This should not happen with current dispute update use case unless something has been changed");
 				// TODO - determine what to do if the violationTicketCount list sizes don't match
 			}
 		}

--- a/src/backend/oracle-data-api/src/main/resources/occm-openapi-spec.yaml
+++ b/src/backend/oracle-data-api/src/main/resources/occm-openapi-spec.yaml
@@ -284,6 +284,24 @@ paths:
                 $ref: '#/components/schemas/ResponseResult'
       tags:
         - Violation Ticket
+  /v1/updateViolationTicket:
+    put:
+      requestBody:
+        description: body
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ViolationTicket'
+        required: true
+      responses:
+        '200':
+          description: Ok
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResponseResult'
+      tags:
+        - Violation Ticket
 components:
   schemas:
     AgenciesListResult:


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- Updated OpenApi spec file to integrate dispute update endpoint from ORDS.
- Added new DisputeRepository custom update method to be able to update a given dispute with its id both through ORDS and in H2 database.
- Added JUnit tests for update dispute ORDS request.
 
## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Ran Oracle API locally and sent proper request to the update dispute endpoint and confirmed the records in both ORDS and H2 updated successfully.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
