### PR TITLE
TCVP-1833 Added jjDisputeStatus to find query

### DIFF
--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/mapper/DisputeMapper.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/mapper/DisputeMapper.java
@@ -19,7 +19,7 @@ import ca.bc.gov.open.jag.tco.oracledataapi.model.DisputeStatus;
 import ca.bc.gov.open.jag.tco.oracledataapi.model.Plea;
 import ca.bc.gov.open.jag.tco.oracledataapi.model.ViolationTicketCount;
 import ca.bc.gov.open.jag.tco.oracledataapi.model.YesNo;
-import ca.bc.gov.open.jag.tco.oracledataapi.repository.impl.ords.DisputeRepositoryImpl;
+import ca.bc.gov.open.jag.tco.oracledataapi.util.DateUtil;
 
 /**
  * This mapper maps from ORDS dispute model to Oracle Data API dispute model
@@ -45,7 +45,7 @@ public interface DisputeMapper {
 	@Mapping(source = "dispute.disputantGiven1Nm", target = "disputantGivenName1")
 	@Mapping(source = "dispute.disputantGiven2Nm", target = "disputantGivenName2")
 	@Mapping(source = "dispute.disputantGiven3Nm", target = "disputantGivenName3")
-	@Mapping(source = "dispute.disputantBirthDt", target = "disputantBirthdate", dateFormat = DisputeRepositoryImpl.DATE_FORMAT)
+	@Mapping(source = "dispute.disputantBirthDt", target = "disputantBirthdate", dateFormat = DateUtil.DATE_FORMAT)
 	@Mapping(source = "dispute.disputantOrganizationNm", target = "disputantOrganization")
 	@Mapping(source = "dispute.disputantDrvLicNumberTxt", target = "driversLicenceNumber")
 	@Mapping(source = "dispute.drvLicIssuedCtryId", target = "driversLicenceIssuedCountryId")
@@ -108,7 +108,7 @@ public interface DisputeMapper {
 	@Mapping(source = "drvLicIssuedCountryTxt", target = "violationTicket.driversLicenceCountry")
 	@Mapping(source = "drvLicIssuedYearNo", target = "violationTicket.driversLicenceIssuedYear")
 	@Mapping(source = "drvLicExpiryYearNo", target = "violationTicket.driversLicenceExpiryYear")
-	@Mapping(source = "disputantBirthDt", target = "violationTicket.disputantBirthdate", dateFormat = DisputeRepositoryImpl.DATE_FORMAT)
+	@Mapping(source = "disputantBirthDt", target = "violationTicket.disputantBirthdate", dateFormat = DateUtil.DATE_FORMAT)
 	@Mapping(source = "addressTxt", target = "violationTicket.address")
 	@Mapping(source = "addressCityTxt", target = "violationTicket.addressCity")
 	@Mapping(source = "addressProvinceTxt", target = "violationTicket.addressProvince")

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/mapper/ViolationTicketMapper.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/mapper/ViolationTicketMapper.java
@@ -17,7 +17,7 @@ import ca.bc.gov.open.jag.tco.oracledataapi.model.DisputeCount;
 import ca.bc.gov.open.jag.tco.oracledataapi.model.DisputeStatus;
 import ca.bc.gov.open.jag.tco.oracledataapi.model.ViolationTicketCount;
 import ca.bc.gov.open.jag.tco.oracledataapi.model.YesNo;
-import ca.bc.gov.open.jag.tco.oracledataapi.repository.impl.ords.DisputeRepositoryImpl;
+import ca.bc.gov.open.jag.tco.oracledataapi.util.DateUtil;
 
 /**
  * This mapper maps from Oracle Data API dispute model to ORDS dispute data
@@ -42,7 +42,7 @@ public interface ViolationTicketMapper {
 	@Mapping(target = "dispute.disputantGiven1Nm", source = "disputantGivenName1")
 	@Mapping(target = "dispute.disputantGiven2Nm", source = "disputantGivenName2")
 	@Mapping(target = "dispute.disputantGiven3Nm", source = "disputantGivenName3")
-	@Mapping(target = "dispute.disputantBirthDt", source = "disputantBirthdate", dateFormat = DisputeRepositoryImpl.DATE_FORMAT)
+	@Mapping(target = "dispute.disputantBirthDt", source = "disputantBirthdate", dateFormat = DateUtil.DATE_FORMAT)
 	@Mapping(target = "dispute.disputantOrganizationNm", source = "disputantOrganization")
 	@Mapping(target = "dispute.disputantDrvLicNumberTxt", source = "driversLicenceNumber")
 	@Mapping(target = "dispute.drvLicIssuedIntlProvTxt", source = "driversLicenceProvince")
@@ -109,7 +109,7 @@ public interface ViolationTicketMapper {
 	@Mapping(target = "drvLicIssuedCountryTxt", source = "violationTicket.driversLicenceCountry")
 	@Mapping(target = "drvLicIssuedYearNo", source = "violationTicket.driversLicenceIssuedYear")
 	@Mapping(target = "drvLicExpiryYearNo", source = "violationTicket.driversLicenceExpiryYear")
-	@Mapping(target = "disputantBirthDt", source = "violationTicket.disputantBirthdate", dateFormat = DisputeRepositoryImpl.DATE_FORMAT)
+	@Mapping(target = "disputantBirthDt", source = "violationTicket.disputantBirthdate", dateFormat = DateUtil.DATE_FORMAT)
 	@Mapping(target = "addressTxt", source = "violationTicket.address")
 	@Mapping(target = "addressCityTxt", source = "violationTicket.addressCity")
 	@Mapping(target = "addressProvinceTxt", source = "violationTicket.addressProvince")

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/model/DisputeResult.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/model/DisputeResult.java
@@ -12,6 +12,14 @@ import lombok.Setter;
 public class DisputeResult {
 
 	private Long disputeId;
+
 	private DisputeStatus disputeStatus;
+
+	private JJDisputeStatus jjDisputeStatus;
+
+	public DisputeResult(Long disputeId, DisputeStatus disputeStatus) {
+		this.disputeId = disputeId;
+		this.disputeStatus = disputeStatus;
+	}
 
 }

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/repository/impl/ords/DisputeRepositoryImpl.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/repository/impl/ords/DisputeRepositoryImpl.java
@@ -30,15 +30,12 @@ import ca.bc.gov.open.jag.tco.oracledataapi.model.DisputeResult;
 import ca.bc.gov.open.jag.tco.oracledataapi.model.DisputeStatus;
 import ca.bc.gov.open.jag.tco.oracledataapi.model.ViolationTicketCount;
 import ca.bc.gov.open.jag.tco.oracledataapi.repository.DisputeRepository;
+import ca.bc.gov.open.jag.tco.oracledataapi.util.DateUtil;
 
 @ConditionalOnProperty(name = "repository.dispute", havingValue = "ords", matchIfMissing = false)
 @Qualifier("disputeRepository")
 @Repository
 public class DisputeRepositoryImpl implements DisputeRepository {
-
-	public static final String DATE_TIME_FORMAT = "yyyy-MM-dd'T'HH:mm:ss'Z'";
-	public static final String DATE_FORMAT = "yyyy-MM-dd";
-	public static final String TIME_FORMAT = "HH:mm";
 
 	private static Logger logger = LoggerFactory.getLogger(DisputeRepositoryImpl.class);
 
@@ -65,7 +62,7 @@ public class DisputeRepositoryImpl implements DisputeRepository {
 		String statusShortName = excludeStatus != null ? excludeStatus.toShortName() : null;
 
 		if (olderThan != null) {
-			SimpleDateFormat simpleDateFormat = new SimpleDateFormat(DATE_FORMAT);
+			SimpleDateFormat simpleDateFormat = new SimpleDateFormat(DateUtil.DATE_FORMAT);
 			olderThanDate = simpleDateFormat.format(olderThan);
 		}
 
@@ -86,7 +83,7 @@ public class DisputeRepositoryImpl implements DisputeRepository {
 
 	@Override
 	public List<DisputeResult> findByTicketNumberAndTime(String ticketNumber, Date issuedTime) {
-		SimpleDateFormat simpleDateFormat = new SimpleDateFormat(TIME_FORMAT);
+		SimpleDateFormat simpleDateFormat = new SimpleDateFormat(DateUtil.TIME_FORMAT);
 		String time = simpleDateFormat.format(issuedTime);
 		ViolationTicketListResponse response = violationTicketApi.v1ViolationTicketListGet(null, null, ticketNumber, null, time);
 		List<Dispute> extractedDisputes = extractDisputes(response);
@@ -204,8 +201,8 @@ public class DisputeRepositoryImpl implements DisputeRepository {
 
 	@Override
 	public void unassignDisputes(Date olderThan) {
-		SimpleDateFormat simpleDateFormat = new SimpleDateFormat(DATE_TIME_FORMAT);
-		simpleDateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+		SimpleDateFormat simpleDateFormat = new SimpleDateFormat(DateUtil.DATE_TIME_FORMAT);
+		simpleDateFormat.setTimeZone(TimeZone.getTimeZone("UTC")); //FIXME: UTC is a time standard, not a time zone - I think this should be GMT.
 		String dateStr = simpleDateFormat.format(olderThan);
 
 		logger.debug("Unassigning Disputes older than '{}'", dateStr);

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/util/DateUtil.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/util/DateUtil.java
@@ -1,0 +1,22 @@
+package ca.bc.gov.open.jag.tco.oracledataapi.util;
+
+import java.util.Date;
+
+import org.apache.commons.lang3.time.DateFormatUtils;
+
+public class DateUtil {
+
+	public static final String DATE_TIME_FORMAT = "yyyy-MM-dd'T'HH:mm:ss'Z'";
+	public static final String DATE_FORMAT = "yyyy-MM-dd";
+	public static final String TIME_FORMAT = "HH:mm";
+
+	/**
+	 * Returns the time portion (HH:mm) of the given date in 24-hour clock (GMT).
+	 * @param date
+	 * @return
+	 */
+	public static String formatAsHourMinuteUTC(Date date) {
+		return DateFormatUtils.formatUTC(date, TIME_FORMAT);
+	}
+
+}

