### PR TITLE
TCVP-1903 functionality to save/retrieve ocr json data to/from object storage

### DIFF
--- a/src/backend/TrafficCourts/Common/Features/FilePersistence/FilePersistenceService.cs
+++ b/src/backend/TrafficCourts/Common/Features/FilePersistence/FilePersistenceService.cs
@@ -22,4 +22,6 @@ public abstract class FilePersistenceService : IFilePersistenceService
         string id = Guid.NewGuid().ToString("n");
         return $"{id}.{mimeType.Extension}";
     }
+
+    public abstract Task<T?> GetJsonDataAsync<T>(string filename, CancellationToken cancellationToken) where T : class;
 }

--- a/src/backend/TrafficCourts/Common/Features/FilePersistence/FilePersistenceService.cs
+++ b/src/backend/TrafficCourts/Common/Features/FilePersistence/FilePersistenceService.cs
@@ -14,6 +14,7 @@ public abstract class FilePersistenceService : IFilePersistenceService
     }
 
     public abstract Task<string> SaveFileAsync(MemoryStream data, CancellationToken cancellationToken);
+    public abstract Task<string> SaveJsonFileAsync<T>(T data, string filename, CancellationToken cancellationToken);
     public abstract Task<MemoryStream> GetFileAsync(string filename, CancellationToken cancellationToken);
 
     protected string GetFileName(FileMimeType mimeType)

--- a/src/backend/TrafficCourts/Common/Features/FilePersistence/IFilePersistenceService.cs
+++ b/src/backend/TrafficCourts/Common/Features/FilePersistence/IFilePersistenceService.cs
@@ -31,4 +31,13 @@ public interface IFilePersistenceService
     /// <returns></returns>
     /// <exception cref="FileNotFoundException">The file was not found.</exception>
     Task<MemoryStream> GetFileAsync(string filename, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Gets generic deserialized json object by filename if target deserialization object type matches.
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <param name="filename"></param>
+    /// <param name="cancellationToken"></param>
+    /// <returns></returns>
+    Task<T?> GetJsonDataAsync<T>(string filename, CancellationToken cancellationToken) where T : class;
 }

--- a/src/backend/TrafficCourts/Common/Features/FilePersistence/IFilePersistenceService.cs
+++ b/src/backend/TrafficCourts/Common/Features/FilePersistence/IFilePersistenceService.cs
@@ -14,6 +14,16 @@ public interface IFilePersistenceService
     Task<string> SaveFileAsync(MemoryStream data, CancellationToken cancellationToken);
 
     /// <summary>
+    /// Serializes generic object data into a JSON object and saves it to the persistence location with object type, created date (meta data) within the headers.
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <param name="data"></param>
+    /// <param name="filename"></param>
+    /// <param name="cancellationToken"></param>
+    /// <returns>The unique file name can be used to retrieve or reference.</returns>
+    Task<string> SaveJsonFileAsync<T>(T data, string filename, CancellationToken cancellationToken);
+
+    /// <summary>
     /// Gets the file by name.
     /// </summary>
     /// <param name="filename"></param>

--- a/src/backend/TrafficCourts/Common/Features/FilePersistence/InMemoryFilePersistenceService.cs
+++ b/src/backend/TrafficCourts/Common/Features/FilePersistence/InMemoryFilePersistenceService.cs
@@ -46,4 +46,8 @@ public class InMemoryFilePersistenceService : FilePersistenceService
         return Task.FromResult(string.Empty);
     }
 
+    public override Task<string> SaveJsonFileAsync<T>(T data, string filename, CancellationToken cancellationToken)
+    {
+        throw new NotImplementedException();
+    }
 }

--- a/src/backend/TrafficCourts/Common/Features/FilePersistence/InMemoryFilePersistenceService.cs
+++ b/src/backend/TrafficCourts/Common/Features/FilePersistence/InMemoryFilePersistenceService.cs
@@ -29,6 +29,11 @@ public class InMemoryFilePersistenceService : FilePersistenceService
         return Task.FromResult(stream);
     }
 
