### PR TITLE
use dynamic jj list from keycloak

### DIFF
--- a/src/frontend/staff-portal/src/app/components/jj-dispute-info/jj-dispute/jj-dispute.component.html
+++ b/src/frontend/staff-portal/src/app/components/jj-dispute-info/jj-dispute/jj-dispute.component.html
@@ -204,7 +204,7 @@
           <mat-form-field class="select-box-only">
             <mat-select [(ngModel)]="selectedJJ" placeholder="choose a JJ">
               <mat-option [value]=""></mat-option>
-              <mat-option *ngFor="let jj of jjList" [value]="jj.idir"><i>JJ {{ jj.name }}</i></mat-option>
+              <mat-option *ngFor="let jj of jjList" [value]="authService.getIDIR(jj)"><i>JJ {{ authService.getFullName(jj) }}</i></mat-option>
             </mat-select>
           </mat-form-field>
         </div>

--- a/src/frontend/staff-portal/src/app/components/jj-dispute-info/jj-dispute/jj-dispute.component.ts
+++ b/src/frontend/staff-portal/src/app/components/jj-dispute-info/jj-dispute/jj-dispute.component.ts
@@ -4,13 +4,15 @@ import { ActivatedRoute } from '@angular/router';
 import { LoggerService } from '@core/services/logger.service';
 import { UtilsService } from '@core/services/utils.service';
 import { MockConfigService } from 'tests/mocks/mock-config.service';
-import { JJDisputeService, JJTeamMember } from '../../../services/jj-dispute.service';
+import { JJDisputeService } from '../../../services/jj-dispute.service';
 import { JJDispute } from '../../../api/model/jJDispute.model';
 import { Subscription } from 'rxjs';
 import { JJDisputedCount, JJDisputeStatus, JJDisputedCountRequestReduction, JJDisputedCountRequestTimeToPay } from 'app/api/model/models';
 import { DialogOptions } from '@shared/dialogs/dialog-options.model';
 import { ConfirmDialogComponent } from '@shared/dialogs/confirm-dialog/confirm-dialog.component';
 import { MatDialog } from '@angular/material/dialog';
