### PR TITLE
TCVP-1975 saved dispute changes

### DIFF
--- a/src/backend/TrafficCourts/Test/Workflow.Service/Consumers/DisputantUpdateRequestAcceptedConsumerTest.cs
+++ b/src/backend/TrafficCourts/Test/Workflow.Service/Consumers/DisputantUpdateRequestAcceptedConsumerTest.cs
@@ -1,0 +1,101 @@
+﻿using MassTransit;
+using Microsoft.Extensions.Logging;
+using Moq;
+using System.Threading;
+using System.Threading.Tasks;
+using TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0;
+using TrafficCourts.Messaging.MessageContracts;
+using TrafficCourts.Workflow.Service.Consumers;
+using TrafficCourts.Workflow.Service.Services;
+using Xunit;
+
+namespace TrafficCourts.Test.Workflow.Service.Consumers;
+
+public class DisputantUpdateRequestAcceptedConsumerTest
+{
+    private readonly DisputantUpdateRequestAccepted _message;
+    private readonly Dispute _dispute;
+    private readonly DisputantUpdateRequest _updateRequest;
+    private readonly Mock<ILogger<DisputantUpdateRequestAcceptedConsumer>> _mockLogger;
+    private readonly Mock<IOracleDataApiService> _oracleDataApiService;
+    private readonly Mock<ConsumeContext<DisputantUpdateRequestAccepted>> _context;
+    private readonly DisputantUpdateRequestAcceptedConsumer _consumer;
+
+    public DisputantUpdateRequestAcceptedConsumerTest()
+    {
+        _message = new(1); 
+        _dispute = new()
+        {
+            DisputeId = 1,
+        };
+        _updateRequest = new()
+        {
+            DisputantUpdateRequestId = 1,
+            DisputeId = 1
+        };
+
+        _mockLogger = new();
+        _oracleDataApiService = new();
+        _oracleDataApiService.Setup(_ => _.UpdateDisputantUpdateRequestStatusAsync(1, DisputantUpdateRequestStatus.ACCEPTED, It.IsAny<CancellationToken>())).Returns(Task.FromResult(_updateRequest));
+        _oracleDataApiService.Setup(_ => _.GetDisputeByIdAsync(1, It.IsAny<CancellationToken>())).Returns(Task.FromResult(_dispute));
+        _oracleDataApiService.Setup(_ => _.UpdateDisputeAsync(1, _dispute, It.IsAny<CancellationToken>())).Returns(Task.FromResult(_dispute));
+        _context = new();
+        _context.Setup(_ => _.Message).Returns(_message);
+        _context.Setup(_ => _.CancellationToken).Returns(CancellationToken.None);
+
+        _consumer = new(_mockLogger.Object, _oracleDataApiService.Object);
+    }
+
+    [Fact]
+    public async Task TestDisputantUpdateRequestAcceptedConsumer_AddressUpdates()
+    {
+        // Arrange
+        _updateRequest.Status = DisputantUpdateRequestStatus2.ACCEPTED;
+        _updateRequest.UpdateType = DisputantUpdateRequestUpdateType.DISPUTANT_ADDRESS;
+        _updateRequest.UpdateJson = "{ \"addressLine1\": \"addr1\", \"addressLine2\": \"addr2\", \"addressLine3\": \"addr3\", \"addressCity\": \"city\", \"addressProvince\": \"BC\", \"postalCode\": \"A1B2C3\"}";        
+
+        // Act
+        await _consumer.Consume(_context.Object);
+
+        // Assert
+        Assert.Equal("addr1", _dispute.AddressLine1);
+        Assert.Equal("addr2", _dispute.AddressLine2);
+        Assert.Equal("addr3", _dispute.AddressLine3);
+        Assert.Equal("city", _dispute.AddressCity);
+        Assert.Equal("BC", _dispute.AddressProvince);
+        Assert.Equal("A1B2C3", _dispute.PostalCode);
+    }
+
+    [Fact]
+    public async Task TestDisputantUpdateRequestAcceptedConsumer_NameUpdates()
+    {
+        // Arrange
+        _updateRequest.Status = DisputantUpdateRequestStatus2.ACCEPTED;
+        _updateRequest.UpdateType = DisputantUpdateRequestUpdateType.DISPUTANT_NAME;
+        _updateRequest.UpdateJson = "{ \"disputantGivenName1\": \"fname1\", \"disputantGivenName2\": \"fname2\", \"disputantGivenName3\": \"fname3\", \"disputantSurname\": \"lname\" }";
+        
+        // Act
+        await _consumer.Consume(_context.Object);
+
+        // Assert
+        Assert.Equal("fname1", _dispute.DisputantGivenName1);
+        Assert.Equal("fname2", _dispute.DisputantGivenName2);
+        Assert.Equal("fname3", _dispute.DisputantGivenName3);
+        Assert.Equal("lname", _dispute.DisputantSurname);
+    }
+
+    [Fact]
+    public async Task TestDisputantUpdateRequestAcceptedConsumer_PhoneUpdates()
+    {
+        // Arrange
+        _updateRequest.Status = DisputantUpdateRequestStatus2.ACCEPTED;
+        _updateRequest.UpdateType = DisputantUpdateRequestUpdateType.DISPUTANT_PHONE;
+        _updateRequest.UpdateJson = "{ \"homePhoneNumber\": \"2505556666\" }";
+
+        // Act
+        await _consumer.Consume(_context.Object);
+
+        // Assert
+        Assert.Equal("2505556666", _dispute.HomePhoneNumber);
+    }
+}