+    public override Task<T?> GetJsonDataAsync<T>(string filename, CancellationToken cancellationToken) where T : class
+    {
+        throw new NotImplementedException();
+    }
+
     public override Task<string> SaveFileAsync(MemoryStream data, CancellationToken cancellationToken)
     {
         var mimeType = data.GetMimeType();

--- a/src/backend/TrafficCourts/Common/Features/FilePersistence/MinioFilePersistenceService.cs
+++ b/src/backend/TrafficCourts/Common/Features/FilePersistence/MinioFilePersistenceService.cs
@@ -19,6 +19,8 @@ public class MinioFilePersistenceService : FilePersistenceService
     private readonly IClock _clock;
     private readonly string _bucketName;
     private const string CreatedAtDateTimeFormat = "yyyy-MM-ddTHH:mm";
+    private const string CreatedAtHeader = "createdAt";
+    private const string TypeHeader = "type";
 
     public MinioFilePersistenceService(
         IObjectOperations objectOperations,
@@ -146,10 +148,10 @@ public class MinioFilePersistenceService : FilePersistenceService
 
         // The metadata (object type and created timestamp) of the json object that will be saved in object store
         Dictionary<string, string> headers = new();
-        headers.Add("CreatedAt", createdAt);
+        headers.Add(CreatedAtHeader, createdAt);
         if (objectType != null)
         {
-            headers.Add("Type", objectType);
+            headers.Add(TypeHeader, objectType);
         }
 
         using var scope = _logger.BeginScope(new Dictionary<string, object>
@@ -215,7 +217,7 @@ public class MinioFilePersistenceService : FilePersistenceService
                 return null;
             }
             Dictionary<string, string> headers = status.MetaData;
-            if (headers.TryGetValue("type", out string? objectType))
+            if (headers.TryGetValue(TypeHeader, out string? objectType))
             {
                 if (objectType != targetType.Name)
                 {

--- a/src/backend/TrafficCourts/Common/Features/FilePersistence/MinioFilePersistenceService.cs
+++ b/src/backend/TrafficCourts/Common/Features/FilePersistence/MinioFilePersistenceService.cs
@@ -225,9 +225,8 @@ public class MinioFilePersistenceService : FilePersistenceService
                     return null;
                 }
             }
-            string jsonString = Encoding.UTF8.GetString(objectStream.ToArray());
 
-            return JsonSerializer.Deserialize<T>(jsonString);
+            return JsonSerializer.Deserialize<T>(objectStream);
         }
         catch (BucketNotFoundException exception)
         {

--- a/src/backend/TrafficCourts/Common/Features/FilePersistence/MinioFilePersistenceService.cs
+++ b/src/backend/TrafficCourts/Common/Features/FilePersistence/MinioFilePersistenceService.cs
@@ -138,10 +138,9 @@ public class MinioFilePersistenceService : FilePersistenceService
 
         string createdAt = _clock.GetCurrentInstant().ToDateTimeUtc().ToString(CreatedAtDateTimeFormat);
 
-        // Serialize data to a JSON string
-        string serializedJsonData = JsonSerializer.Serialize(data);
-        // Convert serialized string data into byte stream to save as a file
-        MemoryStream dataJsonStream = new(Encoding.UTF8.GetBytes(serializedJsonData));
+        // Convert the provided data into UTF-8 encoded JSON and write it to stream to save as a file
+        var dataJsonStream = _memoryStreamManager.GetStream();
+        JsonSerializer.Serialize(dataJsonStream, data);
 
         if (dataJsonStream.Length == 0) throw new ArgumentException("No data to save", nameof(dataJsonStream));
 

--- a/src/backend/TrafficCourts/Common/Features/FilePersistence/MinioFilePersistenceService.cs
+++ b/src/backend/TrafficCourts/Common/Features/FilePersistence/MinioFilePersistenceService.cs
@@ -129,7 +129,7 @@ public class MinioFilePersistenceService : FilePersistenceService
     public override async Task<string> SaveJsonFileAsync<T>(T data, string filename, CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(data);
-        ArgumentNullException.ThrowIfNull(filename);
+        if (string.IsNullOrEmpty(filename)) throw new ArgumentException("No filename provided to save", nameof(filename));
 
         // The type of the data that can be dynamically determined and used to deserialize
         Type dataType = typeof(T);
@@ -246,7 +246,7 @@ public class MinioFilePersistenceService : FilePersistenceService
         catch (Exception exception)
         {
             _logger.LogWarning(exception, "Error fetching file from object storage");
-            throw new MinioFilePersistenceException("Error getting file", exception); // TODO: add exception parameter that handles Exception data type
+            throw new MinioFilePersistenceException("Error getting file", exception);
         }
     }
 }


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- [TCVP-1903](https://justice.gov.bc.ca/jira/browse/TCVP-1903)
- Fixes a bug that was causing not being able to save OCR violation ticket JSON data into database through changing the approach to save and retrieve the data from Minio object storage.
- Added a generic file persistence service method to save json objects into minio object storage. Also updated dispute create process to store ocr violation ticket data in object storage as json file with a filename same as created dispute's violationTicketGuid.
- Added a file persistence service method to get deserialized json object by filename if target deserialization object type matches. Also updated Staff API dispute service to retrieve the OcrViolationTicket from object storage.
- Added xUnit tests.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Ran the services locally and confirmed the ocr violation ticket json object is saved to minio object storage and retrieved from successfully. Ran Xunit tests.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
