### PR TITLE
TCVP-1956 Fix lawyer address field mapping

### DIFF
--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/mapper/DisputeMapper.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/mapper/DisputeMapper.java
@@ -217,10 +217,11 @@ public interface DisputeMapper {
 			if (addressLine1 == null && addressLine2 == null && addressLine3 == null) {
 				dispute.setLawyerAddress(null);
 			} else {
-				dispute.setLawyerAddress(
-						addressLine1 == null ? "" : addressLine1 + " " +
-								addressLine2 == null ? "" : addressLine2 + " " +
-										addressLine3 == null ? "" : addressLine3);
+				String fullLawyerAddress = "";
+				fullLawyerAddress += addressLine1 == null ? "" : addressLine1 + " ";
+				fullLawyerAddress += addressLine2 == null ? "" : addressLine2 + " ";
+				fullLawyerAddress += addressLine3 == null ? "" : addressLine3;
+				dispute.setLawyerAddress(fullLawyerAddress);
 			}
 		}
 	}

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/mapper/DisputeMapper.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/mapper/DisputeMapper.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 import org.apache.commons.lang3.StringUtils;
 import org.mapstruct.AfterMapping;
+import org.mapstruct.InjectionStrategy;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.MappingTarget;
@@ -24,6 +25,7 @@ import ca.bc.gov.open.jag.tco.oracledataapi.repository.impl.ords.DisputeReposito
  * This mapper maps from ORDS dispute model to Oracle Data API dispute model
  */
 @Mapper
