### PR TITLE
TCVP-1983 add disputant update requests status change

### DIFF
--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/controller/v1_0/DisputeController.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/controller/v1_0/DisputeController.java
@@ -423,4 +423,27 @@ public class DisputeController {
 		return new ResponseEntity<DisputantUpdateRequest>(disputantUpdateRequest, HttpStatus.OK);
 	}
 
+	/**
+	 * PUT endpoint that updates the status of one or more DisputantUpdateRequest records to PENDING from HOLD.
+	 *
+	 * @param List of IDs of DisputantUpdateRequest records' status to be updated to pending
+	 */
+	@PutMapping("/dispute/updateRequest/{ids}/pending")
+	@Operation(summary = "An endpoint that updates the status of one or more DisputantUpdateRequest records to PENDING from HOLD.")
+	@ApiResponses({
+		@ApiResponse(responseCode = "200", description = "Ok. DisputantUpdateRequest records updated to status PENDING."),
+		@ApiResponse(responseCode = "404", description = "DisputantUpdateRequest records could not be found."),
+		@ApiResponse(responseCode = "405", description = "A DisputantUpdateRequest status can only be set to PENDING iff status is HOLD. Update failed."),
+		@ApiResponse(responseCode = "500", description = "Internal Server Error. Status Update failed.")
+	})
+	public ResponseEntity<Void> updateDisputantUpdateRequestsStatusToPending(
+			@PathVariable(name = "ids")
+			@Parameter(description = "The id of the DisputantUpdateRequest record to update.")
+			List<Long> updateRequestIds) {
+		logger.debug("PUT /dispute/updateRequest/{}/pending called", updateRequestIds);
+
+		disputeService.updateDisputantUpdateRequestsStatusPending(updateRequestIds);
+		return ResponseEntity.ok().build();
+	}
+
 }

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/model/DisputantUpdateRequestStatus.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/model/DisputantUpdateRequestStatus.java
@@ -4,6 +4,7 @@ public enum DisputantUpdateRequestStatus implements ShortNamedEnum {
 
 	PENDING("PEN"),
 	ACCEPTED("ACC"),
+	HOLD("HOL"),
 	REJECTED("REJ");
 
 	private String shortName;

--- a/src/backend/oracle-data-api/src/test/java/ca/bc/gov/open/jag/tco/oracledataapi/service/DisputeServiceH2Test.java
+++ b/src/backend/oracle-data-api/src/test/java/ca/bc/gov/open/jag/tco/oracledataapi/service/DisputeServiceH2Test.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.UUID;
@@ -110,12 +111,8 @@ class DisputeServiceH2Test extends BaseTestSuite {
 
 	@Test
 	public void testDisputantUpdateRequest() throws Exception {
-		String noticeOfDisputeGuid = UUID.randomUUID().toString();
-
-		Dispute dispute = new Dispute();
-		dispute.setStatus(DisputeStatus.NEW);
-		dispute.setNoticeOfDisputeGuid(noticeOfDisputeGuid);
-		dispute = disputeRepository.save(dispute);
+		Dispute dispute = createAndSaveDispute();
+		String noticeOfDisputeGuid = dispute.getNoticeOfDisputeGuid();
 
 		String json = "{ \"address_line1\": \"123 Main Street\", \"address_line2\": \"\", \"address_line3\": \"\" }";
 		DisputantUpdateRequest updateRequest = new DisputantUpdateRequest();
@@ -149,11 +146,95 @@ class DisputeServiceH2Test extends BaseTestSuite {
 		});
 	}
 
+	@Test
+	public void testUpdateDisputantUpdateRequestsStatusPending() throws Exception {
+		List<Long> updateRequestIds = new ArrayList<Long>();
+
+		Dispute dispute = createAndSaveDispute();
+		Long disputeId = dispute.getDisputeId();
+		String noticeOfDisputeGuid = dispute.getNoticeOfDisputeGuid();
+
+		Long updateDisputantUpdateRequestId1 = createDisputantUpdateRequestWithStatusAndDisputeId(noticeOfDisputeGuid, DisputantUpdateRequestStatus.HOLD, disputeId);
+		updateRequestIds.add(updateDisputantUpdateRequestId1);
+		Long updateDisputantUpdateRequestId2 = createDisputantUpdateRequestWithStatusAndDisputeId(noticeOfDisputeGuid, DisputantUpdateRequestStatus.HOLD, disputeId);
+		updateRequestIds.add(updateDisputantUpdateRequestId2);
+		Long updateDisputantUpdateRequestId3 = createDisputantUpdateRequestWithStatusAndDisputeId(noticeOfDisputeGuid, DisputantUpdateRequestStatus.HOLD, disputeId);
+		updateRequestIds.add(updateDisputantUpdateRequestId3);
+
+		disputeService.updateDisputantUpdateRequestsStatusPending(updateRequestIds);
+
+		List<DisputantUpdateRequest> updateRequests = disputeService.findDisputantUpdateRequestByDisputeId(disputeId);
+
+		assertEquals(3, updateRequests.size());
+
+		for (DisputantUpdateRequest disputantUpdateRequest : updateRequests) {
+			assertEquals(DisputantUpdateRequestStatus.PENDING, disputantUpdateRequest.getStatus());
+		}
+	}
+
+	@Test
+	public void testUpdateDisputantUpdateRequestsStatusPending_404() throws Exception {
+		List<Long> updateRequestIds = new ArrayList<Long>();
+
+		Dispute dispute = createAndSaveDispute();
+		Long disputeId = dispute.getDisputeId();
+		String noticeOfDisputeGuid = dispute.getNoticeOfDisputeGuid();
+
+		Long updateDisputantUpdateRequestId1 = createDisputantUpdateRequestWithStatusAndDisputeId(noticeOfDisputeGuid, DisputantUpdateRequestStatus.HOLD, disputeId);
+		updateRequestIds.add(updateDisputantUpdateRequestId1);
+		updateRequestIds.add(Long.valueOf(987L));
+		updateRequestIds.add(Long.valueOf(985L));
+
+		assertThrows(NoSuchElementException.class, () -> {
+			disputeService.updateDisputantUpdateRequestsStatusPending(updateRequestIds);
+		});
+	}
+
+	@Test
+	public void testUpdateDisputantUpdateRequestsStatusPending_405() throws Exception {
+		List<Long> updateRequestIds = new ArrayList<Long>();
+
+		Dispute dispute = createAndSaveDispute();
+		Long disputeId = dispute.getDisputeId();
+		String noticeOfDisputeGuid = dispute.getNoticeOfDisputeGuid();
+
+		Long updateDisputantUpdateRequestId1 = createDisputantUpdateRequestWithStatusAndDisputeId(noticeOfDisputeGuid, DisputantUpdateRequestStatus.HOLD, disputeId);
+		updateRequestIds.add(updateDisputantUpdateRequestId1);
+		Long updateDisputantUpdateRequestId2 = createDisputantUpdateRequestWithStatusAndDisputeId(noticeOfDisputeGuid, DisputantUpdateRequestStatus.PENDING, disputeId);
+		updateRequestIds.add(updateDisputantUpdateRequestId2);
+
+		assertThrows(NotAllowedException.class, () -> {
+			disputeService.updateDisputantUpdateRequestsStatusPending(updateRequestIds);
+		});
+	}
+
 	private Long saveDispute(DisputeStatus disputeStatus) {
 		Dispute dispute = new Dispute();
 		dispute.setStatus(disputeStatus);
 
 		return disputeRepository.save(dispute).getDisputeId();
+	}
+
+	private Long createDisputantUpdateRequestWithStatusAndDisputeId(String noticeOfDisputeGuid, DisputantUpdateRequestStatus status, Long disputeId) {
+
+		String json = "{ \"address_line1\": \"123 Main Street\", \"address_line2\": \"\", \"address_line3\": \"\" }";
+		DisputantUpdateRequest updateRequest = new DisputantUpdateRequest();
+		updateRequest.setDisputeId(disputeId);
+		updateRequest.setStatus(status);
+		updateRequest.setUpdateType(DisputantUpdateRequestType.DISPUTANT_ADDRESS);
+		updateRequest.setUpdateJson(json);
+		DisputantUpdateRequest savedUpdateReq = disputeService.saveDisputantUpdateRequest(noticeOfDisputeGuid, updateRequest);
+
+		return savedUpdateReq.getDisputantUpdateRequestId();
+	}
+
+	private Dispute createAndSaveDispute() {
+		String noticeOfDisputeGuid = UUID.randomUUID().toString();
+
+		Dispute dispute = new Dispute();
+		dispute.setStatus(DisputeStatus.NEW);
+		dispute.setNoticeOfDisputeGuid(noticeOfDisputeGuid);
+		return disputeRepository.save(dispute);
 	}
 
 }


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- [TCVP-1983](https://justice.gov.bc.ca/jira/browse/TCVP-1983)
- Added 'HOLD' status to DisputantUpdateRequestStatus enum.
- Created the endpoint and service to receive a list of DisputantUpdateRequest IDs and based on those IDs, update the status of one or more DisputantUpdateRequest records to PENDING from HOLD only.
- Changing the status is only permitted from HOLD to PENDING for any of the DisputantUpdateRequest records submitted.
- Partial update is not allowed. If any of the submitted IDs cannot be found in the database, the whole update will throw 404 and all statuses will remain the same. 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Tested by creating new test records in H2 database and successfully updating statuses of the given records as well as verified that it throws the proper exceptions. mvn verify. 

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
