### PR TITLE
Add mirrored image streams for version we depend on

### DIFF
--- a/infrastructure/openshift/tools/image-streams/dotnet.yaml
+++ b/infrastructure/openshift/tools/image-streams/dotnet.yaml
@@ -1,0 +1,78 @@
+---
+kind: ImageStream
+apiVersion: image.openshift.io/v1
+metadata:
+  name: dotnet-aspnet
+  namespace: 0198bb-tools
+  labels:
+    usage: build-pipeline-image
+spec:
+  lookupPolicy:
+    local: true
+  tags:
+    - name: '6.0'
+      from:
+        kind: DockerImage
+        name: 'mcr.microsoft.com/dotnet/aspnet:6.0'
+        imagePullSecret: 'pipeline-docker-hub-pull'
+      referencePolicy:
+        type: Source
+    - name: '7.0'
+      from:
+        kind: DockerImage
+        name: 'mcr.microsoft.com/dotnet/aspnet:7.0'
+        imagePullSecret: 'pipeline-docker-hub-pull'
+      referencePolicy:
+        type: Source
+---
+kind: ImageStream
+apiVersion: image.openshift.io/v1
+metadata:
+  name: dotnet-runtime
+  namespace: 0198bb-tools
+  labels:
+    usage: build-pipeline-image
+spec:
+  lookupPolicy:
+    local: true
+  tags:
+    - name: '6.0'
+      from:
+        kind: DockerImage
+        name: 'mcr.microsoft.com/dotnet/runtime:6.0'
+        imagePullSecret: 'pipeline-docker-hub-pull'
+      referencePolicy:
+        type: Source
+    - name: '7.0'
+      from:
+        kind: DockerImage
+        name: 'mcr.microsoft.com/dotnet/runtime:7.0'
+        imagePullSecret: 'pipeline-docker-hub-pull'
+      referencePolicy:
+        type: Source
+---
+kind: ImageStream
+apiVersion: image.openshift.io/v1
+metadata:
+  name: dotnet-sdk
+  namespace: 0198bb-tools
+  labels:
+    usage: build-pipeline-image
+spec:
+  lookupPolicy:
+    local: true
+  tags:
+    - name: '6.0'
+      from:
+        kind: DockerImage
+        name: 'mcr.microsoft.com/dotnet/aspnet:6.0'
+        imagePullSecret: 'pipeline-docker-hub-pull'
+      referencePolicy:
+        type: Source
+    - name: '7.0'
+      from:
+        kind: DockerImage
+        name: 'mcr.microsoft.com/dotnet/aspnet:7.0'
+        imagePullSecret: 'pipeline-docker-hub-pull'
+      referencePolicy:
+        type: Source

--- a/infrastructure/openshift/tools/image-streams/eclipse-temurin.yaml
+++ b/infrastructure/openshift/tools/image-streams/eclipse-temurin.yaml
@@ -1,0 +1,18 @@
+kind: ImageStream
+apiVersion: image.openshift.io/v1
+metadata:
+  name: eclipse-temurin
+  namespace: 0198bb-tools
+  labels:
+    usage: build-pipeline-image
+spec:
+  lookupPolicy:
+    local: true
+  tags:
+    - name: '11'
+      from:
+        kind: DockerImage
+        name: 'docker.io/eclipse-temurin:11'
+        imagePullSecret: 'pipeline-docker-hub-pull'
+      referencePolicy:
+        type: Source

--- a/infrastructure/openshift/tools/image-streams/maven.yaml
+++ b/infrastructure/openshift/tools/image-streams/maven.yaml
@@ -1,0 +1,18 @@
+kind: ImageStream
+apiVersion: image.openshift.io/v1
+metadata:
+  name: maven
+  namespace: 0198bb-tools
+  labels:
+    usage: build-pipeline-image
+spec:
+  lookupPolicy:
+    local: true
+  tags:
+    - name: '3.8.6-jdk-11'
+      from:
+        kind: DockerImage
+        name: 'docker.io/maven:3.8.6-jdk-11'
+        imagePullSecret: 'pipeline-docker-hub-pull'
+      referencePolicy:
+        type: Source