--- a/src/backend/TrafficCourts/Test/Workflow.Service/Mappings/MappingTests.cs
+++ b/src/backend/TrafficCourts/Test/Workflow.Service/Mappings/MappingTests.cs
@@ -115,4 +115,17 @@ public class MappingTests
         Assert.Equal(source.LawyerAddress, target.LawyerAddress);
         Assert.Equal(source.LawyerPhoneNumber, target.LawyerPhoneNumber);
     }
+
+    [Fact]
+    public void TestJsonDeserializer()
+    {
+        string json = "{ \"disputantGivenName1\": \"fname1\", \"disputantGivenName2\": \"fname2\", \"disputantGivenName3\": \"fname3\", \"disputantSurname\": \"lname\" }";
+        Dispute? patch = Newtonsoft.Json.JsonConvert.DeserializeObject<Dispute>(json);
+        Assert.NotNull(patch);
+        Assert.Equal("fname1", patch.DisputantGivenName1);
+        Assert.Equal("fname2", patch.DisputantGivenName2);
+        Assert.Equal("fname3", patch.DisputantGivenName3);
+        Assert.Equal("lname", patch.DisputantSurname);
+    }
+
 }

--- a/src/backend/TrafficCourts/Workflow.Service/Consumers/DisputantUpdateRequestAcceptedConsumer.cs
+++ b/src/backend/TrafficCourts/Workflow.Service/Consumers/DisputantUpdateRequestAcceptedConsumer.cs
@@ -1,5 +1,7 @@
 ﻿using AutoMapper;
 using MassTransit;
+using Newtonsoft.Json;
+using System.Text.Json;
 using TrafficCourts.Common.Features.Mail;
 using TrafficCourts.Common.Features.Mail.Model;
 using TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0;
