### PR TITLE
TCVP-1974 added RejectDisputeUpdateRequest endpoint

### DIFF
--- a/src/backend/TrafficCourts/Common/Features/Mail/Model/MailTemplateCollection.cs
+++ b/src/backend/TrafficCourts/Common/Features/Mail/Model/MailTemplateCollection.cs
@@ -52,9 +52,17 @@ namespace TrafficCourts.Common.Features.Mail.Model
             },
         new MailTemplate()
             {
-                TemplateName = "DisputantUpdateRequestApprovedTemplate",
+                TemplateName = "DisputantUpdateRequestAcceptedTemplate",
                 Sender = "DoNotReply@tickets.gov.bc.ca",
                 SubjectTemplate = "TBD (ie. Disputant contact information changes approved)",
+                HtmlContentTemplate = "TBD",
+                PlainContentTemplate = "TBD"
+            },
+        new MailTemplate()
+            {
+                TemplateName = "DisputantUpdateRequestRejectedTemplate",
+                Sender = "DoNotReply@tickets.gov.bc.ca",
+                SubjectTemplate = "TBD (ie. Disputant contact information changes rejected)",
                 HtmlContentTemplate = "TBD",
                 PlainContentTemplate = "TBD"
             },

--- a/src/backend/TrafficCourts/Messaging/MessageContracts/DisputantUpdateRequestRejected.cs
+++ b/src/backend/TrafficCourts/Messaging/MessageContracts/DisputantUpdateRequestRejected.cs
@@ -1,0 +1,20 @@
+﻿namespace TrafficCourts.Messaging.MessageContracts;
+
+/// <summary>
+/// Message to indicate a DisputantUpdateRequest was rejected (a citizen submitted a request to update their Disputant contact information, which staff has rejected).
+/// Consumers of this message are expected to:
+/// 
+/// TCVP-1974
+/// - call oracle-data-api to update DisputantUpdateRequest status.
+/// - send confirmation email indicating request was rejected
+/// - populate file/email history records
+/// </summary>
+public class DisputantUpdateRequestRejected
+{
+    public DisputantUpdateRequestRejected(long updateRequestId)
+    {
+        UpdateRequestId = updateRequestId;
+    }
+
+    public long UpdateRequestId { get; set; }
+}

--- a/src/backend/TrafficCourts/Staff.Service/Controllers/DisputeController.cs
+++ b/src/backend/TrafficCourts/Staff.Service/Controllers/DisputeController.cs
@@ -472,4 +472,20 @@ public class DisputeController : StaffControllerBase<DisputeController>
         await _disputeService.AcceptDisputeUpdateRequestAsync(updateStatusId, cancellationToken);
         return Ok();
     }
+
+    /// <summary>
+    /// Rejects a DisputantUpdateRequest record, setting it's status to REJECTED.
+    /// </summary>
+    /// <param name="updateStatusId">Unique identifier for a specific DisputantUpdateRequest record to reject.</param>
+    /// <param name="cancellationToken"></param>
+    /// <returns></returns>
+    [HttpPut("updateRequest/{updateStatusId}/reject")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+    [KeycloakAuthorize(Resources.Dispute, Scopes.Update)]
+    public async Task<IActionResult> RejectDisputeUpdateRequestAsync(long updateStatusId, CancellationToken cancellationToken)
+    {
+        await _disputeService.RejectDisputeUpdateRequestAsync(updateStatusId, cancellationToken);
+        return Ok();
+    }
 }

--- a/src/backend/TrafficCourts/Staff.Service/Services/DisputeService.cs
+++ b/src/backend/TrafficCourts/Staff.Service/Services/DisputeService.cs
@@ -227,10 +227,26 @@ public class DisputeService : IDisputeService
     {
         // TCVP-1975 - consumers of this message are expected to:
         // - call oracle-data-api to patch the Dispute with the DisputantUpdateRequest changes.
-        // - call oracle-data-api to update flag in OCCAM.
+        // - call oracle-data-api to update request status in OCCAM.
         // - send confirmation email indicating request was accepted
         // - populate file/email history records
         DisputantUpdateRequestAccepted message = new(updateStatusId);
+        await _bus.PublishWithLog(_logger, message, cancellationToken);
+    }
+
+    /// <summary>
+    /// Rejects a citizen's requested changes to their Disputant Contact information.
+    /// </summary>
+    /// <param name="updateStatusId"></param>
+    /// <param name="cancellationToken"></param>
+    /// <returns></returns>
+    public async Task RejectDisputeUpdateRequestAsync(long updateStatusId, CancellationToken cancellationToken)
+    {
+        // TCVP-1974 - consumers of this message are expected to:
+        // - call oracle-data-api to update request status in OCCAM.
+        // - send confirmation email indicating request was rejected
+        // - populate file/email history records
+        DisputantUpdateRequestRejected message = new(updateStatusId);
         await _bus.PublishWithLog(_logger, message, cancellationToken);
     }
 }