+import { UserRepresentation } from 'app/api/model/models';
+import { AuthService } from 'app/services/auth.service';
 
 @Component({
   selector: 'app-jj-dispute',
@@ -32,7 +34,7 @@ export class JJDisputeComponent implements OnInit {
   public timeToPayCountsHeading: string = "";
   public fineReductionCountsHeading: string = "";
   public remarks: string = "";
-  public jjList: JJTeamMember[];
+  public jjList: UserRepresentation[];
   public selectedJJ: string;
   public RequestTimeToPay = JJDisputedCountRequestTimeToPay;
   public RequestReduction = JJDisputedCountRequestReduction;
@@ -45,6 +47,7 @@ export class JJDisputeComponent implements OnInit {
     private jjDisputeService: JJDisputeService,
     private dialog: MatDialog,
     private logger: LoggerService,
+    public authService: AuthService
   ) {
     this.isMobile = this.utilsService.isMobile();
     this.jjList = this.jjDisputeService.jjList;

--- a/src/frontend/staff-portal/src/app/components/jj-workbench/jj-dispute-assignments/jj-dispute-assignments.component.html
+++ b/src/frontend/staff-portal/src/app/components/jj-workbench/jj-dispute-assignments/jj-dispute-assignments.component.html
@@ -15,7 +15,7 @@
   <div style="display: flex; flex-direction: row; flex-direction: flex-start;">
     <mat-select [(ngModel)]="bulkjjAssignedTo" style="width:250px; background-color: #f2f2f2;">
       <mat-option value="unassigned"><i>choose a person</i></mat-option>
-      <mat-option *ngFor="let jj of jjDisputeService.jjList" [value]="jj.idir"><i>JJ {{ jj.name }}</i></mat-option>
+      <mat-option *ngFor="let jj of jjDisputeService.jjList" [value]="authService.getIDIR(jj)"><i>JJ {{ authService.getFullName(jj) }}</i></mat-option>
     </mat-select>
     &nbsp;<button mat-raised-button [disabled]="getBulkButtonDisabled()" (click)="onBulkAssign()" style="width: 100px"><b>Submit</b></button>
   </div>
@@ -46,7 +46,7 @@
       <td mat-cell *matCellDef="let element" style="width:200px !important">
         <mat-select [(ngModel)]="element.jjAssignedTo" (selectionChange)="onAssign(element)" *ngIf="bulkjjAssignedTo==='' || bulkjjAssignedTo === 'unassigned'">
           <mat-option value="unassigned">unassigned</mat-option>
-          <mat-option *ngFor="let jj of jjDisputeService.jjList" [value]="jj.idir">JJ {{ jj.name }}</mat-option>
+          <mat-option *ngFor="let jj of jjDisputeService.jjList" [value]="authService.getIDIR(jj)">JJ {{ authService.getFullName(jj) }}</mat-option>
         </mat-select>
         <div *ngIf="bulkjjAssignedTo !== '' && bulkjjAssignedTo !== 'unassigned'">
           <span *ngIf="element.jjAssignedTo !== null && element.jjAssignedTo !== 'unassigned'">JJ {{ element.jjAssignedToName }}</span>
@@ -151,7 +151,7 @@
       <td mat-cell *matCellDef="let element" style="width:200px !important">
         <mat-select [(ngModel)]="element.jjAssignedTo" (selectionChange)="onAssign(element)" *ngIf="bulkjjAssignedTo==='' || bulkjjAssignedTo=== 'unassigned'">
           <mat-option value="unassigned">unassigned</mat-option>
-          <mat-option *ngFor="let jj of jjDisputeService.jjList" [value]="jj.idir">JJ {{ jj.name }}</mat-option>
+          <mat-option *ngFor="let jj of jjDisputeService.jjList" [value]="authService.getIDIR(jj)">JJ {{ authService.getFullName(jj) }}</mat-option>
         </mat-select>
         <div *ngIf="bulkjjAssignedTo !== '' && bulkjjAssignedTo !== 'unassigned'">
           <span *ngIf="element.jjAssignedTo !== null && element.jjAssignedTo !== 'unassigned'">JJ {{ element.jjAssignedToName }}</span>

--- a/src/frontend/staff-portal/src/app/components/jj-workbench/jj-dispute-assignments/jj-dispute-assignments.component.ts
+++ b/src/frontend/staff-portal/src/app/components/jj-workbench/jj-dispute-assignments/jj-dispute-assignments.component.ts
@@ -2,12 +2,13 @@ import { Component, OnInit, ViewChild, AfterViewInit, Output, EventEmitter, Inpu
 import { MatTableDataSource } from '@angular/material/table';
 import { MatSort, Sort } from '@angular/material/sort';
 import { CourthouseConfig } from '@config/config.model';
-import { JJDisputeService, JJTeamMember } from 'app/services/jj-dispute.service';
+import { JJDisputeService } from 'app/services/jj-dispute.service';
 import { JJDispute } from '../../../api/model/jJDispute.model';
 import { MockConfigService } from 'tests/mocks/mock-config.service';
 import { LoggerService } from '@core/services/logger.service';
 import { Subscription } from 'rxjs';
 import { MatCheckboxChange } from '@angular/material/checkbox';
+import { AuthService } from 'app/services/auth.service';
 
 @Component({
   selector: 'app-jj-dispute-assignments',
@@ -43,6 +44,7 @@ export class JJDisputeAssignmentsComponent implements OnInit, AfterViewInit {
     public jjDisputeService: JJDisputeService,
     private logger: LoggerService,
     public mockConfigService: MockConfigService,
+    public authService: AuthService
 
   ) {
 
@@ -58,7 +60,6 @@ export class JJDisputeAssignmentsComponent implements OnInit, AfterViewInit {
    }
 
   ngOnInit(): void {
-    this.jjDisputeService.jjList = this.jjDisputeService.jjList.sort((a: JJTeamMember, b: JJTeamMember) => { if (a.name < b.name) { return -1; } else { return 1 } });
     this.getAll("A");
   }
 
@@ -116,7 +117,7 @@ export class JJDisputeAssignmentsComponent implements OnInit, AfterViewInit {
       this.data = response.filter(x => this.jjDisputeService.JJDisputeStatusEditable.indexOf(x.status) >= 0);
       this.data = this.data.sort((a: JJDisputeView, b: JJDisputeView) => { if (a.submittedDate > b.submittedDate) { return -1; } else { return 1 } });
       this.data.forEach(x => {
-          x.jjAssignedToName = this.jjDisputeService.jjList.filter(y => y.idir === x.jjAssignedTo)[0]?.name;
+          x.jjAssignedToName = this.authService.getFullName(this.jjDisputeService.jjList?.filter(y => this.authService.getIDIR(y) === x.jjAssignedTo)[0]);
           x.bulkAssign = false;
         });
       this.resetAssignedUnassigned();
@@ -182,7 +183,8 @@ export class JJDisputeAssignmentsComponent implements OnInit, AfterViewInit {
         'JJDisputeAssignmentsComponent::putJJDispute response',
         response
       );
-      updateDispute.jjAssignedToName = this.jjDisputeService.jjList.filter(y => y.idir === updateDispute.jjAssignedTo)[0]?.name;
+      const jjFound = this.jjDisputeService.jjList?.filter(y => this.authService.getIDIR(y) === updateDispute.jjAssignedTo)[0];
+      updateDispute.jjAssignedToName = this.authService.getFullName(jjFound);
       this.data[index] = updateDispute;
       this.resetAssignedUnassigned();
     });

--- a/src/frontend/staff-portal/src/app/components/staff-workbench/dispute-decision-inbox/dispute-decision-inbox.component.ts
+++ b/src/frontend/staff-portal/src/app/components/staff-workbench/dispute-decision-inbox/dispute-decision-inbox.component.ts
@@ -78,8 +78,8 @@ export class DisputeDecisionInboxComponent implements OnInit, AfterViewInit {
       this.dataSource.data = this.data;
 
       this.data.forEach(x => {
-        x.jjAssignedToName = this.jjDisputeService.jjList.filter(y => y.idir === x.jjAssignedTo)[0]?.name;
-        x.vtcAssignedToName = this.jjDisputeService.jjList.filter(y => y.idir === x.vtcAssignedTo)[0]?.name;
+        x.jjAssignedToName = this.authService.getFullName(this.jjDisputeService.jjList?.filter(y => this.authService.getIDIR(y) === x.jjAssignedTo)[0]);
+        x.vtcAssignedToName = this.authService.getFullName(this.jjDisputeService.vtcList?.filter(y => this.authService.getIDIR(y) === x.vtcAssignedTo)[0]);
       });
 
       // initially sort by decision date within status

--- a/src/frontend/staff-portal/src/app/config/config.service.ts
+++ b/src/frontend/staff-portal/src/app/config/config.service.ts
@@ -22,6 +22,7 @@ export class ConfigService implements IConfigService {
     ''
   );
   private disputeError: BehaviorSubject<string> = new BehaviorSubject<string>('');
+  private keycloakError: BehaviorSubject<string> = new BehaviorSubject<string>('');
   private historyError: BehaviorSubject<string> = new BehaviorSubject<string>('');
   private disputeCreateError: BehaviorSubject<string> =
     new BehaviorSubject<string>('');
@@ -54,6 +55,10 @@ export class ConfigService implements IConfigService {
 
   public get dispute_error(): string {
     return this.disputeError.value;
+  }
+
+  public get keycloak_error(): string {
+    return this.keycloakError.value;
   }
 
   public get history_error(): string {

--- a/src/frontend/staff-portal/src/app/services/jj-dispute.service.ts
+++ b/src/frontend/staff-portal/src/app/services/jj-dispute.service.ts
@@ -4,7 +4,7 @@ import { ToastService } from '@core/services/toast.service';
 import { Observable, BehaviorSubject, of } from 'rxjs';
 import { catchError, map } from 'rxjs/operators';
 import { EventEmitter, Injectable } from '@angular/core';
-import { JJService, JJDispute, JJDisputeStatus, JJDisputeRemark } from 'app/api';
+import { JJService, JJDispute, JJDisputeStatus, JJDisputeRemark, UserRepresentation } from 'app/api';
 import { AuthService } from './auth.service';
 import { cloneDeep } from 'lodash';
 
@@ -18,20 +18,8 @@ export class JJDisputeService {
   public JJDisputeStatusEditable: JJDisputeStatus[] = [JJDisputeStatus.New, JJDisputeStatus.Review, JJDisputeStatus.InProgress];
   public JJDisputeStatusComplete: JJDisputeStatus[] = [JJDisputeStatus.Confirmed, JJDisputeStatus.RequireCourtHearing, JJDisputeStatus.RequireMoreInfo];
   public refreshDisputes: EventEmitter<any> = new EventEmitter();
-
-  // TODO dynamically get list of JJs
-  public jjList: JJTeamMember[] = [
-    { idir: "ldame@idir", name: "Lorraine Dame" },
-    { idir: "philbold@idir", name: "Phil Bolduc" },
-    { idir: "choban@idir", name: "Chris Hoban" },
-    { idir: "kneufeld@idir", name: "Kevin Neufeld" },
-    { idir: "colmohig@idir", name: "Colm O'Higgins" },
-    { idir: "bkarahan@idir", name: "Burak Karahan" },
-    { idir: "twwong@idir", name: "Tsunwai Wong" },
-    { idir: "ewong@idir", name: "Elaine Wong" },
-    { idir: "jmoffet@idir", name: "Jeffrey Moffet" },
-    { idir: "rspress@idir", name: "Roberta Press" },
-  ];
+  public jjList: Array<UserRepresentation>;
+  public vtcList: Array<UserRepresentation>;
 
   constructor(
     private toastService: ToastService,
@@ -40,6 +28,13 @@ export class JJDisputeService {
     private jjApiService: JJService,
     private authService: AuthService
   ) {
+    this.authService.getUsersInGroup("judicial-justice").subscribe(results => {
+      this.jjList = results;
+      this.jjList = this.jjList.sort((a: UserRepresentation, b: UserRepresentation) => { if (this.authService.getFullName(a) < this.authService.getFullName(b)) { return -1; } else { return 1 } });
+    });
+    this.authService.getUsersInGroup("vtc-staff").subscribe(results => {
+      this.vtcList = results;
+    });
   }
 
   /**
@@ -177,5 +172,3 @@ export class JJDisputeService {
     return futureDate;
   }
 }
-
-export interface JJTeamMember { idir: string, name: string; }


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- stop using hard coded list of JJs, needed for functional user testing

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?
- sign into staff portal using test user id that has no special keycloak privileges except belonging to group admin-judicial-justice
- confirm that user can see list of JJs in staff portal

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
