### PR TITLE
Ensure transaction date and time are the same on each record

### DIFF
--- a/src/backend/TrafficCourts/Messaging/MessageContracts/DisputeApproved.cs
+++ b/src/backend/TrafficCourts/Messaging/MessageContracts/DisputeApproved.cs
@@ -2,7 +2,14 @@
 {
     public class DisputeApproved
     {
-        public string CitizenName { get; set; } = String.Empty;
+        [Obsolete($"Use {nameof(GivenName1)}, {nameof(GivenName2)},  {nameof(GivenName3)} and {nameof(Surname)}")]
+        public string? CitizenName { get; set; }
+
+        public string? Surname { get; set; }
+        public string? GivenName1 { get; set; }
+        public string? GivenName2 { get; set; }
+        public string? GivenName3 { get; set; }
+
         public DateTime? TicketIssuanceDate { get; set; }
         public string TicketFileNumber { get; set; } = String.Empty;
         public string IssuingOrganization { get; set; } = String.Empty;

--- a/src/backend/TrafficCourts/Staff.Service/Mappers/Mapper.cs
+++ b/src/backend/TrafficCourts/Staff.Service/Mappers/Mapper.cs
@@ -8,7 +8,11 @@ public class Mapper
     public static DisputeApproved ToDisputeApproved(Dispute dispute)
     {
         DisputeApproved target = new();
-        target.CitizenName = dispute.DisputantGivenName1 + " " + (dispute.DisputantGivenName2 is not null ? (dispute.DisputantGivenName2 + " ") : "") + (dispute.DisputantGivenName3 is not null ? (dispute.DisputantGivenName3 + " ") : "") + dispute.DisputantSurname;
+        target.CitizenName = null;
+        target.Surname = dispute.DisputantSurname;
+        target.GivenName1 = dispute.DisputantGivenName1;
+        target.GivenName2 = dispute.DisputantGivenName2;
+        target.GivenName3 = dispute.DisputantGivenName3;
         target.TicketIssuanceDate = dispute.IssuedTs?.DateTime;
         target.TicketFileNumber = dispute.TicketNumber;
         target.IssuingOrganization = dispute.ViolationTicket.DetachmentLocation;

--- a/src/backend/TrafficCourts/TrafficCourts.Arc.Dispute.Client/ArcDisputeClient.g.cs
+++ b/src/backend/TrafficCourts/TrafficCourts.Arc.Dispute.Client/ArcDisputeClient.g.cs
@@ -258,11 +258,8 @@ namespace TrafficCourts.Arc.Dispute.Client
         [Newtonsoft.Json.JsonProperty("lockout_flag", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public int Lockout_flag { get; set; }
 
-        [Newtonsoft.Json.JsonProperty("transaction_date", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public System.DateTime Transaction_date { get; set; }
-
-        [Newtonsoft.Json.JsonProperty("transaction_time", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public System.DateTime Transaction_time { get; set; }
+        [Newtonsoft.Json.JsonProperty("transaction_date_time", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public System.DateTime Transaction_date_time { get; set; }
 
         [Newtonsoft.Json.JsonProperty("transaction_location", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public int Transaction_location { get; set; }
@@ -340,7 +337,20 @@ namespace TrafficCourts.Arc.Dispute.Client
     public partial class TcoDisputeTicket
     {
         [Newtonsoft.Json.JsonProperty("citizen_name", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [System.Obsolete]
         public string Citizen_name { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("surname", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Surname { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("given_name1", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Given_name1 { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("given_name2", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Given_name2 { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("given_name3", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Given_name3 { get; set; }
 
         [Newtonsoft.Json.JsonProperty("ticket_issuance_date", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public System.DateTime Ticket_issuance_date { get; set; }

--- a/src/backend/TrafficCourts/TrafficCourts.Arc.Dispute.Client/swagger.json
+++ b/src/backend/TrafficCourts/TrafficCourts.Arc.Dispute.Client/swagger.json
@@ -94,11 +94,7 @@
             "type": "integer",
             "format": "int32"
           },
-          "transaction_date": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "transaction_time": {
+          "transaction_date_time": {
             "type": "string",
             "format": "date-time"
           },
@@ -193,6 +189,23 @@
         "type": "object",
         "properties": {
           "citizen_name": {
+            "type": "string",
+            "nullable": true,
+            "deprecated": true
+          },
+          "surname": {
+            "type": "string",
+            "nullable": true
+          },
+          "given_name1": {
+            "type": "string",
+            "nullable": true
+          },
+          "given_name2": {
+            "type": "string",
+            "nullable": true
+          },
+          "given_name3": {
             "type": "string",
             "nullable": true
           },

--- a/src/backend/TrafficCourts/TrafficCourts.Arc.Dispute.Service/Mappings/DisputeTicketToArcFileRecordListConverter.cs
+++ b/src/backend/TrafficCourts/TrafficCourts.Arc.Dispute.Service/Mappings/DisputeTicketToArcFileRecordListConverter.cs
@@ -28,6 +28,7 @@ namespace TrafficCourts.Arc.Dispute.Service.Mappings
                 adnotated.EffectiveDate = source.TicketIssuanceDate;
                 // There has to be two spaces between the 10th character and the "01" at the end for ARC to process the file properly
                 adnotated.FileNumber = source.TicketFileNumber.ToUpper() + "  01";
+                adnotated.CountNumber = ticket.Count.ToString("D3"); // left pad with zeros
                 adnotated.MvbClientNumber = DriversLicence.WithCheckDigit(source.DriversLicence);
                 
                 // Map adnotated ticket specific data

--- a/src/backend/TrafficCourts/TrafficCourts.Arc.Dispute.Service/Models/ArcFileRecord.cs
+++ b/src/backend/TrafficCourts/TrafficCourts.Arc.Dispute.Service/Models/ArcFileRecord.cs
@@ -1,15 +1,28 @@
-﻿namespace TrafficCourts.Arc.Dispute.Service.Models
+﻿using System.Text.Json.Serialization;
+
+namespace TrafficCourts.Arc.Dispute.Service.Models
 {
     public abstract class ArcFileRecord
     {
         public int LockoutFlag { get; set; }
-        public DateTime TransactionDate { get; set; }
-        public DateTime TransactionTime { get; set; }
+        public DateTime TransactionDateTime { get; set; }
+        /// <summary>
+        /// Mapped to seprate output field, so we need a separate property for date.
+        /// </summary>
+        [JsonIgnore]
+        public DateTime TransactionDate => TransactionDateTime;
+
+        /// <summary>
+        /// Mapped to seprate output field, so we need a separate property for time.
+        /// </summary>
+        [JsonIgnore]
+        public DateTime TransactionTime => TransactionDateTime;
+
         public int TransactionLocation { get; } = 20254;
         public DateTime EffectiveDate { get; set; }
         public string Owner { get; } = "00001";
         public string FileNumber { get; set; } = String.Empty;
-        public string CountNumber { get; set; } = "001";
+        public string CountNumber { get; set; } = "000"; // 000 in an output would represent an error
         public string ReceivableType { get; } = "M";
         public string MvbClientNumber { get; set; } = String.Empty;
         public string UpdateFlag { get; set; } = String.Empty;
@@ -27,7 +40,7 @@
         public string Paragraph { get; set; } = String.Empty;
         public string Subparagraph { get; set; } = String.Empty;
         public string Act { get; set; } = String.Empty;
-        public double OriginalAmount { get; set; }
+        public decimal OriginalAmount { get; set; }
         public string Organization { get; set; } = String.Empty;
         public string OrganizationLocation { get; set; } = String.Empty;
         public DateTime ServiceDate { get; set; }

--- a/src/backend/TrafficCourts/TrafficCourts.Arc.Dispute.Service/Models/TcoDisputeTicket.cs
+++ b/src/backend/TrafficCourts/TrafficCourts.Arc.Dispute.Service/Models/TcoDisputeTicket.cs
@@ -1,62 +1,104 @@
 ﻿using Newtonsoft.Json;
-using System.Text.Json.Serialization;
 
 namespace TrafficCourts.Arc.Dispute.Service.Models
 {
     public class TcoDisputeTicket
     {
-        [JsonProperty("citizen_name"), JsonRequired]
+        /// <summary>
+        /// Depricated. Use Surname, GivenName1, GivenName2, GivenName3
+        /// </summary>
+        [Obsolete($"Use {nameof(GivenName1)}, {nameof(GivenName2)},  {nameof(GivenName3)} and {nameof(Surname)}")]
+        [JsonProperty("citizen_name")]
         public string CitizenName { get; set; } = String.Empty;
-        [JsonProperty("ticket_issuance_date"), JsonRequired]
+
+        [JsonProperty("citizen_surname")]
+        //[JsonRequired] // make required when CitizenName is removed
+        public string? Surname { get; set; } = String.Empty;
+
+        [JsonProperty("citizen_given_name_1")]
+        public string? GivenName1 { get; set; }
+
+        [JsonProperty("citizen_given_name_2")]
+        public string? GivenName2 { get; set; }
+
+        [JsonProperty("citizen_given_name_3")]
+        public string? GivenName3 { get; set; }
+
+        [JsonProperty("ticket_issuance_date")]
+        [JsonRequired]
         public DateTime TicketIssuanceDate { get; set; }
-        [JsonProperty("ticket_file_number"), JsonRequired]
+
+        [JsonProperty("ticket_file_number")]
+        [JsonRequired]
         public string TicketFileNumber { get; set; } = String.Empty;
+
         [JsonProperty("issuing_organization")]
         public string IssuingOrganization { get; set; } = String.Empty;
-        [JsonProperty("issuing_location"), JsonRequired]
+        
+        [JsonProperty("issuing_location")]
+        [JsonRequired]
         public string IssuingLocation { get; set; } = String.Empty;
-        [JsonProperty("drivers_licence"), JsonRequired]
+        
+        [JsonProperty("drivers_licence")]
+        [JsonRequired]
         public string DriversLicence { get; set; } = String.Empty;
-        [JsonProperty("ticket_counts"), JsonRequired]
+        
+        [JsonProperty("ticket_counts")]
+        [JsonRequired]
         public List<TicketCount> TicketDetails { set; get; } = new();
+
         [JsonProperty("street_address")]
         public string? StreetAddress { get; set; }
+        
         [JsonProperty("city")]
         public string? City { get; set; }
+        
         [JsonProperty("province")]
         public string? Province { get; set; }
+        
         [JsonProperty("postal_code")]
         public string? PostalCode { get; set; }
+        
         [JsonProperty("email")]
         public string? Email { get; set; }
+        
         [JsonProperty("dispute_counts")]
         public IList<DisputeCount>? DisputeCounts { get; set; }
     }
 
     public class TicketCount
     {
-        [JsonRequired, JsonProperty("count")]
+        [JsonProperty("count")]
+        [JsonRequired]
         public int Count { get; set; } = 0;
+
         [JsonProperty("subparagraph")]
         public string? Subparagraph { get; set; }
+        
         [JsonProperty("section")]
         public string Section { get; set; } = String.Empty;
+        
         [JsonProperty("subsection")]
         public string? Subsection { get; set; }
+        
         [JsonProperty("paragraph")]
         public string? Paragraph { get; set; }
+        
         [JsonProperty("act")]
         public string Act { get; set; } = "MVA";
-        [JsonRequired, JsonProperty("amount")]
-        public double Amount { get; set; }
+        
+        [JsonProperty("amount")]
+        [JsonRequired]
+        public decimal Amount { get; set; }
     }
 
     public partial class DisputeCount
     {
-        [JsonRequired, JsonProperty("count")]
+        [JsonProperty("count")]
+        [JsonRequired]
         public int Count { get; set; }
+
         [JsonProperty("dispute_type")]
         public string? DisputeType { get; set; }
     }
-
 }


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- fixes issue where transaction date and time are slightly different on each record.
- removes the milliseconds from the date and times
- splits out the name fields into separate properties - CitizenName is deprecated but will be used first if not null.

![image](https://user-images.githubusercontent.com/1844480/206032633-3b56affc-9d34-4820-8308-cd6fcb57e2ed.png)


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [ ] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
