### PR TITLE
Rename and update mapping for ocr violation ticket json field

### DIFF
--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/mapper/DisputeMapper.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/mapper/DisputeMapper.java
@@ -81,7 +81,7 @@ public interface DisputeMapper {
 	@Mapping(source = "dispute.disputantDetectOcrIssuesYn", target = "disputantDetectedOcrIssues")
 	@Mapping(source = "dispute.disputantOcrIssuesTxt", target = "disputantOcrIssues")
 	@Mapping(source = "dispute.systemDetectOcrIssuesYn", target = "systemDetectedOcrIssues")
-	@Mapping(source = "dispute.ocrViolationTicketJsonTxt", target = "ocrTicketFilename")
+	@Mapping(source = "dispute.ocrTicketJsonFilenameTxt", target = "ocrTicketFilename")
 	// Map violation ticket data from ORDS to Oracle Data API violation ticket model
 	@Mapping(source = "entUserId", target = "violationTicket.createdBy")
 	@Mapping(source = "entDtm", target = "violationTicket.createdTs")

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/mapper/ViolationTicketMapper.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/mapper/ViolationTicketMapper.java
@@ -81,7 +81,7 @@ public interface ViolationTicketMapper {
 	@Mapping(target = "dispute.disputantDetectOcrIssuesYn", source = "disputantDetectedOcrIssues")
 	@Mapping(target = "dispute.disputantOcrIssuesTxt", source = "disputantOcrIssues")
 	@Mapping(target = "dispute.systemDetectOcrIssuesYn", source = "systemDetectedOcrIssues")
-	@Mapping(target = "dispute.ocrViolationTicketJsonTxt", source = "ocrTicketFilename")
+	@Mapping(target = "dispute.ocrTicketJsonFilenameTxt", source = "ocrTicketFilename")
 	// TODO - need replace the default constant values below to set the IDs from the actual dispute model source from request
 	@Mapping(target = "dispute.addressCtryId", constant = "1")
 	@Mapping(target = "dispute.drvLicIssuedCtryId", constant = "1")

--- a/src/backend/oracle-data-api/src/main/resources/occm-openapi-spec.yaml
+++ b/src/backend/oracle-data-api/src/main/resources/occm-openapi-spec.yaml
@@ -614,7 +614,9 @@ components:
           format: nullable
         noticeOfDisputeGuid:
           type: string
-        ocrViolationTicketJsonTxt:
+          format: nullable
+          maxLength: 36
+        ocrTicketJsonFilenameTxt:
           type: string
           format: nullable
         officerPinTxt:


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- Refactored Oracle Data API to match database changes for renaming ocrViolationTicketJsonTxt field to ocrTicketJsonFilenameTxt.
- Updated mappings and open api spec for ocrTicketJsonFilenameTxt.
- Updated noticeOfDisputeGuid in open api spec to set max length to 36 chars.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
