### PR TITLE
TCVP-1982 Fix unassign disputes

### DIFF
--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/repository/impl/ords/DisputeRepositoryImpl.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/repository/impl/ords/DisputeRepositoryImpl.java
@@ -6,6 +6,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Optional;
+import java.util.TimeZone;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
@@ -204,6 +205,7 @@ public class DisputeRepositoryImpl implements DisputeRepository {
 	@Override
 	public void unassignDisputes(Date olderThan) {
 		SimpleDateFormat simpleDateFormat = new SimpleDateFormat(DATE_TIME_FORMAT);
+		simpleDateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
 		String dateStr = simpleDateFormat.format(olderThan);
 
 		logger.debug("Unassigning Disputes older than '{}'", dateStr);


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- [TCVP-1982](https://justice.gov.bc.ca/jira/browse/TCVP-1982)
- Fixed the timezone issue with unassign disputes trigger since the olderThan date field was passed to the database in wrong timezone.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Tested by creating a dispute record having a userAssignedDtm field set to more than 1 hour ago and manually triggered the unassign disputes and the result was successful.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