--- a/src/backend/oracle-data-api/src/main/resources/occm-openapi-spec.yaml
+++ b/src/backend/oracle-data-api/src/main/resources/occm-openapi-spec.yaml
@@ -5,7 +5,7 @@ info:
   version: 1.0.0
 servers:
   - description: local
-    url: 'https://ords-0198bb-dev.apps.silver.devops.gov.bc.ca'
+    url: 'https://ords-0198bb-dev.apps.silver.devops.gov.bc.ca/occamords/occam/'
 paths:
   /v1/ping:
     get:

--- a/src/backend/oracle-data-api/src/test/java/ca/bc/gov/open/jag/tco/oracledataapi/controller/v1_0/DisputeControllerTest.java
+++ b/src/backend/oracle-data-api/src/test/java/ca/bc/gov/open/jag/tco/oracledataapi/controller/v1_0/DisputeControllerTest.java
@@ -28,6 +28,7 @@ import ca.bc.gov.open.jag.tco.oracledataapi.BaseTestSuite;
 import ca.bc.gov.open.jag.tco.oracledataapi.model.Dispute;
 import ca.bc.gov.open.jag.tco.oracledataapi.model.DisputeResult;
 import ca.bc.gov.open.jag.tco.oracledataapi.model.DisputeStatus;
