### PR TITLE
TCVP-1995 added GET jjDispute endpoint

### DIFF
--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/config/OrdsTcoApiClientConfiguration.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/config/OrdsTcoApiClientConfiguration.java
@@ -6,6 +6,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 import ca.bc.gov.open.jag.tco.oracledataapi.ords.tco.api.HealthApi;
+import ca.bc.gov.open.jag.tco.oracledataapi.ords.tco.api.JjDisputeApi;
 import ca.bc.gov.open.jag.tco.oracledataapi.ords.tco.api.handler.ApiClient;
 
 @Configuration
@@ -29,6 +30,11 @@ public class OrdsTcoApiClientConfiguration {
 	@Bean
 	public HealthApi ordsTcoHealthApi(ApiClient ordsTcoApiClient) {
 		return new HealthApi(ordsTcoApiClient);
+	}
+
+	@Bean
+	public JjDisputeApi ordsTcoJjDisputeApi(ApiClient ordsTcoApiClient) {
+		return new JjDisputeApi(ordsTcoApiClient);
 	}
 
 }

--- a/src/backend/oracle-data-api/src/main/resources/tco-openapi-spec.yaml
+++ b/src/backend/oracle-data-api/src/main/resources/tco-openapi-spec.yaml
@@ -20,8 +20,175 @@ paths:
                 $ref: '#/components/schemas/PingResult'
       tags:
         - Health
+  /v1/jjDispute:
+    get:
+      parameters:
+        - name: ticketNumber
+          in: query
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Ok
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/JJDispute'
+      tags:
+        - JJDispute
 components:
   schemas:
+    AuditBase:
+      type: object
+      properties:
+        entDtm:
+          type: string
+          format: date-time
+          x-field-extra-annotation: "@com.fasterxml.jackson.annotation.JsonFormat(pattern=\"yyyy-MM-dd'T'HH:mm:ss'Z'\")"
+        entUserId:
+          type: string
+        updDtm:
+          type: string
+          format: date-time
+          x-field-extra-annotation: "@com.fasterxml.jackson.annotation.JsonFormat(pattern=\"yyyy-MM-dd'T'HH:mm:ss'Z'\")"
+        updUserId:
+          type: string
+          format: nullable
+    JJDispute:
+      type: object
+      properties:
+        addressLine1Txt:
+          type: string
+        addressLine2Txt:
+          type: string
+          format: nullable
+        addressLine3Txt:       
+          type: string 
+          format: nullable
+        courtHearingTypeCd:  
+          type: string 
+          format: nullable
+        detachmentLocationTxt:
+          type: string
+        disputantBirthDt:
+          type: string
+          format: date  
+        disputantDrvLicNumberTxt:
+          type: string
+        disputantGiven1Nm:
+          type: string
+        disputantGiven2Nm:
+          type: string
+          format: nullable
+        disputantGiven3Nm:
+          type: string
+          format: nullable
+        disputantSurnameTxt:
+          type: string
+        disputeCounts:
+          type: array
+          items:
+            $ref: '#/components/schemas/JJDisputeCount'
+        disputeId:
+          type: integer
+        disputeRemarks:
+          type: array
+          items:
+            $ref: '#/components/schemas/JJDisputeRemarks'
+        disputeStatusTypeCd:
+          type: string
+        drvLicIssuedCtryId:
+          type: string
+        drvLicIssuedProvSeqNo:
+          type: string
+        emailAddressTxt:
+          type: string
+        icbcReceivedDt:
+          type: string
+          format: date  
+        interpreterLanguageCd:
+          type: string
+          format: nullable
+        issuedTs:
+          type: string
+          format: date-time
+          x-field-extra-annotation: "@com.fasterxml.jackson.annotation.JsonFormat(pattern=\"yyyy-MM-dd'T'HH:mm'Z'\")"
+        lawFirmNm:
+          type: string
+        lawyerGiven1Nm:
+          type: string
+          format: nullable
+        lawyerGiven2Nm:
+          type: string
+          format: nullable
+        lawyerGiven3Nm:
+          type: string
+          format: nullable
+        lawyerSurnameNm:
+          type: string
+          format: nullable
+        offenceLocationTxt:
+          type: string
+          format: nullable
+        submittedDt:
+          type: string
+          format: date  
+        ticketNumberTxt:
+          type: string
+      allOf:
+        - $ref: '#/components/schemas/AuditBase'
+    JJDisputeCount:
+      type: object
+      properties:
+        adjustedAmt:
+          type: double
+        commentsTxt:
+          type: string
+        countNo:
+          type: string
+        disputeCountId:
+          type: integer
+        disputeId:
+          type: string
+        fineDueDt:
+          type: string
+        includesSurchargeYn:
+          type: string
+        pleaCd:
+          type: string
+        requestCourtAppearanceYn:
+          type: string
+        requestReductionYn:
+          type: string
+        requestTimeToPayYn:
+          type: string
+        revisedDueDt:
+          type: date
+        statuteId:
+          type: string
+        totalFineAmt:
+          type: double
+        violationDt:
+          type: date
+      allOf:
+        - $ref: '#/components/schemas/AuditBase'
+    JJDisputeRemarks:
+      type: object
+      properties:
+        disputeRemarkId:
+          type: string
+        disputeId:
+          type: string
+        disputeRemarkTxt:
+          type: string
+        fullUserNameTxt:
+          type: string
+        remarksMadeDtm:
+          type: string
+          format: date-time
+          x-field-extra-annotation: "@com.fasterxml.jackson.annotation.JsonFormat(pattern=\"yyyy-MM-dd'T'HH:mm:ss'Z'\")"
+      allOf:
+        - $ref: '#/components/schemas/AuditBase'
     PingResult:
       type: object
       properties:

--- a/src/backend/oracle-data-api/src/test/java/ca/bc/gov/open/jag/tco/oracledataapi/service/DisputeServiceOrdsTcoTest.java
+++ b/src/backend/oracle-data-api/src/test/java/ca/bc/gov/open/jag/tco/oracledataapi/service/DisputeServiceOrdsTcoTest.java
@@ -9,6 +9,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 import ca.bc.gov.open.jag.tco.oracledataapi.BaseTestSuite;
 import ca.bc.gov.open.jag.tco.oracledataapi.ords.tco.api.HealthApi;
+import ca.bc.gov.open.jag.tco.oracledataapi.ords.tco.api.JjDisputeApi;
+import ca.bc.gov.open.jag.tco.oracledataapi.ords.tco.api.model.JJDispute;
 import ca.bc.gov.open.jag.tco.oracledataapi.ords.tco.api.model.PingResult;
 
 @EnabledIfEnvironmentVariable(named = "JJDISPUTE_REPOSITORY_SRC", matches = "ords")
@@ -17,11 +19,24 @@ class DisputeServiceOrdsTcoTest extends BaseTestSuite {
 	@Autowired
 	private HealthApi ordsTcoHealthApi;
 
+	@Autowired
+	private JjDisputeApi ordsTcoJjDisputeApi;
+
 	@Test
 	void testPingOrdsTco() throws Exception {
 		PingResult pingResult = ordsTcoHealthApi.ping();
 		assertNotNull(pingResult);
 		assertEquals("success", pingResult.getStatus());
+	}
+
+	@Test
+	void testJjDispute_GET() throws Exception {
+		// TODO: replace this test with a POST/GET/PUT/DELETE to confirm CRUD
+		// Hard-coded TicketNumber for now since there are no POST/DELETE endpoints yet.
+		JJDispute jjDispute = ordsTcoJjDisputeApi.v1JjDisputeGet("EA90100004");
+
+		assertNotNull(jjDispute);
+		assertEquals("EA90100004", jjDispute.getTicketNumberTxt());
 	}
 
 }


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

TCVP-1995

Added an OpenAPI endpoint for ORDS-TCO for retrieving a JJDispute from TCO.
Added an integration test to confirm the record successfully pulls from the database.

The datatype of each field is mostly just string for now.  Someone with database access will need to go through each field and confirm the datatype and nullable aspects.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

mvn verify

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