--- a/src/backend/TrafficCourts/Staff.Service/Services/IDisputeService.cs
+++ b/src/backend/TrafficCourts/Staff.Service/Services/IDisputeService.cs
@@ -83,4 +83,12 @@ public interface IDisputeService
     /// <param name="cancellationToken"></param>
     /// <returns></returns>
     Task AcceptDisputeUpdateRequestAsync(long updateStatusId, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Rejects a citizen's requested changes to their Disputant Contact information.
+    /// </summary>
+    /// <param name="updateStatusId"></param>
+    /// <param name="cancellationToken"></param>
+    /// <returns></returns>
+    Task RejectDisputeUpdateRequestAsync(long updateStatusId, CancellationToken cancellationToken);
 }

--- a/src/backend/TrafficCourts/Test/Workflow.Service/Consumers/DisputantUpdateRequestRejectedConsumerTest.cs
+++ b/src/backend/TrafficCourts/Test/Workflow.Service/Consumers/DisputantUpdateRequestRejectedConsumerTest.cs
@@ -1,0 +1,90 @@
+﻿using MassTransit;
+using Microsoft.Extensions.Logging;
+using Moq;
+using System.Threading;
+using System.Threading.Tasks;
+using TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0;
+using TrafficCourts.Messaging.MessageContracts;
+using TrafficCourts.Workflow.Service.Consumers;
+using TrafficCourts.Workflow.Service.Services;
+using Xunit;
+
+namespace TrafficCourts.Test.Workflow.Service.Consumers;
+
+public class DisputantUpdateRequestRejectedConsumerTest
+{
+    private readonly DisputantUpdateRequestRejected _message;
+    private readonly Dispute _dispute;
+    private readonly DisputantUpdateRequest _updateRequest;
+    private readonly Mock<ILogger<DisputantUpdateRequestRejectedConsumer>> _mockLogger;
+    private readonly Mock<IOracleDataApiService> _oracleDataApiService;
+    private readonly Mock<ConsumeContext<DisputantUpdateRequestRejected>> _context;
+    private readonly DisputantUpdateRequestRejectedConsumer _consumer;
+
+    public DisputantUpdateRequestRejectedConsumerTest()
+    {
+        _message = new(1); 
+        _dispute = new()
+        {
+            DisputeId = 1,
+        };
+        _updateRequest = new()
+        {
+            DisputantUpdateRequestId = 1,
+            DisputeId = 1,
+            Status = DisputantUpdateRequestStatus2.REJECTED
+        };
+
+        _mockLogger = new();
+        _oracleDataApiService = new();
+        _oracleDataApiService.Setup(_ => _.UpdateDisputantUpdateRequestStatusAsync(1, DisputantUpdateRequestStatus.REJECTED, It.IsAny<CancellationToken>())).Returns(Task.FromResult(_updateRequest));
+        _oracleDataApiService.Setup(_ => _.GetDisputeByIdAsync(1, It.IsAny<CancellationToken>())).Returns(Task.FromResult(_dispute));
+        _context = new();
+        _context.Setup(_ => _.Message).Returns(_message);
+        _context.Setup(_ => _.CancellationToken).Returns(CancellationToken.None);
+
+        _consumer = new(_mockLogger.Object, _oracleDataApiService.Object);
+    }
+
+    [Fact]
+    public async Task TestDisputantUpdateRequestRejectedConsumer_AddressUpdates()
+    {
+        // Arrange
+        _updateRequest.UpdateType = DisputantUpdateRequestUpdateType.DISPUTANT_ADDRESS;
+        _updateRequest.UpdateJson = "{ \"addressLine1\": \"addr1\", \"addressLine2\": \"addr2\", \"addressLine3\": \"addr3\", \"addressCity\": \"city\", \"addressProvince\": \"BC\", \"postalCode\": \"A1B2C3\"}";        
+
+        // Act
+        await _consumer.Consume(_context.Object);
+
+        // Assert
+        Assert.Equal(DisputantUpdateRequestStatus2.REJECTED, _updateRequest.Status);
+    }
+
+    [Fact]
+    public async Task TestDisputantUpdateRequestRejectedConsumer_NameUpdates()
+    {
+        // Arrange
+        _updateRequest.UpdateType = DisputantUpdateRequestUpdateType.DISPUTANT_NAME;
+        _updateRequest.UpdateJson = "{ \"disputantGivenName1\": \"fname1\", \"disputantGivenName2\": \"fname2\", \"disputantGivenName3\": \"fname3\", \"disputantSurname\": \"lname\" }";
+        
+        // Act
+        await _consumer.Consume(_context.Object);
+
+        // Assert
+        Assert.Equal(DisputantUpdateRequestStatus2.REJECTED, _updateRequest.Status);
+    }
+
+    [Fact]
+    public async Task TestDisputantUpdateRequestRejectedConsumer_PhoneUpdates()
+    {
+        // Arrange
+        _updateRequest.UpdateType = DisputantUpdateRequestUpdateType.DISPUTANT_PHONE;
+        _updateRequest.UpdateJson = "{ \"homePhoneNumber\": \"2505556666\" }";
+
+        // Act
+        await _consumer.Consume(_context.Object);
+
+        // Assert
+        Assert.Equal(DisputantUpdateRequestStatus2.REJECTED, _updateRequest.Status);
+    }
+}