@@ -10,16 +12,14 @@ namespace TrafficCourts.Workflow.Service.Consumers;
 
 public class DisputantUpdateRequestAcceptedConsumer : IConsumer<DisputantUpdateRequestAccepted>
 {
-    private readonly ILogger<DisputantUpdateRequestAccepted> _logger;
+    private readonly ILogger<DisputantUpdateRequestAcceptedConsumer> _logger;
     private readonly IOracleDataApiService _oracleDataApiService;
-    private readonly IMapper _mapper;
     private static readonly string _approvedDisputantUpdateRequestEmailTemplateName = "DisputantUpdateRequestApprovedTemplate";
 
-    public DisputantUpdateRequestAcceptedConsumer(ILogger<DisputantUpdateRequestAccepted> logger, IOracleDataApiService oracleDataApiService, IMapper mapper)
+    public DisputantUpdateRequestAcceptedConsumer(ILogger<DisputantUpdateRequestAcceptedConsumer> logger, IOracleDataApiService oracleDataApiService)
     {
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _oracleDataApiService = oracleDataApiService ?? throw new ArgumentNullException(nameof(oracleDataApiService));
-        _mapper = mapper ?? throw new ArgumentNullException(nameof(mapper));
     }
 
     public async Task Consume(ConsumeContext<DisputantUpdateRequestAccepted> context)
@@ -36,16 +36,48 @@ public class DisputantUpdateRequestAcceptedConsumer : IConsumer<DisputantUpdateR
         // Set the status of the DisputantUpdateRequest object to ACCEPTED.
         DisputantUpdateRequest updateRequest = await _oracleDataApiService.UpdateDisputantUpdateRequestStatusAsync(message.UpdateRequestId, DisputantUpdateRequestStatus.ACCEPTED, context.CancellationToken);
 
-        // TODO: patch Dispute with changes in the updateRequest object
+        if (updateRequest.UpdateJson is not null)
+        {
+            // Get the current Dispute by id
+            Dispute dispute = await _oracleDataApiService.GetDisputeByIdAsync(updateRequest.DisputeId, context.CancellationToken);
 
-        // Get the updated Dispute by id (note, this may not be needed if the patch returns the full Dispute object)
-        Dispute dispute = await _oracleDataApiService.GetDisputeByIdAsync(updateRequest.DisputeId, context.CancellationToken);
+            // Extract patched Dispute values per updateType
+            Dispute? patch = JsonConvert.DeserializeObject<Dispute>(updateRequest.UpdateJson);
+            switch (updateRequest.UpdateType)
+            {
+                case DisputantUpdateRequestUpdateType.DISPUTANT_ADDRESS:
+                    dispute.AddressLine1 = patch?.AddressLine1;
+                    dispute.AddressLine2 = patch?.AddressLine2;
+                    dispute.AddressLine3 = patch?.AddressLine3;
+                    dispute.AddressCity = patch?.AddressCity;
+                    dispute.AddressProvince = patch?.AddressProvince;
+                    dispute.PostalCode = patch?.PostalCode;
+                    break;
+                case DisputantUpdateRequestUpdateType.DISPUTANT_PHONE:
+                    dispute.HomePhoneNumber = patch?.HomePhoneNumber;
+                    break;
+                case DisputantUpdateRequestUpdateType.DISPUTANT_NAME:
+                    dispute.DisputantGivenName1 = patch?.DisputantGivenName1;
+                    dispute.DisputantGivenName2 = patch?.DisputantGivenName2;
+                    dispute.DisputantGivenName3 = patch?.DisputantGivenName3;
+                    dispute.DisputantSurname = patch?.DisputantSurname;
+                    break;
+                default:
+                    break;
+            }
 
-        // send confirmation email to end user indicating their request was accepted
-        PublishEmailConfirmation(dispute, context);
+            // Save changes
+            dispute = await _oracleDataApiService.UpdateDisputeAsync(dispute.DisputeId, dispute, context.CancellationToken);
 
-        // populate file history
-        PublishFileHistoryLog(dispute, context);
+            // send confirmation email to end user indicating their request was accepted
+            if (dispute.EmailAddressVerified)
+            {
+                PublishEmailConfirmation(dispute, context);
+            }
+
+            // populate file history
+            PublishFileHistoryLog(dispute, context);
+        }
     }
 
     private async void PublishEmailConfirmation(Dispute dispute, ConsumeContext<DisputantUpdateRequestAccepted> context)
@@ -63,25 +95,30 @@ public class DisputantUpdateRequestAcceptedConsumer : IConsumer<DisputantUpdateR
             return;
         }
 
