### PR TITLE
TCVP-1963 added DisputantUpdateRequest model

### DIFF
--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/model/Auditable.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/model/Auditable.java
@@ -8,6 +8,8 @@ import javax.persistence.EntityListeners;
 import javax.persistence.MappedSuperclass;
 import javax.persistence.Temporal;
 
+import org.hibernate.annotations.TypeDef;
+import org.hibernate.annotations.TypeDefs;
 import org.springframework.data.annotation.CreatedBy;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedBy;
@@ -22,6 +24,10 @@ import lombok.Setter;
  * An abstract Auditable class that auto-populates <code>createdBy</code>, <code>createdTs</code>, <code>modifiedBy</code>, and
  * <code>modifiedTs</code> fields. Classes need only to extend this class to add auditing fields to a model object.
  */
+@TypeDefs({
+	@TypeDef(name = "disputantUpdateStatus", defaultForType = DisputantUpdateStatus.class, typeClass = ShortNamedEnumType.class),
+	@TypeDef(name = "disputantUpdateType", defaultForType = DisputantUpdateType.class, typeClass = ShortNamedEnumType.class)
+})
 @MappedSuperclass
 @Getter
 @Setter

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/model/DisputantUpdateRequest.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/model/DisputantUpdateRequest.java
@@ -1,0 +1,48 @@
+package ca.bc.gov.open.jag.tco.oracledataapi.model;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table
+@Getter
+@Setter
+@NoArgsConstructor
+public class DisputantUpdateRequest extends Auditable<String> {
+
+	@Schema(description = "ID", accessMode = Schema.AccessMode.READ_ONLY)
+	@Id
+	@GeneratedValue
+	private Long disputantUpdateRequestId;
+
+	@Column
+	@NotNull
+	private Long disputeId;
+
+	@Column(length = 3)
+	@Schema(nullable = false)
+	@NotNull
+	private DisputantUpdateStatus status;
+
+	@Column(length = 3)
+	@Schema(nullable = false)
+	@NotNull
+	private DisputantUpdateType updateType;
+
+	@Column(length = 1000)
+	@Schema(nullable = false)
+	@Size(min = 3, max = 1000)
+	@NotNull
+	private String updateJson;
+
+}

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/model/DisputantUpdateStatus.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/model/DisputantUpdateStatus.java
@@ -1,0 +1,20 @@
+package ca.bc.gov.open.jag.tco.oracledataapi.model;
+
+public enum DisputantUpdateStatus implements ShortNamedEnum {
+
+	PENDING("PEN"),
+	ACCEPTED("ACC"),
+	REJECTED("REJ");
+
+	private String shortName;
+
+	private DisputantUpdateStatus(String shortName) {
+		this.shortName = shortName;
+	}
+
+	@Override
+	public String getShortName() {
+		return shortName;
+	}
+
+}

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/model/DisputantUpdateType.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/model/DisputantUpdateType.java
@@ -1,0 +1,23 @@
+package ca.bc.gov.open.jag.tco.oracledataapi.model;
+
+
+public enum DisputantUpdateType implements ShortNamedEnum {
+
+	DISPUTANT_ADDRESS("ADR"),
+	DISPUTANT_PHONE("PHN"),
+	DISPUTANT_NAME("NAM"),
+	COUNT("CNT"),
+	COURT_OPTIONS("COP");
+
+	private String shortName;
+
+	private DisputantUpdateType(String shortName) {
+		this.shortName = shortName;
+	}
+
+	@Override
+	public String getShortName() {
+		return shortName;
+	}
+
+}

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/model/ShortNamedEnum.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/model/ShortNamedEnum.java
@@ -1,0 +1,11 @@
+package ca.bc.gov.open.jag.tco.oracledataapi.model;
+
+/**
+ * This class is a simple interface that is registered with Hibernate specifically for Enums. When serialized and deserialized from the database, the
+ * short name is used instead of the full name (as required by ORDS).
+ */
+public interface ShortNamedEnum {
+
+	public String getShortName();
+
+}

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/model/ShortNamedEnumType.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/model/ShortNamedEnumType.java
@@ -1,0 +1,100 @@
+package ca.bc.gov.open.jag.tco.oracledataapi.model;
+
+import java.io.Serializable;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Types;
+import java.util.Properties;
+
+import org.hibernate.HibernateException;
+import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.usertype.DynamicParameterizedType;
+import org.hibernate.usertype.UserType;
+
+public class ShortNamedEnumType implements DynamicParameterizedType, UserType {
+
+	private Class<? extends Enum<?>> enumClass;
+
+	@Override
+	public int[] sqlTypes() {
+		return new int[] { Types.VARCHAR };
+	}
+
+	@Override
+	public Class<? extends Enum<?>> returnedClass() {
+		return enumClass;
+	}
+
+	@Override
+	public boolean equals(Object x, Object y) throws HibernateException {
+		return x == y;
+	}
+
+	@Override
+	public int hashCode(Object x) throws HibernateException {
+		return x == null ? 0 : x.hashCode();
+	}
+
+	@Override
+	public Object nullSafeGet(ResultSet rs, String[] names, SharedSessionContractImplementor session, Object owner)
+			throws HibernateException, SQLException {
+		String shortCode = rs.getString(names[0]);
+		if (rs.wasNull()) {
+			return null;
+		}
+		for (Enum<?> value : returnedClass().getEnumConstants()) {
+			if (value instanceof ShortNamedEnum) {
+				ShortNamedEnum shortEnum = (ShortNamedEnum) value;
+				if (shortEnum.getShortName().equals(shortCode)) {
+					return value;
+				}
+			}
+		}
+		throw new IllegalStateException("Unknown " + returnedClass().getSimpleName() + " label");
+	}
+
+	@Override
+	public void nullSafeSet(PreparedStatement st, Object value, int index, SharedSessionContractImplementor session)
+			throws HibernateException, SQLException {
+		if (value == null) {
+			st.setNull(index, Types.VARCHAR);
+		}
+		else {
+			st.setString(index, ((ShortNamedEnum) value).getShortName());
+		}
+	}
+
+	@Override
+	public Object deepCopy(Object value) throws HibernateException {
+		return value;
+	}
+
+	@Override
+	public boolean isMutable() {
+		return false;
+	}
+
+	@Override
+	public Serializable disassemble(Object value) throws HibernateException {
+		return (Serializable) value;
+	}
+
+	@Override
+	public Object assemble(Serializable cached, Object owner) throws HibernateException {
+		return cached;
+	}
+
+	@Override
+	public Object replace(Object original, Object target, Object owner) throws HibernateException {
+		return original;
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public void setParameterValues(Properties parameters) {
+		ParameterType params = (ParameterType) parameters.get(PARAMETER_TYPE);
+		enumClass = params.getReturnedClass();
+	}
+
+}

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/repository/DisputantUpdateRequestRepository.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/repository/DisputantUpdateRequestRepository.java
@@ -1,0 +1,9 @@
+package ca.bc.gov.open.jag.tco.oracledataapi.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import ca.bc.gov.open.jag.tco.oracledataapi.model.DisputantUpdateRequest;
+
+public interface DisputantUpdateRequestRepository extends JpaRepository<DisputantUpdateRequest, Long> {
+
+}

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/service/DisputeService.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/service/DisputeService.java
@@ -21,12 +21,14 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import ca.bc.gov.open.jag.tco.oracledataapi.error.NotAllowedException;
+import ca.bc.gov.open.jag.tco.oracledataapi.model.DisputantUpdateRequest;
 import ca.bc.gov.open.jag.tco.oracledataapi.model.Dispute;
 import ca.bc.gov.open.jag.tco.oracledataapi.model.DisputeCount;
 import ca.bc.gov.open.jag.tco.oracledataapi.model.DisputeResult;
 import ca.bc.gov.open.jag.tco.oracledataapi.model.DisputeStatus;
 import ca.bc.gov.open.jag.tco.oracledataapi.model.ViolationTicket;
 import ca.bc.gov.open.jag.tco.oracledataapi.model.ViolationTicketCount;
+import ca.bc.gov.open.jag.tco.oracledataapi.repository.DisputantUpdateRequestRepository;
 import ca.bc.gov.open.jag.tco.oracledataapi.repository.DisputeRepository;
 
 @Service
@@ -36,6 +38,9 @@ public class DisputeService {
 
 	@Autowired
 	DisputeRepository disputeRepository;
+
+	@Autowired
+	private DisputantUpdateRequestRepository disputantUpdateRequestRepository;
 
 	@PersistenceContext
 	private EntityManager entityManager;
@@ -314,6 +319,22 @@ public class DisputeService {
 	 */
 	public List<DisputeResult> findDispute(String ticketNumber, Date issuedTime) {
 		return disputeRepository.findByTicketNumberAndTime(ticketNumber, issuedTime);
+	}
+
+	/**
+	 * Persists an update request for a Disputant's contact information
+	 * @param updateRequest must not be null
+	 */
+	public DisputantUpdateRequest save(DisputantUpdateRequest updateRequest) {
+		return disputantUpdateRequestRepository.save(updateRequest);
+	}
+
+	/**
+	 * Retrieves a DisputantUpdateRequest by id
+	 * @param id must not be null
+	 */
+	public DisputantUpdateRequest findDisputantUpdateRequestById(Long id) {
+		return disputantUpdateRequestRepository.findById(id).orElseThrow();
 	}
 
 }

--- a/src/backend/oracle-data-api/src/test/java/ca/bc/gov/open/jag/tco/oracledataapi/service/DisputeServiceH2Test.java
+++ b/src/backend/oracle-data-api/src/test/java/ca/bc/gov/open/jag/tco/oracledataapi/service/DisputeServiceH2Test.java
@@ -1,5 +1,7 @@
 package ca.bc.gov.open.jag.tco.oracledataapi.service;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.junit.jupiter.api.Test;
@@ -10,6 +12,9 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 
 import ca.bc.gov.open.jag.tco.oracledataapi.BaseTestSuite;
 import ca.bc.gov.open.jag.tco.oracledataapi.error.NotAllowedException;
+import ca.bc.gov.open.jag.tco.oracledataapi.model.DisputantUpdateRequest;
+import ca.bc.gov.open.jag.tco.oracledataapi.model.DisputantUpdateStatus;
+import ca.bc.gov.open.jag.tco.oracledataapi.model.DisputantUpdateType;
 import ca.bc.gov.open.jag.tco.oracledataapi.model.Dispute;
 import ca.bc.gov.open.jag.tco.oracledataapi.model.DisputeStatus;
 
@@ -97,6 +102,26 @@ class DisputeServiceH2Test extends BaseTestSuite {
 		assertThrows(NotAllowedException.class, () -> {
 			disputeService.setStatus(id, null);
 		});
+	}
+
+	@Test
+	void testDisputantUpdateRequest() throws Exception {
+		String json = "{ \"address_line1\": \"123 Main Street\", \"address_line2\": \"\", \"address_line3\": \"\" }";
+		DisputantUpdateRequest updateRequest = new DisputantUpdateRequest();
+		updateRequest.setDisputeId(Long.valueOf(1L));
+		updateRequest.setStatus(DisputantUpdateStatus.PENDING);
+		updateRequest.setUpdateType(DisputantUpdateType.DISPUTANT_ADDRESS);
+		updateRequest.setUpdateJson(json);
+		DisputantUpdateRequest savedUpdateReq = disputeService.save(updateRequest);
+
+		assertNotNull(savedUpdateReq.getDisputantUpdateRequestId());
+
+		savedUpdateReq = disputeService.findDisputantUpdateRequestById(savedUpdateReq.getDisputantUpdateRequestId());
+
+		assertEquals(1L, savedUpdateReq.getDisputeId().longValue());
+		assertEquals(DisputantUpdateStatus.PENDING, savedUpdateReq.getStatus());
+		assertEquals(DisputantUpdateType.DISPUTANT_ADDRESS, savedUpdateReq.getUpdateType());
+		assertEquals(json, savedUpdateReq.getUpdateJson());
 	}
 
 	private Long saveDispute(DisputeStatus disputeStatus) {


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

TCVP-1963

Added a model object for DisputantUpdateRequests. This is the first step for TCVP-1963, endpoints forthcoming.
- the disputeId is just a Long since this this object may be stored in H2 for now, while the parent Dispute object in ORDs. 
- added a DisputantUpdateType enum that when serialized to the database, appears as a 3 character short name, not the full enum name.
- added a ShortNamedEnum to easily serialize/deserialize enums to/from the database.
- added junit test

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

mvn verify

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
