### PR TITLE
TCVP-1848 integrate get dispute by noticeOfDisputeId ORDS

### DIFF
--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/repository/DisputeRepository.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/repository/DisputeRepository.java
@@ -18,7 +18,7 @@ public interface DisputeRepository {
 	public List<Dispute> findByStatusNot(DisputeStatus excludeStatus);
 
 	/** Fetch all records which do not have the specified status and older than the given date. */
-	public List<Dispute> findByStatusNotAndCreatedTsBefore(DisputeStatus excludeStatus, Date olderThan);
+	public List<Dispute> findByStatusNotAndCreatedTsBeforeAndNoticeOfDisputeId(DisputeStatus excludeStatus, Date olderThan, String noticeOfDisputeId);
 
 	/** Fetch all records that matches the emailVerificationToken. */
 	@Deprecated

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/repository/impl/ords/DisputeRepositoryImpl.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/repository/impl/ords/DisputeRepositoryImpl.java
@@ -50,16 +50,16 @@ public class DisputeRepositoryImpl implements DisputeRepository {
 
 	@Override
 	public List<Dispute> findByCreatedTsBefore(Date olderThan) {
-		return findByStatusNotAndCreatedTsBefore(null, olderThan);
+		return findByStatusNotAndCreatedTsBeforeAndNoticeOfDisputeId(null, olderThan, null);
 	}
 
 	@Override
 	public List<Dispute> findByStatusNot(DisputeStatus excludeStatus) {
-		return findByStatusNotAndCreatedTsBefore(excludeStatus, null);
+		return findByStatusNotAndCreatedTsBeforeAndNoticeOfDisputeId(excludeStatus, null, null);
 	}
 
 	@Override
-	public List<Dispute> findByStatusNotAndCreatedTsBefore(DisputeStatus excludeStatus, Date olderThan) {
+	public List<Dispute> findByStatusNotAndCreatedTsBeforeAndNoticeOfDisputeId(DisputeStatus excludeStatus, Date olderThan, String noticeOfDisputeId) {
 		List<Dispute> disputesToReturn = new ArrayList<Dispute>();
 		String olderThanDate = null ;
 		String statusShortName = excludeStatus != null ? excludeStatus.toShortName() : null;
@@ -70,7 +70,7 @@ public class DisputeRepositoryImpl implements DisputeRepository {
 		}
 
 		try {
-			ViolationTicketListResponse response = violationTicketApi.v1ViolationTicketListGet(olderThanDate, statusShortName, null, null);
+			ViolationTicketListResponse response = violationTicketApi.v1ViolationTicketListGet(olderThanDate, statusShortName, null, noticeOfDisputeId);
 			if (response != null && !response.getViolationTickets().isEmpty()) {
 				logger.debug("Successfully returned disputes from ORDS that are older than " + olderThan + " and excluding the status: " + excludeStatus);
 
@@ -94,7 +94,7 @@ public class DisputeRepositoryImpl implements DisputeRepository {
 
 	@Override
 	public List<Dispute> findByNoticeOfDisputeId(String noticeOfDisputeId) {
-		throw new NotYetImplementedException();
+		return findByStatusNotAndCreatedTsBeforeAndNoticeOfDisputeId(null, null, noticeOfDisputeId);
 	}
 
 	@Override
@@ -136,7 +136,7 @@ public class DisputeRepositoryImpl implements DisputeRepository {
 
 	@Override
 	public List<Dispute> findAll() {
-		return findByStatusNotAndCreatedTsBefore(null, null);
+		return findByStatusNotAndCreatedTsBeforeAndNoticeOfDisputeId(null, null, null);
 	}
 
 	@Override

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/service/DisputeService.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/service/DisputeService.java
@@ -52,7 +52,7 @@ public class DisputeService {
 		} else if (excludeStatus == null) {
 			return disputeRepository.findByCreatedTsBefore(olderThan);
 		} else {
-			return disputeRepository.findByStatusNotAndCreatedTsBefore(excludeStatus, olderThan);
+			return disputeRepository.findByStatusNotAndCreatedTsBeforeAndNoticeOfDisputeId(excludeStatus, olderThan, null);
 		}
 	}
 
@@ -293,6 +293,9 @@ public class DisputeService {
 			String msg = String.format("Dispute could not be found with noticeOfDisputeId: {1}", noticeOfDisputeId);
 			logger.error(msg);
 			return null;
+		}
+		if (findByNoticeOfDisputeId.size() > 1) {
+			logger.warn("Unexpected number of disputes returned. More than 1 dispute have been returned based on the provided noticeOfDisputeId: " + noticeOfDisputeId);
 		}
 		return findByNoticeOfDisputeId.get(0);
 	}

--- a/src/backend/oracle-data-api/src/main/resources/occm-openapi-spec.yaml
+++ b/src/backend/oracle-data-api/src/main/resources/occm-openapi-spec.yaml
@@ -157,7 +157,7 @@ paths:
           description: ''
           schema:
             type: string
-        - name: noticeOfDisputeId
+        - name: emailVerificationGuid
           in: query
           description: ''
           schema:

--- a/src/backend/oracle-data-api/src/test/java/ca/bc/gov/open/jag/tco/oracledataapi/service/impl/ords/DisputeServiceImplTest.java
+++ b/src/backend/oracle-data-api/src/test/java/ca/bc/gov/open/jag/tco/oracledataapi/service/impl/ords/DisputeServiceImplTest.java
@@ -336,14 +336,15 @@ class DisputeServiceImplTest extends BaseTestSuite {
 		Date now = new Date();
 		String olderThanDate = dateToString(now, DisputeRepositoryImpl.DATE_FORMAT);
 		DisputeStatus excludedStatus = DisputeStatus.CANCELLED;
+		String noticeOfDisputeId = java.util.UUID.randomUUID().toString();
 		ViolationTicketListResponse response = new ViolationTicketListResponse();
 		List<ViolationTicket> violationTickets = new ArrayList<ViolationTicket>();
 		response.setViolationTickets(violationTickets);
 
-		Mockito.when(violationTicketApi.v1ViolationTicketListGet(olderThanDate, excludedStatus.toShortName(), null, null)).thenReturn(response);
+		Mockito.when(violationTicketApi.v1ViolationTicketListGet(olderThanDate, excludedStatus.toShortName(), null, noticeOfDisputeId)).thenReturn(response);
 
 		assertDoesNotThrow(() -> {
-			repository.findByStatusNotAndCreatedTsBefore(excludedStatus, now);
+			repository.findByStatusNotAndCreatedTsBeforeAndNoticeOfDisputeId(excludedStatus, now, noticeOfDisputeId);
 		});
 	}
 
@@ -352,14 +353,15 @@ class DisputeServiceImplTest extends BaseTestSuite {
 		Date now = new Date();
 		String olderThanDate = dateToString(now, DisputeRepositoryImpl.DATE_FORMAT);
 		DisputeStatus excludedStatus = DisputeStatus.CANCELLED;
+		String noticeOfDisputeId = java.util.UUID.randomUUID().toString();
 		ViolationTicketListResponse response = new ViolationTicketListResponse();
 		List<ViolationTicket> violationTickets = new ArrayList<ViolationTicket>();
 		response.setViolationTickets(violationTickets);
 
-		Mockito.when(violationTicketApi.v1ViolationTicketListGet(olderThanDate, excludedStatus.toShortName(), null, null)).thenThrow(ApiException.class);
+		Mockito.when(violationTicketApi.v1ViolationTicketListGet(olderThanDate, excludedStatus.toShortName(), null, noticeOfDisputeId)).thenThrow(ApiException.class);
 
 		assertThrows(InternalServerErrorException.class, () -> {
-			repository.findByStatusNotAndCreatedTsBefore(excludedStatus, now);
+			repository.findByStatusNotAndCreatedTsBeforeAndNoticeOfDisputeId(excludedStatus, now, noticeOfDisputeId);
 		});
 	}
 


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

-  [TCVP-1848](https://justice.gov.bc.ca/jira/browse/TCVP-1848)
- Added functionality to return dispute(s) from H2 database and through ords based on the optional noticeOfDisputeId provided as a parameter.
- Updated JUnit tests.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