--- a/src/backend/TrafficCourts/Workflow.Service/Consumers/DisputantUpdateRequestAcceptedConsumer.cs
+++ b/src/backend/TrafficCourts/Workflow.Service/Consumers/DisputantUpdateRequestAcceptedConsumer.cs
@@ -14,7 +14,7 @@ public class DisputantUpdateRequestAcceptedConsumer : IConsumer<DisputantUpdateR
 {
     private readonly ILogger<DisputantUpdateRequestAcceptedConsumer> _logger;
     private readonly IOracleDataApiService _oracleDataApiService;
-    private static readonly string _approvedDisputantUpdateRequestEmailTemplateName = "DisputantUpdateRequestApprovedTemplate";
+    private static readonly string _acceptedDisputantUpdateRequestEmailTemplateName = "DisputantUpdateRequestAcceptedTemplate";
 
     public DisputantUpdateRequestAcceptedConsumer(ILogger<DisputantUpdateRequestAcceptedConsumer> logger, IOracleDataApiService oracleDataApiService)
     {
@@ -82,10 +82,10 @@ public class DisputantUpdateRequestAcceptedConsumer : IConsumer<DisputantUpdateR
 
     private async void PublishEmailConfirmation(Dispute dispute, ConsumeContext<DisputantUpdateRequestAccepted> context)
     {
-        var template = MailTemplateCollection.DefaultMailTemplateCollection.FirstOrDefault(t => t.TemplateName == _approvedDisputantUpdateRequestEmailTemplateName);
+        var template = MailTemplateCollection.DefaultMailTemplateCollection.FirstOrDefault(t => t.TemplateName == _acceptedDisputantUpdateRequestEmailTemplateName);
         if (template == null)
         {
-            _logger.LogError("Email {Template} not found", _approvedDisputantUpdateRequestEmailTemplateName);
+            _logger.LogError("Email {Template} not found", _acceptedDisputantUpdateRequestEmailTemplateName);
             return;
         }
 

--- a/src/backend/TrafficCourts/Workflow.Service/Consumers/DisputantUpdateRequestRejectedConsumer.cs
+++ b/src/backend/TrafficCourts/Workflow.Service/Consumers/DisputantUpdateRequestRejectedConsumer.cs
@@ -1,0 +1,89 @@
+﻿using MassTransit;
+using TrafficCourts.Common.Features.Mail;
+using TrafficCourts.Common.Features.Mail.Model;
+using TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0;
+using TrafficCourts.Messaging.MessageContracts;
+using TrafficCourts.Workflow.Service.Services;
+
+namespace TrafficCourts.Workflow.Service.Consumers;
+
+public class DisputantUpdateRequestRejectedConsumer : IConsumer<DisputantUpdateRequestRejected>
+{
+    private readonly ILogger<DisputantUpdateRequestRejectedConsumer> _logger;
+    private readonly IOracleDataApiService _oracleDataApiService;
+    private static readonly string _rejectedDisputantUpdateRequestEmailTemplateName = "DisputantUpdateRequestRejectedTemplate";
+
+    public DisputantUpdateRequestRejectedConsumer(ILogger<DisputantUpdateRequestRejectedConsumer> logger, IOracleDataApiService oracleDataApiService)
+    {
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _oracleDataApiService = oracleDataApiService ?? throw new ArgumentNullException(nameof(oracleDataApiService));
+    }
+
+    public async Task Consume(ConsumeContext<DisputantUpdateRequestRejected> context)
+    {
+        // TCVP-1974
+        // - call oracle-data-api to update DisputantUpdateRequest status.
+        // - send confirmation email indicating request was rejected
+        // - populate file/email history records
+
+        _logger.LogDebug("Consuming message");
+        DisputantUpdateRequestRejected message = context.Message;
+
+        // Set the status of the DisputantUpdateRequest object to REJECTED.
+        DisputantUpdateRequest updateRequest = await _oracleDataApiService.UpdateDisputantUpdateRequestStatusAsync(message.UpdateRequestId, DisputantUpdateRequestStatus.REJECTED, context.CancellationToken);
+
+        // Get the current Dispute by id
+        Dispute dispute = await _oracleDataApiService.GetDisputeByIdAsync(updateRequest.DisputeId, context.CancellationToken);
+
+        // send confirmation email to end user indicating their request was rejected
+        if (dispute.EmailAddressVerified)
+        {
+            PublishEmailConfirmation(dispute, context);
+        }
+
+        // populate file history
+        PublishFileHistoryLog(dispute, context);
+    }
+
+    private async void PublishEmailConfirmation(Dispute dispute, ConsumeContext<DisputantUpdateRequestRejected> context)
+    {
+        var template = MailTemplateCollection.DefaultMailTemplateCollection.FirstOrDefault(t => t.TemplateName == _rejectedDisputantUpdateRequestEmailTemplateName);
+        if (template == null)
+        {
+            _logger.LogError("Email {Template} not found", _rejectedDisputantUpdateRequestEmailTemplateName);
+            return;
+        }
+
+        if (dispute.EmailAddress is null)
+        {
+            _logger.LogError("EmailAddress is null on Dispute");
+            return;
+        }
+
+        SendDispuantEmail emailMessage = new()
+        {
+            NoticeOfDisputeGuid = new System.Guid(dispute.NoticeOfDisputeGuid),
+            TicketNumber = dispute.TicketNumber,
+            Message = new EmailMessage()
+            {
+                From = template.Sender,
+                To = dispute.EmailAddress,
+                Subject = template.SubjectTemplate,
+                TextContent = template.PlainContentTemplate,
+                HtmlContent = template.HtmlContentTemplate,
+            }
+        };
+
+        await context.PublishWithLog(_logger, emailMessage, context.CancellationToken);
+    }
+
+    private async void PublishFileHistoryLog(Dispute dispute, ConsumeContext<DisputantUpdateRequestRejected> context)
+    {
+        SaveFileHistoryRecord fileHistoryRecord = new()
+        {
+            TicketNumber = dispute.TicketNumber,
+            Description = "Disputant update request rejected."
+        };
+        await context.PublishWithLog(_logger, fileHistoryRecord, context.CancellationToken);
+    }
+}


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

TCVP-1974
Created an endpoint in the staff-api that rejects a DisputantUpdateRequest
`/api/dispute/updaterequest/{id}/reject`

The endpoint (via the workflow worker service)
- calls oracle-data-api to update DisputantUpdateRequest status.
- send confirmation email indicating request was rejected
- adds a file history record

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
