### PR TITLE
TCVP-1911 and TCVP-1919 - save and get all dates in UTC

### DIFF
--- a/src/backend/oracle-data-api/pom.xml
+++ b/src/backend/oracle-data-api/pom.xml
@@ -309,11 +309,8 @@
 							<invokerPackage>${default-package}.api.handler</invokerPackage>
 							<typeMappings>
 								<typeMapping>OffsetDateTime=java.util.Date</typeMapping>
-								<typeMapping>LocalDate=java.sql.Date</typeMapping>
+								<typeMapping>LocalDate=java.util.Date</typeMapping>
 							</typeMappings>
-							<importMappings>
-								<importMapping>java.time.LocalDate=java.sql.Date</importMapping>
-							</importMappings>
 						</configuration>
 					</execution>
 				</executions>

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/mapper/DisputeMapper.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/mapper/DisputeMapper.java
@@ -29,9 +29,9 @@ public interface DisputeMapper {
 	DisputeMapper INSTANCE = Mappers.getMapper(DisputeMapper.class);
 
 	// Map dispute data from ORDS to Oracle Data API dispute model
-	@Mapping(source = "dispute.entDtm", target = "createdTs", dateFormat = DisputeRepositoryImpl.DATE_TIME_FORMAT)
+	@Mapping(source = "dispute.entDtm", target = "createdTs")
 	@Mapping(source = "dispute.entUserId", target = "createdBy")
-	@Mapping(source = "dispute.updDtm", target = "modifiedTs", dateFormat = DisputeRepositoryImpl.DATE_TIME_FORMAT)
+	@Mapping(source = "dispute.updDtm", target = "modifiedTs")
 	@Mapping(source = "dispute.updUserId", target = "modifiedBy")
 	@Mapping(source = "dispute.disputeId", target = "disputeId")
 	@Mapping(source = "dispute.disputeStatusTypeCd", target = "status", qualifiedByName="mapDisputeStatus")
@@ -78,7 +78,7 @@ public interface DisputeMapper {
 	@Mapping(source = "dispute.disputantCommentTxt", target = "disputantComment")
 	@Mapping(source = "dispute.rejectedReasonTxt", target = "rejectedReason")
 	@Mapping(source = "dispute.userAssignedTo", target = "userAssignedTo")
-	@Mapping(source = "dispute.userAssignedDtm", target = "userAssignedTs", dateFormat = DisputeRepositoryImpl.DATE_TIME_FORMAT)
+	@Mapping(source = "dispute.userAssignedDtm", target = "userAssignedTs")
 	@Mapping(source = "dispute.disputantDetectOcrIssuesYn", target = "disputantDetectedOcrIssues")
 	@Mapping(source = "dispute.disputantOcrIssuesTxt", target = "disputantOcrIssues")
 	@Mapping(source = "dispute.systemDetectOcrIssuesYn", target = "systemDetectedOcrIssues")

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/mapper/ViolationTicketMapper.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/mapper/ViolationTicketMapper.java
@@ -27,9 +27,9 @@ public interface ViolationTicketMapper {
 	ViolationTicketMapper INSTANCE = Mappers.getMapper(ViolationTicketMapper.class);
 
 	// Map from Oracle Data API dispute model to ORDS dispute data
-	@Mapping(target = "dispute.entDtm", source = "createdTs", dateFormat = DisputeRepositoryImpl.DATE_TIME_FORMAT)
+	@Mapping(target = "dispute.entDtm", source = "createdTs")
 	@Mapping(target = "dispute.entUserId", source = "createdBy")
-	@Mapping(target = "dispute.updDtm", source = "modifiedTs", dateFormat = DisputeRepositoryImpl.DATE_TIME_FORMAT)
+	@Mapping(target = "dispute.updDtm", source = "modifiedTs")
 	@Mapping(target = "dispute.updUserId", source = "modifiedBy")
 	@Mapping(target = "dispute.disputeId", source = "disputeId")
 	@Mapping(target = "dispute.disputeStatusTypeCd", source = "status", qualifiedByName="mapDisputeStatus")
@@ -78,7 +78,7 @@ public interface ViolationTicketMapper {
 	@Mapping(target = "dispute.disputantCommentTxt", source = "disputantComment")
 	@Mapping(target = "dispute.rejectedReasonTxt", source = "rejectedReason")
 	@Mapping(target = "dispute.userAssignedTo", source = "userAssignedTo")
-	@Mapping(target = "dispute.userAssignedDtm", source = "userAssignedTs", dateFormat = DisputeRepositoryImpl.DATE_TIME_FORMAT)
+	@Mapping(target = "dispute.userAssignedDtm", source = "userAssignedTs")
 	@Mapping(target = "dispute.disputantDetectOcrIssuesYn", source = "disputantDetectedOcrIssues")
 	@Mapping(target = "dispute.disputantOcrIssuesTxt", source = "disputantOcrIssues")
 	@Mapping(target = "dispute.systemDetectOcrIssuesYn", source = "systemDetectedOcrIssues")

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/model/Auditable.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/model/Auditable.java
@@ -33,7 +33,7 @@ public abstract class Auditable<U> {
 	@Column(updatable = false)
 	private U createdBy;
 
-	/** The timestamp this record was created. */
+	/** The timestamp this record was created. This should always be in UTC date-time (ISO 8601) format */
 	@CreatedDate
 	@Temporal(TIMESTAMP)
 	@Column(updatable = false)
@@ -44,7 +44,7 @@ public abstract class Auditable<U> {
 	@Schema(nullable = true)
 	private U modifiedBy;
 
-	/** The timestamp this record was last modified. */
+	/** The timestamp this record was last modified. This should always be in UTC date-time (ISO 8601) format*/
 	@LastModifiedDate
 	@Temporal(TIMESTAMP)
 	@Schema(nullable = true)

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/model/Dispute.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/model/Dispute.java
@@ -63,7 +63,7 @@ public class Dispute extends Auditable<String> {
 
 	/**
 	 * The date and time the violation ticket was issue. Time must only be hours and
-	 * minutes.
+	 * minutes. This should always be in UTC date-time (ISO 8601) format
 	 */
 	@Column
 	@Temporal(TemporalType.TIMESTAMP)
@@ -72,6 +72,7 @@ public class Dispute extends Auditable<String> {
 
 	/**
 	 * The date and time the citizen submitted the notice of dispute.
+	 * This should always be in UTC date-time (ISO 8601) format
 	 */
 	@Column
 	@Schema(nullable = true)
@@ -215,6 +216,7 @@ public class Dispute extends Auditable<String> {
 
 	/**
 	 * Indicates whether the disputant's email address is verified or not.
+	 * This should always be in UTC date (ISO 8601) format
 	 */
 	@Column
 	private Boolean emailAddressVerified = Boolean.FALSE;
@@ -373,6 +375,7 @@ public class Dispute extends Auditable<String> {
 
 	/**
 	 * The date and time a dispute was assigned to a Staff to be reviewed.
+	 * This should always be in UTC date-time (ISO 8601) format
 	 */
 	@Column
 	@Schema(nullable = true)

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/model/ViolationTicket.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/model/ViolationTicket.java
@@ -43,130 +43,130 @@ import lombok.Setter;
 public class ViolationTicket extends Auditable<String> {
 
 	@Schema(description = "ID", accessMode = Schema.AccessMode.READ_ONLY)
-    @Id
-    @GeneratedValue
-    private Long violationTicketId;
+	@Id
+	@GeneratedValue
+	private Long violationTicketId;
 
-    /**
-     * The violation ticket number.
-     */
-    @Column(length = 50)
-    @Schema(nullable = true)
-    private String ticketNumber;
+	/**
+	 * The violation ticket number.
+	 */
+	@Column(length = 50)
+	@Schema(nullable = true)
+	private String ticketNumber;
 
-    /**
+	/**
 	 * Name of the organization of the disputant
 	 */
 	@Column(length = 150)
 	@Schema(nullable = true)
 	private String disputantOrganizationName;
 
-    /**
-     * The surname or corporate name.
-     */
-    @Column(length = 100)
-    @Schema(nullable = true)
-    private String disputantSurname;
+	/**
+	 * The surname or corporate name.
+	 */
+	@Column(length = 100)
+	@Schema(nullable = true)
+	private String disputantSurname;
 
-    /**
-     * The given names or corporate name continued.
-     */
-    @Column(length = 200)
-    @Schema(nullable = true)
-    private String disputantGivenNames;
+	/**
+	 * The given names or corporate name continued.
+	 */
+	@Column(length = 200)
+	@Schema(nullable = true)
+	private String disputantGivenNames;
 
-   /**
+	/**
 	 * The person issued the ticket has been identified as a young person.
 	 */
 	@Schema(nullable = true)
 	@Enumerated(EnumType.STRING)
-    private YesNo isYoungPerson;
+	private YesNo isYoungPerson;
 
-    /**
-     * The drivers licence number. Note not all jurisdictions will use numeric drivers licence numbers.
-     */
-    @Size(min = 7, max = 30)
-    @Column(length = 30)
-    @Schema(nullable = true, minLength = 7, maxLength = 30)
-    private String disputantDriversLicenceNumber;
+	/**
+	 * The drivers licence number. Note not all jurisdictions will use numeric drivers licence numbers.
+	 */
+	@Size(min = 7, max = 30)
+	@Column(length = 30)
+	@Schema(nullable = true, minLength = 7, maxLength = 30)
+	private String disputantDriversLicenceNumber;
 
-    /**
+	/**
 	 * Disputant client number
 	 */
 	@Column(length = 30)
 	@Schema(nullable = true)
 	private String disputantClientNumber;
 
-	 /**
-     * The province or state the drivers licence was issued by.
-     */
+	/**
+	 * The province or state the drivers licence was issued by.
+	 */
 	@Size(max = 100)
 	@Column(length = 100)
-    @Schema(nullable = true)
-    private String driversLicenceProvince;
+	@Schema(nullable = true)
+	private String driversLicenceProvince;
 
 	@Size(max = 100)
 	@Column(length = 100)
 	private String driversLicenceCountry = "Unknown"; // FIXME: Hard-coded constant for now
 
-    /**
-     * The year the drivers licence was issued.
-     */
-    @Column(length = 4)
-    @Schema(nullable = true)
-    private Integer driversLicenceIssuedYear;
+	/**
+	 * The year the drivers licence was issued.
+	 */
+	@Column(length = 4)
+	@Schema(nullable = true)
+	private Integer driversLicenceIssuedYear;
 
-    /**
-     * The year the drivers licence expires.
-     */
-    @Column(length = 4)
-    @Schema(nullable = true)
-    private Integer driversLicenceExpiryYear;
+	/**
+	 * The year the drivers licence expires.
+	 */
+	@Column(length = 4)
+	@Schema(nullable = true)
+	private Integer driversLicenceExpiryYear;
 
-     /**
-     * The birthdate of the individual the violation ticket was issued to.
-     */
-    @Column
-    @Schema(nullable = true)
-    private Date disputantBirthdate;
+	/**
+	 * The birthdate of the individual the violation ticket was issued to.
+	 */
+	@Column
+	@Schema(nullable = true)
+	private Date disputantBirthdate;
 
-    /**
-     * The address of the individual the violation ticket was issued to.
-     */
-    @Size(max = 100)
-    @Column(length = 100)
-    @Schema(nullable = true)
-    private String address;
+	/**
+	 * The address of the individual the violation ticket was issued to.
+	 */
+	@Size(max = 100)
+	@Column(length = 100)
+	@Schema(nullable = true)
+	private String address;
 
-    /**
-     * The city of the individual the violation ticket was issued to.
-     */
-    @Column(length = 100)
-    @Schema(nullable = true)
-    private String addressCity;
+	/**
+	 * The city of the individual the violation ticket was issued to.
+	 */
+	@Column(length = 100)
+	@Schema(nullable = true)
+	private String addressCity;
 
-    /**
-     * The province or state of the individual the violation ticket was issued to.
-     */
-    @Column(length = 100)
-    @Schema(nullable = true)
-    private String addressProvince;
+	/**
+	 * The province or state of the individual the violation ticket was issued to.
+	 */
+	@Column(length = 100)
+	@Schema(nullable = true)
+	private String addressProvince;
 
-    /**
-     * The postal code or zip code.
-     */
-    @Column(length = 10)
-    @Schema(nullable = true)
-    private String addressPostalCode;
+	/**
+	 * The postal code or zip code.
+	 */
+	@Column(length = 10)
+	@Schema(nullable = true)
+	private String addressPostalCode;
 
-    /**
-     * The address country.
-     */
-    @Column(length = 100)
-    @Schema(nullable = true)
-    private String addressCountry;
+	/**
+	 * The address country.
+	 */
+	@Column(length = 100)
+	@Schema(nullable = true)
+	private String addressCountry;
 
-    /**
+	/**
 	 * Officer Pin
 	 */
 	@Column(length = 10)
@@ -174,65 +174,66 @@ public class ViolationTicket extends Auditable<String> {
 	private String officerPin;
 
 	/**
-     * Detachment location.
-     */
-    @Column(length = 150)
-    @Schema(nullable = true)
-    private String detachmentLocation;
+	 * Detachment location.
+	 */
+	@Column(length = 150)
+	@Schema(nullable = true)
+	private String detachmentLocation;
 
-    /**
-     * The date and time the violation ticket was issue. Time must only be hours and minutes.
-     */
-    @Column
-    @Schema(nullable = true)
+	/**
+	 * The date and time the violation ticket was issue. Time must only be hours and minutes.
+	 * This should always be in UTC date-time (ISO 8601) format
+	 */
+	@Column
+	@Schema(nullable = true)
 	@Temporal(TemporalType.TIMESTAMP)
-    private Date issuedTs;
+	private Date issuedTs;
 
-    /**
-     * The violation ticket was issued on this road or highway.
-     */
-    @Column(length = 100)
-    @Schema(nullable = true)
-    private String issuedOnRoadOrHighway;
+	/**
+	 * The violation ticket was issued on this road or highway.
+	 */
+	@Column(length = 100)
+	@Schema(nullable = true)
+	private String issuedOnRoadOrHighway;
 
-    @Column(length = 100)
-    @Schema(nullable = true)
-    private String issuedAtOrNearCity;
+	@Column(length = 100)
+	@Schema(nullable = true)
+	private String issuedAtOrNearCity;
 
-    /**
+	/**
 	 * The address represents a change of address. The address on the violation would be different from the address on the drivers licence or provided identification.
 	 */
 	@Schema(nullable = true)
 	@Enumerated(EnumType.STRING)
 	private YesNo isChangeOfAddress;
 
-    /**
+	/**
 	 * The enforcement officer says that he or she has reasonable grounds to believe, and does believe, that the above named as the vehicle driver.
 	 */
 	@Schema(nullable = true)
 	@Enumerated(EnumType.STRING)
 	private YesNo isDriver;
 
-     /**
+	/**
 	 * The enforcement officer says that he or she has reasonable grounds to believe, and does believe, that the above named as the vehicle owner.
 	 */
 	@Schema(nullable = true)
 	@Enumerated(EnumType.STRING)
 	private YesNo isOwner;
 
-    /**
-     * Court location.
-     */
-    @Column(length = 150)
-    @Schema(nullable = true)
-    private String courtLocation;
+	/**
+	 * Court location.
+	 */
+	@Column(length = 150)
+	@Schema(nullable = true)
+	private String courtLocation;
 
-    @JsonManagedReference
-    @OneToMany(targetEntity=ViolationTicketCount.class, cascade = CascadeType.ALL, fetch = FetchType.LAZY, orphanRemoval = true)
-    @JoinColumn(name="violation_ticket_id", referencedColumnName="violationTicketId")
-    private List<ViolationTicketCount> violationTicketCounts = new ArrayList<ViolationTicketCount>();
+	@JsonManagedReference
+	@OneToMany(targetEntity=ViolationTicketCount.class, cascade = CascadeType.ALL, fetch = FetchType.LAZY, orphanRemoval = true)
+	@JoinColumn(name="violation_ticket_id", referencedColumnName="violationTicketId")
+	private List<ViolationTicketCount> violationTicketCounts = new ArrayList<ViolationTicketCount>();
 
-    @JsonBackReference
+	@JsonBackReference
 	@OneToOne
 	@JoinColumn(name = "dispute_id", referencedColumnName = "disputeId")
 	@Schema(hidden = true)

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/repository/impl/ords/DisputeRepositoryImpl.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/repository/impl/ords/DisputeRepositoryImpl.java
@@ -35,8 +35,7 @@ import ca.bc.gov.open.jag.tco.oracledataapi.repository.DisputeRepository;
 @Repository
 public class DisputeRepositoryImpl implements DisputeRepository {
 
-	public static final String DATE_TIME_FORMAT = "yyyy-MM-dd HH:mm:ss";
-
+	public static final String DATE_TIME_FORMAT = "yyyy-MM-dd'T'HH:mm:ss'Z'";
 	public static final String DATE_FORMAT = "yyyy-MM-dd";
 	public static final String TIME_FORMAT = "HH:mm";
 
@@ -61,7 +60,7 @@ public class DisputeRepositoryImpl implements DisputeRepository {
 
 	@Override
 	public List<Dispute> findByStatusNotAndCreatedTsBeforeAndNoticeOfDisputeGuid(DisputeStatus excludeStatus, Date olderThan, String noticeOfDisputeGuid) {
-				String olderThanDate = null ;
+		String olderThanDate = null ;
 		String statusShortName = excludeStatus != null ? excludeStatus.toShortName() : null;
 
 		if (olderThan != null) {

--- a/src/backend/oracle-data-api/src/main/resources/occm-openapi-spec.yaml
+++ b/src/backend/oracle-data-api/src/main/resources/occm-openapi-spec.yaml
@@ -451,13 +451,13 @@ components:
         entDtm:
           type: string
           format: date-time
-          x-field-extra-annotation: "@com.fasterxml.jackson.annotation.JsonFormat(pattern=\"yyyy-MM-dd HH:mm:ss\")"
+          x-field-extra-annotation: "@com.fasterxml.jackson.annotation.JsonFormat(pattern=\"yyyy-MM-dd'T'HH:mm:ss'Z'\")"
         entUserId:
           type: string
         updDtm:
           type: string
           format: date-time
-          x-field-extra-annotation: "@com.fasterxml.jackson.annotation.JsonFormat(pattern=\"yyyy-MM-dd HH:mm:ss\")"
+          x-field-extra-annotation: "@com.fasterxml.jackson.annotation.JsonFormat(pattern=\"yyyy-MM-dd'T'HH:mm:ss'Z'\")"
         updUserId:
           type: string
           format: nullable
@@ -541,6 +541,7 @@ components:
         filingDt:
           type: string
           format: date
+          x-field-extra-annotation: "@com.fasterxml.jackson.annotation.JsonFormat(pattern=\"yyyy-MM-dd'Z'\")"
         fineReductionReasonTxt:
           type: string
         homePhoneNumberTxt:
@@ -550,8 +551,8 @@ components:
           format: nullable
         issuedDt:
           type: string
-          # FIXME: this should be date-time but can't at the moment - ORDS is unable to parse ISO format, ie, "2022-10-31T01:30:00.000-07:00"
-          format: date
+          format: date-time
+          x-field-extra-annotation: "@com.fasterxml.jackson.annotation.JsonFormat(pattern=\"yyyy-MM-dd'T'HH:mm'Z'\")"
         jjAssignedTo:
           type: string
           format: nullable
@@ -632,19 +633,16 @@ components:
           format: nullable
         submittedDt:
           type: string
-          format: date
+          format: date-time
+          x-field-extra-annotation: "@com.fasterxml.jackson.annotation.JsonFormat(pattern=\"yyyy-MM-dd'T'HH:mm:ss'Z'\")"
         systemDetectOcrIssuesYn:
           type: string
         timeToPayReasonTxt:
           type: string
-        updDtm:
-          type: string
-        updUserId:
-          type: string
-          format: nullable
         userAssignedDtm:
           type: string
-          format: nullable
+          format: date-time
+          x-field-extra-annotation: "@com.fasterxml.jackson.annotation.JsonFormat(pattern=\"yyyy-MM-dd'T'HH:mm:ss'Z'\")"
         userAssignedTo:
           type: string
           format: nullable
@@ -776,8 +774,8 @@ components:
           format: nullable
         issuedDt:
           type: string
-          # FIXME: this should be date-time but can't at the moment - ORDS is unable to parse ISO format, ie, "2022-10-31T01:30:00.000-07:00"
-          format: date
+          format: date-time
+          x-field-extra-annotation: "@com.fasterxml.jackson.annotation.JsonFormat(pattern=\"yyyy-MM-dd'T'HH:mm'Z'\")"
         issuedOnRoadOrHighwayTxt:
           type: string
           format: nullable

--- a/src/backend/oracle-data-api/src/test/java/ca/bc/gov/open/jag/tco/oracledataapi/service/impl/ords/DisputeServiceImplTest.java
+++ b/src/backend/oracle-data-api/src/test/java/ca/bc/gov/open/jag/tco/oracledataapi/service/impl/ords/DisputeServiceImplTest.java
@@ -349,7 +349,7 @@ class DisputeServiceImplTest extends BaseTestSuite {
 		ViolationTicket violationTicket = new ViolationTicket();
 		violationTicket.setDispute(dispute);
 		violationTicket.setTicketNumberTxt(ticketNumber);
-		violationTicket.setIssuedDt(new java.sql.Date(issuedDate.getTime()));
+		violationTicket.setIssuedDt(new java.util.Date(issuedDate.getTime()));
 
 		ViolationTicketListResponse validResponse = new ViolationTicketListResponse();
 		validResponse.setViolationTickets(new ArrayList<ViolationTicket>());


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- Fixes the bugs: [TCVP-1911](https://justice.gov.bc.ca/jira/browse/TCVP-1911) and [TCVP-1919](https://justice.gov.bc.ca/jira/browse/TCVP-1919)
- Updated all date-time fields' format to be compatible with UTC time ISO standard as well as match those fields' format in JSON for ORDS serialization/deserialization of date-time format.
- Removed unnecessary usage of java.sql.Date library from the pom file for generated sources and tests.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Created a new dispute record in Oracle database with all date fields provided by sending a request through Oracle API. Sent a GET request to the Oracle API to return the same record and compared the date fields' format with the ones that are returned from ORDS and confirmed that the fields have equal dates in correct format. Also the returned dates are same as the ones that were requested to save.

Ran DisputeServiceOrdsTest JUnit test.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
