### PR TITLE
TCVP-1855 Added mapping method to parse lawyer address field

### DIFF
--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/mapper/ViolationTicketMapper.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/mapper/ViolationTicketMapper.java
@@ -2,11 +2,8 @@ package ca.bc.gov.open.jag.tco.oracledataapi.mapper;
 
 import java.util.List;
 
-import org.apache.commons.lang3.StringUtils;
-import org.mapstruct.AfterMapping;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
-import org.mapstruct.MappingTarget;
 import org.mapstruct.Named;
 import org.mapstruct.factory.Mappers;
 
@@ -20,9 +17,9 @@ import ca.bc.gov.open.jag.tco.oracledataapi.repository.impl.ords.DisputeReposito
 
 @Mapper
 public interface ViolationTicketMapper {
-
+	
 	ViolationTicketMapper INSTANCE = Mappers.getMapper(ViolationTicketMapper.class);
-
+	
 	// Map from Oracle Data API dispute model to ORDS dispute data
 	@Mapping(target = "dispute.entDtm", source = "createdTs", dateFormat = DisputeRepositoryImpl.DATE_TIME_FORMAT)
 	@Mapping(target = "dispute.entUserId", source = "createdBy")
@@ -55,7 +52,7 @@ public interface ViolationTicketMapper {
 	@Mapping(target = "dispute.filingDt", source = "filingDate")
 	@Mapping(target = "dispute.representedByLawyerYn", source = "representedByLawyer")
 	@Mapping(target = "dispute.lawFirmNm", source = "lawFirmName")
-	// After mapping method to parse address source into multiple address fields
+	// TODO - need add an after mapping method to parse address source into multiple address fields
 	@Mapping(target = "dispute.lawFirmAddrLine1Txt", ignore = true)
 	@Mapping(target = "dispute.lawFirmAddrLine2Txt", ignore = true)
 	@Mapping(target = "dispute.lawFirmAddrLine3Txt", ignore = true)
@@ -119,7 +116,7 @@ public interface ViolationTicketMapper {
 	// Map from Oracle Data API violation ticket count model to ORDS violation ticket counts data
 	@Mapping(target = "violationTicketCounts", source = "violationTicket.violationTicketCounts")
 	ViolationTicket convertDisputeToViolationTicketDto (Dispute dispute);
-
+	
 	@Mapping(target = "entUserId", source = "createdBy")
 	@Mapping(target = "entDtm", source = "createdTs")
 	@Mapping(target = "updUserId", source = "modifiedBy")
@@ -167,10 +164,10 @@ public interface ViolationTicketMapper {
 	default ca.bc.gov.open.jag.tco.oracledataapi.api.model.DisputeCount mapDisputeCount(ViolationTicketCount violationTicketCount) {
 		int countNo = violationTicketCount.getCountNo();
 		List<DisputeCount> disputeCounts = violationTicketCount.getViolationTicket().getDispute().getDisputeCounts();
-
+		
 		if ( disputeCounts == null || disputeCounts.isEmpty()) {
-			return null;
-		}
+            return null;
+        }
 
 		for (DisputeCount disputeCount : disputeCounts) {
 			if (disputeCount.getCountNo() == countNo) {
@@ -179,7 +176,7 @@ public interface ViolationTicketMapper {
 				count.setEntUserId(disputeCount.getCreatedBy());
 				count.setUpdDtm(disputeCount.getModifiedTs());
 				count.setUpdUserId(disputeCount.getModifiedBy());
-
+				
 				if (disputeCount.getPleaCode() != null) {
 					count.setPleaCd(disputeCount.getPleaCode().toString());
 				}
@@ -195,30 +192,6 @@ public interface ViolationTicketMapper {
 				return count;
 			}
 		}
-		return null;
-	}
-
-	@AfterMapping
-	default void setLawyerAddress(@MappingTarget ViolationTicket violationTicket, Dispute dispute) {
-		if (dispute != null && violationTicket != null && violationTicket.getDispute() != null && !StringUtils.isBlank(dispute.getLawyerAddress())) {
-			int addressLength = dispute.getLawyerAddress().length();
-			String lawyerAddress = dispute.getLawyerAddress();
-			String addressLine1 = "";
-			String addressLine2 = "";
-			String addressLine3 = "";
-			if (addressLength > 200) {
-				addressLine1 = lawyerAddress.substring(0, 100);
-				addressLine2 = lawyerAddress.substring(100, 200);
-				addressLine3 = lawyerAddress.substring(200, addressLength);
-			} else if (addressLength > 100) {
-				addressLine1 = lawyerAddress.substring(0, 100);
-				addressLine2 = lawyerAddress.substring(100, addressLength);
-			} else {
-				addressLine1 = lawyerAddress;
-			}
-			violationTicket.getDispute().setLawFirmAddrLine1Txt(addressLine1);
-			violationTicket.getDispute().setLawFirmAddrLine2Txt(addressLine2);
-			violationTicket.getDispute().setLawFirmAddrLine3Txt(addressLine3);
-		}
+	    return null;
 	}
 }

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/mapper/ViolationTicketMapper.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/mapper/ViolationTicketMapper.java
@@ -2,8 +2,11 @@ package ca.bc.gov.open.jag.tco.oracledataapi.mapper;
 
 import java.util.List;
 
+import org.apache.commons.lang3.StringUtils;
+import org.mapstruct.AfterMapping;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
+import org.mapstruct.MappingTarget;
 import org.mapstruct.Named;
 import org.mapstruct.factory.Mappers;
 
@@ -17,9 +20,9 @@ import ca.bc.gov.open.jag.tco.oracledataapi.repository.impl.ords.DisputeReposito
 
 @Mapper
 public interface ViolationTicketMapper {
-	
+
 	ViolationTicketMapper INSTANCE = Mappers.getMapper(ViolationTicketMapper.class);
-	
+
 	// Map from Oracle Data API dispute model to ORDS dispute data
 	@Mapping(target = "dispute.entDtm", source = "createdTs", dateFormat = DisputeRepositoryImpl.DATE_TIME_FORMAT)
 	@Mapping(target = "dispute.entUserId", source = "createdBy")
@@ -52,7 +55,7 @@ public interface ViolationTicketMapper {
 	@Mapping(target = "dispute.filingDt", source = "filingDate")
 	@Mapping(target = "dispute.representedByLawyerYn", source = "representedByLawyer")
 	@Mapping(target = "dispute.lawFirmNm", source = "lawFirmName")
-	// TODO - need add an after mapping method to parse address source into multiple address fields
+	// After mapping method to parse address source into multiple address fields
 	@Mapping(target = "dispute.lawFirmAddrLine1Txt", ignore = true)
 	@Mapping(target = "dispute.lawFirmAddrLine2Txt", ignore = true)
 	@Mapping(target = "dispute.lawFirmAddrLine3Txt", ignore = true)
@@ -116,7 +119,7 @@ public interface ViolationTicketMapper {
 	// Map from Oracle Data API violation ticket count model to ORDS violation ticket counts data
 	@Mapping(target = "violationTicketCounts", source = "violationTicket.violationTicketCounts")
 	ViolationTicket convertDisputeToViolationTicketDto (Dispute dispute);
-	
+
 	@Mapping(target = "entUserId", source = "createdBy")
 	@Mapping(target = "entDtm", source = "createdTs")
 	@Mapping(target = "updUserId", source = "modifiedBy")
@@ -164,10 +167,10 @@ public interface ViolationTicketMapper {
 	default ca.bc.gov.open.jag.tco.oracledataapi.api.model.DisputeCount mapDisputeCount(ViolationTicketCount violationTicketCount) {
 		int countNo = violationTicketCount.getCountNo();
 		List<DisputeCount> disputeCounts = violationTicketCount.getViolationTicket().getDispute().getDisputeCounts();
-		
+
 		if ( disputeCounts == null || disputeCounts.isEmpty()) {
-            return null;
-        }
+			return null;
+		}
 
 		for (DisputeCount disputeCount : disputeCounts) {
 			if (disputeCount.getCountNo() == countNo) {
@@ -176,7 +179,7 @@ public interface ViolationTicketMapper {
 				count.setEntUserId(disputeCount.getCreatedBy());
 				count.setUpdDtm(disputeCount.getModifiedTs());
 				count.setUpdUserId(disputeCount.getModifiedBy());
-				
+
 				if (disputeCount.getPleaCode() != null) {
 					count.setPleaCd(disputeCount.getPleaCode().toString());
 				}
@@ -192,6 +195,30 @@ public interface ViolationTicketMapper {
 				return count;
 			}
 		}
-	    return null;
+		return null;
+	}
+
+	@AfterMapping
+	default void setLawyerAddress(@MappingTarget ViolationTicket violationTicket, Dispute dispute) {
+		if (dispute != null && violationTicket != null && violationTicket.getDispute() != null && !StringUtils.isBlank(dispute.getLawyerAddress())) {
+			int addressLength = dispute.getLawyerAddress().length();
+			String lawyerAddress = dispute.getLawyerAddress();
+			String addressLine1 = "";
+			String addressLine2 = "";
+			String addressLine3 = "";
+			if (addressLength > 200) {
+				addressLine1 = lawyerAddress.substring(0, 100);
+				addressLine2 = lawyerAddress.substring(100, 200);
+				addressLine3 = lawyerAddress.substring(200, addressLength);
+			} else if (addressLength > 100) {
+				addressLine1 = lawyerAddress.substring(0, 100);
+				addressLine2 = lawyerAddress.substring(100, addressLength);
+			} else {
+				addressLine1 = lawyerAddress;
+			}
+			violationTicket.getDispute().setLawFirmAddrLine1Txt(addressLine1);
+			violationTicket.getDispute().setLawFirmAddrLine2Txt(addressLine2);
+			violationTicket.getDispute().setLawFirmAddrLine3Txt(addressLine3);
+		}
 	}
 }

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/model/Dispute.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/model/Dispute.java
@@ -55,21 +55,21 @@ public class Dispute extends Auditable<String> {
 	@Schema(nullable = true) // FIXME: this field should not be nullable (temp nullable for now to get things working).
 	private String noticeOfDisputeId;
 
-	/**
-	 * The violation ticket number.
-	 */
-	@Column(length = 50)
-	@Schema(nullable = false)
-	private String ticketNumber;
+	 /**
+     * The violation ticket number.
+     */
+    @Column(length = 50)
+    @Schema(nullable = false)
+    private String ticketNumber;
 
 	/**
-	 * Court location.
-	 */
-	@Column(length = 150)
-	@Schema(nullable = true)
-	private String courtLocation;
+     * Court location.
+     */
+    @Column(length = 150)
+    @Schema(nullable = true)
+    private String courtLocation;
 
-	/**
+    /**
 	 * The date and time the violation ticket was issue. Time must only be hours and
 	 * minutes.
 	 */
@@ -246,7 +246,7 @@ public class Dispute extends Auditable<String> {
 	@Column
 	@Enumerated(EnumType.STRING)
 	@Schema(nullable = true)
-	private YesNo representedByLawyer;
+    private YesNo representedByLawyer;
 
 	/**
 	 * Name of the law firm that will represent the disputant at the hearing.
@@ -287,9 +287,8 @@ public class Dispute extends Auditable<String> {
 	/**
 	 * Address of the lawyer who will represent the disputant at the hearing.
 	 */
-	@Size(max = 300)
-	@Column(length = 300)
-	@Schema(maxLength = 300, nullable = true)
+	@Column(length = 200)
+	@Schema(nullable = true)
 	private String lawyerAddress;
 
 	/**
@@ -336,7 +335,7 @@ public class Dispute extends Auditable<String> {
 	 */
 	@Schema(nullable = true)
 	@Enumerated(EnumType.STRING)
-	private YesNo interpreterRequired;
+    private YesNo interpreterRequired;
 
 	/**
 	 * Number of witness that the disputant intends to call.
@@ -398,7 +397,7 @@ public class Dispute extends Auditable<String> {
 	@Column
 	@Schema(nullable = true)
 	@Enumerated(EnumType.STRING)
-	private YesNo disputantDetectedOcrIssues;
+    private YesNo disputantDetectedOcrIssues;
 
 	/**
 	 * The description of the issue with OCR ticket if the citizen has detected any.
@@ -414,7 +413,7 @@ public class Dispute extends Auditable<String> {
 	@Column
 	@Schema(nullable= false)
 	@Enumerated(EnumType.STRING)
-	private YesNo systemDetectedOcrIssues;
+    private YesNo systemDetectedOcrIssues;
 
 	/**
 	 * All OCR Violation ticket data serialized into a JSON string.
@@ -436,10 +435,10 @@ public class Dispute extends Auditable<String> {
 	@JoinColumn(name = "dispute_status_type_cd", referencedColumnName="disputeStatusTypeCode")
 	private DisputeStatusType disputeStatusType;
 
-	@JsonManagedReference(value="dispute_count_reference")
-	@OneToMany(targetEntity=DisputeCount.class, cascade = CascadeType.ALL, fetch = FetchType.LAZY, orphanRemoval = true)
-	@JoinColumn(name="dispute_id", referencedColumnName="disputeId")
-	private List<DisputeCount> disputeCounts = new ArrayList<DisputeCount>();
+    @JsonManagedReference(value="dispute_count_reference")
+    @OneToMany(targetEntity=DisputeCount.class, cascade = CascadeType.ALL, fetch = FetchType.LAZY, orphanRemoval = true)
+    @JoinColumn(name="dispute_id", referencedColumnName="disputeId")
+    private List<DisputeCount> disputeCounts = new ArrayList<DisputeCount>();
 
 	public void setViolationTicket(ViolationTicket ticket) {
 		if (ticket == null) {

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/model/Dispute.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/model/Dispute.java
@@ -55,21 +55,21 @@ public class Dispute extends Auditable<String> {
 	@Schema(nullable = true) // FIXME: this field should not be nullable (temp nullable for now to get things working).
 	private String noticeOfDisputeId;
 
-	 /**
-     * The violation ticket number.
-     */
-    @Column(length = 50)
-    @Schema(nullable = false)
-    private String ticketNumber;
+	/**
+	 * The violation ticket number.
+	 */
+	@Column(length = 50)
+	@Schema(nullable = false)
+	private String ticketNumber;
 
 	/**
-     * Court location.
-     */
-    @Column(length = 150)
-    @Schema(nullable = true)
-    private String courtLocation;
+	 * Court location.
+	 */
+	@Column(length = 150)
+	@Schema(nullable = true)
+	private String courtLocation;
 
-    /**
+	/**
 	 * The date and time the violation ticket was issue. Time must only be hours and
 	 * minutes.
 	 */
@@ -246,7 +246,7 @@ public class Dispute extends Auditable<String> {
 	@Column
 	@Enumerated(EnumType.STRING)
 	@Schema(nullable = true)
-    private YesNo representedByLawyer;
+	private YesNo representedByLawyer;
 
 	/**
 	 * Name of the law firm that will represent the disputant at the hearing.
@@ -287,8 +287,9 @@ public class Dispute extends Auditable<String> {
 	/**
 	 * Address of the lawyer who will represent the disputant at the hearing.
 	 */
-	@Column(length = 200)
-	@Schema(nullable = true)
+	@Size(max = 300)
+	@Column(length = 300)
+	@Schema(maxLength = 300, nullable = true)
 	private String lawyerAddress;
 
 	/**
@@ -335,7 +336,7 @@ public class Dispute extends Auditable<String> {
 	 */
 	@Schema(nullable = true)
 	@Enumerated(EnumType.STRING)
-    private YesNo interpreterRequired;
+	private YesNo interpreterRequired;
 
 	/**
 	 * Number of witness that the disputant intends to call.
@@ -397,7 +398,7 @@ public class Dispute extends Auditable<String> {
 	@Column
 	@Schema(nullable = true)
 	@Enumerated(EnumType.STRING)
-    private YesNo disputantDetectedOcrIssues;
+	private YesNo disputantDetectedOcrIssues;
 
 	/**
 	 * The description of the issue with OCR ticket if the citizen has detected any.
@@ -413,7 +414,7 @@ public class Dispute extends Auditable<String> {
 	@Column
 	@Schema(nullable= false)
 	@Enumerated(EnumType.STRING)
-    private YesNo systemDetectedOcrIssues;
+	private YesNo systemDetectedOcrIssues;
 
 	/**
 	 * All OCR Violation ticket data serialized into a JSON string.
@@ -435,10 +436,10 @@ public class Dispute extends Auditable<String> {
 	@JoinColumn(name = "dispute_status_type_cd", referencedColumnName="disputeStatusTypeCode")
 	private DisputeStatusType disputeStatusType;
 
-    @JsonManagedReference(value="dispute_count_reference")
-    @OneToMany(targetEntity=DisputeCount.class, cascade = CascadeType.ALL, fetch = FetchType.LAZY, orphanRemoval = true)
-    @JoinColumn(name="dispute_id", referencedColumnName="disputeId")
-    private List<DisputeCount> disputeCounts = new ArrayList<DisputeCount>();
+	@JsonManagedReference(value="dispute_count_reference")
+	@OneToMany(targetEntity=DisputeCount.class, cascade = CascadeType.ALL, fetch = FetchType.LAZY, orphanRemoval = true)
+	@JoinColumn(name="dispute_id", referencedColumnName="disputeId")
+	private List<DisputeCount> disputeCounts = new ArrayList<DisputeCount>();
 
 	public void setViolationTicket(ViolationTicket ticket) {
 		if (ticket == null) {

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/model/Dispute.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/model/Dispute.java
@@ -55,21 +55,21 @@ public class Dispute extends Auditable<String> {
 	@Schema(nullable = true) // FIXME: this field should not be nullable (temp nullable for now to get things working).
 	private String noticeOfDisputeGuid;
 
-	 /**
-     * The violation ticket number.
-     */
-    @Column(length = 50)
-    @Schema(nullable = false)
-    private String ticketNumber;
+	/**
+	 * The violation ticket number.
+	 */
+	@Column(length = 50)
+	@Schema(nullable = false)
+	private String ticketNumber;
 
 	/**
-     * Court location.
-     */
-    @Column(length = 150)
-    @Schema(nullable = true)
-    private String courtLocation;
+	 * Court location.
+	 */
+	@Column(length = 150)
+	@Schema(nullable = true)
+	private String courtLocation;
 
-    /**
+	/**
 	 * The date and time the violation ticket was issue. Time must only be hours and
 	 * minutes.
 	 */
@@ -239,7 +239,7 @@ public class Dispute extends Auditable<String> {
 	@Column
 	@Enumerated(EnumType.STRING)
 	@Schema(nullable = true)
-    private YesNo representedByLawyer;
+	private YesNo representedByLawyer;
 
 	/**
 	 * Name of the law firm that will represent the disputant at the hearing.
@@ -280,8 +280,9 @@ public class Dispute extends Auditable<String> {
 	/**
 	 * Address of the lawyer who will represent the disputant at the hearing.
 	 */
-	@Column(length = 200)
-	@Schema(nullable = true)
+	@Size(max = 300)
+	@Column(length = 300)
+	@Schema(maxLength = 300, nullable = true)
 	private String lawyerAddress;
 
 	/**
@@ -328,7 +329,7 @@ public class Dispute extends Auditable<String> {
 	 */
 	@Schema(nullable = true)
 	@Enumerated(EnumType.STRING)
-    private YesNo interpreterRequired;
+	private YesNo interpreterRequired;
 
 	/**
 	 * Number of witness that the disputant intends to call.
@@ -390,7 +391,7 @@ public class Dispute extends Auditable<String> {
 	@Column
 	@Schema(nullable = true)
 	@Enumerated(EnumType.STRING)
-    private YesNo disputantDetectedOcrIssues;
+	private YesNo disputantDetectedOcrIssues;
 
 	/**
 	 * The description of the issue with OCR ticket if the citizen has detected any.
@@ -406,7 +407,7 @@ public class Dispute extends Auditable<String> {
 	@Column
 	@Schema(nullable= false)
 	@Enumerated(EnumType.STRING)
-    private YesNo systemDetectedOcrIssues;
+	private YesNo systemDetectedOcrIssues;
 
 	/**
 	 * All OCR Violation ticket data serialized into a JSON string.
@@ -428,10 +429,10 @@ public class Dispute extends Auditable<String> {
 	@JoinColumn(name = "dispute_status_type_cd", referencedColumnName="disputeStatusTypeCode")
 	private DisputeStatusType disputeStatusType;
 
-    @JsonManagedReference(value="dispute_count_reference")
-    @OneToMany(targetEntity=DisputeCount.class, cascade = CascadeType.ALL, fetch = FetchType.LAZY, orphanRemoval = true)
-    @JoinColumn(name="dispute_id", referencedColumnName="disputeId")
-    private List<DisputeCount> disputeCounts = new ArrayList<DisputeCount>();
+	@JsonManagedReference(value="dispute_count_reference")
+	@OneToMany(targetEntity=DisputeCount.class, cascade = CascadeType.ALL, fetch = FetchType.LAZY, orphanRemoval = true)
+	@JoinColumn(name="dispute_id", referencedColumnName="disputeId")
+	private List<DisputeCount> disputeCounts = new ArrayList<DisputeCount>();
 
 	public void setViolationTicket(ViolationTicket ticket) {
 		if (ticket == null) {


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- [TCVP-1855](https://justice.gov.bc.ca/jira/browse/TCVP-1885)
- Added an after mapping method to parse address source into multiple address fields based on the column length when inserting data through ORDS.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Ran the app locally and sent a request to save a dispute with lawyer address field having more than 200 characters and confirmed that it was parsed into separate fields.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