-        var emailMessage = new EmailMessage()
+        SendDispuantEmail emailMessage = new()
         {
-            From = template.Sender,
-            To = dispute.EmailAddress,
-            Subject = template.SubjectTemplate,
-            TextContent = template.PlainContentTemplate,
-            HtmlContent = template.HtmlContentTemplate,
-        };
-
-        await context.PublishWithLog(_logger, emailMessage, context.CancellationToken);
-    }
-
-    private async void PublishFileHistoryLog(Dispute dispute, ConsumeContext<DisputantUpdateRequestAccepted> context)
-    {
-        SaveFileHistoryRecord fileHistoryRecord = new()
-        {
+            NoticeOfDisputeGuid = new System.Guid(dispute.NoticeOfDisputeGuid),
             TicketNumber = dispute.TicketNumber,
-            Description = "Disputant update request accepted."
-        };
-        await context.PublishWithLog(_logger, fileHistoryRecord, context.CancellationToken);
-    }
+            Message = new EmailMessage()
+            {
+                From = template.Sender,
+                To = dispute.EmailAddress,
+                Subject = template.SubjectTemplate,
+                TextContent = template.PlainContentTemplate,
+                HtmlContent = template.HtmlContentTemplate,
+            }
+    };
+
+    await context.PublishWithLog(_logger, emailMessage, context.CancellationToken);
+}
+
+private async void PublishFileHistoryLog(Dispute dispute, ConsumeContext<DisputantUpdateRequestAccepted> context)
+{
+    SaveFileHistoryRecord fileHistoryRecord = new()
+    {
+        TicketNumber = dispute.TicketNumber,
+        Description = "Disputant update request accepted."
+    };
+    await context.PublishWithLog(_logger, fileHistoryRecord, context.CancellationToken);
+}
 }

--- a/src/backend/TrafficCourts/Workflow.Service/Services/IOracleDataApiService.cs
+++ b/src/backend/TrafficCourts/Workflow.Service/Services/IOracleDataApiService.cs
@@ -11,6 +11,7 @@ namespace TrafficCourts.Workflow.Service.Services
         Task VerifyDisputeEmailAsync(long disputeId, CancellationToken cancellationToken);
         Task<ICollection<DisputeResult>> SearchDisputeAsync(string ticketNumber, string issuedTime, CancellationToken cancellationToken);
         Task<Dispute> GetDisputeByIdAsync(long disputeId, CancellationToken cancellationToken);
+        Task<Dispute> UpdateDisputeAsync(long disputeId, Dispute dispute, CancellationToken cancellationToken);
         Task<DisputantUpdateRequest> UpdateDisputantUpdateRequestStatusAsync(long disputantUpdateRequestId, DisputantUpdateRequestStatus disputantUpdateRequestStatus, CancellationToken cancellationToken);
     }
 }

--- a/src/backend/TrafficCourts/Workflow.Service/Services/OracleDataApiService.cs
+++ b/src/backend/TrafficCourts/Workflow.Service/Services/OracleDataApiService.cs
@@ -105,6 +105,18 @@ public class OracleDataApiService : IOracleDataApiService
         }
     }
 
+    public async Task<Dispute> UpdateDisputeAsync(long disputeId, Dispute dispute, CancellationToken cancellationToken)
+    {
+        try
+        {
+            return await _client.UpdateDisputeAsync(disputeId, dispute, cancellationToken);
+        }
+        catch (Exception)
+        {
+            throw;
+        }
+    }
+
     public async Task<DisputantUpdateRequest> UpdateDisputantUpdateRequestStatusAsync(long disputantUpdateRequestId, DisputantUpdateRequestStatus disputantUpdateRequestStatus, CancellationToken cancellationToken)
     {
         try


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

TCVP-1975
Added logic to save dispute changes per the DisputantUpdateRequest object when the request is accepted.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

dotnet test
docker-compose up

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
