### PR TITLE
TCVP-1918 enforced duplicate field TicketNumber has same values

### DIFF
--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/service/DisputeService.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/service/DisputeService.java
@@ -8,8 +8,10 @@ import java.util.Optional;
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
 import javax.transaction.Transactional;
+import javax.validation.ConstraintViolationException;
 
 import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.time.DateUtils;
 import org.slf4j.Logger;
@@ -81,6 +83,13 @@ public class DisputeService {
 			dispute.getViolationTicket().setViolationTicketId(null);
 			for (ViolationTicketCount violationTicketCount : dispute.getViolationTicket().getViolationTicketCounts()) {
 				violationTicketCount.setViolationTicketCountId(null);
+			}
+
+			// It is an error if the duplicate field TicketNumber has different values.
+			if (ObjectUtils.compare(dispute.getTicketNumber(), dispute.getViolationTicket().getTicketNumber()) != 0) {
+				String msg = String.format("TicketNumber of the Dispute (%s) and ViolationTicket (%s) are different!", dispute.getTicketNumber(), dispute.getViolationTicket().getTicketNumber());
+				logger.error(msg);
+				throw new ConstraintViolationException(msg, null);
 			}
 		}
 		return disputeRepository.saveAndFlush(dispute);

--- a/src/backend/oracle-data-api/src/test/java/ca/bc/gov/open/jag/tco/oracledataapi/controller/v1_0/DisputeControllerTest.java
+++ b/src/backend/oracle-data-api/src/test/java/ca/bc/gov/open/jag/tco/oracledataapi/controller/v1_0/DisputeControllerTest.java
@@ -57,6 +57,24 @@ class DisputeControllerTest extends BaseTestSuite {
 	}
 
 	@Test
+	public void testSaveDispute_InvalidTicketNumber() throws Exception {
+		// TCVP-1918 mismatched ticketNumber should yield a 400 BAD REQUEST
+
+		// Create a single Dispute
+		Dispute dispute = RandomUtil.createDispute();
+		dispute.setTicketNumber("AX00000000");
+		dispute.getViolationTicket().setTicketNumber("AB11111111");
+
+		mvc.perform(MockMvcRequestBuilders
+				.post("/api/v1.0/dispute")
+				.principal(getPrincipal())
+				.content(asJsonString(dispute))
+				.contentType(MediaType.APPLICATION_JSON)
+				.accept(MediaType.APPLICATION_JSON))
+				.andExpect(status().isBadRequest());
+	}
+
+	@Test
 	public void testRejectDispute() throws Exception {
 		// Create a single Dispute
 		Dispute dispute = RandomUtil.createDispute();
@@ -260,6 +278,7 @@ class DisputeControllerTest extends BaseTestSuite {
 		Dispute dispute = RandomUtil.createDispute();
 		dispute.setTicketNumber("AX12345678");
 		dispute.setIssuedTs(DateUtils.parseDate("14:54", "HH:mm"));
+		dispute.setViolationTicket(null);
 		Long disputeId = saveDispute(dispute);
 
 		// try searching for exact match. Expect to find the dispute

--- a/src/backend/oracle-data-api/src/test/java/ca/bc/gov/open/jag/tco/oracledataapi/util/RandomUtil.java
+++ b/src/backend/oracle-data-api/src/test/java/ca/bc/gov/open/jag/tco/oracledataapi/util/RandomUtil.java
@@ -186,6 +186,7 @@ public class RandomUtil {
 		dispute.setStatus(DisputeStatus.NEW);
 		dispute.setDisputantGivenName1(randomGivenName());
 		dispute.setDisputantSurname(randomSurname());
+		dispute.setViolationTicket(new ViolationTicket());
 		return dispute;
 	}
 
@@ -405,7 +406,7 @@ public class RandomUtil {
 		violationTicket.setIsOwner(randomYN());
 		violationTicket.setIsYoungPerson(randomYN());
 		violationTicket.setOfficerPin(randomAlphanumeric(10));
-		violationTicket.setTicketNumber(randomTicketNumber());
+		violationTicket.setTicketNumber(dispute.getTicketNumber());
 		violationTicket.setViolationTicketCounts(createViolationTicketCounts(violationTicket));
 		violationTicket.setDispute(dispute);
 


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

TCVP-1918

- Updated the saving of a Dispute in the oracle-data-api to throw a 400 if the duplicate TicketNumber on the Dispute and ViolationTicket doesn't match.
- Added junit test

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

mvn verify

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
