### PR TITLE
TCVP-1903 - Part 2- Save OCR Ticket JSON Filename

### DIFF
--- a/src/backend/TrafficCourts/Citizen.Service/Features/Disputes/Create.cs
+++ b/src/backend/TrafficCourts/Citizen.Service/Features/Disputes/Create.cs
@@ -159,7 +159,7 @@ namespace TrafficCourts.Citizen.Service.Features.Disputes
 
                     if (violationTicket != null)
                     {
-                        var ocrTicketFilename = await _filePersistenceService.SaveJsonFileAsync(violationTicket, noticeOfDisputeGuid.ToString(), cancellationToken);
+                        submitNoticeOfDispute.OcrTicketFilename = await _filePersistenceService.SaveJsonFileAsync(violationTicket, noticeOfDisputeGuid.ToString(), cancellationToken);
                     }
 
                     if (lookedUpViolationTicket != null)

--- a/src/backend/TrafficCourts/Common/OpenAPIs/OracleDataAPI/v1_0/OracleDataApi.v1_0.json
+++ b/src/backend/TrafficCourts/Common/OpenAPIs/OracleDataAPI/v1_0/OracleDataApi.v1_0.json
@@ -6,7 +6,7 @@
   },
   "servers": [
     {
-      "url": "http://localhost:5010",
+      "url": "http://localhost:8080",
       "description": "Generated server url"
     }
   ],
@@ -1755,7 +1755,9 @@
             "type": "string",
             "enum": [ "Y", "N" ]
           },
