### PR TITLE
TCVP-1834 updated findDisputeByTicketNumber endpoint

### DIFF
--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/controller/v1_0/DisputeController.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/controller/v1_0/DisputeController.java
@@ -92,27 +92,27 @@ public class DisputeController {
 	}
 
 	/**
-	 * GET endpoint that finds Disputes by TicketNumber and IssuedTime.
+	 * GET endpoint that finds Dispute statuses by TicketNumber and IssuedTime.
 	 *
-	 * @param ticketNumber of the ViolationTicket.ticketNumber to search for
-	 * @param issuedTime the time portion of the ViolationTicket.issuedTs field
+	 * @param ticketNumber of the Dispute.ticketNumber to search for
+	 * @param issuedTime the time portion of the Dispute.issuedTs field
 	 * @return {@link Dispute}
 	 */
-	@Operation(summary = "Finds Disputes by TicketNumber and IssuedTime.")
+	@Operation(summary = "Finds Dispute statuses by TicketNumber and IssuedTime.")
 	@ApiResponses({
 		@ApiResponse(responseCode = "200", description = "Ok."),
 		@ApiResponse(responseCode = "400", description = "Bad Request, check parameters."),
 		@ApiResponse(responseCode = "500", description = "Internal Server Error. Search failed.")
 	})
-	@GetMapping("/dispute")
+	@GetMapping("/dispute/status")
 	public ResponseEntity<List<DisputeResult>> findDispute(
 			@RequestParam
 			@Pattern(regexp = "[A-Z]{2}\\d{8}")
-			@Parameter(description = "The TicketNumber to search for (of the format XX00000000)", example = "AX12345678")
+			@Parameter(description = "The Dispute.ticketNumber to search for (of the format XX00000000)", example = "AX12345678")
 			String ticketNumber,
 			@RequestParam
 			@DateTimeFormat(pattern="HH:mm")
-			@Parameter(description = "The time portion of the IssuedTs field to search for (of the format HH:mm)", example = "14:53", schema = @Schema(type="string"))
+			@Parameter(description = "The time portion of the Dispute.issuedTs field to search for (of the format HH:mm). Time is in UTC.", example = "14:53", schema = @Schema(type="string"))
 			Date issuedTime) {
 		logger.debug("GET /disputes called");
 		return new ResponseEntity<List<DisputeResult>>(disputeService.findDispute(ticketNumber, issuedTime), HttpStatus.OK);

--- a/src/backend/oracle-data-api/src/test/java/ca/bc/gov/open/jag/tco/oracledataapi/controller/v1_0/DisputeControllerTest.java
+++ b/src/backend/oracle-data-api/src/test/java/ca/bc/gov/open/jag/tco/oracledataapi/controller/v1_0/DisputeControllerTest.java
@@ -299,7 +299,7 @@ class DisputeControllerTest extends BaseTestSuite {
 	@Test
 	public void testFindByTicketNumberAndTime_Null() throws Exception {
 		mvc.perform(MockMvcRequestBuilders
-				.get("/api/v1.0/dispute")) // missing parameters
+				.get("/api/v1.0/dispute/status")) // missing parameters
 				.andExpect(status().isBadRequest());
 	}
 
@@ -314,7 +314,7 @@ class DisputeControllerTest extends BaseTestSuite {
 		})
 	public void testFindByTicketNumberAndTime_Invalid(String ticketNumber, String issuedTime) throws Exception {
 		mvc.perform(MockMvcRequestBuilders
-				.get("/api/v1.0/dispute")
+				.get("/api/v1.0/dispute/status")
 				.param("ticketNumber", ticketNumber)
 				.param("issuedTime", issuedTime))
 				.andExpect(status().isBadRequest());
@@ -433,7 +433,7 @@ class DisputeControllerTest extends BaseTestSuite {
 
 	/** Issues a GET request to /api/v1.0/dispute with the required ticketNumber and time to find a Dispute. */
 	private List<DisputeResult> findDispute(String ticketNumber, String issuedTime) {
-		UriComponentsBuilder uriBuilder = fromUriString("/dispute")
+		UriComponentsBuilder uriBuilder = fromUriString("/dispute/status")
 				.queryParam("ticketNumber", ticketNumber)
 				.queryParam("issuedTime", issuedTime);
 		ResponseEntity<List<DisputeResult>> results = getForEntity(uriBuilder, new ParameterizedTypeReference<List<DisputeResult>>() {});


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

TCVP-1834

Moved the endpoint to /api/dispute/status to make is more clear that this endpoint doesn't return a Dispute, but rather DisputeStatuses.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

mvn verify

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