+import ca.bc.gov.open.jag.tco.oracledataapi.util.DateUtil;
 import ca.bc.gov.open.jag.tco.oracledataapi.util.RandomUtil;
 
 class DisputeControllerTest extends BaseTestSuite {
@@ -277,7 +278,7 @@ class DisputeControllerTest extends BaseTestSuite {
 		// Create a single Dispute
 		Dispute dispute = RandomUtil.createDispute();
 		dispute.setTicketNumber("AX12345678");
-		dispute.setIssuedTs(DateUtils.parseDate("14:54", "HH:mm"));
+		dispute.setIssuedTs(DateUtils.parseDate("14:54", DateUtil.TIME_FORMAT));
 		dispute.setViolationTicket(null);
 		Long disputeId = saveDispute(dispute);
 

--- a/src/backend/oracle-data-api/src/test/java/ca/bc/gov/open/jag/tco/oracledataapi/controller/v1_0/JJDisputeControllerTest.java
+++ b/src/backend/oracle-data-api/src/test/java/ca/bc/gov/open/jag/tco/oracledataapi/controller/v1_0/JJDisputeControllerTest.java
@@ -27,6 +27,7 @@ import ca.bc.gov.open.jag.tco.oracledataapi.model.JJDispute;
 import ca.bc.gov.open.jag.tco.oracledataapi.model.JJDisputeStatus;
 import ca.bc.gov.open.jag.tco.oracledataapi.repository.JJDisputeRepository;
 import ca.bc.gov.open.jag.tco.oracledataapi.security.PreAuthenticatedToken;
+import ca.bc.gov.open.jag.tco.oracledataapi.util.DateUtil;
 import ca.bc.gov.open.jag.tco.oracledataapi.util.RandomUtil;
 
 class JJDisputeControllerTest extends BaseTestSuite {
@@ -97,12 +98,12 @@ class JJDisputeControllerTest extends BaseTestSuite {
 		 JJDispute dispute1 = jjDisputeRepository.save(RandomUtil.createJJDispute().toBuilder()
 				 .jjAssignedTo("Steven Strange")
 				 .ticketNumber("AX12345678")
-				 .violationDate(DateUtils.parseDate("12:45", "HH:mm"))
+				 .violationDate(DateUtils.parseDate("12:45", DateUtil.TIME_FORMAT))
 				 .build());
 		 JJDispute dispute2 = jjDisputeRepository.save(RandomUtil.createJJDispute().toBuilder()
 				 .jjAssignedTo("Tony Stark")
 				 .ticketNumber("AX00000000")
-				 .violationDate(DateUtils.parseDate("14:32", "HH:mm"))
+				 .violationDate(DateUtils.parseDate("14:32", DateUtil.TIME_FORMAT))
 				 .build());
 		 List<String> ticketNumbers = Arrays.asList(dispute1.getTicketNumber(), dispute2.getTicketNumber());
 
@@ -113,12 +114,12 @@ class JJDisputeControllerTest extends BaseTestSuite {
 		assertTrue(ticketNumbers.contains(allDisputes.get(1).getTicketNumber()));
 
 		// Assert request returns one record
-		allDisputes = IterableUtils.toList(jjDisputeController.getJJDisputes(null, "AX12345678", DateUtils.parseDate("12:45", "HH:mm")));
+		allDisputes = IterableUtils.toList(jjDisputeController.getJJDisputes(null, "AX12345678", DateUtils.parseDate("12:45", DateUtil.TIME_FORMAT)));
 		assertEquals(1, allDisputes.size());
 		assertEquals(dispute1.getTicketNumber(), allDisputes.get(0).getTicketNumber());
 
 		// Assert request returns one record
-		allDisputes = IterableUtils.toList(jjDisputeController.getJJDisputes(null, "AX12345678", DateUtils.parseDate("14:32", "HH:mm")));
+		allDisputes = IterableUtils.toList(jjDisputeController.getJJDisputes(null, "AX12345678", DateUtils.parseDate("14:32", DateUtil.TIME_FORMAT)));
 		assertEquals(0, allDisputes.size()); // mismatched terms - search should return nothing
 	}
 

--- a/src/backend/oracle-data-api/src/test/java/ca/bc/gov/open/jag/tco/oracledataapi/service/impl/ords/DisputeServiceImplTest.java
+++ b/src/backend/oracle-data-api/src/test/java/ca/bc/gov/open/jag/tco/oracledataapi/service/impl/ords/DisputeServiceImplTest.java
@@ -5,7 +5,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 
-import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -13,6 +12,7 @@ import java.util.NoSuchElementException;
 
 import javax.ws.rs.InternalServerErrorException;
 
+import org.apache.commons.lang3.time.DateFormatUtils;
 import org.apache.commons.lang3.time.DateUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -29,6 +29,7 @@ import ca.bc.gov.open.jag.tco.oracledataapi.model.Dispute;
 import ca.bc.gov.open.jag.tco.oracledataapi.model.DisputeResult;
 import ca.bc.gov.open.jag.tco.oracledataapi.model.DisputeStatus;
 import ca.bc.gov.open.jag.tco.oracledataapi.repository.impl.ords.DisputeRepositoryImpl;
+import ca.bc.gov.open.jag.tco.oracledataapi.util.DateUtil;
 
 
 class DisputeServiceImplTest extends BaseTestSuite {
@@ -270,7 +271,7 @@ class DisputeServiceImplTest extends BaseTestSuite {
 	@Test
 	public void testUnassignExpect200() throws Exception {
 		Date now = new Date();
-		String assignedBeforeTs = dateToString(now, DisputeRepositoryImpl.DATE_TIME_FORMAT);
+		String assignedBeforeTs = dateToString(now, DateUtil.DATE_TIME_FORMAT);
 		ResponseResult response = new ResponseResult();
 		response.setStatus("1");
 
@@ -284,7 +285,7 @@ class DisputeServiceImplTest extends BaseTestSuite {
 	@Test
 	public void testUnassignExpect500_ApiException() throws Exception {
 		Date now = new Date();
-		String assignedBeforeTs = dateToString(now, DisputeRepositoryImpl.DATE_TIME_FORMAT);
+		String assignedBeforeTs = dateToString(now, DateUtil.DATE_TIME_FORMAT);
 
 		Mockito.when(violationTicketApi.v1UnassignViolationTicketPost(assignedBeforeTs)).thenThrow(ApiException.class);
 
@@ -296,7 +297,7 @@ class DisputeServiceImplTest extends BaseTestSuite {
 	@Test
 	public void testUnassignExpect500_noErrorMsg() throws Exception {
 		Date now = new Date();
-		String assignedBeforeTs = dateToString(now, DisputeRepositoryImpl.DATE_TIME_FORMAT);
+		String assignedBeforeTs = dateToString(now, DateUtil.DATE_TIME_FORMAT);
 		ResponseResult response = new ResponseResult();
 		response.setStatus("0"); // 0 status (meaning failure) and no message
 
@@ -310,7 +311,7 @@ class DisputeServiceImplTest extends BaseTestSuite {
 	@Test
 	public void testUnassignExpect500_nullReponse() throws Exception {
 		Date now = new Date();
-		String assignedBeforeTs = dateToString(now, DisputeRepositoryImpl.DATE_TIME_FORMAT);
+		String assignedBeforeTs = dateToString(now, DateUtil.DATE_TIME_FORMAT);
 
 		Mockito.when(violationTicketApi.v1UnassignViolationTicketPost(assignedBeforeTs)).thenReturn(null);
 
@@ -322,7 +323,7 @@ class DisputeServiceImplTest extends BaseTestSuite {
 	@Test
 	public void testUnassignExpect500_withErrorMsg() throws Exception {
 		Date now = new Date();
-		String assignedBeforeTs = dateToString(now, DisputeRepositoryImpl.DATE_TIME_FORMAT);
+		String assignedBeforeTs = dateToString(now, DateUtil.DATE_TIME_FORMAT);
 		ResponseResult response = new ResponseResult();
 		response.setStatus("0"); // 0 status (meaning failure)
 		response.setException("some failure cause");
@@ -340,7 +341,7 @@ class DisputeServiceImplTest extends BaseTestSuite {
 		DisputeStatus disputeStatus = DisputeStatus.PROCESSING;
 		String ticketNumber = "AX00000000";
 		String issuedDateStr = "13:54";
-		Date issuedDate = DateUtils.parseDate(issuedDateStr, "HH:mm");
+		Date issuedDate = DateUtils.parseDate(issuedDateStr, DateUtil.TIME_FORMAT);
 
 		ca.bc.gov.open.jag.tco.oracledataapi.api.model.Dispute dispute = new ca.bc.gov.open.jag.tco.oracledataapi.api.model.Dispute();
 		dispute.setDisputeId(disputeId.toString());
@@ -368,7 +369,7 @@ class DisputeServiceImplTest extends BaseTestSuite {
 		disputeResults = repository.findByTicketNumberAndTime("AX", issuedDate);
 		assertEquals(0, disputeResults.size());
 
-		disputeResults = repository.findByTicketNumberAndTime(ticketNumber, DateUtils.parseDate("13:55", "HH:mm"));
+		disputeResults = repository.findByTicketNumberAndTime(ticketNumber, DateUtils.parseDate("13:55", DateUtil.TIME_FORMAT));
 		assertEquals(0, disputeResults.size());
 	}
 
@@ -384,7 +385,7 @@ class DisputeServiceImplTest extends BaseTestSuite {
 	@Test
 	public void testGetAllDisputesExpect200() throws Exception {
 		Date now = new Date();
-		String olderThanDate = dateToString(now, DisputeRepositoryImpl.DATE_FORMAT);
+		String olderThanDate = dateToString(now, DateUtil.DATE_FORMAT);
 		DisputeStatus excludedStatus = DisputeStatus.CANCELLED;
 		String noticeOfDisputeGuid = java.util.UUID.randomUUID().toString();
 		ViolationTicketListResponse response = new ViolationTicketListResponse();
@@ -401,7 +402,7 @@ class DisputeServiceImplTest extends BaseTestSuite {
 	@Test
 	public void testGetAllDisputesExpect500_InternalServerError() throws Exception {
 		Date now = new Date();
-		String olderThanDate = dateToString(now, DisputeRepositoryImpl.DATE_FORMAT);
+		String olderThanDate = dateToString(now, DateUtil.DATE_FORMAT);
 		DisputeStatus excludedStatus = DisputeStatus.CANCELLED;
 		String noticeOfDisputeGuid = java.util.UUID.randomUUID().toString();
 		ViolationTicketListResponse response = new ViolationTicketListResponse();
@@ -497,8 +498,7 @@ class DisputeServiceImplTest extends BaseTestSuite {
 	}
 
 	private String dateToString(Date date, String format) {
-		SimpleDateFormat dateFormat = new SimpleDateFormat(format);
-		return dateFormat.format(date);
+		return DateFormatUtils.formatUTC(date, format);
 	}
 
 }

--- a/src/backend/oracle-data-api/src/test/java/ca/bc/gov/open/jag/tco/oracledataapi/util/DateUtilTest.java
+++ b/src/backend/oracle-data-api/src/test/java/ca/bc/gov/open/jag/tco/oracledataapi/util/DateUtilTest.java
@@ -1,0 +1,20 @@
+package ca.bc.gov.open.jag.tco.oracledataapi.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.text.ParseException;
+import java.util.Date;
+
+import org.apache.commons.lang3.time.DateFormatUtils;
+import org.apache.commons.lang3.time.DateUtils;
+import org.junit.jupiter.api.Test;
+
+class DateUtilTest {
+
+	@Test
+	void test() throws ParseException {
+		Date date = DateUtils.parseDate("2022-03-29T13:45:30-07:00", DateFormatUtils.ISO_8601_EXTENDED_DATETIME_TIME_ZONE_FORMAT.getPattern());
+		assertEquals("20:45", DateUtil.formatAsHourMinuteUTC(date));
+	}
+
+}


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

TCVP-1833
Enhanced the returned result for the `/api/v1.0/dispute/status` endpoint to also include jjDispute status.

Sample response in Swagger:
`curl -X 'GET' 'http://localhost:5010/api/v1.0/dispute/status?ticketNumber=AX12345678&issuedTime=08%3A00'
`
![image](https://user-images.githubusercontent.com/55215368/206309029-030ee065-6cfa-4640-8e1b-db2f571c4169.png)

- Fixed junit tests
- Refactored/moved DisputeRepositoryImpl.DATE_TIME_FORMAT to a DateUtil class

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