-          "ocrViolationTicket": {
+          "ocrTicketFilename": {
+            "maxLength": 100,
+            "minLength": 0,
             "type": "string",
             "nullable": true
           },

--- a/src/backend/TrafficCourts/Common/OpenAPIs/OracleDataAPI/v1_0/OracleDataApiClient.g.cs
+++ b/src/backend/TrafficCourts/Common/OpenAPIs/OracleDataAPI/v1_0/OracleDataApiClient.g.cs
@@ -4224,8 +4224,9 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
         [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
         public DisputeSystemDetectedOcrIssues SystemDetectedOcrIssues { get; set; }
 
-        [Newtonsoft.Json.JsonProperty("ocrViolationTicket", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public string OcrViolationTicket { get; set; }
+        [Newtonsoft.Json.JsonProperty("ocrTicketFilename", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [System.ComponentModel.DataAnnotations.StringLength(100)]
+        public string OcrTicketFilename { get; set; }
 
         [Newtonsoft.Json.JsonProperty("violationTicket", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public ViolationTicket ViolationTicket { get; set; }

--- a/src/backend/TrafficCourts/Messaging/MessageContracts/SubmitNoticeOfDispute.cs
+++ b/src/backend/TrafficCourts/Messaging/MessageContracts/SubmitNoticeOfDispute.cs
@@ -199,9 +199,9 @@ public class SubmitNoticeOfDispute
     public ViolationTicket? ViolationTicket { get; set; }
 
     /// <summary>
-    /// JSON serialized OCR data.
+    /// Filename of JSON serialized OCR data that is saved in object storage.
     /// </summary>
-    public string? OcrViolationTicket { get; set; }
+    public string? OcrTicketFilename { get; set; }
 
     public IList<DisputeCount> DisputeCounts { get; set; } = new List<DisputeCount>();
 }

--- a/src/backend/TrafficCourts/Staff.Service/Services/DisputeService.cs
+++ b/src/backend/TrafficCourts/Staff.Service/Services/DisputeService.cs
@@ -51,9 +51,13 @@ public class DisputeService : IDisputeService
     {
         Dispute dispute = await _oracleDataApi.GetDisputeAsync(disputeId, cancellationToken);
 
-        // Try to retrieve OCR Violation Ticket Data from object storage for the given NoticeOfDisputeGuid (filename)
-        OcrViolationTicket? ocrViolationTicket = await _filePersistenceService.GetJsonDataAsync<OcrViolationTicket>(dispute.NoticeOfDisputeGuid, cancellationToken);
-        dispute.ViolationTicket.OcrViolationTicket = ocrViolationTicket;
+        OcrViolationTicket? ocrViolationTicket = null;
+        if (!string.IsNullOrEmpty(dispute.OcrTicketFilename))
+        {
+            // Retrieve deserialized OCR Violation Ticket JSON Data from object storage for the given filename (NoticeOfDisputeGuid)
+            ocrViolationTicket = await _filePersistenceService.GetJsonDataAsync<OcrViolationTicket>(dispute.OcrTicketFilename, cancellationToken);
+            dispute.ViolationTicket.OcrViolationTicket = ocrViolationTicket;
+        }
 
         // If OcrViolationTicket != null, then this Violation Ticket was scanned using the Azure OCR Form Recognizer at one point.
         // If so, retrieve the image from object storage and return it as well.
@@ -61,25 +65,22 @@ public class DisputeService : IDisputeService
         {
             dispute.ViolationTicket.ViolationTicketImage = await GetViolationTicketImageAsync(ocrViolationTicket.ImageFilename, cancellationToken);
         }
-        
-        // deserialize json string to violation ticket fields
-        if (dispute.OcrViolationTicket != null) dispute.ViolationTicket.OcrViolationTicket = System.Text.Json.JsonSerializer.Deserialize<OcrViolationTicket>(dispute.OcrViolationTicket);
 
         return dispute;
     }
 
     /// <summary>
-    /// Extracts the path to the image located in the object store from the dispute record, or null if not filename could be found.
+    /// Extracts the path to the image located in the object store from the JSON string, or null if not filename could be found.
     /// </summary>
-    /// <param name="dispute"></param>
+    /// <param name="json"></param>
     /// <returns></returns>
-    public string? GetViolationTicketImageFilename(Dispute dispute)
+    public string? GetViolationTicketImageFilename(string json)
     {
-        if (dispute.OcrViolationTicket is not null)
+        if (json is not null)
         {
             try
             {
-                JsonElement element = JsonSerializer.Deserialize<JsonElement>(dispute.OcrViolationTicket);
+                JsonElement element = JsonSerializer.Deserialize<JsonElement>(json);
                 if (element.ValueKind == JsonValueKind.Object && element.TryGetProperty("ImageFilename", out JsonElement imageFilename))
                 {
                     return imageFilename.GetString();
@@ -103,7 +104,7 @@ public class DisputeService : IDisputeService
     /// <returns></returns>
     private async Task<ViolationTicketImage?> GetViolationTicketImageAsync(string? imageFilename, CancellationToken cancellationToken)
     {
-        if (String.IsNullOrEmpty(imageFilename))
+        if (string.IsNullOrEmpty(imageFilename))
         {
             return null;
         }

--- a/src/backend/TrafficCourts/Test/Workflow.Service/Mappings/MappingTests.cs
+++ b/src/backend/TrafficCourts/Test/Workflow.Service/Mappings/MappingTests.cs
@@ -61,7 +61,7 @@ public class MappingTests
         Assert.Equal(source.TimeToPayReason, target.TimeToPayReason);
         Assert.Equal(source.DisputantDetectedOcrIssues, target.DisputantDetectedOcrIssues);
         Assert.Equal(source.DisputantOcrIssues, target.DisputantOcrIssues);
-        Assert.Equal(source.OcrViolationTicket, target.OcrViolationTicket);
+        Assert.Equal(source.OcrTicketFilename, target.OcrTicketFilename);
         Assert.Equal(source.ViolationTicket?.TicketNumber, target.ViolationTicket.TicketNumber);
         Assert.Equal(source.ViolationTicket?.DisputantSurname, target.ViolationTicket.DisputantSurname);
         Assert.Equal(source.ViolationTicket?.DisputantGivenNames, target.ViolationTicket.DisputantGivenNames);

--- a/src/backend/TrafficCourts/TrafficCourts.Staff.Service.Test/Services/DisputeServiceTest.cs
+++ b/src/backend/TrafficCourts/TrafficCourts.Staff.Service.Test/Services/DisputeServiceTest.cs
@@ -31,10 +31,9 @@ public class DisputeServiceTest
         Dispute dispute = new();
         dispute.DisputeId = 1;
         dispute.ViolationTicket = new();
-        dispute.OcrViolationTicket = json;
 
         //When
-        string? filename = service.GetViolationTicketImageFilename(dispute);
+        string? filename = service.GetViolationTicketImageFilename(json);
 
         //Then
         Assert.Equal(expectedFilename, filename);

--- a/src/backend/TrafficCourts/Workflow.Service/Services/OracleDataApiService.cs
+++ b/src/backend/TrafficCourts/Workflow.Service/Services/OracleDataApiService.cs
@@ -20,7 +20,7 @@ public class OracleDataApiService : IOracleDataApiService
     public async Task<long> CreateDisputeAsync(Dispute dispute, CancellationToken cancellationToken)
     {
         // stub out the ViolationTicket if the submitted Dispute has associated OCR scan results.
-        if (!string.IsNullOrEmpty(dispute.OcrViolationTicket))
+        if (!string.IsNullOrEmpty(dispute.OcrTicketFilename))
         {
             dispute.ViolationTicket = new();
             dispute.ViolationTicket.TicketNumber = dispute.TicketNumber;

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/mapper/DisputeMapper.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/mapper/DisputeMapper.java
@@ -81,7 +81,7 @@ public interface DisputeMapper {
 	@Mapping(source = "dispute.disputantDetectOcrIssuesYn", target = "disputantDetectedOcrIssues")
 	@Mapping(source = "dispute.disputantOcrIssuesTxt", target = "disputantOcrIssues")
 	@Mapping(source = "dispute.systemDetectOcrIssuesYn", target = "systemDetectedOcrIssues")
-	@Mapping(source = "dispute.ocrViolationTicketJsonTxt", target = "ocrViolationTicket")
+	@Mapping(source = "dispute.ocrViolationTicketJsonTxt", target = "ocrTicketFilename")
 	// Map violation ticket data from ORDS to Oracle Data API violation ticket model
 	@Mapping(source = "entUserId", target = "violationTicket.createdBy")
 	@Mapping(source = "entDtm", target = "violationTicket.createdTs")
@@ -169,8 +169,8 @@ public interface DisputeMapper {
 	@Named("mapCounts")
 	default List<DisputeCount> mapCounts(List<ca.bc.gov.open.jag.tco.oracledataapi.api.model.ViolationTicketCount> violationTicketCounts) {
 		if ( violationTicketCounts == null || violationTicketCounts.isEmpty()) {
-            return null;
-        }
+			return null;
+		}
 
 		List<DisputeCount> disputeCounts = new ArrayList<DisputeCount>();
 
@@ -203,11 +203,11 @@ public interface DisputeMapper {
 				disputeCounts.add(count);
 			}
 		}
-	    return disputeCounts;
+		return disputeCounts;
 	}
 
 	@AfterMapping
-    default void setLawyerAddress(@MappingTarget Dispute dispute, ViolationTicket violationTicket) {
+	default void setLawyerAddress(@MappingTarget Dispute dispute, ViolationTicket violationTicket) {
 		ca.bc.gov.open.jag.tco.oracledataapi.api.model.Dispute disputeFromApi = violationTicket.getDispute();
 		if (dispute != null && violationTicket != null && disputeFromApi != null) {
 			String addressLine1 = disputeFromApi.getLawFirmAddrLine1Txt();
@@ -217,10 +217,10 @@ public interface DisputeMapper {
 				dispute.setLawyerAddress(null);
 			} else {
 				dispute.setLawyerAddress(
-		        		addressLine1 == null ? "" : addressLine1 + " " +
-		        		addressLine2 == null ? "" : addressLine2 + " " +
-		        		addressLine3 == null ? "" : addressLine3);
+						addressLine1 == null ? "" : addressLine1 + " " +
+								addressLine2 == null ? "" : addressLine2 + " " +
+										addressLine3 == null ? "" : addressLine3);
 			}
 		}
-    }
+	}
 }

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/mapper/ViolationTicketMapper.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/mapper/ViolationTicketMapper.java
@@ -81,7 +81,7 @@ public interface ViolationTicketMapper {
 	@Mapping(target = "dispute.disputantDetectOcrIssuesYn", source = "disputantDetectedOcrIssues")
 	@Mapping(target = "dispute.disputantOcrIssuesTxt", source = "disputantOcrIssues")
 	@Mapping(target = "dispute.systemDetectOcrIssuesYn", source = "systemDetectedOcrIssues")
-	@Mapping(target = "dispute.ocrViolationTicketJsonTxt", source = "ocrViolationTicket")
+	@Mapping(target = "dispute.ocrViolationTicketJsonTxt", source = "ocrTicketFilename")
 	// TODO - need replace the default constant values below to set the IDs from the actual dispute model source from request
 	@Mapping(target = "dispute.addressCtryId", constant = "1")
 	@Mapping(target = "dispute.drvLicIssuedCtryId", constant = "1")

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/model/Dispute.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/model/Dispute.java
@@ -13,7 +13,6 @@ import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
-import javax.persistence.Lob;
 import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
 import javax.persistence.OneToOne;
@@ -405,12 +404,12 @@ public class Dispute extends Auditable<String> {
 	private YesNo systemDetectedOcrIssues;
 
 	/**
-	 * All OCR Violation ticket data serialized into a JSON string.
+	 * Filename of JSON serialized OCR data that is saved in object storage.
 	 */
-	@Column
-	@Lob
-	@Schema(nullable = true)
-	private String ocrViolationTicket;
+	@Size(max = 100)
+	@Column(length = 100)
+	@Schema(maxLength = 100, nullable = true)
+	private String ocrTicketFilename;
 
 	@JsonManagedReference
 	@OneToOne(fetch = FetchType.LAZY, optional = true, cascade = CascadeType.ALL, orphanRemoval = true, mappedBy = "dispute")

--- a/src/backend/oracle-data-api/src/test/java/ca/bc/gov/open/jag/tco/oracledataapi/util/RandomUtil.java
+++ b/src/backend/oracle-data-api/src/test/java/ca/bc/gov/open/jag/tco/oracledataapi/util/RandomUtil.java
@@ -117,12 +117,12 @@ public class RandomUtil {
 	};
 
 	public final static String[] COMMON_EMAIL_ADDRESSES = new String[] {
-		"1@1.com",
-		"2@2.ca",
-		"3@3.com",
-		"Lucas@4.com",
-		"Stacy@5.com",
-		"Arlington@6.com"
+			"1@1.com",
+			"2@2.ca",
+			"3@3.com",
+			"Lucas@4.com",
+			"Stacy@5.com",
+			"Arlington@6.com"
 	};
 
 	public final static String[] COMMON_CITY_NAMES = new String[] {
@@ -357,7 +357,7 @@ public class RandomUtil {
 		dispute.setLawyerPhoneNumber(randomNumeric(20));
 		dispute.setLawyerSurname(randomAlphabetic(30));
 		dispute.setNoticeOfDisputeGuid(UUID.randomUUID().toString());
-		dispute.setOcrViolationTicket(randomAlphabetic(4000));
+		dispute.setOcrTicketFilename(randomAlphabetic(100));
 		dispute.setOfficerPin(randomAlphabetic(10));
 		dispute.setPostalCode(randomAlphanumeric(10));
 		dispute.setRejectedReason(randomAlphabetic(500));


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- TCVP-1903
- Added functionality to save filename of an OCRed violation ticket in the database instead of saving the whole violation ticket JSON.
- Used the filename for a few validations to determine the violation ticket type and retrieve ticket data from object storage.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
