### PR TITLE
TCVP-2012 Created Workflow Service DisputantUpdateRequestConsumer

### DIFF
--- a/src/backend/TrafficCourts/Common/OpenAPIs/OracleDataAPI/v1_0/OracleDataApi.v1_0.json
+++ b/src/backend/TrafficCourts/Common/OpenAPIs/OracleDataAPI/v1_0/OracleDataApi.v1_0.json
@@ -2448,6 +2448,7 @@
           },
           "jjDisputeHearingType": {
             "type": "string",
+            "nullable": true,
             "enum": [ "UNKNOWN", "COURT_APPEARANCE", "WRITTEN_REASONS" ]
           }
         }

--- a/src/backend/TrafficCourts/Common/OpenAPIs/OracleDataAPI/v1_0/OracleDataApiClient.g.cs
+++ b/src/backend/TrafficCourts/Common/OpenAPIs/OracleDataAPI/v1_0/OracleDataApiClient.g.cs
@@ -5394,9 +5394,9 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
         [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
         public DisputeResultJjDisputeStatus? JjDisputeStatus { get; set; }
 
-        [Newtonsoft.Json.JsonProperty("jjDisputeHearingType", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [Newtonsoft.Json.JsonProperty("jjDisputeHearingType", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
-        public DisputeResultJjDisputeHearingType JjDisputeHearingType { get; set; }
+        public DisputeResultJjDisputeHearingType? JjDisputeHearingType { get; set; }
 
         private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
 

--- a/src/backend/TrafficCourts/Test/Workflow.Service/Consumers/DisputantUpdateRequestConsumerTest.cs
+++ b/src/backend/TrafficCourts/Test/Workflow.Service/Consumers/DisputantUpdateRequestConsumerTest.cs
@@ -1,0 +1,138 @@
+﻿using MassTransit;
+using Microsoft.Extensions.Logging;
+using Moq;
+using System.Threading;
+using System.Threading.Tasks;
+using TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0;
+using TrafficCourts.Workflow.Service.Consumers;
+using TrafficCourts.Workflow.Service.Services;
+using Xunit;
+using DisputantUpdateRequest = TrafficCourts.Messaging.MessageContracts.DisputantUpdateRequest;
+
+namespace TrafficCourts.Test.Workflow.Service.Consumers;
+
+public class DisputantUpdateRequestConsumerTest
+{
+    private readonly DisputantUpdateRequest _message;
+    private Common.OpenAPIs.OracleDataApi.v1_0.DisputantUpdateRequest _updateRequest;
+    private readonly Mock<ILogger<DisputantUpdateRequestConsumer>> _mockLogger;
+    private readonly Mock<IOracleDataApiService> _oracleDataApiService;
+    private readonly Mock<ConsumeContext<DisputantUpdateRequest>> _context;
+    private readonly DisputantUpdateRequestConsumer _consumer;
+
+    public DisputantUpdateRequestConsumerTest()
+    {
+        _message = new()
+        {
+            NoticeOfDisputeGuid = new System.Guid("08dadc6b-c307-e6d4-0a58-0a6101000000"),
+        }; 
+        _updateRequest = new();
+        _mockLogger = new();
+        _oracleDataApiService = new();
+        _oracleDataApiService.Setup(_ => _.SaveDisputantUpdateRequestAsync(_message.NoticeOfDisputeGuid.ToString(), _updateRequest, It.IsAny<CancellationToken>())).Returns(Task.FromResult<long>(1));
+        _context = new();
+        _context.Setup(_ => _.Message).Returns(_message);
+        _context.Setup(_ => _.CancellationToken).Returns(CancellationToken.None);
+        _consumer = new(_mockLogger.Object, _oracleDataApiService.Object);
+    }
+
+    [Fact]
+    public async Task TestDisputantUpdateRequestConsumer_Blank()
+    {
+        // Arrange
+
+        // Act
+        await _consumer.Consume(_context.Object);
+
+        // Assert the oracle service was never called.
+        _oracleDataApiService.Verify(m => m.SaveDisputantUpdateRequestAsync(It.IsAny<string>(), It.IsAny<Common.OpenAPIs.OracleDataApi.v1_0.DisputantUpdateRequest>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Theory]
+    [InlineData("fname1", "", "", "")]
+    [InlineData("", "fname2", "", "")]
+    [InlineData("", "", "fname3", "")]
+    [InlineData("", "", "", "lname")]
+    [InlineData("fname1", null, null, null)]
+    [InlineData(null, "fname2", null, null)]
+    [InlineData(null, null, "fname3", null)]
+    [InlineData(null, null, null, "lname")]
+    public async Task TestDisputantUpdateRequestConsumer_Name(string fname1, string fname2, string fname3, string lname)
+    {
+        // Arrange
+        _message.DisputantGivenName1 = fname1;
+        _message.DisputantGivenName2 = fname2;
+        _message.DisputantGivenName3 = fname3;
+        _message.DisputantSurname = lname;
+
+        // Act
+        await _consumer.Consume(_context.Object);
+
+        // Assert the oracle service was called once, INSERTing an update request of type DISPUTANT_NAME and status PENDING.
+        _oracleDataApiService.Verify(m => m.SaveDisputantUpdateRequestAsync(_message.NoticeOfDisputeGuid.ToString(),
+            It.Is<Common.OpenAPIs.OracleDataApi.v1_0.DisputantUpdateRequest>(a =>
+                a.Status == DisputantUpdateRequestStatus2.PENDING &&
+                a.UpdateType == DisputantUpdateRequestUpdateType.DISPUTANT_NAME
+            ), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Theory]
+    [InlineData("addr1", "", "", "", "", "", null, null, null)]
+    [InlineData("", "addr2", "", "", "", "", null, null, null)]
+    [InlineData("", "", "addr3", "", "", "", null, null, null)]
+    [InlineData("", "", "", "city", "", "", null, null, null)]
+    [InlineData("", "", "", "", "prov", "", null, null, null)]
+    [InlineData("", "", "", "", "", "postal", null, null, null)]
+    [InlineData("", "", "", "", "", "", 1, null, null)]
+    [InlineData("", "", "", "", "", "", null, 1, null)]
+    [InlineData("", "", "", "", "", "", null, null, 1)]
+    [InlineData("addr1", null, null, null, null, null, null, null, null)]
+    [InlineData(null, "addr2", null, null, null, null, null, null, null)]
+    [InlineData(null, null, "addr3", null, null, null, null, null, null)]
+    [InlineData(null, null, null, "city", null, null, null, null, null)]
+    [InlineData(null, null, null, null, "prov", null, null, null, null)]
+    [InlineData(null, null, null, null, null, "postal", null, null, null)]
+    [InlineData(null, null, null, null, null, null, 1, null, null)]
+    [InlineData(null, null, null, null, null, null, null, 1, null)]
+    [InlineData(null, null, null, null, null, null, null, null, 1)]
+    public async Task TestDisputantUpdateRequestConsumer_Address(string? addr1, string? addr2, string? addr3, string? city, string? prov, string? postal, int? pid, int? pno, int? aid)
+    {
+        // Arrange
+        _message.AddressLine1 = addr1;
+        _message.AddressLine2 = addr2;
+        _message.AddressLine3 = addr3;
+        _message.AddressCity = city;
+        _message.AddressProvince = prov;
+        _message.PostalCode = postal;
+        _message.AddressProvinceCountryId = pid;
+        _message.AddressProvinceSeqNo = pno;
+        _message.AddressCountryId = aid;
+
+        // Act
+        await _consumer.Consume(_context.Object);
+
+        // Assert the oracle service was called once, INSERTing an update request of type DISPUTANT_ADDRESS and status PENDING.
+        _oracleDataApiService.Verify(m => m.SaveDisputantUpdateRequestAsync(_message.NoticeOfDisputeGuid.ToString(),
+            It.Is<Common.OpenAPIs.OracleDataApi.v1_0.DisputantUpdateRequest>(a =>
+                a.Status == DisputantUpdateRequestStatus2.PENDING &&
+                a.UpdateType == DisputantUpdateRequestUpdateType.DISPUTANT_ADDRESS
+            ), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task TestDisputantUpdateRequestConsumer_Phone()
+    {
+        // Arrange
+        _message.HomePhoneNumber = "2505556666";
+
+        // Act
+        await _consumer.Consume(_context.Object);
+
+        // Assert the oracle service was called once, INSERTing an update request of type DISPUTANT_PHONE and status PENDING.
+        _oracleDataApiService.Verify(m => m.SaveDisputantUpdateRequestAsync(_message.NoticeOfDisputeGuid.ToString(), 
+            It.Is<Common.OpenAPIs.OracleDataApi.v1_0.DisputantUpdateRequest>(a =>
+                a.Status == DisputantUpdateRequestStatus2.PENDING &&
+                a.UpdateType == DisputantUpdateRequestUpdateType.DISPUTANT_PHONE
+            ), It.IsAny<CancellationToken>()), Times.Once);
+    }
+}

--- a/src/backend/TrafficCourts/Workflow.Service/Consumers/DisputantUpdateRequestAcceptedConsumer.cs
+++ b/src/backend/TrafficCourts/Workflow.Service/Consumers/DisputantUpdateRequestAcceptedConsumer.cs
@@ -108,18 +108,18 @@ public class DisputantUpdateRequestAcceptedConsumer : IConsumer<DisputantUpdateR
                 TextContent = template.PlainContentTemplate,
                 HtmlContent = template.HtmlContentTemplate,
             }
-    };
+        };
 
-    await context.PublishWithLog(_logger, emailMessage, context.CancellationToken);
-}
+        await context.PublishWithLog(_logger, emailMessage, context.CancellationToken);
+    }
 
-private async void PublishFileHistoryLog(Dispute dispute, ConsumeContext<DisputantUpdateRequestAccepted> context)
-{
-    SaveFileHistoryRecord fileHistoryRecord = new()
+    private async void PublishFileHistoryLog(Dispute dispute, ConsumeContext<DisputantUpdateRequestAccepted> context)
     {
-        TicketNumber = dispute.TicketNumber,
-        Description = "Disputant update request accepted."
-    };
-    await context.PublishWithLog(_logger, fileHistoryRecord, context.CancellationToken);
-}
+        SaveFileHistoryRecord fileHistoryRecord = new()
+        {
+            TicketNumber = dispute.TicketNumber,
+            Description = "Disputant update request accepted."
+        };
+        await context.PublishWithLog(_logger, fileHistoryRecord, context.CancellationToken);
+    }
 }

--- a/src/backend/TrafficCourts/Workflow.Service/Consumers/DisputantUpdateRequestConsumer.cs
+++ b/src/backend/TrafficCourts/Workflow.Service/Consumers/DisputantUpdateRequestConsumer.cs
@@ -1,0 +1,76 @@
+﻿
+
+using MassTransit;
+using System.Text.Json;
+using TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0;
+using TrafficCourts.Workflow.Service.Services;
+using DisputantUpdateRequest = TrafficCourts.Messaging.MessageContracts.DisputantUpdateRequest;
+
+namespace TrafficCourts.Workflow.Service.Consumers;
+
+public class DisputantUpdateRequestConsumer : IConsumer<DisputantUpdateRequest>
+{
+    private readonly ILogger<DisputantUpdateRequestConsumer> _logger;
+    private readonly IOracleDataApiService _oracleDataApiService;
+
+    public DisputantUpdateRequestConsumer(ILogger<DisputantUpdateRequestConsumer> logger, IOracleDataApiService oracleDataApiService)
+    {
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _oracleDataApiService = oracleDataApiService ?? throw new ArgumentNullException(nameof(oracleDataApiService));
+    }
+
+    public async Task Consume(ConsumeContext<DisputantUpdateRequest> context)
+    {
+        _logger.LogDebug("Consuming message");
+        DisputantUpdateRequest message = context.Message;
+
+        Common.OpenAPIs.OracleDataApi.v1_0.DisputantUpdateRequest disputantUpdateRequest = new()
+        {
+            Status = DisputantUpdateRequestStatus2.PENDING,
+            UpdateJson = JsonSerializer.Serialize(message)
+        };
+
+        if (message.EmailAddress is not null)
+        {
+            // Set status to HOLD. This status will be used if there are any subsequent name, address, or phone update requests
+            // The status will move from HOLD to PENDING when the disputant's email has been verified.
+            disputantUpdateRequest.Status = DisputantUpdateRequestStatus2.HOLD;
+
+            // TODO: Start email saga. TCVP-2009
+        }
+
+        // If some or all name fields have data, send a DISPUTANT_NAME update request
+        if (!string.IsNullOrEmpty(message.DisputantGivenName1)
+            || !string.IsNullOrEmpty(message.DisputantGivenName2)
+            || !string.IsNullOrEmpty(message.DisputantGivenName3)
+            || !string.IsNullOrEmpty(message.DisputantSurname)
+            )
+        {
+            disputantUpdateRequest.UpdateType = DisputantUpdateRequestUpdateType.DISPUTANT_NAME;
+            await _oracleDataApiService.SaveDisputantUpdateRequestAsync(message.NoticeOfDisputeGuid.ToString(), disputantUpdateRequest, context.CancellationToken);
+        }
+
+        // If some or all address fields have data, send a DISPUTANT_ADDRESS update request
+        if (!string.IsNullOrEmpty(message.AddressLine1)
+            || !string.IsNullOrEmpty(message.AddressLine2)
+            || !string.IsNullOrEmpty(message.AddressLine3)
+            || !string.IsNullOrEmpty(message.AddressCity)
+            || !string.IsNullOrEmpty(message.AddressProvince)
+            || !string.IsNullOrEmpty(message.PostalCode)
+            || message.AddressProvinceCountryId is not null
+            || message.AddressProvinceSeqNo is not null
+            || message.AddressCountryId is not null
+            )
+        {
+            disputantUpdateRequest.UpdateType = DisputantUpdateRequestUpdateType.DISPUTANT_ADDRESS;
+            await _oracleDataApiService.SaveDisputantUpdateRequestAsync(message.NoticeOfDisputeGuid.ToString(), disputantUpdateRequest, context.CancellationToken);
+        }
+
+        // If some or all phone fields have data, send a DISPUTANT_PHONE update request
+        if (message.HomePhoneNumber is not null) 
+        {
+            disputantUpdateRequest.UpdateType = DisputantUpdateRequestUpdateType.DISPUTANT_PHONE;
+            await _oracleDataApiService.SaveDisputantUpdateRequestAsync(message.NoticeOfDisputeGuid.ToString(), disputantUpdateRequest, context.CancellationToken);
+        }
+    }
+}

--- a/src/backend/TrafficCourts/Workflow.Service/Services/IOracleDataApiService.cs
+++ b/src/backend/TrafficCourts/Workflow.Service/Services/IOracleDataApiService.cs
@@ -13,6 +13,9 @@ namespace TrafficCourts.Workflow.Service.Services
         Task<Dispute> GetDisputeByIdAsync(long disputeId, CancellationToken cancellationToken);
         Task<Dispute> UpdateDisputeAsync(long disputeId, Dispute dispute, CancellationToken cancellationToken);
         Task<ICollection<JJDispute>> GetJJDisputesAsync(string jjAssignedTo, string ticketNumber, string violationTime, System.Threading.CancellationToken cancellationToken);
+
+        // DisputantUpdateRequest endpoints
+        Task<long> SaveDisputantUpdateRequestAsync(string guid, DisputantUpdateRequest disputantUpdateRequest, CancellationToken cancellationToken);
         Task<DisputantUpdateRequest> UpdateDisputantUpdateRequestStatusAsync(long disputantUpdateRequestId, DisputantUpdateRequestStatus disputantUpdateRequestStatus, CancellationToken cancellationToken);
     }
 }

--- a/src/backend/TrafficCourts/Workflow.Service/Services/OracleDataApiService.cs
+++ b/src/backend/TrafficCourts/Workflow.Service/Services/OracleDataApiService.cs
@@ -105,6 +105,18 @@ public class OracleDataApiService : IOracleDataApiService
         }
     }
 
+    public async Task<long> SaveDisputantUpdateRequestAsync(string guid, DisputantUpdateRequest disputantUpdateRequest, CancellationToken cancellationToken)
+    {
+        try
+        {
+            return await _client.SaveDisputantUpdateRequestAsync(guid, disputantUpdateRequest, cancellationToken);
+        }
+        catch (Exception)
+        {
+            throw;
+        }
+    }
+
     public async Task<Dispute> UpdateDisputeAsync(long disputeId, Dispute dispute, CancellationToken cancellationToken)
     {
         try

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/model/DisputeResult.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/model/DisputeResult.java
@@ -1,8 +1,5 @@
 package ca.bc.gov.open.jag.tco.oracledataapi.model;
 
-import javax.persistence.EnumType;
-import javax.persistence.Enumerated;
-
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -24,7 +21,7 @@ public class DisputeResult {
 	@Schema(nullable = true)
 	private JJDisputeStatus jjDisputeStatus;
 
-	@Enumerated(EnumType.STRING)
+	@Schema(nullable = true)
 	private JJDisputeHearingType jjDisputeHearingType;
 
 	public DisputeResult(Long disputeId, String noticeOfDisputeGuid, DisputeStatus disputeStatus) {


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

TCVP-2012

- Created DisputantUpdateRequestConsumer
- Added useless C# Moq Tests

The consumer will consume a DisputantUpdateRequest request and will save necessary DisputantUpdateRequest records into ORDS.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

docker-compose up, confirmed messages from citizen-api go through the workflow service and are saved in the H2 database.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