--- a/infrastructure/openshift/tools/image-streams/node.yaml
+++ b/infrastructure/openshift/tools/image-streams/node.yaml
@@ -1,0 +1,39 @@
+kind: ImageStream
+apiVersion: image.openshift.io/v1
+metadata:
+  name: node
+  namespace: 0198bb-tools
+  labels:
+    usage: build-pipeline-image
+spec:
+  lookupPolicy:
+    local: true
+  tags:
+    - name: '14.18'
+      from:
+        kind: DockerImage
+        name: 'docker.io/node:14.18'
+        imagePullSecret: 'pipeline-docker-hub-pull'
+      referencePolicy:
+        type: Source
+    - name: '14.21.1'
+      from:
+        kind: DockerImage
+        name: 'docker.io/node:14.21.1'
+        imagePullSecret: 'pipeline-docker-hub-pull'
+      referencePolicy:
+        type: Source
+    - name: '16.18.1'
+      from:
+        kind: DockerImage
+        name: 'docker.io/node:16.18.1'
+        imagePullSecret: 'pipeline-docker-hub-pull'
+      referencePolicy:
+        type: Source
+    - name: '18.12.1'
+      from:
+        kind: DockerImage
+        name: 'docker.io/node:18.12.1'
+        imagePullSecret: 'pipeline-docker-hub-pull'
+      referencePolicy:
+        type: Source

--- a/infrastructure/openshift/tools/image-streams/rabbitmq.yaml
+++ b/infrastructure/openshift/tools/image-streams/rabbitmq.yaml
@@ -1,0 +1,39 @@
+kind: ImageStream
+apiVersion: image.openshift.io/v1
+metadata:
+  name: rabbitmq
+  namespace: 0198bb-tools
+  labels:
+    usage: runtime-image
+spec:
+  lookupPolicy:
+    local: true
+  tags:
+    - name: '3.9.13-debian-10-r55'
+      from:
+        kind: DockerImage
+        name: 'docker.io/bitnami/rabbitmq:3.9.13-debian-10-r55'
+        imagePullSecret: 'pipeline-docker-hub-pull'
+      referencePolicy:
+        type: Source
+    - name: '3.9.14-debian-10-r2'
+      from:
+        kind: DockerImage
+        name: 'docker.io/bitnami/rabbitmq:3.9.14-debian-10-r2'
+        imagePullSecret: 'pipeline-docker-hub-pull'
+      referencePolicy:
+        type: Source
+    - name: '3.9.26-debian-11-r0'
+      from:
+        kind: DockerImage
+        name: 'docker.io/bitnami/rabbitmq:3.9.26-debian-11-r0'
+        imagePullSecret: 'pipeline-docker-hub-pull'
+      referencePolicy:
+        type: Source
+    - name: '3.10.12-debian-11-r0'
+      from:
+        kind: DockerImage
+        name: 'docker.io/bitnami/rabbitmq:3.10.12-debian-11-r0'
+        imagePullSecret: 'pipeline-docker-hub-pull'
+      referencePolicy:
+        type: Source

--- a/infrastructure/openshift/tools/image-streams/redis-exporter.yaml
+++ b/infrastructure/openshift/tools/image-streams/redis-exporter.yaml
@@ -1,0 +1,18 @@
+kind: ImageStream
+apiVersion: image.openshift.io/v1
+metadata:
+  name: redis-exporter
+  namespace: 0198bb-tools
+  labels:
+    usage: runtime-image
+spec:
+  lookupPolicy:
+    local: true
+  tags:
+    - name: '1.36.0-debian-10-r5'
+      from:
+        kind: DockerImage
+        name: 'docker.io/bitnami/redis-exporter:1.36.0-debian-10-r5'
+        imagePullSecret: 'pipeline-docker-hub-pull'
+      referencePolicy:
+        type: Source

--- a/infrastructure/openshift/tools/image-streams/redis.yaml
+++ b/infrastructure/openshift/tools/image-streams/redis.yaml
@@ -1,0 +1,32 @@
+kind: ImageStream
+apiVersion: image.openshift.io/v1
+metadata:
+  name: redis
+  namespace: 0198bb-tools
+  labels:
+    usage: runtime-image
+spec:
+  lookupPolicy:
+    local: true
+  tags:
+    - name: '6.2.6-debian-10-r158'
+      from:
+        kind: DockerImage
+        name: 'docker.io/bitnami/redis:6.2.6-debian-10-r158'
+        imagePullSecret: 'pipeline-docker-hub-pull'
+      referencePolicy:
+        type: Source
+    - name: '6.2.7-debian-11-r62'
+      from:
+        kind: DockerImage
+        name: 'docker.io/bitnami/redis:6.2.7-debian-11-r62'
+        imagePullSecret: 'pipeline-docker-hub-pull'
+      referencePolicy:
+        type: Source
+    - name: '7.0.5-debian-11-r23'
+      from:
+        kind: DockerImage
+        name: 'docker.io/bitnami/redis:7.0.5-debian-11-r23'
+        imagePullSecret: 'pipeline-docker-hub-pull'
+      referencePolicy:
+        type: Source


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- Adds image stream objects for builds. I tried to add to ArgoCD, but ArgoCD does not like OpenShift specific objects.

these will need to be `oc apply`ed

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [ ] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
