### PR TITLE
Fix mapping of name on dispute ARC record. Add unit tests

### DIFF
--- a/src/backend/TrafficCourts/TrafficCourts.Arc.Dispute.Service/Mappings/DisputeTicketToArcFileRecordListConverter.cs
+++ b/src/backend/TrafficCourts/TrafficCourts.Arc.Dispute.Service/Mappings/DisputeTicketToArcFileRecordListConverter.cs
@@ -97,11 +97,11 @@ namespace TrafficCourts.Arc.Dispute.Service.Mappings
                         // Mapping disputed ticket specific data
                         ServiceDate = source.TicketIssuanceDate,
                         Name = GetName(source),
-                        DisputeType = disputeCount.DisputeType?.ToUpper() ?? "A", //TODO: Find out what dispute type actually means
-                        StreetAddress = source.StreetAddress?.ToUpper() ?? String.Empty,
-                        City = source.City?.ToUpper() ?? String.Empty,
-                        Province = source.Province?.ToUpper() ?? String.Empty,
-                        PostalCode = source.PostalCode?.ToUpper() ?? String.Empty
+                        DisputeType = disputeCount.DisputeType?.Trim().ToUpper() ?? "A", //TODO: Find out what dispute type actually means
+                        StreetAddress = source.StreetAddress?.Trim().ToUpper() ?? String.Empty,
+                        City = source.City?.Trim().ToUpper() ?? String.Empty,
+                        Province = source.Province?.Trim().ToUpper() ?? String.Empty,
+                        PostalCode = source.PostalCode?.Trim().ToUpper() ?? String.Empty
                     };
 
                     destination.Add(disputed);

--- a/src/backend/TrafficCourts/TrafficCourts.Arc.Dispute.Service/Mappings/DisputeTicketToArcFileRecordListConverter.cs
+++ b/src/backend/TrafficCourts/TrafficCourts.Arc.Dispute.Service/Mappings/DisputeTicketToArcFileRecordListConverter.cs
@@ -23,7 +23,8 @@ namespace TrafficCourts.Arc.Dispute.Service.Mappings
             // Additional minutes between the transaction times since each transaction timestamp for EV and ED must be unique for ARC to process
             var now = GetCurrentDate();
 
-            foreach (TicketCount ticket in source.TicketDetails)
+            // process each of the ticket counts in "count" order
+            foreach (TicketCount ticket in source.TicketDetails.OrderBy(_ => _.Count))
             {
                 AdnotatedTicket adnotated = new();
 
@@ -95,7 +96,7 @@ namespace TrafficCourts.Arc.Dispute.Service.Mappings
 
                         // Mapping disputed ticket specific data
                         ServiceDate = source.TicketIssuanceDate,
-                        Name = ReverseName(source.CitizenName),
+                        Name = GetName(source),
                         DisputeType = disputeCount.DisputeType?.ToUpper() ?? "A", //TODO: Find out what dispute type actually means
                         StreetAddress = source.StreetAddress?.ToUpper() ?? String.Empty,
                         City = source.City?.ToUpper() ?? String.Empty,
@@ -116,47 +117,39 @@ namespace TrafficCourts.Arc.Dispute.Service.Mappings
         {
             // the name used to come thru as a citizen name field
             // but in later release, the name is split into individual fields
-            if (!string.IsNullOrEmpty(ticket.CitizenName))
+            if (!string.IsNullOrWhiteSpace(ticket.CitizenName))
             {
                 return ReverseName(ticket.CitizenName);
             }
 
             StringBuilder name = new StringBuilder();
-            if (!string.IsNullOrEmpty(ticket.Surname))
+            if (AppendIfNotIsNullOrWhiteSpace(name, ticket.Surname))
             {
-                name.Append(ticket.Surname);
-                name.Append(',');
+                name.Append(','); // add comma after surname
             }
 
-            if (!string.IsNullOrEmpty(ticket.GivenName1))
+            AppendIfNotIsNullOrWhiteSpace(name, ticket.GivenName1);
+            AppendIfNotIsNullOrWhiteSpace(name, ticket.GivenName2);
+            AppendIfNotIsNullOrWhiteSpace(name, ticket.GivenName3);
+
+            return name.ToString().ToUpper(); // name always needs to be converted to upper case
+        }
+
+        private static bool AppendIfNotIsNullOrWhiteSpace(StringBuilder buffer, string? value)
+        {
+            if (!string.IsNullOrWhiteSpace(value))
             {
-                if (name.Length != 0)
+                if (buffer.Length != 0)
                 {
-                    name.Append(' ');
+                    // add a space before the previous text
+                    buffer.Append(' ');
                 }
-                name.Append(ticket.GivenName1.Trim());
+
+                buffer.Append(value.Trim());
+                return true;
             }
 
-            if (!string.IsNullOrEmpty(ticket.GivenName2))
-            {
-                if (name.Length != 0)
-                {
-                    name.Append(' ');
-                }
-                name.Append(ticket.GivenName2.Trim());
-            }
-
-            if (!string.IsNullOrEmpty(ticket.GivenName3))
-            {
-                if (name.Length != 0)
-                {
-                    name.Append(' ');
-                }
-                
-                name.Append(ticket.GivenName3.Trim());
-            }
-
-            return name.ToString();
+            return false;
         }
 
         internal static string ReverseName(string name)

--- a/src/backend/TrafficCourts/TrafficCourts.Arc.Dispute.Service/Models/TcoDisputeTicket.cs
+++ b/src/backend/TrafficCourts/TrafficCourts.Arc.Dispute.Service/Models/TcoDisputeTicket.cs
@@ -9,7 +9,7 @@ namespace TrafficCourts.Arc.Dispute.Service.Models
         /// </summary>
         [Obsolete($"Use {nameof(GivenName1)}, {nameof(GivenName2)},  {nameof(GivenName3)} and {nameof(Surname)}")]
         [JsonProperty("citizen_name")]
-        public string CitizenName { get; set; } = String.Empty;
+        public string? CitizenName { get; set; } = String.Empty;
 
         [JsonProperty("citizen_surname")]
         //[JsonRequired] // make required when CitizenName is removed
@@ -63,7 +63,7 @@ namespace TrafficCourts.Arc.Dispute.Service.Models
         public string? Email { get; set; }
         
         [JsonProperty("dispute_counts")]
-        public IList<DisputeCount>? DisputeCounts { get; set; }
+        public List<DisputeCount> DisputeCounts { get; set; } = new();
     }
 
     public class TicketCount


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- Fix issue where dispute record citizen name was not mapped the same way as the adnotated record
- Added unit tests to validate the citizen's name is mapped correctly

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [ ] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
