### PR TITLE
TCVP-2007 Added PUT endpoint to process a disputant's contact info

### DIFF
--- a/src/backend/TrafficCourts/Citizen.Service/Models/Dispute/DisputantContactInformation.cs
+++ b/src/backend/TrafficCourts/Citizen.Service/Models/Dispute/DisputantContactInformation.cs
@@ -1,0 +1,113 @@
+﻿using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Serialization;
+
+namespace TrafficCourts.Citizen.Service.Models.Dispute;
+
+/// <summary>
+/// A subset of a Disputant's contact information that can be requested to update via a PUT /api/dispute/{guidhash}/contact endpoint.
+/// </summary>
+public class DisputantContactInformation
+{
+    /// <summary>
+    /// The disputant's email address.
+    /// </summary>
+    [JsonPropertyName("email_address")]
+    [MaxLength(100)]
+    public string? EmailAddress { get; set; } = null!;
+
+    /// <summary>
+    /// The first given name or corporate name continued.
+    /// </summary>
+    [JsonPropertyName("disputant_given_name1")]
+    [MaxLength(30)]
+    public string? DisputantGivenName1 { get; set; } = null!;
+
+    /// <summary>
+    /// The second given name
+    /// </summary>
+    [JsonPropertyName("disputant_given_name2")]
+    [MaxLength(30)]
+    public string? DisputantGivenName2 { get; set; } = null!;
+
+    /// <summary>
+    /// The third given name 
+    /// </summary>
+    [JsonPropertyName("disputant_given_name3")]
+    [MaxLength(30)]
+    public string? DisputantGivenName3 { get; set; } = null!;
+
+    /// <summary>
+    /// The surname or corporate name.
+    /// </summary>
+    [JsonPropertyName("disputant_surname")]
+    [MaxLength(30)]
+    public string? DisputantSurname { get; set; } = null!;
+
+    /// <summary>
+    /// The mailing address of the disputant.
+    /// </summary>
+    [JsonPropertyName("address_line1")]
+    [MaxLength(100)]
+    public string? AddressLine1 { get; set; } = null!;
+
+    /// <summary>
+    /// The mailing address of the disputant.
+    /// </summary>
+    [JsonPropertyName("address_line2")]
+    [MaxLength(100)]
+    public string? AddressLine2 { get; set; } = null!;
+
+    /// <summary>
+    /// The mailing address of the disputant.
+    /// </summary>
+    [JsonPropertyName("address_line3")]
+    [MaxLength(100)]
+    public string? AddressLine3 { get; set; } = null!;
+
+    /// <summary>
+    /// The mailing address city of the disputant.
+    /// </summary>
+    [JsonPropertyName("address_city")]
+    [MaxLength(30)]
+    public string? AddressCity { get; set; } = null!;
+
+    /// <summary>
+    /// The mailing address province of the disputant.
+    /// </summary>
+    [JsonPropertyName("address_province")]
+    [MaxLength(30)]
+    public string? AddressProvince { get; set; } = null!;
+
+    /// <summary>
+    /// The mailing address province's country code of the disputant.
+    /// </summary>
+    [JsonPropertyName("address_province_country_id")]
+    public int? AddressProvinceCountryId { get; set; }
+
+    /// <summary>
+    /// The mailing address province's sequence number of the disputant.
+    /// </summary>
+    [JsonPropertyName("address_province_seq_no")]
+    public int? AddressProvinceSeqNo { get; set; }
+
+    /// <summary>
+    /// The mailing address country id of the disputant.
+    /// </summary>
+    [JsonPropertyName("address_country_id")]
+    public int? AddressCountryId { get; set; }
+
+    /// <summary>
+    /// The mailing address postal code or zip code of the disputant.
+    /// </summary>
+    [JsonPropertyName("postal_code")]
+    [MaxLength(10)]
+    public string? PostalCode { get; set; } = null!;
+
+    /// <summary>
+    /// The disputant's home phone number.
+    /// </summary>
+    [JsonPropertyName("home_phone_number")]
+    [MaxLength(20)]
+    public string? HomePhoneNumber { get; set; } = null!;
+}
+

--- a/src/backend/TrafficCourts/Citizen.Service/Models/Dispute/DisputeCount.cs
+++ b/src/backend/TrafficCourts/Citizen.Service/Models/Dispute/DisputeCount.cs
@@ -2,39 +2,37 @@
 using System.Text.Json.Serialization;
 using TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0;
 
-namespace TrafficCourts.Citizen.Service.Models.Dispute
+namespace TrafficCourts.Citizen.Service.Models.Dispute;
+
+public class DisputeCount
 {
-    public class DisputeCount
-    {
-        /// <summary>
-        /// Represents the dispuant plea on count.
-        /// </summary>
-        [JsonPropertyName("plea_cd")]
-        public DisputeCountPleaCode PleaCode { get; set; }
+    /// <summary>
+    /// Represents the dispuant plea on count.
+    /// </summary>
+    [JsonPropertyName("plea_cd")]
+    public DisputeCountPleaCode PleaCode { get; set; }
 
-        /// <summary>
-        /// The count number. Must be unique within an individual dispute.
-        /// </summary>
-        [JsonPropertyName("count_no")]
-        public short CountNo { get; set; }
+    /// <summary>
+    /// The count number. Must be unique within an individual dispute.
+    /// </summary>
+    [JsonPropertyName("count_no")]
+    public short CountNo { get; set; }
 
-        /// <summary>
-        /// The disputant is requesting time to pay the ticketed amount.
-        /// </summary>
-        [JsonPropertyName("request_time_to_pay")]
-        public DisputeCountRequestTimeToPay? RequestTimeToPay { get; set; }
+    /// <summary>
+    /// The disputant is requesting time to pay the ticketed amount.
+    /// </summary>
+    [JsonPropertyName("request_time_to_pay")]
+    public DisputeCountRequestTimeToPay? RequestTimeToPay { get; set; }
 
-        /// <summary>
-        /// The disputant is requesting a reduction of the ticketed amount.
-        /// </summary>
-        [JsonPropertyName("request_reduction")]
-        public DisputeCountRequestReduction? RequestReduction { get; set; }
+    /// <summary>
+    /// The disputant is requesting a reduction of the ticketed amount.
+    /// </summary>
+    [JsonPropertyName("request_reduction")]
+    public DisputeCountRequestReduction? RequestReduction { get; set; }
 
-        /// <summary>
-        /// Does the want to appear in court?
-        /// </summary>
-        [JsonPropertyName("request_court_appearance")]
-        public DisputeCountRequestCourtAppearance? RequestCourtAppearance { get; set; }
-    }
-
+    /// <summary>
+    /// Does the want to appear in court?
+    /// </summary>
+    [JsonPropertyName("request_court_appearance")]
+    public DisputeCountRequestCourtAppearance? RequestCourtAppearance { get; set; }
 }

