### PR TITLE
Created junit test to confirm Mapping to/from ords

### DIFF
--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/config/ApiClientConfiguration.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/config/ApiClientConfiguration.java
@@ -22,7 +22,7 @@ public class ApiClientConfiguration {
         apiClient.setBasePath(configProperties.getOrdsRestApiUrl());
 
         // Set to true to see actual request/response messages sent/received from ORDs.
-        apiClient.setDebugging(false);
+        apiClient.setDebugging(configProperties.isOrdsRestApiDebug());
 
         return apiClient;
     }

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/config/ConfigProperties.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/config/ConfigProperties.java
@@ -9,7 +9,7 @@ import lombok.Setter;
 
 /**
  * Externalized configuration for easy access to properties
- * 
+ *
  * @author 237563
  *
  */
@@ -18,17 +18,21 @@ import lombok.Setter;
 @Getter
 @Setter
 public class ConfigProperties {
-	
+
 	// ORDS Service properties
 	@Value("${ords.rest-api.url}")
     private String ordsRestApiUrl;
-    
+
     @Value("${ords.rest-api.timeout}")
     private int ordsRestApiTimeout;
-    
+
     @Value("${ords.rest-api.retry.count}")
     private long ordsRestApiRetryCount;
-    
+
     @Value("${ords.rest-api.retry.delay}")
     private long ordsRestApiRetryDelay;
+
+    @Value("${ords.rest-api.debug}")
+    private boolean ordsRestApiDebug;
+
 }

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/mapper/DisputeMapper.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/mapper/DisputeMapper.java
@@ -32,7 +32,7 @@ public interface DisputeMapper {
 	@Mapping(source = "dispute.updUserId", target = "modifiedBy")
 	@Mapping(source = "dispute.disputeId", target = "disputeId")
 	@Mapping(source = "dispute.disputeStatusTypeCd", target = "status", qualifiedByName="mapDisputeStatus")
-	@Mapping(source = "dispute.courtLocationTxt", target = "courtLocation")
+	@Mapping(source = "courtLocationTxt", target = "courtLocation")
 	@Mapping(source = "dispute.issuedDt", target = "issuedTs")
 	@Mapping(source = "dispute.submittedDt", target = "submittedTs")
 	@Mapping(source = "dispute.disputantSurnameNm", target = "disputantSurname")

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/model/Dispute.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/model/Dispute.java
@@ -179,7 +179,8 @@ public class Dispute extends Auditable<String> {
 	/**
 	 * The mailing address city of the disputant.
 	 */
-	@Column
+	@Size(max = 30)
+	@Column(length = 30)
 	@Schema(nullable = true)
 	private String addressCity;
 
@@ -295,7 +296,8 @@ public class Dispute extends Auditable<String> {
 	/**
 	 * Email address of the lawyer who will represent the disputant at the hearing.
 	 */
-	@Column
+	@Size(max = 100)
+	@Column(length = 100)
 	@Schema(nullable = true)
 	private String lawyerEmail;
 

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/model/ViolationTicket.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/model/ViolationTicket.java
@@ -100,7 +100,8 @@ public class ViolationTicket extends Auditable<String> {
 	 /**
      * The province or state the drivers licence was issued by.
      */
-    @Column
+	@Size(max = 100)
+	@Column(length = 100)
     @Schema(nullable = true)
     private String driversLicenceProvince;
 
@@ -128,7 +129,8 @@ public class ViolationTicket extends Auditable<String> {
     /**
      * The address of the individual the violation ticket was issued to.
      */
-    @Column
+    @Size(max = 100)
+    @Column(length = 100)
     @Schema(nullable = true)
     private String address;
 

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/model/ViolationTicketCount.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/model/ViolationTicketCount.java
@@ -60,7 +60,7 @@ public class ViolationTicketCount extends Auditable<String> {
 	@Column(length = 5)
 	@Schema(nullable = true)
     private String actOrRegulationNameCode;
-	
+
 	/**
 	 * The count is flagged as an offence to an act. Cannot be true, if is_regulation is true.
 	 */
@@ -68,7 +68,7 @@ public class ViolationTicketCount extends Auditable<String> {
 	@Schema(nullable = true)
 	@Enumerated(EnumType.STRING)
     private YesNo isAct;
-	
+
 	/**
 	 * The count is flagged as an offence to a regulation. Cannot be true, if is_act is true.
 	 */
@@ -76,32 +76,32 @@ public class ViolationTicketCount extends Auditable<String> {
 	@Schema(nullable = true)
 	@Enumerated(EnumType.STRING)
     private YesNo isRegulation;
-	
+
 	/**
 	 * The section part of the full section. For example, "127"
 	 */
-	@Column
+	@Column(length = 15)
 	@Schema(nullable = true, accessMode = Schema.AccessMode.READ_ONLY)
     private String section;
 
 	/**
 	 * The subsection part of the full section. For example, "(1)"
 	 */
-	@Column
+	@Column(length = 4)
 	@Schema(nullable = true, accessMode = Schema.AccessMode.READ_ONLY)
     private String subsection;
 
 	/**
 	 * The paragraph part of the full section. For example, "(a)"
 	 */
-	@Column
+	@Column(length = 3)
 	@Schema(nullable = true, accessMode = Schema.AccessMode.READ_ONLY)
     private String paragraph;
-	
+
 	/**
 	 * The subparagraph part of the full section. For example, "(ii)"
 	 */
-	@Column
+	@Column(length = 5)
 	@Schema(nullable = true, accessMode = Schema.AccessMode.READ_ONLY)
     private String subparagraph;
 
@@ -111,7 +111,7 @@ public class ViolationTicketCount extends Auditable<String> {
 	@Column(precision = 8, scale = 2)
 	@Schema(nullable = true)
     private Float ticketedAmount;
-	
+
 	@JsonBackReference
 	@ManyToOne(targetEntity=ViolationTicket.class, fetch = FetchType.LAZY)
     @JoinColumn(name="violation_ticket_id", referencedColumnName="violationTicketId")

--- a/src/backend/oracle-data-api/src/main/resources/application.yml
+++ b/src/backend/oracle-data-api/src/main/resources/application.yml
@@ -122,6 +122,8 @@ repository:
 # ORDS CLIENT properties
 ords:
   rest-api:
+    # If true, will enable debugging for all API calls to see request/response objects 
+    debug: ${ORDS_API_DEBUG:false}
     url: ${ORDS_API_URL:localhost}
     # The connection timeout limit in miliseconds
     timeout: ${ORDS_API_TIMEOUT_MS:2000}

--- a/src/backend/oracle-data-api/src/main/resources/occm-openapi-spec.yaml
+++ b/src/backend/oracle-data-api/src/main/resources/occm-openapi-spec.yaml
@@ -550,6 +550,7 @@ components:
           format: nullable
         issuedDt:
           type: string
+          # FIXME: this should be date-time but can't at the moment - ORDS is unable to parse ISO format, ie, "2022-10-31T01:30:00.000-07:00"
           format: date
         jjAssignedTo:
           type: string
@@ -773,6 +774,7 @@ components:
           format: nullable
         issuedDt:
           type: string
+          # FIXME: this should be date-time but can't at the moment - ORDS is unable to parse ISO format, ie, "2022-10-31T01:30:00.000-07:00"
           format: date
         issuedOnRoadOrHighwayTxt:
           type: string

--- a/src/backend/oracle-data-api/src/test/java/ca/bc/gov/open/jag/tco/oracledataapi/service/DisputeServiceH2Test.java
+++ b/src/backend/oracle-data-api/src/test/java/ca/bc/gov/open/jag/tco/oracledataapi/service/DisputeServiceH2Test.java
@@ -6,13 +6,15 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 
 import ca.bc.gov.open.jag.tco.oracledataapi.BaseTestSuite;
 import ca.bc.gov.open.jag.tco.oracledataapi.error.NotAllowedException;
 import ca.bc.gov.open.jag.tco.oracledataapi.model.Dispute;
 import ca.bc.gov.open.jag.tco.oracledataapi.model.DisputeStatus;
 
-class DisputeServiceTest extends BaseTestSuite {
+@ConditionalOnProperty(name = "repository.dispute", havingValue = "h2", matchIfMissing = true)
+class DisputeServiceH2Test extends BaseTestSuite {
 
 	@Autowired
 	private DisputeService disputeService;

--- a/src/backend/oracle-data-api/src/test/java/ca/bc/gov/open/jag/tco/oracledataapi/service/DisputeServiceOrdsTest.java
+++ b/src/backend/oracle-data-api/src/test/java/ca/bc/gov/open/jag/tco/oracledataapi/service/DisputeServiceOrdsTest.java
@@ -1,0 +1,125 @@
+package ca.bc.gov.open.jag.tco.oracledataapi.service;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.Iterator;
+import java.util.List;
+
+import org.apache.commons.lang3.builder.Diff;
+import org.apache.commons.lang3.builder.ReflectionDiffBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
+import org.apache.commons.lang3.time.DateFormatUtils;
+import org.assertj.core.util.Arrays;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+
+import ca.bc.gov.open.jag.tco.oracledataapi.BaseTestSuite;
+import ca.bc.gov.open.jag.tco.oracledataapi.model.Dispute;
+import ca.bc.gov.open.jag.tco.oracledataapi.util.RandomUtil;
+
+@ConditionalOnProperty(name = "repository.dispute", havingValue = "ords", matchIfMissing = true)
+class DisputeServiceOrdsTest extends BaseTestSuite {
+
+	@Autowired
+	private DisputeService disputeService;
+
+	@Test
+	public void testOrdsPersistance() {
+		// This test creates a Dispute where all fields are populated, saves it to ORDs, loads it from ORDs,
+		// and then compares the values of all fields to the original copy - they should be identical (except for the noted ignoredFields).
+
+		Dispute dispute = RandomUtil.createFullyPopulatedDispute();
+		Dispute savedDispute = disputeService.save(dispute);
+
+		List<Diff<?>> disputeDiffs = getDifferences(dispute, savedDispute,
+				//"disputeId",
+				"violationTicket",
+				"disputeCounts",
+				"createdBy",
+				"createdTs");
+		logDiffs(disputeDiffs, "Dispute");
+
+		List<Diff<?>> disputeCntDiffs = getDifferences(dispute.getDisputeCounts().get(0), savedDispute.getDisputeCounts().get(0),
+				"dispute",
+				"createdBy",
+				"createdTs");
+		logDiffs(disputeCntDiffs, "DisputeCount");
+
+		List<Diff<?>> vioTicketDiffs = getDifferences(dispute.getViolationTicket(), savedDispute.getViolationTicket(),
+				"violationTicketId",
+				"dispute",
+				"violationTicketCounts",
+				"createdBy",
+				"createdTs");
+		logDiffs(vioTicketDiffs, "ViolationTicket");
+
+		List<Diff<?>> vioTicketCntDiffs = getDifferences(dispute.getViolationTicket().getViolationTicketCounts().get(0), savedDispute.getViolationTicket().getViolationTicketCounts().get(0),
+				"violationTicketCountId",
+				"violationTicket",
+				"createdBy",
+				"createdTs");
+		logDiffs(vioTicketCntDiffs, "ViolationTicketCount");
+
+		// cleanup ORDs
+		disputeService.delete(savedDispute.getDisputeId());
+
+		assertTrue(disputeDiffs.isEmpty());
+		assertTrue(disputeCntDiffs.isEmpty());
+		assertTrue(vioTicketDiffs.isEmpty());
+		assertTrue(vioTicketCntDiffs.isEmpty());
+	}
+
+	private void logDiffs(List<Diff<?>> diffs, String objectClass) {
+		if (!diffs.isEmpty()) {
+			System.out.println("\n" + objectClass + " Diffs:");
+			for (Diff<?> diff : diffs) {
+				logDiff(diff);
+			}
+		}
+
+	}
+
+	private <T> List<Diff<?>> getDifferences(T lhs, T rhs, String... ignoredFields) {
+		List<Diff<?>> diffs = new ArrayList<Diff<?>>(new ReflectionDiffBuilder<T>(lhs, rhs, ToStringStyle.JSON_STYLE).build().getDiffs());
+		List<Object> skippedFields = Arrays.asList(ignoredFields);
+
+		for (Iterator<Diff<?>> iterator = diffs.iterator(); iterator.hasNext();) {
+			Diff<?> diff = iterator.next();
+
+			// skip known field differences and child objects
+			if (skippedFields.contains(diff.getFieldName())) {
+				iterator.remove();
+			}
+		}
+
+		return diffs;
+	}
+
+	private void logDiff(Diff<?> diff) {
+		if (diff.getKey() != null && diff.getKey() instanceof Date) {
+			StringBuffer sb = new StringBuffer();
+			sb.append("[");
+			sb.append(diff.getFieldName());
+			sb.append(": ");
+			if (diff.getFieldName().endsWith("Ts")) {
+				sb.append(diff.getLeft() == null ? "null" : DateFormatUtils.ISO_8601_EXTENDED_DATETIME_TIME_ZONE_FORMAT.format(diff.getLeft()));
+				sb.append(", ");
+				sb.append(diff.getRight() == null ? "null" : DateFormatUtils.ISO_8601_EXTENDED_DATETIME_TIME_ZONE_FORMAT.format(diff.getRight()));
+			}
+			else {
+				sb.append(diff.getLeft() == null ? "null" : DateFormatUtils.ISO_8601_EXTENDED_DATE_FORMAT.format(diff.getLeft()));
+				sb.append(", ");
+				sb.append(diff.getRight() == null ? "null" : DateFormatUtils.ISO_8601_EXTENDED_DATE_FORMAT.format(diff.getRight()));
+			}
+			sb.append("]");
+			System.out.println(sb);
+		}
+		else {
+			System.out.println(diff.toString());
+		}
+	}
+
+}

--- a/src/backend/oracle-data-api/src/test/java/ca/bc/gov/open/jag/tco/oracledataapi/util/RandomUtil.java
+++ b/src/backend/oracle-data-api/src/test/java/ca/bc/gov/open/jag/tco/oracledataapi/util/RandomUtil.java
@@ -320,7 +320,7 @@ public class RandomUtil {
 	public static Dispute createFullyPopulatedDispute() {
 		Dispute dispute = new Dispute();
 
-		dispute.setAddressCity(randomCity()); // TODO: what is the max length of this field?
+		dispute.setAddressCity(randomAlphanumeric(30));
 		dispute.setAddressLine1(randomAlphanumeric(100)); // FIXME: Column length disparity - ORDs is 100, H2 is 500
 		dispute.setAddressLine2(randomAlphanumeric(100)); // FIXME: Column length disparity - ORDs is 100, H2 is 500
 		dispute.setAddressLine3(randomAlphanumeric(100)); // FIXME: Column length disparity - ORDs is 100, H2 is 500
@@ -349,7 +349,7 @@ public class RandomUtil {
 		dispute.setInterpreterRequired(randomYN());
 		dispute.setIssuedTs(randomDateTime());
 		dispute.setLawyerAddress(randomAlphanumeric(300));
-		dispute.setLawyerEmail(randomAlphanumeric(20)); // TODO: what is the max length of this field?
+		dispute.setLawyerEmail(randomAlphanumeric(100));
 		dispute.setLawyerGivenName1(randomAlphabetic(30));
 		dispute.setLawyerGivenName2(randomAlphabetic(30));
 		dispute.setLawyerGivenName3(randomAlphabetic(30));
@@ -380,7 +380,7 @@ public class RandomUtil {
 
 	public static ViolationTicket createViolationTicket(Dispute dispute) {
 		ViolationTicket violationTicket = new ViolationTicket();
-		violationTicket.setAddress(randomAlphanumeric(30)); // TODO: what is the max length of this field?
+		violationTicket.setAddress(randomAlphanumeric(100));
 		violationTicket.setAddressCity(randomAlphanumeric(100));
 		violationTicket.setAddressCountry(randomAlphanumeric(100));
 		violationTicket.setAddressPostalCode(randomAlphanumeric(10));
@@ -392,7 +392,7 @@ public class RandomUtil {
 		violationTicket.setDisputantGivenNames(randomAlphabetic(200));
 		violationTicket.setDisputantDriversLicenceNumber(randomAlphanumeric(30));
 		violationTicket.setDisputantClientNumber(randomAlphanumeric(30));
-		violationTicket.setDriversLicenceProvince(randomAlphabetic(2)); // TODO: what is the max length of this field?
+		violationTicket.setDriversLicenceProvince(randomAlphabetic(100));
 		violationTicket.setDriversLicenceIssuedYear(Integer.valueOf(randomNumeric(4)));
 		violationTicket.setDriversLicenceExpiryYear(Integer.valueOf(randomNumeric(4)));
 		violationTicket.setDisputantBirthdate(randomDate());

--- a/src/backend/oracle-data-api/src/test/java/ca/bc/gov/open/jag/tco/oracledataapi/util/RandomUtil.java
+++ b/src/backend/oracle-data-api/src/test/java/ca/bc/gov/open/jag/tco/oracledataapi/util/RandomUtil.java
@@ -229,8 +229,9 @@ public class RandomUtil {
 		return (int) Math.round((Math.random() * (max - min)) + min);
 	}
 
-	public static float randomFloat(double min, double max) {
-		return (float) ((Math.random() * (max - min)) + min);
+	public static Float randomCurrency(double min, double max) {
+		double amount = ((Math.random() * (max - min)) + min);
+		return Float.valueOf((float) (Math.round(amount * 100.0) / 100.0));
 	}
 
 	public static long randomLong(long min, long max) {
@@ -424,7 +425,7 @@ public class RandomUtil {
 		count.setSubsection(randomAlphanumeric(4));
 		count.setParagraph(randomAlphanumeric(3));
 		count.setSubparagraph(randomAlphanumeric(5));
-		count.setTicketedAmount(Float.valueOf(randomFloat(0.01, 999999.99)));
+		count.setTicketedAmount(randomCurrency(0.01, 999999.99));
 		count.setViolationTicket(violationTicket);
 
 		violationTickets.add(count);

--- a/src/backend/oracle-data-api/src/test/java/ca/bc/gov/open/jag/tco/oracledataapi/util/RandomUtil.java
+++ b/src/backend/oracle-data-api/src/test/java/ca/bc/gov/open/jag/tco/oracledataapi/util/RandomUtil.java
@@ -1,16 +1,28 @@
 package ca.bc.gov.open.jag.tco.oracledataapi.util;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Calendar;
 import java.util.Date;
+import java.util.List;
+import java.util.Random;
 import java.util.UUID;
 
+import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.time.DateUtils;
 
 import ca.bc.gov.open.jag.tco.oracledataapi.model.Dispute;
+import ca.bc.gov.open.jag.tco.oracledataapi.model.DisputeCount;
 import ca.bc.gov.open.jag.tco.oracledataapi.model.DisputeStatus;
+import ca.bc.gov.open.jag.tco.oracledataapi.model.DisputeStatusType;
 import ca.bc.gov.open.jag.tco.oracledataapi.model.EmailHistory;
 import ca.bc.gov.open.jag.tco.oracledataapi.model.FileHistory;
 import ca.bc.gov.open.jag.tco.oracledataapi.model.JJDispute;
 import ca.bc.gov.open.jag.tco.oracledataapi.model.JJDisputeStatus;
+import ca.bc.gov.open.jag.tco.oracledataapi.model.Plea;
+import ca.bc.gov.open.jag.tco.oracledataapi.model.ViolationTicket;
+import ca.bc.gov.open.jag.tco.oracledataapi.model.ViolationTicketCount;
 import ca.bc.gov.open.jag.tco.oracledataapi.model.YesNo;
 
 public class RandomUtil {
@@ -103,7 +115,7 @@ public class RandomUtil {
 			"Wilson",
 			"Young"
 	};
-	
+
 	public final static String[] COMMON_EMAIL_ADDRESSES = new String[] {
 		"1@1.com",
 		"2@2.ca",
@@ -189,7 +201,7 @@ public class RandomUtil {
 		dispute.setViolationDate(randomDate(DateUtils.addDays(new Date(), -30), new Date())); // random date in the last 30 days
 		return dispute;
 	}
-	
+
 	public static EmailHistory createEmailHistory() {
 		EmailHistory emailHistory = new EmailHistory();
 		emailHistory.setTicketNumber(UUID.randomUUID().toString());
@@ -200,35 +212,39 @@ public class RandomUtil {
 		emailHistory.setToEmailAddress(randomEmailAddress());
 		return emailHistory;
 	}
-	
+
 	public static FileHistory createFileHistory() {
 		FileHistory fileHistory = new FileHistory();
 		fileHistory.setTicketNumber(UUID.randomUUID().toString());
 		fileHistory.setDescription(UUID.randomUUID().toString());
 		return fileHistory;
 	}
-	
+
 	public static String randomEmailAddress() {
-    	int index = randomInt(0, COMMON_EMAIL_ADDRESSES.length-1);
-    	return COMMON_EMAIL_ADDRESSES[index];		
+		int index = randomInt(0, COMMON_EMAIL_ADDRESSES.length - 1);
+		return COMMON_EMAIL_ADDRESSES[index];
 	}
 
 	public static int randomInt(int min, int max) {
-		return (int) Math.round((Math.random() * (max-min)) + min);
+		return (int) Math.round((Math.random() * (max - min)) + min);
+	}
+
+	public static float randomFloat(double min, double max) {
+		return (float) ((Math.random() * (max - min)) + min);
 	}
 
 	public static long randomLong(long min, long max) {
-		return Math.round((Math.random() * (max-min)) + min);
+		return Math.round((Math.random() * (max - min)) + min);
 	}
 
 	public static String randomSurname() {
-    	int index = randomInt(0, COMMON_LAST_NAMES.length-1);
-    	return COMMON_LAST_NAMES[index];
+		int index = randomInt(0, COMMON_LAST_NAMES.length - 1);
+		return COMMON_LAST_NAMES[index];
 	}
 
 	public static String randomGivenName() {
-    	int index = randomInt(0, COMMON_FIRST_NAMES.length-1);
-    	return COMMON_FIRST_NAMES[index];
+		int index = randomInt(0, COMMON_FIRST_NAMES.length - 1);
+		return COMMON_FIRST_NAMES[index];
 	}
 
 	private static String randomName() {
@@ -236,17 +252,202 @@ public class RandomUtil {
 	}
 
 	public static String randomCity() {
-    	int index = randomInt(0, COMMON_CITY_NAMES.length-1);
-    	return COMMON_CITY_NAMES[index];
+		int index = randomInt(0, COMMON_CITY_NAMES.length - 1);
+		return COMMON_CITY_NAMES[index];
 	}
 
-    public static Date randomDate(Date minDate, Date maxDate) {
-        Date date = new Date();
-        long minMilliSecs = minDate.getTime();
-        long maxMilliSecs = maxDate.getTime();
-        long l = randomLong(minMilliSecs, maxMilliSecs);
-        date.setTime(l);
-        return date;
-    }
+	public static Date randomDate(Date minDate, Date maxDate) {
+		Date date = new Date();
+		long minMilliSecs = minDate.getTime();
+		long maxMilliSecs = maxDate.getTime();
+		long l = randomLong(minMilliSecs, maxMilliSecs);
+		date.setTime(l);
+		return date;
+	}
+
+	/**
+	 * Creates a random TicketNumber of the form AA00000000
+	 */
+	public static String randomTicketNumber() {
+		return randomAlphabetic(2).toUpperCase() + randomNumeric(8);
+	}
+
+	/**
+	 * Creates a random string whose length is the number of characters specified. Characters will be chosen from the set of Latin alphabetic
+	 * characters (a-z, A-Z).
+	 */
+	public static String randomAlphabetic(int count) {
+		return RandomStringUtils.randomAlphabetic(count);
+	}
+
+	/**
+	 * Creates a random string whose length is the number of characters specified. Characters will be chosen from the set of numeric characters.
+	 */
+	public static String randomNumeric(int count) {
+		return RandomStringUtils.randomNumeric(count);
+	}
+
+	/**
+	 * Creates a random string whose length is the number of characters specified.
+	 * Characters will be chosen from the set of Latin alphabetic characters (a-z, A-Z) and the digits 0-9.
+	 */
+	public static String randomAlphanumeric(int count) {
+		return RandomStringUtils.randomAlphanumeric(count);
+	}
+
+	/**
+	 * Returns a random date within the last year.
+	 */
+	public static Date randomDate() {
+		return DateUtils.ceiling(randomDateTime(), Calendar.DAY_OF_MONTH);
+	}
+
+	/**
+	 * Returns a random date within the last year.
+	 */
+	public static Date randomDateTime() {
+		return randomDate(DateUtils.addYears(new Date(), -1), new Date());
+	}
+
+	public static YesNo randomYN() {
+		return (new Random().nextBoolean()) ? YesNo.Y : YesNo.N;
+	}
+
+
+	/**
+	 * Creates a Dispute where every field is populated with random data to the maximum character limit appropriate for each field.
+	 */
+	public static Dispute createFullyPopulatedDispute() {
+		Dispute dispute = new Dispute();
+
+		dispute.setAddressCity(randomCity()); // TODO: what is the max length of this field?
+		dispute.setAddressLine1(randomAlphanumeric(100)); // FIXME: Column length disparity - ORDs is 100, H2 is 500
+		dispute.setAddressLine2(randomAlphanumeric(100)); // FIXME: Column length disparity - ORDs is 100, H2 is 500
+		dispute.setAddressLine3(randomAlphanumeric(100)); // FIXME: Column length disparity - ORDs is 100, H2 is 500
+		dispute.setAddressProvince(randomAlphabetic(30));
+		dispute.setCourtLocation(randomAlphabetic(150));
+		dispute.setDetachmentLocation(randomAlphabetic(150));
+		dispute.setDisputantBirthdate(randomDate());
+		dispute.setDisputantClientId(null);
+		dispute.setDisputantComment(randomAlphabetic(4000));
+		dispute.setDisputantDetectedOcrIssues(randomYN());
+		dispute.setDisputantGivenName1(randomAlphabetic(30));
+		dispute.setDisputantGivenName2(randomAlphabetic(30));
+		dispute.setDisputantGivenName3(randomAlphabetic(30));
+		dispute.setDisputantOcrIssues(randomAlphabetic(500));
+		dispute.setDisputantOrganization(randomAlphabetic(150));
+		dispute.setDisputantSurname(randomAlphabetic(30));
+		dispute.setDisputeCounts(createDisputeCounts(dispute));
+		dispute.setDisputeStatusType(createDisputeStatusType());
+		dispute.setDriversLicenceNumber(randomAlphanumeric(30));
+		dispute.setDriversLicenceProvince(randomAlphabetic(30));
+		dispute.setEmailAddress(randomAlphanumeric(100));
+		dispute.setFilingDate(randomDate());
+		dispute.setFineReductionReason(randomAlphabetic(500));
+		dispute.setHomePhoneNumber(randomNumeric(20));
+		dispute.setInterpreterLanguage(randomAlphabetic(10)); // TODO: what is the max length of this field?
+		dispute.setInterpreterRequired(randomYN());
+		dispute.setIssuedTs(randomDateTime());
+		dispute.setLawyerAddress(randomAlphanumeric(300));
+		dispute.setLawyerEmail(randomAlphanumeric(20)); // TODO: what is the max length of this field?
+		dispute.setLawyerGivenName1(randomAlphabetic(30));
+		dispute.setLawyerGivenName2(randomAlphabetic(30));
+		dispute.setLawyerGivenName3(randomAlphabetic(30));
+		dispute.setLawyerPhoneNumber(randomNumeric(20));
+		dispute.setLawyerSurname(randomAlphabetic(30));
+		dispute.setNoticeOfDisputeGuid(UUID.randomUUID().toString());
+		dispute.setOcrViolationTicket(randomAlphabetic(4000));
+		dispute.setOfficerPin(randomAlphabetic(10));
+		dispute.setPostalCode(randomAlphanumeric(10));
+		dispute.setRejectedReason(randomAlphabetic(500));
+		dispute.setRepresentedByLawyer(randomYN());
+		dispute.setStatus(DisputeStatus.NEW);
+		dispute.setSubmittedTs(randomDateTime());
+		dispute.setSystemDetectedOcrIssues(randomYN());
+		dispute.setTicketNumber(randomTicketNumber());
+		dispute.setTimeToPayReason(randomAlphabetic(500));
+		dispute.setUserAssignedTo(randomAlphabetic(30));
+		dispute.setUserAssignedTs(randomDateTime());
+		dispute.setViolationTicket(createViolationTicket(dispute));
+		dispute.setWitnessNo(Integer.valueOf(randomNumeric(3)));
+		dispute.setWorkPhoneNumber(randomNumeric(20));
+
+		// 36 character field
+		assertTrue(dispute.getNoticeOfDisputeGuid().length() == 36);
+
+		return dispute;
+	}
+
+	public static ViolationTicket createViolationTicket(Dispute dispute) {
+		ViolationTicket violationTicket = new ViolationTicket();
+		violationTicket.setAddress(randomAlphanumeric(30)); // TODO: what is the max length of this field?
+		violationTicket.setAddressCity(randomAlphanumeric(100));
+		violationTicket.setAddressCountry(randomAlphanumeric(100));
+		violationTicket.setAddressPostalCode(randomAlphanumeric(10));
+		violationTicket.setAddressProvince(randomAlphanumeric(100));
+		violationTicket.setCourtLocation(randomAlphanumeric(150));
+		violationTicket.setDetachmentLocation(randomAlphanumeric(150));
+		violationTicket.setDisputantOrganizationName(randomAlphabetic(150));
+		violationTicket.setDisputantSurname(randomAlphabetic(100));
+		violationTicket.setDisputantGivenNames(randomAlphabetic(200));
+		violationTicket.setDisputantDriversLicenceNumber(randomAlphanumeric(30));
+		violationTicket.setDisputantClientNumber(randomAlphanumeric(30));
+		violationTicket.setDriversLicenceProvince(randomAlphabetic(2)); // TODO: what is the max length of this field?
+		violationTicket.setDriversLicenceIssuedYear(Integer.valueOf(randomNumeric(4)));
+		violationTicket.setDriversLicenceExpiryYear(Integer.valueOf(randomNumeric(4)));
+		violationTicket.setDisputantBirthdate(randomDate());
+		violationTicket.setIssuedAtOrNearCity(randomAlphanumeric(100));
+		violationTicket.setIssuedOnRoadOrHighway(randomAlphanumeric(100));
+		violationTicket.setIssuedTs(randomDateTime());
+		violationTicket.setIsChangeOfAddress(randomYN());
+		violationTicket.setIsDriver(randomYN());
+		violationTicket.setIsOwner(randomYN());
+		violationTicket.setIsYoungPerson(randomYN());
+		violationTicket.setOfficerPin(randomAlphanumeric(10));
+		violationTicket.setTicketNumber(randomTicketNumber());
+		violationTicket.setViolationTicketCounts(createViolationTicketCounts(violationTicket));
+		violationTicket.setDispute(dispute);
+
+		return violationTicket;
+	}
+
+	public static List<ViolationTicketCount> createViolationTicketCounts(ViolationTicket violationTicket) {
+		ArrayList<ViolationTicketCount> violationTickets = new ArrayList<ViolationTicketCount>();
+
+		ViolationTicketCount count = new ViolationTicketCount();
+		count.setCountNo(1);
+		count.setDescription(randomAlphanumeric(4000));
+		count.setActOrRegulationNameCode(randomAlphabetic(5));
+		count.setIsAct(randomYN());
+		count.setIsRegulation(randomYN());
+		count.setSection(randomAlphanumeric(15));
+		count.setSubsection(randomAlphanumeric(4));
+		count.setParagraph(randomAlphanumeric(3));
+		count.setSubparagraph(randomAlphanumeric(5));
+		count.setTicketedAmount(Float.valueOf(randomFloat(0.01, 999999.99)));
+		count.setViolationTicket(violationTicket);
+
+		violationTickets.add(count);
+		return violationTickets;
+	}
+
+	public static DisputeStatusType createDisputeStatusType() {
+		return null;
+	}
+
+	public static List<DisputeCount> createDisputeCounts(Dispute dispute) {
+		ArrayList<DisputeCount> disputeCounts = new ArrayList<DisputeCount>();
+
+		DisputeCount count = new DisputeCount();
+		count.setCountNo(1);
+		count.setPleaCode(Plea.G);
+		count.setRequestTimeToPay(randomYN());
+		count.setRequestReduction(randomYN());
+		count.setRequestCourtAppearance(randomYN());
+		count.setDispute(dispute);
+		disputeCounts.add(count);
+
+		return disputeCounts;
+	}
 
 }

--- a/src/backend/oracle-data-api/src/test/resources/application.yml
+++ b/src/backend/oracle-data-api/src/test/resources/application.yml
@@ -26,6 +26,8 @@ repository:
 # ORDS CLIENT properties
 ords:
   rest-api:
+    # If true, will enable debugging for all API calls to see request/response objects 
+    debug: ${ORDS_API_DEBUG:false}
     url: ${ORDS_API_URL:localhost}
     timeout: 2000
     retry:


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

Create junit regression test to confirm Mapping to/from ORDS. The test creates a fully populated Dispute where every field is at the character limit, persists to ORDS, reads the new records from ORDS, then compares and prints the differences - the original and persisted objects should be identical.

- created ENV variable for enabling ORDS debugging
- fixed mapping of courtLocation
- fixed missing size constraints in TCO model
- moved DisputeServiceTest to DisputeServiceH2Test and created new DisputeServiceOrdsTest 

To run this test, ensure the following ENV variables are set:
- DISPUTE_REPOSITORY_SRC
- ORDS_API_URL
- ORDS_API_DEBUG

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

`mvn test -Dtest="DisputeServiceOrdsTest" -DDISPUTE_REPOSITORY_SRC=ords -DORDS_API_URL=...`

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
