### PR TITLE
TCVP-1963 Added endpoints for DisputantUpdateRequest

### DIFF
--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/controller/v1_0/DisputeController.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/controller/v1_0/DisputeController.java
@@ -26,6 +26,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import ca.bc.gov.open.jag.tco.oracledataapi.model.DisputantUpdateRequest;
+import ca.bc.gov.open.jag.tco.oracledataapi.model.DisputantUpdateStatus;
 import ca.bc.gov.open.jag.tco.oracledataapi.model.Dispute;
 import ca.bc.gov.open.jag.tco.oracledataapi.model.DisputeResult;
 import ca.bc.gov.open.jag.tco.oracledataapi.model.DisputeStatus;
@@ -346,6 +348,75 @@ public class DisputeController {
 	public void unassignDisputes() {
 		logger.debug("GET /disputes/unassign called");
 		disputeService.unassignDisputes();
+	}
+
+	/**
+	 * POST endpoint that inserts a DisputantUpdateRequest into persistent storage linked to the Dispute identified by the noticeOfDisputeGuid.
+	 *
+	 * @param dispute to be saved
+	 * @return id of the saved {@link DisputantUpdateRequest}
+	 */
+	@PostMapping("/dispute/{guid}/updateRequest")
+	@Operation(summary = "An endpoint that inserts a DisputantUpdateRequest into persistent storage.")
+	@ApiResponses({
+		@ApiResponse(responseCode = "200", description = "Ok. DisputantUpdateRequest record saved."),
+		@ApiResponse(responseCode = "404", description = "Dispute could not be found."),
+		@ApiResponse(responseCode = "500", description = "Internal Server Error. Save failed.")
+	})
+	public ResponseEntity<Long> saveDisputantUpdateRequest(
+			@PathVariable(name = "guid")
+			@Parameter(description = "The noticeOfDisputeGuid of the Dispute to associate with.")
+			String noticeOfDisputeGuid,
+			@RequestBody
+			DisputantUpdateRequest disputantUpdateRequest) {
+		logger.debug("POST /dispute/{}/updateRequest called", noticeOfDisputeGuid);
+
+		Long disputantUpdateRequestId = disputeService.saveDisputantUpdateRequest(noticeOfDisputeGuid, disputantUpdateRequest).getDisputantUpdateRequestId();
+		return new ResponseEntity<Long>(disputantUpdateRequestId, HttpStatus.OK);
+	}
+
+	/**
+	 * Get endpoint that retrieves all <code>DisputantUpdateRequest</code>s from persistent storage that is associated with the given Dispute via disputeId.
+	 *
+	 * @param disputantUpdateRequest id to be retrieved
+	 * @return id of the saved {@link DisputantUpdateRequest}
+	 */
+	@GetMapping("/dispute/{id}/updateRequest")
+	@Operation(summary = "An endpoint that retrieves all DisputantUpdateRequest for a given Dispute.")
+	@ApiResponses({
+		@ApiResponse(responseCode = "200", description = "Ok. DisputantUpdateRequest record saved."),
+		@ApiResponse(responseCode = "404", description = "Dispute could not be found."),
+		@ApiResponse(responseCode = "500", description = "Internal Server Error. Save failed.")
+	})
+	public ResponseEntity<List<DisputantUpdateRequest>> getDisputantUpdateRequest(@PathVariable @Parameter(description = "The disputeId of the Dispute.") Long id) {
+		logger.debug("GET /dispute/{}/updateRequest called", id);
+		return new ResponseEntity<List<DisputantUpdateRequest>>(disputeService.findDisputantUpdateRequestByDisputeId(id), HttpStatus.OK);
+	}
+
+	/**
+	 * PUT endpoint that updates the status of a DisputantUpdateRequest record.
+	 *
+	 * @param status to be saved
+	 * @return id of the saved {@link DisputantUpdateRequest}
+	 */
+	@PutMapping("/dispute/updateRequest/{id}")
+	@Operation(summary = "An endpoint that updates the status of a DisputantUpdateRequest record.")
+	@ApiResponses({
+		@ApiResponse(responseCode = "200", description = "Ok. DisputantUpdateRequest updated."),
+		@ApiResponse(responseCode = "404", description = "DisputantUpdateRequest could not be found."),
+		@ApiResponse(responseCode = "500", description = "Internal Server Error. Save failed.")
+	})
+	public ResponseEntity<DisputantUpdateRequest> updateDisputantUpdateRequestStatus(
+			@PathVariable(name = "id")
+			@Parameter(description = "The id of the DisputantUpdateRequest record to update.")
+			Long updateRequestId,
+			@RequestParam
+			@Parameter(description = "The status the request record should be updated to.", example = "ACCEPTED")
+			DisputantUpdateStatus status) {
+		logger.debug("PUT /dispute/updateRequest/{id} called", updateRequestId);
+
+		DisputantUpdateRequest disputantUpdateRequest = disputeService.updateDisputantUpdateRequest(updateRequestId, status);
+		return new ResponseEntity<DisputantUpdateRequest>(disputantUpdateRequest, HttpStatus.OK);
 	}
 
 }

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/model/DisputantUpdateRequest.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/model/DisputantUpdateRequest.java
@@ -26,7 +26,6 @@ public class DisputantUpdateRequest extends Auditable<String> {
 	private Long disputantUpdateRequestId;
 
 	@Column
-	@NotNull
 	private Long disputeId;
 
 	@Column(length = 3)

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/repository/DisputantUpdateRequestRepository.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/repository/DisputantUpdateRequestRepository.java
@@ -1,9 +1,14 @@
 package ca.bc.gov.open.jag.tco.oracledataapi.repository;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import ca.bc.gov.open.jag.tco.oracledataapi.model.DisputantUpdateRequest;
 
 public interface DisputantUpdateRequestRepository extends JpaRepository<DisputantUpdateRequest, Long> {
+
+	/** Fetch all records that matches the DisputeId. */
+	public List<DisputantUpdateRequest> findByDisputeId(Long disputeId);
 
 }


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

TCVP-1963
Added endpoints:
```
POST /api/dispute/{guid}/updateRequest
GET /api/dispute/{id}/updateRequest
PUT /api/dispute/updateRequest/{id}
```
The POST will create a new DisputantUpdateRequest record in H2
The GET will return all DisputantUpdateRequest records in H2 that for the given disputeId.
The PUT will upstate the status of a particular DisputantUpdateRequest record in H2.

Added junit tests

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

mvn verify

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