--- a/src/backend/TrafficCourts/Citizen.Service/Models/Dispute/NoticeOfDispute.cs
+++ b/src/backend/TrafficCourts/Citizen.Service/Models/Dispute/NoticeOfDispute.cs
@@ -3,266 +3,264 @@ using System.ComponentModel.DataAnnotations;
 using System.Text.Json.Serialization;
 using TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0;
 
-namespace TrafficCourts.Citizen.Service.Models.Dispute
+namespace TrafficCourts.Citizen.Service.Models.Dispute;
+
+/// <summary>
+/// Represents a violation ticket notice of dispute.
+/// </summary>
+public class NoticeOfDispute
 {
     /// <summary>
-    /// Represents a violation ticket notice of dispute.
+    /// The violation ticket number.
     /// </summary>
-    public class NoticeOfDispute
-    {
-        /// <summary>
-        /// The violation ticket number.
-        /// </summary>
-        [JsonPropertyName("ticket_number")]
-        [MaxLength(12)]
-        public string? TicketNumber { get; set; } = null!;
+    [JsonPropertyName("ticket_number")]
+    [MaxLength(12)]
+    public string? TicketNumber { get; set; } = null!;
 
-        /// <summary>
-        /// The date and time the violation ticket was issue. Time must only be hours and minutes.
-        /// </summary>
-        [JsonPropertyName("issued_date")]
-        public DateTime IssuedTs { get; set; }
+    /// <summary>
+    /// The date and time the violation ticket was issue. Time must only be hours and minutes.
+    /// </summary>
+    [JsonPropertyName("issued_date")]
+    public DateTime IssuedTs { get; set; }
 
-        /// <summary>
-        /// The surname or corporate name.
-        /// </summary>
-        [JsonPropertyName("disputant_surname")]
-        public string DisputantSurname { get; set; } = null!;
+    /// <summary>
+    /// The surname or corporate name.
+    /// </summary>
+    [JsonPropertyName("disputant_surname")]
+    public string DisputantSurname { get; set; } = null!;
 
-        /// <summary>
-        /// The first given name or corporate name continued.
-        /// </summary>
-        [JsonPropertyName("disputant_given_name1")]
-        public string DisputantGivenName1 { get; set; } = null!;
+    /// <summary>
+    /// The first given name or corporate name continued.
+    /// </summary>
+    [JsonPropertyName("disputant_given_name1")]
+    public string DisputantGivenName1 { get; set; } = null!;
 
-        /// <summary>
-        /// The second given name
-        /// </summary>
-        [JsonPropertyName("disputant_given_name2")]
-        public string? DisputantGivenName2 { get; set; } = null!;
+    /// <summary>
+    /// The second given name
+    /// </summary>
+    [JsonPropertyName("disputant_given_name2")]
+    public string? DisputantGivenName2 { get; set; } = null!;
 
-        /// <summary>
-        /// The third given name 
-        /// </summary>
-        [JsonPropertyName("disputant_given_name3")]
-        public string? DisputantGivenName3 { get; set; } = null!;
+    /// <summary>
+    /// The third given name 
+    /// </summary>
+    [JsonPropertyName("disputant_given_name3")]
+    public string? DisputantGivenName3 { get; set; } = null!;
 
-        /// <summary>
-        /// The disputant's birthdate.
-        /// </summary>
-        [JsonPropertyName("disputant_birthdate")]
-        [SwaggerSchema(Format = "date")]
-        public DateTime DisputantBirthdate { get; set; }
+    /// <summary>
+    /// The disputant's birthdate.
+    /// </summary>
+    [JsonPropertyName("disputant_birthdate")]
+    [SwaggerSchema(Format = "date")]
+    public DateTime DisputantBirthdate { get; set; }
 
-        /// <summary>
-        /// The drivers licence number. Note not all jurisdictions will use numeric drivers licence numbers.
-        /// </summary>
-        [JsonPropertyName("drivers_licence_number")]
-        public string DriversLicenceNumber { get; set; } = null!;
+    /// <summary>
+    /// The drivers licence number. Note not all jurisdictions will use numeric drivers licence numbers.
+    /// </summary>
+    [JsonPropertyName("drivers_licence_number")]
+    public string DriversLicenceNumber { get; set; } = null!;
 
-        /// <summary>
-        /// The province or state the drivers licence was issued by.
-        /// </summary>
-        [JsonPropertyName("drivers_licence_province")]
-        public string DriversLicenceProvince { get; set; } = null!;
+    /// <summary>
+    /// The province or state the drivers licence was issued by.
+    /// </summary>
+    [JsonPropertyName("drivers_licence_province")]
+    public string DriversLicenceProvince { get; set; } = null!;
 
-        /// <summary>
-        /// The province sequence number of the drivers licence was issued by.
-        /// </summary>
-        [JsonPropertyName("drivers_licence_province_seq_no")]
-        public int? DriversLicenceProvinceSeqNo { get; set; }
+    /// <summary>
+    /// The province sequence number of the drivers licence was issued by.
+    /// </summary>
+    [JsonPropertyName("drivers_licence_province_seq_no")]
+    public int? DriversLicenceProvinceSeqNo { get; set; }
 
-        /// <summary>
-        /// The country code of the drivers licence was issued by.
-        /// </summary>
-        [JsonPropertyName("drivers_licence_country_id")]
-        public int? DriversLicenceCountryId { get; set; }
+    /// <summary>
+    /// The country code of the drivers licence was issued by.
+    /// </summary>
+    [JsonPropertyName("drivers_licence_country_id")]
+    public int? DriversLicenceCountryId { get; set; }
 
-        /// <summary>
-        /// The mailing address of the disputant.
-        /// </summary>
-        [JsonPropertyName("address_line1")]
-        public string AddressLine1 { get; set; } = null!;
+    /// <summary>
+    /// The mailing address of the disputant.
+    /// </summary>
+    [JsonPropertyName("address_line1")]
+    public string AddressLine1 { get; set; } = null!;
 
-        /// <summary>
-        /// The mailing address of the disputant.
-        /// </summary>
-        [JsonPropertyName("address_line2")]
-        public string? AddressLine2 { get; set; } = null!;
+    /// <summary>
+    /// The mailing address of the disputant.
+    /// </summary>
+    [JsonPropertyName("address_line2")]
+    public string? AddressLine2 { get; set; } = null!;
 
-        /// <summary>
-        /// The mailing address of the disputant.
-        /// </summary>
-        [JsonPropertyName("address_line3")]
-        public string? AddressLine3 { get; set; } = null!;
+    /// <summary>
+    /// The mailing address of the disputant.
+    /// </summary>
+    [JsonPropertyName("address_line3")]
+    public string? AddressLine3 { get; set; } = null!;
 
-        /// <summary>
-        /// The mailing address city of the disputant.
-        /// </summary>
-        [JsonPropertyName("address_city")]
-        public string AddressCity { get; set; } = null!;
+    /// <summary>
+    /// The mailing address city of the disputant.
+    /// </summary>
+    [JsonPropertyName("address_city")]
+    public string AddressCity { get; set; } = null!;
 
-        /// <summary>
-        /// The mailing address province of the disputant.
-        /// </summary>
-        [JsonPropertyName("address_province")]
-        public string AddressProvince { get; set; } = null!;
+    /// <summary>
+    /// The mailing address province of the disputant.
+    /// </summary>
+    [JsonPropertyName("address_province")]
+    public string AddressProvince { get; set; } = null!;
 
-        /// <summary>
-        /// The mailing address province's country code of the disputant.
-        /// </summary>
-        [JsonPropertyName("address_province_country_id")]
-        public int? AddressProvinceCountryId { get; set; }
+    /// <summary>
+    /// The mailing address province's country code of the disputant.
+    /// </summary>
+    [JsonPropertyName("address_province_country_id")]
+    public int? AddressProvinceCountryId { get; set; }
 
-        /// <summary>
-        /// The mailing address province's sequence number of the disputant.
-        /// </summary>
-        [JsonPropertyName("address_province_seq_no")]
-        public int? AddressProvinceSeqNo { get; set; }
+    /// <summary>
+    /// The mailing address province's sequence number of the disputant.
+    /// </summary>
+    [JsonPropertyName("address_province_seq_no")]
+    public int? AddressProvinceSeqNo { get; set; }
 
-        /// <summary>
-        /// The mailing address country id of the disputant.
-        /// </summary>
-        [JsonPropertyName("address_country_id")]
-        public int? AddressCountryId { get; set; }
+    /// <summary>
+    /// The mailing address country id of the disputant.
+    /// </summary>
+    [JsonPropertyName("address_country_id")]
+    public int? AddressCountryId { get; set; }
 
-        /// <summary>
-        /// The mailing address postal code or zip code of the disputant.
-        /// </summary>
-        [JsonPropertyName("postal_code")]
-        public string PostalCode { get; set; } = null!;
+    /// <summary>
+    /// The mailing address postal code or zip code of the disputant.
+    /// </summary>
+    [JsonPropertyName("postal_code")]
+    public string PostalCode { get; set; } = null!;
 
-        /// <summary>
-        /// The disputant's home phone number.
-        /// </summary>
-        [JsonPropertyName("home_phone_number")]
-        public string? HomePhoneNumber { get; set; } = null!;
+    /// <summary>
+    /// The disputant's home phone number.
+    /// </summary>
+    [JsonPropertyName("home_phone_number")]
+    public string? HomePhoneNumber { get; set; } = null!;
 
-        /// <summary>
-        /// The disputant's work phone number.
-        /// </summary>
-        [JsonPropertyName("work_phone_number")]
-        public string? WorkPhoneNumber { get; set; }
+    /// <summary>
+    /// The disputant's work phone number.
+    /// </summary>
+    [JsonPropertyName("work_phone_number")]
+    public string? WorkPhoneNumber { get; set; }
 
-        /// <summary>
-        /// The disputant's email address.
-        /// </summary>
-        [JsonPropertyName("email_address")]
-        public string? EmailAddress { get; set; } = null!;
+    /// <summary>
+    /// The disputant's email address.
+    /// </summary>
+    [JsonPropertyName("email_address")]
+    public string? EmailAddress { get; set; } = null!;
 
-        /// <summary>
-        /// The disputant intends to be represented by a lawyer at the hearing.
-        /// </summary>
-        [JsonPropertyName("represented_by_lawyer")]
-        public DisputeRepresentedByLawyer RepresentedByLawyer { get; set; } = DisputeRepresentedByLawyer.N;
+    /// <summary>
+    /// The disputant intends to be represented by a lawyer at the hearing.
+    /// </summary>
+    [JsonPropertyName("represented_by_lawyer")]
+    public DisputeRepresentedByLawyer RepresentedByLawyer { get; set; } = DisputeRepresentedByLawyer.N;
 
-        /// <summary>
-        /// Name of the law firm that will represent the disputant at the hearing.
-        /// </summary>
-        [JsonPropertyName("law_firm_name")]
-        public string? LawFirmName { get; set; } = String.Empty;
+    /// <summary>
+    /// Name of the law firm that will represent the disputant at the hearing.
+    /// </summary>
+    [JsonPropertyName("law_firm_name")]
+    public string? LawFirmName { get; set; } = String.Empty;
 
-        /// <summary>
-        /// Surname of the lawyer who will represent the disputant at the hearing.
-        /// </summary>
-        [JsonPropertyName("lawyer_surname")]
-        public string? LawyerSurname { get; set; } = String.Empty;
+    /// <summary>
+    /// Surname of the lawyer who will represent the disputant at the hearing.
+    /// </summary>
+    [JsonPropertyName("lawyer_surname")]
+    public string? LawyerSurname { get; set; } = String.Empty;
 
-        /// <summary>
-        /// Given Name 1 of the lawyer who will represent the disputant at the hearing.
-        /// </summary>
-        [JsonPropertyName("lawyer_given_name1")]
-        public string? LawyerGivenName1 { get; set; } = String.Empty;
+    /// <summary>
+    /// Given Name 1 of the lawyer who will represent the disputant at the hearing.
+    /// </summary>
+    [JsonPropertyName("lawyer_given_name1")]
+    public string? LawyerGivenName1 { get; set; } = String.Empty;
 
-        /// <summary>
-        /// Given Name 2 of the lawyer who will represent the disputant at the hearing.
-        /// </summary>
-        [JsonPropertyName("lawyer_given_name2")]
-        public string? LawyerGivenName2 { get; set; } = String.Empty;
+    /// <summary>
+    /// Given Name 2 of the lawyer who will represent the disputant at the hearing.
+    /// </summary>
+    [JsonPropertyName("lawyer_given_name2")]
+    public string? LawyerGivenName2 { get; set; } = String.Empty;
 
-        /// <summary>
-        /// Given Name 3 of the lawyer who will represent the disputant at the hearing.
-        /// </summary>
-        [JsonPropertyName("lawyer_given_name3")]
-        public string? LawyerGivenName3 { get; set; } = String.Empty;
+    /// <summary>
+    /// Given Name 3 of the lawyer who will represent the disputant at the hearing.
+    /// </summary>
+    [JsonPropertyName("lawyer_given_name3")]
+    public string? LawyerGivenName3 { get; set; } = String.Empty;
 
-        /// <summary>
-        /// Email address of the lawyer who will represent the disputant at the hearing.
-        /// </summary>
-        [JsonPropertyName("lawyer_email")]
-        public string? LawyerEmail { get; set; } = String.Empty;
+    /// <summary>
+    /// Email address of the lawyer who will represent the disputant at the hearing.
+    /// </summary>
+    [JsonPropertyName("lawyer_email")]
+    public string? LawyerEmail { get; set; } = String.Empty;
 
-        /// <summary>
-        /// Address of the lawyer who will represent the disputant at the hearing.
-        /// </summary>
-        [JsonPropertyName("lawyer_address")]
-        public string? LawyerAddress { get; set; } = String.Empty;
+    /// <summary>
+    /// Address of the lawyer who will represent the disputant at the hearing.
+    /// </summary>
+    [JsonPropertyName("lawyer_address")]
+    public string? LawyerAddress { get; set; } = String.Empty;
 
-        /// <summary>
-        /// Address of the lawyer who will represent the disputant at the hearing.
-        /// </summary>
-        [JsonPropertyName("lawyer_phone_number")]
-        public string? LawyerPhoneNumber { get; set; } = String.Empty;
+    /// <summary>
+    /// Address of the lawyer who will represent the disputant at the hearing.
+    /// </summary>
+    [JsonPropertyName("lawyer_phone_number")]
+    public string? LawyerPhoneNumber { get; set; } = String.Empty;
 
-        /// <summary>
-        /// The disputant requires spoken language interpreter. The language name is indicated in this field.
-        /// </summary>
-        [JsonPropertyName("interpreter_language_cd")]
-        public string? InterpreterLanguageCd { get; set; }
+    /// <summary>
+    /// The disputant requires spoken language interpreter. The language name is indicated in this field.
+    /// </summary>
+    [JsonPropertyName("interpreter_language_cd")]
+    public string? InterpreterLanguageCd { get; set; }
 
-        /// <summary>
-        /// Interpreter Required
-        /// </summary>
-        [JsonPropertyName("interprer_required")]
-        public DisputeInterpreterRequired? InterpreterRequired { get; set; } = DisputeInterpreterRequired.N;
+    /// <summary>
+    /// Interpreter Required
+    /// </summary>
+    [JsonPropertyName("interprer_required")]
+    public DisputeInterpreterRequired? InterpreterRequired { get; set; } = DisputeInterpreterRequired.N;
 
-        /// <summary>
-        /// The number of witnesses that the disputant intends to call.
-        /// </summary>
-        [JsonPropertyName("witness_no")]
-        public int WitnessNo { get; set; }
+    /// <summary>
+    /// The number of witnesses that the disputant intends to call.
+    /// </summary>
+    [JsonPropertyName("witness_no")]
+    public int WitnessNo { get; set; }
 
-        /// <summary>
-        /// The reason that disputant declares for requesting a fine reduction.
-        /// </summary>
-        [JsonPropertyName("fine_reduction_reason")]
-        public string? FineReductionReason { get; set; }
+    /// <summary>
+    /// The reason that disputant declares for requesting a fine reduction.
+    /// </summary>
+    [JsonPropertyName("fine_reduction_reason")]
+    public string? FineReductionReason { get; set; }
 
-        /// <summary>
-        /// The reason that disputant declares for requesting more time to pay the amount on the violation ticket.
-        /// </summary>
-        [JsonPropertyName("time_to_pay_reason")]
-        public string? TimeToPayReason { get; set; }
+    /// <summary>
+    /// The reason that disputant declares for requesting more time to pay the amount on the violation ticket.
+    /// </summary>
+    [JsonPropertyName("time_to_pay_reason")]
+    public string? TimeToPayReason { get; set; }
 
-        /// <summary>
-        /// Identifier for whether the citizen has detected any issues with the OCR ticket result or not.
-        /// </summary>
-        [JsonPropertyName("disputant_detected_ocr_issues")]
-        public DisputeDisputantDetectedOcrIssues? DisputantDetectedOcrIssues { get; set; } = DisputeDisputantDetectedOcrIssues.N;
+    /// <summary>
+    /// Identifier for whether the citizen has detected any issues with the OCR ticket result or not.
+    /// </summary>
+    [JsonPropertyName("disputant_detected_ocr_issues")]
+    public DisputeDisputantDetectedOcrIssues? DisputantDetectedOcrIssues { get; set; } = DisputeDisputantDetectedOcrIssues.N;
 
-        /// <summary>
-        /// The description of the issue with OCR ticket if the citizen has detected any.
-        /// </summary>
-        [JsonPropertyName("disputant_ocr_issues")]
-        public string? DisputantOcrIssues { get; set; }
+    /// <summary>
+    /// The description of the issue with OCR ticket if the citizen has detected any.
+    /// </summary>
+    [JsonPropertyName("disputant_ocr_issues")]
+    public string? DisputantOcrIssues { get; set; }
 
-        /// <summary>
-        /// The unique identifier for the Violation Ticket (OCR or looked up) for this dispute.
-        /// </summary>
-        [JsonPropertyName("ticket_id")]
-        public string TicketId { get; set; } = null!;
+    /// <summary>
+    /// The unique identifier for the Violation Ticket (OCR or looked up) for this dispute.
+    /// </summary>
+    [JsonPropertyName("ticket_id")]
+    public string TicketId { get; set; } = null!;
 
-        /// <summary>
-        /// Detachment Location
-        /// </summary>
-        [JsonPropertyName("detachment_location")]
-        public string? DetachmentLocation { get; set; } = null!;
+    /// <summary>
+    /// Detachment Location
+    /// </summary>
+    [JsonPropertyName("detachment_location")]
+    public string? DetachmentLocation { get; set; } = null!;
 
-        /// <summary>
-        /// Dispute Counts
-        /// </summary>
-        [JsonPropertyName("dispute_counts")]
-        public ICollection<DisputeCount>? DisputeCounts { get; set; }
-    }
-
+    /// <summary>
+    /// Dispute Counts
+    /// </summary>
+    [JsonPropertyName("dispute_counts")]
+    public ICollection<DisputeCount>? DisputeCounts { get; set; }
 }