+(componentModel = "spring", injectionStrategy = InjectionStrategy.CONSTRUCTOR) // This is required for tests to work
 public interface DisputeMapper {
 
 	DisputeMapper INSTANCE = Mappers.getMapper(DisputeMapper.class);
@@ -218,8 +220,8 @@ public interface DisputeMapper {
 				dispute.setLawyerAddress(null);
 			} else {
 				String fullLawyerAddress = "";
-				fullLawyerAddress += addressLine1 == null ? "" : addressLine1 + " ";
-				fullLawyerAddress += addressLine2 == null ? "" : addressLine2 + " ";
+				fullLawyerAddress += addressLine1 == null ? "" : addressLine1;
+				fullLawyerAddress += addressLine2 == null ? "" : addressLine2;
 				fullLawyerAddress += addressLine3 == null ? "" : addressLine3;
 				dispute.setLawyerAddress(fullLawyerAddress);
 			}

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/mapper/ViolationTicketMapper.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/mapper/ViolationTicketMapper.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import org.apache.commons.lang3.StringUtils;
 import org.mapstruct.AfterMapping;
+import org.mapstruct.InjectionStrategy;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.MappingTarget;
@@ -22,6 +23,7 @@ import ca.bc.gov.open.jag.tco.oracledataapi.repository.impl.ords.DisputeReposito
  * This mapper maps from Oracle Data API dispute model to ORDS dispute data
  */
 @Mapper
+(componentModel = "spring", injectionStrategy = InjectionStrategy.CONSTRUCTOR) // This is required for tests to work
 public interface ViolationTicketMapper {
 
 	ViolationTicketMapper INSTANCE = Mappers.getMapper(ViolationTicketMapper.class);

--- a/src/backend/oracle-data-api/src/test/java/ca/bc/gov/open/jag/tco/oracledataapi/mapper/DisputeMapperTest.java
+++ b/src/backend/oracle-data-api/src/test/java/ca/bc/gov/open/jag/tco/oracledataapi/mapper/DisputeMapperTest.java
@@ -1,0 +1,41 @@
+package ca.bc.gov.open.jag.tco.oracledataapi.mapper;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import ca.bc.gov.open.jag.tco.oracledataapi.BaseTestSuite;
+import ca.bc.gov.open.jag.tco.oracledataapi.api.model.Dispute;
+import ca.bc.gov.open.jag.tco.oracledataapi.api.model.ViolationTicket;
+
+public class DisputeMapperTest extends BaseTestSuite{
+
+	private DisputeMapper disputeMapper;
+
+	@Autowired
+	private DisputeMapperImpl disputeMapperImpl;
+
+	@BeforeEach
+	void setUp() {
+		disputeMapper = disputeMapperImpl;
+	}
+
+	@Test
+	void testMapToDispute_shouldReturnFullLawyerAddress() {
+		ViolationTicket testViolationTicket = new ViolationTicket();
+		Dispute testDispute = new Dispute();
+		// Lawyer Address string split into three different address fields each having 100 characters
+		testDispute.setLawFirmAddrLine1Txt("Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce accumsan nulla quam, non aliquam erat");
+		testDispute.setLawFirmAddrLine2Txt(" porttitor eu. Vivamus ornare ante nec eros luctus, non tincidunt ipsum interdum. Aliquam felis feli");
+		testDispute.setLawFirmAddrLine3Txt("s, ullamcorper non rutrum sit amet, sollicitudin sit amet lectus. Quisque non massa dolor porttitor.");
+		testViolationTicket.setDispute(testDispute);
+
+		ca.bc.gov.open.jag.tco.oracledataapi.model.Dispute result = disputeMapper.convertViolationTicketDtoToDispute(testViolationTicket);
+
+		assertEquals("Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce accumsan nulla quam, non aliquam erat porttitor eu. "
+				+ "Vivamus ornare ante nec eros luctus, non tincidunt ipsum interdum. Aliquam felis felis, ullamcorper non rutrum sit amet, sollicitudin sit amet lectus. "
+				+ "Quisque non massa dolor porttitor.", result.getLawyerAddress());
+	}
+}

--- a/src/backend/oracle-data-api/src/test/java/ca/bc/gov/open/jag/tco/oracledataapi/mapper/ViolationTicketMapperTest.java
+++ b/src/backend/oracle-data-api/src/test/java/ca/bc/gov/open/jag/tco/oracledataapi/mapper/ViolationTicketMapperTest.java
@@ -1,0 +1,47 @@
+package ca.bc.gov.open.jag.tco.oracledataapi.mapper;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import ca.bc.gov.open.jag.tco.oracledataapi.BaseTestSuite;
+import ca.bc.gov.open.jag.tco.oracledataapi.model.Dispute;
+import ca.bc.gov.open.jag.tco.oracledataapi.model.DisputeStatus;
+import ca.bc.gov.open.jag.tco.oracledataapi.model.DisputeStatusType;
+import ca.bc.gov.open.jag.tco.oracledataapi.model.ViolationTicket;
+
+public class ViolationTicketMapperTest extends BaseTestSuite{
+
+	private ViolationTicketMapper violationTicketMapper;
+
+	@Autowired
+	private ViolationTicketMapperImpl violationTicketMapperImpl;
+
+	@BeforeEach
+	void setUp() {
+		violationTicketMapper = violationTicketMapperImpl;
+	}
+
+	@Test
+	void testMapToViolationTicket_shouldReturnSplitOutLawyerAddress() {
+		Dispute testDispute = new Dispute();
+		ViolationTicket testViolationTicket = new ViolationTicket();
+		DisputeStatusType statusType = new DisputeStatusType();
+		testDispute.setDisputeStatusType(statusType);
+		testDispute.setStatus(DisputeStatus.NEW);
+		testDispute.setViolationTicket(testViolationTicket);
+		// Lawyer Address string having 300 characters (max allowed length for lawyerAddress field)
+		testDispute.setLawyerAddress("Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce accumsan nulla quam, non aliquam erat porttitor eu. "
+				+ "Vivamus ornare ante nec eros luctus, non tincidunt ipsum interdum. Aliquam felis felis, ullamcorper non rutrum sit amet, sollicitudin sit amet lectus. "
+				+ "Quisque non massa dolor porttitor.");
+
+		ca.bc.gov.open.jag.tco.oracledataapi.api.model.ViolationTicket result = violationTicketMapper.convertDisputeToViolationTicketDto(testDispute);
+
+		// Should return split out lawyer address string into 3 different fields each having 100 characters
+		assertEquals("Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce accumsan nulla quam, non aliquam erat", result.getDispute().getLawFirmAddrLine1Txt());
+		assertEquals(" porttitor eu. Vivamus ornare ante nec eros luctus, non tincidunt ipsum interdum. Aliquam felis feli", result.getDispute().getLawFirmAddrLine2Txt());
+		assertEquals("s, ullamcorper non rutrum sit amet, sollicitudin sit amet lectus. Quisque non massa dolor porttitor.", result.getDispute().getLawFirmAddrLine3Txt());
+	}
+}


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- [TCVP-1956](https://justice.gov.bc.ca/jira/browse/TCVP-1956)
- Fixed the after mapping method logic to concatenate multiple lawyer address fields into single field when returning dispute data from ords.
- Added JUnit tests for mappers to verify the logic of lawyer address field custom mapping method.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Ran mvn verify

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