--- a/src/backend/TrafficCourts/Common/OpenAPIs/OracleDataAPI/v1_0/OracleDataApi.v1_0.json
+++ b/src/backend/TrafficCourts/Common/OpenAPIs/OracleDataAPI/v1_0/OracleDataApi.v1_0.json
@@ -1159,14 +1159,14 @@
     "/api/v1.0/dispute/status": {
       "get": {
         "tags": [ "dispute-controller" ],
-        "summary": "Finds Dispute statuses by TicketNumber and IssuedTime.",
+        "summary": "Finds Dispute statuses by TicketNumber and IssuedTime or noticeOfDisputeGuid if specified.",
         "operationId": "findDispute",
         "parameters": [
           {
             "name": "ticketNumber",
             "in": "query",
             "description": "The Dispute.ticketNumber to search for (of the format XX00000000)",
-            "required": true,
+            "required": false,
             "schema": {
               "pattern": "[A-Z]{2}\\d{8}",
               "type": "string"
@@ -1177,9 +1177,16 @@
             "name": "issuedTime",
             "in": "query",
             "description": "The time portion of the Dispute.issuedTs field to search for (of the format HH:mm). Time is in UTC.",
-            "required": true,
+            "required": false,
             "schema": { "type": "string" },
             "example": "14:53"
+          },
+          {
+            "name": "noticeOfDisputeGuid",
+            "in": "query",
+            "description": "The noticeOfDisputeGuid of the Dispute to retreive.",
+            "required": false,
+            "schema": { "type": "string" }
           }
         ],
         "responses": {

--- a/src/backend/TrafficCourts/Common/OpenAPIs/OracleDataAPI/v1_0/OracleDataApiClient.g.cs
+++ b/src/backend/TrafficCourts/Common/OpenAPIs/OracleDataAPI/v1_0/OracleDataApiClient.g.cs
@@ -394,23 +394,25 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
         System.Threading.Tasks.Task<System.Collections.Generic.ICollection<DisputantUpdateRequest>> GetDisputantUpdateRequestsAsync(long id, System.Threading.CancellationToken cancellationToken);
 
         /// <summary>
-        /// Finds Dispute statuses by TicketNumber and IssuedTime.
+        /// Finds Dispute statuses by TicketNumber and IssuedTime or noticeOfDisputeGuid if specified.
         /// </summary>
         /// <param name="ticketNumber">The Dispute.ticketNumber to search for (of the format XX00000000)</param>
         /// <param name="issuedTime">The time portion of the Dispute.issuedTs field to search for (of the format HH:mm). Time is in UTC.</param>
+        /// <param name="noticeOfDisputeGuid">The noticeOfDisputeGuid of the Dispute to retreive.</param>
         /// <returns>Ok.</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
-        System.Threading.Tasks.Task<System.Collections.Generic.ICollection<DisputeResult>> FindDisputeAsync(string ticketNumber, string issuedTime);
+        System.Threading.Tasks.Task<System.Collections.Generic.ICollection<DisputeResult>> FindDisputeAsync(string ticketNumber, string issuedTime, string noticeOfDisputeGuid);
 
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <summary>
-        /// Finds Dispute statuses by TicketNumber and IssuedTime.
+        /// Finds Dispute statuses by TicketNumber and IssuedTime or noticeOfDisputeGuid if specified.
         /// </summary>
         /// <param name="ticketNumber">The Dispute.ticketNumber to search for (of the format XX00000000)</param>
         /// <param name="issuedTime">The time portion of the Dispute.issuedTs field to search for (of the format HH:mm). Time is in UTC.</param>
+        /// <param name="noticeOfDisputeGuid">The noticeOfDisputeGuid of the Dispute to retreive.</param>
         /// <returns>Ok.</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
-        System.Threading.Tasks.Task<System.Collections.Generic.ICollection<DisputeResult>> FindDisputeAsync(string ticketNumber, string issuedTime, System.Threading.CancellationToken cancellationToken);
+        System.Threading.Tasks.Task<System.Collections.Generic.ICollection<DisputeResult>> FindDisputeAsync(string ticketNumber, string issuedTime, string noticeOfDisputeGuid, System.Threading.CancellationToken cancellationToken);
 
         /// <summary>
         /// Retrieves Dispute by the noticeOfDisputeGuid (UUID).
@@ -3707,37 +3709,43 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
         }
 
         /// <summary>
-        /// Finds Dispute statuses by TicketNumber and IssuedTime.
+        /// Finds Dispute statuses by TicketNumber and IssuedTime or noticeOfDisputeGuid if specified.
         /// </summary>
         /// <param name="ticketNumber">The Dispute.ticketNumber to search for (of the format XX00000000)</param>
         /// <param name="issuedTime">The time portion of the Dispute.issuedTs field to search for (of the format HH:mm). Time is in UTC.</param>
+        /// <param name="noticeOfDisputeGuid">The noticeOfDisputeGuid of the Dispute to retreive.</param>
         /// <returns>Ok.</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
-        public virtual System.Threading.Tasks.Task<System.Collections.Generic.ICollection<DisputeResult>> FindDisputeAsync(string ticketNumber, string issuedTime)
+        public virtual System.Threading.Tasks.Task<System.Collections.Generic.ICollection<DisputeResult>> FindDisputeAsync(string ticketNumber, string issuedTime, string noticeOfDisputeGuid)
         {
-            return FindDisputeAsync(ticketNumber, issuedTime, System.Threading.CancellationToken.None);
+            return FindDisputeAsync(ticketNumber, issuedTime, noticeOfDisputeGuid, System.Threading.CancellationToken.None);
         }
 
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <summary>
-        /// Finds Dispute statuses by TicketNumber and IssuedTime.
+        /// Finds Dispute statuses by TicketNumber and IssuedTime or noticeOfDisputeGuid if specified.
         /// </summary>
         /// <param name="ticketNumber">The Dispute.ticketNumber to search for (of the format XX00000000)</param>
         /// <param name="issuedTime">The time portion of the Dispute.issuedTs field to search for (of the format HH:mm). Time is in UTC.</param>
+        /// <param name="noticeOfDisputeGuid">The noticeOfDisputeGuid of the Dispute to retreive.</param>
         /// <returns>Ok.</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
-        public virtual async System.Threading.Tasks.Task<System.Collections.Generic.ICollection<DisputeResult>> FindDisputeAsync(string ticketNumber, string issuedTime, System.Threading.CancellationToken cancellationToken)
+        public virtual async System.Threading.Tasks.Task<System.Collections.Generic.ICollection<DisputeResult>> FindDisputeAsync(string ticketNumber, string issuedTime, string noticeOfDisputeGuid, System.Threading.CancellationToken cancellationToken)
         {
-            if (ticketNumber == null)
-                throw new System.ArgumentNullException("ticketNumber");
-
-            if (issuedTime == null)
-                throw new System.ArgumentNullException("issuedTime");
-
             var urlBuilder_ = new System.Text.StringBuilder();
             urlBuilder_.Append("api/v1.0/dispute/status?");
-            urlBuilder_.Append(System.Uri.EscapeDataString("ticketNumber") + "=").Append(System.Uri.EscapeDataString(ConvertToString(ticketNumber, System.Globalization.CultureInfo.InvariantCulture))).Append("&");
-            urlBuilder_.Append(System.Uri.EscapeDataString("issuedTime") + "=").Append(System.Uri.EscapeDataString(ConvertToString(issuedTime, System.Globalization.CultureInfo.InvariantCulture))).Append("&");
+            if (ticketNumber != null)
+            {
+                urlBuilder_.Append(System.Uri.EscapeDataString("ticketNumber") + "=").Append(System.Uri.EscapeDataString(ConvertToString(ticketNumber, System.Globalization.CultureInfo.InvariantCulture))).Append("&");
+            }
+            if (issuedTime != null)
+            {
+                urlBuilder_.Append(System.Uri.EscapeDataString("issuedTime") + "=").Append(System.Uri.EscapeDataString(ConvertToString(issuedTime, System.Globalization.CultureInfo.InvariantCulture))).Append("&");
+            }
+            if (noticeOfDisputeGuid != null)
+            {
+                urlBuilder_.Append(System.Uri.EscapeDataString("noticeOfDisputeGuid") + "=").Append(System.Uri.EscapeDataString(ConvertToString(noticeOfDisputeGuid, System.Globalization.CultureInfo.InvariantCulture))).Append("&");
+            }
             urlBuilder_.Length--;
 
             var client_ = _httpClient;

--- a/src/backend/TrafficCourts/Messaging/MessageContracts/DisputantUpdateRequest.cs
+++ b/src/backend/TrafficCourts/Messaging/MessageContracts/DisputantUpdateRequest.cs
@@ -1,0 +1,88 @@
+﻿namespace TrafficCourts.Messaging.MessageContracts;
+
+/// <summary>
+/// A subset of a Disputant's contact information that can be requested to update via a PUT /api/dispute/{guidhash}/contact endpoint.
+/// </summary>
+public class DisputantUpdateRequest
+{
+    /// <summary>
+    /// The notice of dispute identifer.
+    /// </summary>
+    public Guid NoticeOfDisputeGuid { get; set; }
+
+    /// <summary>
+    /// The disputant's email address.
+    /// </summary>
+    public string? EmailAddress { get; set; } = null!;
+
+    /// <summary>
+    /// The first given name or corporate name continued.
+    /// </summary>
+    public string? DisputantGivenName1 { get; set; } = null!;
+
+    /// <summary>
+    /// The second given name
+    /// </summary>
+    public string? DisputantGivenName2 { get; set; } = null!;
+
+    /// <summary>
+    /// The third given name 
+    /// </summary>
+    public string? DisputantGivenName3 { get; set; } = null!;
+
+    /// <summary>
+    /// The surname or corporate name.
+    /// </summary>
+    public string? DisputantSurname { get; set; } = null!;
+
+    /// <summary>
+    /// The mailing address of the disputant.
+    /// </summary>
+    public string? AddressLine1 { get; set; } = null!;
+
+    /// <summary>
+    /// The mailing address of the disputant.
+    /// </summary>
+    public string? AddressLine2 { get; set; } = null!;
+
+    /// <summary>
+    /// The mailing address of the disputant.
+    /// </summary>
+    public string? AddressLine3 { get; set; } = null!;
+
+    /// <summary>
+    /// The mailing address city of the disputant.
+    /// </summary>
+    public string? AddressCity { get; set; } = null!;
+
+    /// <summary>
+    /// The mailing address province of the disputant.
+    /// </summary>
+    public string? AddressProvince { get; set; } = null!;
+
+    /// <summary>
+    /// The mailing address postal code or zip code of the disputant.
+    /// </summary>
+    public string? PostalCode { get; set; } = null!;
+
+    /// <summary>
+    /// The mailing address province's country code of the disputant.
+    /// </summary>
+    public int? AddressProvinceCountryId { get; set; }
+
+    /// <summary>
+    /// The mailing address province's sequence number of the disputant.
+    /// </summary>
+    public int? AddressProvinceSeqNo { get; set; }
+
+    /// <summary>
+    /// The mailing address country id of the disputant.
+    /// </summary>
+    public int? AddressCountryId { get; set; }
+
+    /// <summary>
+    /// The disputant's home phone number.
+    /// </summary>
+    public string? HomePhoneNumber { get; set; } = null!;
+}
+

--- a/src/backend/TrafficCourts/Messaging/MessageContracts/SearchDispute.cs
+++ b/src/backend/TrafficCourts/Messaging/MessageContracts/SearchDispute.cs
@@ -4,8 +4,9 @@ namespace TrafficCourts.Messaging.MessageContracts;
 
 public class SearchDisputeRequest
 {
-    public string TicketNumber { get; set; } = String.Empty;
-    public string IssuedTime { get; set; } = String.Empty;
+    public string? TicketNumber { get; set; } = String.Empty;
+    public string? IssuedTime { get; set; } = String.Empty;
+    public Guid? NoticeOfDisputeGuid { get; set; } = null!;
 }
 
 public class SearchDisputeResponse

--- a/src/backend/TrafficCourts/Test/Workflow.Service/Consumers/DisputantUpdateRequestAcceptedConsumerTest.cs
+++ b/src/backend/TrafficCourts/Test/Workflow.Service/Consumers/DisputantUpdateRequestAcceptedConsumerTest.cs
@@ -8,6 +8,7 @@ using TrafficCourts.Messaging.MessageContracts;
 using TrafficCourts.Workflow.Service.Consumers;
 using TrafficCourts.Workflow.Service.Services;
 using Xunit;
+using DisputantUpdateRequest = TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0.DisputantUpdateRequest;
 
 namespace TrafficCourts.Test.Workflow.Service.Consumers;
 

--- a/src/backend/TrafficCourts/Test/Workflow.Service/Consumers/DisputantUpdateRequestRejectedConsumerTest.cs
+++ b/src/backend/TrafficCourts/Test/Workflow.Service/Consumers/DisputantUpdateRequestRejectedConsumerTest.cs
@@ -8,6 +8,7 @@ using TrafficCourts.Messaging.MessageContracts;
 using TrafficCourts.Workflow.Service.Consumers;
 using TrafficCourts.Workflow.Service.Services;
 using Xunit;
+using DisputantUpdateRequest = TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0.DisputantUpdateRequest;
 
 namespace TrafficCourts.Test.Workflow.Service.Consumers;
 

--- a/src/backend/TrafficCourts/Test/Workflow.Service/Consumers/SearchDisputeConsumerTest.cs
+++ b/src/backend/TrafficCourts/Test/Workflow.Service/Consumers/SearchDisputeConsumerTest.cs
@@ -30,7 +30,8 @@ public class SearchDisputeConsumerTest
         _message = new()
         {
             TicketNumber = "AX00000000",
-            IssuedTime = "17:54"
+            IssuedTime = "17:54",
+            NoticeOfDisputeGuid = Guid.NewGuid(),
         };
         _expectedResponse = new();
         _mockLogger = new();
@@ -69,6 +70,7 @@ public class SearchDisputeConsumerTest
             }
         };
 
+        // FIXME: remove jDdisputes here as the hearingType is already included in the DisputeResult response.
         ICollection<JJDispute> jJDisputes = new List<JJDispute>
         {
             new()
@@ -78,7 +80,7 @@ public class SearchDisputeConsumerTest
         };
 
 
-        _oracleDataApiService.Setup(_ => _.SearchDisputeAsync(_message.TicketNumber, _message.IssuedTime, It.IsAny<CancellationToken>())).Returns(Task.FromResult(searchResult));
+        _oracleDataApiService.Setup(_ => _.SearchDisputeAsync(_message.TicketNumber, _message.IssuedTime, _message.NoticeOfDisputeGuid.ToString(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(searchResult));
         _oracleDataApiService.Setup(_ => _.GetJJDisputesAsync("", _message.TicketNumber, _message.IssuedTime, It.IsAny<CancellationToken>())).Returns(Task.FromResult(jJDisputes));
         _expectedResponse.NoticeOfDisputeGuid = "1";
         _expectedResponse.DisputeStatus = "VALIDATED";

--- a/src/backend/TrafficCourts/Workflow.Service/Consumers/DisputantUpdateRequestAcceptedConsumer.cs
+++ b/src/backend/TrafficCourts/Workflow.Service/Consumers/DisputantUpdateRequestAcceptedConsumer.cs
@@ -7,6 +7,7 @@ using TrafficCourts.Common.Features.Mail.Model;
 using TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0;
 using TrafficCourts.Messaging.MessageContracts;
 using TrafficCourts.Workflow.Service.Services;
+using DisputantUpdateRequest = TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0.DisputantUpdateRequest;
 
 namespace TrafficCourts.Workflow.Service.Consumers;
 

--- a/src/backend/TrafficCourts/Workflow.Service/Consumers/DisputantUpdateRequestRejectedConsumer.cs
+++ b/src/backend/TrafficCourts/Workflow.Service/Consumers/DisputantUpdateRequestRejectedConsumer.cs
@@ -4,6 +4,7 @@ using TrafficCourts.Common.Features.Mail.Model;
 using TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0;
 using TrafficCourts.Messaging.MessageContracts;
 using TrafficCourts.Workflow.Service.Services;
+using DisputantUpdateRequest = TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0.DisputantUpdateRequest;
 
 namespace TrafficCourts.Workflow.Service.Consumers;
 

--- a/src/backend/TrafficCourts/Workflow.Service/Consumers/SearchDisputeConsumer.cs
+++ b/src/backend/TrafficCourts/Workflow.Service/Consumers/SearchDisputeConsumer.cs
@@ -28,12 +28,13 @@ namespace TrafficCourts.Workflow.Service.Consumers
         {
             using var scope = _logger.BeginConsumeScope(context);
 
-            string ticketNumber = context.Message.TicketNumber;
-            string issuedTime = context.Message.IssuedTime;
+            string? ticketNumber = context.Message.TicketNumber;
+            string? issuedTime = context.Message.IssuedTime;
+            string? noticeOfDisputeGuid = context.Message.NoticeOfDisputeGuid?.ToString();
             ICollection<DisputeResult> searchResult;
             try
             {
-                searchResult = await _oracleDataApiService.SearchDisputeAsync(context.Message.TicketNumber, context.Message.IssuedTime, context.CancellationToken);
+                searchResult = await _oracleDataApiService.SearchDisputeAsync(ticketNumber, issuedTime, noticeOfDisputeGuid, context.CancellationToken);
                 if (searchResult is null || searchResult.Count == 0)
                 {
                     _logger.LogError("Dispute not found");

--- a/src/backend/TrafficCourts/Workflow.Service/Services/IOracleDataApiService.cs
+++ b/src/backend/TrafficCourts/Workflow.Service/Services/IOracleDataApiService.cs
@@ -9,7 +9,7 @@ namespace TrafficCourts.Workflow.Service.Services
         Task<long> CreateEmailHistoryAsync(EmailHistory emailHistory, CancellationToken cancellationToken);
         Task<long> CreateFileHistoryAsync(FileHistory fileHistory, CancellationToken cancellationToken);
         Task VerifyDisputeEmailAsync(long disputeId, CancellationToken cancellationToken);
-        Task<ICollection<DisputeResult>> SearchDisputeAsync(string ticketNumber, string issuedTime, CancellationToken cancellationToken);
+        Task<ICollection<DisputeResult>> SearchDisputeAsync(string? ticketNumber, string? issuedTime, string? noticeOfDisputeGuid, CancellationToken cancellationToken);
         Task<Dispute> GetDisputeByIdAsync(long disputeId, CancellationToken cancellationToken);
         Task<Dispute> UpdateDisputeAsync(long disputeId, Dispute dispute, CancellationToken cancellationToken);
         Task<ICollection<JJDispute>> GetJJDisputesAsync(string jjAssignedTo, string ticketNumber, string violationTime, System.Threading.CancellationToken cancellationToken);

--- a/src/backend/TrafficCourts/Workflow.Service/Services/OracleDataApiService.cs
+++ b/src/backend/TrafficCourts/Workflow.Service/Services/OracleDataApiService.cs
@@ -81,11 +81,11 @@ public class OracleDataApiService : IOracleDataApiService
         await _client.VerifyDisputeEmailAsync(disputeId);
     }
 
-    public async Task<ICollection<DisputeResult>> SearchDisputeAsync(string ticketNumber, string issuedTime, CancellationToken cancellationToken)
+    public async Task<ICollection<DisputeResult>> SearchDisputeAsync(string? ticketNumber, string? issuedTime, string? noticeOfDisputeGuid, CancellationToken cancellationToken)
     {
         try
         {
-            return await _client.FindDisputeAsync(ticketNumber, issuedTime, cancellationToken);
+            return await _client.FindDisputeAsync(ticketNumber, issuedTime, noticeOfDisputeGuid, cancellationToken);
         }
         catch (Exception)
         {

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/error/ControllerAdvisor.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/error/ControllerAdvisor.java
@@ -77,6 +77,16 @@ public class ControllerAdvisor {
 	}
 
 	/**
+	 * Returns an API HTTP error code of 400 if there are bad parameters.
+	 */
+	@ExceptionHandler(IllegalArgumentException.class)
+	@ResponseStatus(HttpStatus.BAD_REQUEST)
+	public ResponseEntity<Object> handleIllegalArgumentException(IllegalArgumentException ex) {
+		logger.debug("handleIllegalArgumentException", ex);
+		return getResponse(HttpStatus.BAD_REQUEST, "Bad Parameters", ex);
+	}
+
+	/**
 	 * Returns an API HTTP error code of 400 if there are validation errors.
 	 */
 	@ExceptionHandler(HttpMessageNotReadableException.class)

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/service/DisputeService.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/service/DisputeService.java
@@ -1,6 +1,7 @@
 package ca.bc.gov.open.jag.tco.oracledataapi.service;
 
 import java.security.Principal;
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.NoSuchElementException;
@@ -323,10 +324,22 @@ public class DisputeService {
 	}
 
 	/**
-	 * Finds all records that match by Dispute.ticketNumber and the time portion of the Dispute.issuedTs.
+	 * Finds all records that match by Dispute.ticketNumber and the time portion of the Dispute.issuedTs, or by noticeOfDisputeGuid if specified.
+	 * @param noticeOfDisputeGuid
 	 */
-	public List<DisputeResult> findDispute(String ticketNumber, Date issuedTime) {
-		List<DisputeResult> disputeResults = disputeRepository.findByTicketNumberAndTime(ticketNumber, issuedTime);
+	public List<DisputeResult> findDispute(String ticketNumber, Date issuedTime, String noticeOfDisputeGuid) {
+		List<DisputeResult> disputeResults = new ArrayList<DisputeResult>();
+
+		// if noticeOfDisputeGuid is specified, use that
+		if (StringUtils.isNotBlank(noticeOfDisputeGuid)) {
+			for (Dispute dispute : disputeRepository.findByNoticeOfDisputeGuid(noticeOfDisputeGuid)) {
+				disputeResults.add(new DisputeResult(dispute.getDisputeId(), dispute.getStatus()));
+			}
+		}
+		// otherwise, find by ticketNumber and time
+		else {
+			disputeResults.addAll(disputeRepository.findByTicketNumberAndTime(ticketNumber, issuedTime));
+		}
 
 		if (CollectionUtils.isNotEmpty(disputeResults)) {
 			List<JJDispute> jjDisputeResults = jjDisputeRepository.findByTicketNumberAndTime(ticketNumber, issuedTime);

--- a/src/backend/oracle-data-api/src/test/java/ca/bc/gov/open/jag/tco/oracledataapi/controller/v1_0/DisputeControllerTest.java
+++ b/src/backend/oracle-data-api/src/test/java/ca/bc/gov/open/jag/tco/oracledataapi/controller/v1_0/DisputeControllerTest.java
@@ -306,18 +306,20 @@ class DisputeControllerTest extends BaseTestSuite {
 
 	@ParameterizedTest
 	@CsvSource({
-		"AB12345678,123abc", // should be of the format HH:mm
-		"AB12345678,55:99",  // invalid time
-		"AB123456789,14:23", // too long
-		"ABC1234567,14:23",  // invalid regex
-		",14:23",            // invalid ticketNumber
-		"ABC1234567,",       // invalid time
+		"AB12345678,123abc,", // should be of the format HH:mm
+		"AB12345678,55:99,",  // invalid time
+		"AB123456789,14:23,", // too long
+		"ABC1234567,14:23,",  // invalid regex
+		",,",                 // missing parameters
+		"AB12345678,,",       // missing parameter
+		",14:23,",            // missing parameter
 		})
-	public void testFindByTicketNumberAndTime_Invalid(String ticketNumber, String issuedTime) throws Exception {
+	public void testFindByTicketNumberAndTime_Invalid(String ticketNumber, String issuedTime, String noticeOfDisputeGuid) throws Exception {
 		mvc.perform(MockMvcRequestBuilders
 				.get("/api/v1.0/dispute/status")
 				.param("ticketNumber", ticketNumber)
-				.param("issuedTime", issuedTime))
+				.param("issuedTime", issuedTime)
+				.param("noticeOfDisputeGuid", noticeOfDisputeGuid))
 				.andExpect(status().isBadRequest());
 	}
 


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

TCVP-2007

Citizen API - added PUT endpoint to process a disputant's contact info
`PUT /api/dispute/{guidhash}/contact`
body:
```
{
  "email_address": "",
  "disputant_given_name1": "",
  "disputant_given_name2": "",
  "disputant_given_name3": "", 
  "disputant_surname": "", 
  "address_line1": "", 
  "address_line2": "", 
  "address_line3": "", 
  "address_city": "", 
  "address_province": "", 
  "address_province_country_id": "",
  "address_province_seq_no": "",
  "address_country_id": "",
  "postal_code": "", 
  "home_phone_number": ""
}
```
response codes:
**200** - Ok
**400** - If the Dispute's status is not one of [NEW, VALIDATED, PROCESSING] or JJDispute status is non-null
**404** - If the Dispute could not be found.
**500** - Internal Server Error

If the validation passes, the payload is passed to the workflow service.
## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

dotnet test

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
