### PR TITLE
OracleApi - Removed DisputantUpdateRequestStatus.HOLD status

### DIFF
--- a/src/backend/TrafficCourts/Common/OpenAPIs/OracleDataAPI/v1_0/OracleDataApi.v1_0.json
+++ b/src/backend/TrafficCourts/Common/OpenAPIs/OracleDataAPI/v1_0/OracleDataApi.v1_0.json
@@ -618,7 +618,7 @@
             "required": true,
             "schema": {
               "type": "string",
-              "enum": [ "UNKNOWN", "ACCEPTED", "HOLD", "PENDING", "REJECTED" ]
+              "enum": [ "UNKNOWN", "ACCEPTED", "PENDING", "REJECTED" ]
             },
             "example": "ACCEPTED"
           }
@@ -644,47 +644,6 @@
             "description": "Ok. DisputantUpdateRequest updated.",
             "content": { "*/*": { "schema": { "$ref": "#/components/schemas/DisputantUpdateRequest" } } }
           }
-        }
-      }
-    },
-    "/api/v1.0/dispute/updateRequest/{ids}/pending": {
-      "put": {
-        "tags": [ "dispute-controller" ],
-        "summary": "An endpoint that updates the status of one or more DisputantUpdateRequest records to PENDING from HOLD.",
-        "operationId": "updateDisputantUpdateRequestsStatusToPending",
-        "parameters": [
-          {
-            "name": "ids",
-            "in": "path",
-            "description": "The id of the DisputantUpdateRequest record to update.",
-            "required": true,
-            "schema": {
-              "type": "array",
-              "items": {
-                "type": "integer",
-                "format": "int64"
-              }
-            }
-          }
-        ],
-        "responses": {
-          "400": {
-            "description": "Bad Request",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "500": {
-            "description": "Internal Server Error. Status Update failed.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "404": {
-            "description": "DisputantUpdateRequest records could not be found.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "405": {
-            "description": "A DisputantUpdateRequest status can only be set to PENDING iff status is HOLD. Update failed.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "200": { "description": "Ok. DisputantUpdateRequest records updated to status PENDING." }
         }
       }
     },
@@ -2345,7 +2304,7 @@
           },
           "status": {
             "type": "string",
-            "enum": [ "UNKNOWN", "ACCEPTED", "HOLD", "PENDING", "REJECTED" ]
+            "enum": [ "UNKNOWN", "ACCEPTED", "PENDING", "REJECTED" ]
           },
           "updateType": {
             "type": "string",

--- a/src/backend/TrafficCourts/Common/OpenAPIs/OracleDataAPI/v1_0/OracleDataApiClient.g.cs
+++ b/src/backend/TrafficCourts/Common/OpenAPIs/OracleDataAPI/v1_0/OracleDataApiClient.g.cs
@@ -232,23 +232,6 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
         /// <exception cref="ApiException">A server side error occurred.</exception>
         System.Threading.Tasks.Task<DisputantUpdateRequest> UpdateDisputantUpdateRequestStatusAsync(long id, DisputantUpdateRequestStatus disputantUpdateRequestStatus, System.Threading.CancellationToken cancellationToken);
 
-        /// <summary>
-        /// An endpoint that updates the status of one or more DisputantUpdateRequest records to PENDING from HOLD.
-        /// </summary>
-        /// <param name="ids">The id of the DisputantUpdateRequest record to update.</param>
-        /// <returns>Ok. DisputantUpdateRequest records updated to status PENDING.</returns>
-        /// <exception cref="ApiException">A server side error occurred.</exception>
-        System.Threading.Tasks.Task UpdateDisputantUpdateRequestsStatusToPendingAsync(System.Collections.Generic.IEnumerable<long> ids);
-
-        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
-        /// <summary>
-        /// An endpoint that updates the status of one or more DisputantUpdateRequest records to PENDING from HOLD.
-        /// </summary>
-        /// <param name="ids">The id of the DisputantUpdateRequest record to update.</param>
-        /// <returns>Ok. DisputantUpdateRequest records updated to status PENDING.</returns>
-        /// <exception cref="ApiException">A server side error occurred.</exception>
-        System.Threading.Tasks.Task UpdateDisputantUpdateRequestsStatusToPendingAsync(System.Collections.Generic.IEnumerable<long> ids, System.Threading.CancellationToken cancellationToken);
-
         /// <param name="ticketNumber">Ticket number to retrieve related file history.</param>
         /// <returns>OK</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
@@ -2312,127 +2295,6 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             return objectResponse_.Object;
-                        }
-                        else
-                        {
-                            var responseData_ = response_.Content == null ? null : await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
-                            throw new ApiException("The HTTP status code of the response was not expected (" + status_ + ").", status_, responseData_, headers_, null);
-                        }
-                    }
-                    finally
-                    {
-                        if (disposeResponse_)
-                            response_.Dispose();
-                    }
-                }
-            }
-            finally
-            {
-                if (disposeClient_)
-                    client_.Dispose();
-            }
-        }
-
-        /// <summary>
-        /// An endpoint that updates the status of one or more DisputantUpdateRequest records to PENDING from HOLD.
-        /// </summary>
-        /// <param name="ids">The id of the DisputantUpdateRequest record to update.</param>
-        /// <returns>Ok. DisputantUpdateRequest records updated to status PENDING.</returns>
-        /// <exception cref="ApiException">A server side error occurred.</exception>
-        public virtual System.Threading.Tasks.Task UpdateDisputantUpdateRequestsStatusToPendingAsync(System.Collections.Generic.IEnumerable<long> ids)
-        {
-            return UpdateDisputantUpdateRequestsStatusToPendingAsync(ids, System.Threading.CancellationToken.None);
-        }
-
-        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
-        /// <summary>
-        /// An endpoint that updates the status of one or more DisputantUpdateRequest records to PENDING from HOLD.
-        /// </summary>
-        /// <param name="ids">The id of the DisputantUpdateRequest record to update.</param>
-        /// <returns>Ok. DisputantUpdateRequest records updated to status PENDING.</returns>
-        /// <exception cref="ApiException">A server side error occurred.</exception>
-        public virtual async System.Threading.Tasks.Task UpdateDisputantUpdateRequestsStatusToPendingAsync(System.Collections.Generic.IEnumerable<long> ids, System.Threading.CancellationToken cancellationToken)
-        {
-            if (ids == null)
-                throw new System.ArgumentNullException("ids");
-
-            var urlBuilder_ = new System.Text.StringBuilder();
-            urlBuilder_.Append("api/v1.0/dispute/updateRequest/{ids}/pending");
-            urlBuilder_.Replace("{ids}", System.Uri.EscapeDataString(string.Join(",", System.Linq.Enumerable.Select(ids, s_ => ConvertToString(s_, System.Globalization.CultureInfo.InvariantCulture)))));
-
-            var client_ = _httpClient;
-            var disposeClient_ = false;
-            try
-            {
-                using (var request_ = new System.Net.Http.HttpRequestMessage())
-                {
-                    request_.Content = new System.Net.Http.StringContent(string.Empty, System.Text.Encoding.UTF8, "application/json");
-                    request_.Method = new System.Net.Http.HttpMethod("PUT");
-
-                    PrepareRequest(client_, request_, urlBuilder_);
-
-                    var url_ = urlBuilder_.ToString();
-                    request_.RequestUri = new System.Uri(url_, System.UriKind.RelativeOrAbsolute);
-
-                    PrepareRequest(client_, request_, url_);
-
-                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
-                    var disposeResponse_ = true;
-                    try
-                    {
-                        var headers_ = System.Linq.Enumerable.ToDictionary(response_.Headers, h_ => h_.Key, h_ => h_.Value);
-                        if (response_.Content != null && response_.Content.Headers != null)
-                        {
-                            foreach (var item_ in response_.Content.Headers)
-                                headers_[item_.Key] = item_.Value;
-                        }
-
-                        ProcessResponse(client_, response_);
-
-                        var status_ = (int)response_.StatusCode;
-                        if (status_ == 400)
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            throw new ApiException<FileResponse>("Bad Request", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
-                        }
-                        else
-                        if (status_ == 500)
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            throw new ApiException<FileResponse>("Internal Server Error. Status Update failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
-                        }
-                        else
-                        if (status_ == 404)
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            throw new ApiException<FileResponse>("DisputantUpdateRequest records could not be found.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
-                        }
-                        else
-                        if (status_ == 405)
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            throw new ApiException<FileResponse>("A DisputantUpdateRequest status can only be set to PENDING iff status is HOLD. Update failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
-                        }
-                        else
-                        if (status_ == 200)
-                        {
-                            return;
                         }
                         else
                         {
@@ -5419,14 +5281,11 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
         [System.Runtime.Serialization.EnumMember(Value = @"ACCEPTED")]
         ACCEPTED = 1,
 
-        [System.Runtime.Serialization.EnumMember(Value = @"HOLD")]
-        HOLD = 2,
-
         [System.Runtime.Serialization.EnumMember(Value = @"PENDING")]
-        PENDING = 3,
+        PENDING = 2,
 
         [System.Runtime.Serialization.EnumMember(Value = @"REJECTED")]
-        REJECTED = 4,
+        REJECTED = 3,
 
     }
 
@@ -5974,14 +5833,11 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
         [System.Runtime.Serialization.EnumMember(Value = @"ACCEPTED")]
         ACCEPTED = 1,
 
-        [System.Runtime.Serialization.EnumMember(Value = @"HOLD")]
-        HOLD = 2,
-
         [System.Runtime.Serialization.EnumMember(Value = @"PENDING")]
-        PENDING = 3,
+        PENDING = 2,
 
         [System.Runtime.Serialization.EnumMember(Value = @"REJECTED")]
-        REJECTED = 4,
+        REJECTED = 3,
 
     }
 

--- a/src/backend/TrafficCourts/Workflow.Service/Consumers/DisputantUpdateRequestConsumer.cs
+++ b/src/backend/TrafficCourts/Workflow.Service/Consumers/DisputantUpdateRequestConsumer.cs
@@ -32,10 +32,6 @@ public class DisputantUpdateRequestConsumer : IConsumer<DisputantUpdateRequest>
 
         if (message.EmailAddress is not null)
         {
-            // Set status to HOLD. This status will be used if there are any subsequent name, address, or phone update requests
-            // The status will move from HOLD to PENDING when the disputant's email has been verified.
-            disputantUpdateRequest.Status = DisputantUpdateRequestStatus2.HOLD;
-
             // TODO: Start email saga. TCVP-2009
         }
 

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/controller/v1_0/DisputeController.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/controller/v1_0/DisputeController.java
@@ -436,27 +436,4 @@ public class DisputeController {
 		return new ResponseEntity<DisputantUpdateRequest>(disputantUpdateRequest, HttpStatus.OK);
 	}
 
-	/**
-	 * PUT endpoint that updates the status of one or more DisputantUpdateRequest records to PENDING from HOLD.
-	 *
-	 * @param List of IDs of DisputantUpdateRequest records' status to be updated to pending
-	 */
-	@PutMapping("/dispute/updateRequest/{ids}/pending")
-	@Operation(summary = "An endpoint that updates the status of one or more DisputantUpdateRequest records to PENDING from HOLD.")
-	@ApiResponses({
-		@ApiResponse(responseCode = "200", description = "Ok. DisputantUpdateRequest records updated to status PENDING."),
-		@ApiResponse(responseCode = "404", description = "DisputantUpdateRequest records could not be found."),
-		@ApiResponse(responseCode = "405", description = "A DisputantUpdateRequest status can only be set to PENDING iff status is HOLD. Update failed."),
-		@ApiResponse(responseCode = "500", description = "Internal Server Error. Status Update failed.")
-	})
-	public ResponseEntity<Void> updateDisputantUpdateRequestsStatusToPending(
-			@PathVariable(name = "ids")
-			@Parameter(description = "The id of the DisputantUpdateRequest record to update.")
-			List<Long> updateRequestIds) {
-		logger.debug("PUT /dispute/updateRequest/{}/pending called", updateRequestIds);
-
-		disputeService.updateDisputantUpdateRequestsStatusPending(updateRequestIds);
-		return ResponseEntity.ok().build();
-	}
-
 }

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/model/DisputantUpdateRequestStatus.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/model/DisputantUpdateRequestStatus.java
@@ -5,7 +5,6 @@ public enum DisputantUpdateRequestStatus implements ShortNamedEnum {
 	/** Unknown type (undefined). Must be index 0. */
 	UNKNOWN("UKN"),
 	ACCEPTED("ACC"),
-	HOLD("HOL"),
 	PENDING("PEN"),
 	REJECTED("REJ");
 

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/service/DisputeService.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/service/DisputeService.java
@@ -400,28 +400,4 @@ public class DisputeService {
 		return disputantUpdateRequestRepository.save(disputantUpdateRequest);
 	}
 
-	/**
-	 * Updates the status of one or more DisputantUpdateRequest records to PENDING from HOLD only
-	 * @param updateRequestIds
-	 */
-	public void updateDisputantUpdateRequestsStatusPending(List<Long> updateRequestIds) {
-
-		List<DisputantUpdateRequest> disputantUpdateRequestList = disputantUpdateRequestRepository.findAllById(updateRequestIds);
-
-		if (CollectionUtils.isEmpty(disputantUpdateRequestList) || updateRequestIds.size() != disputantUpdateRequestList.size()) {
-			logger.error("One or more disputantUpdateRequest record could not be found for the given IDs: " + updateRequestIds);
-			throw new NoSuchElementException();
-		}
-
-		if(disputantUpdateRequestList.stream().anyMatch(ur -> !DisputantUpdateRequestStatus.HOLD.equals(ur.getStatus()))) {
-			throw new NotAllowedException("Changing the status to %s is only permitted from %s status for any of the DisputantUpdateRequest records submitted.",
-					DisputantUpdateRequestStatus.PENDING, DisputantUpdateRequestStatus.HOLD);
-		}
-
-		for (DisputantUpdateRequest disputantUpdateRequest : disputantUpdateRequestList) {
-			disputantUpdateRequest.setStatus(DisputantUpdateRequestStatus.PENDING);
-			disputantUpdateRequestRepository.save(disputantUpdateRequest);
-		}
-	}
-
 }

--- a/src/backend/oracle-data-api/src/test/java/ca/bc/gov/open/jag/tco/oracledataapi/service/DisputeServiceH2Test.java
+++ b/src/backend/oracle-data-api/src/test/java/ca/bc/gov/open/jag/tco/oracledataapi/service/DisputeServiceH2Test.java
@@ -4,7 +4,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.UUID;
@@ -146,86 +145,11 @@ class DisputeServiceH2Test extends BaseTestSuite {
 		});
 	}
 
-	@Test
-	public void testUpdateDisputantUpdateRequestsStatusPending() throws Exception {
-		List<Long> updateRequestIds = new ArrayList<Long>();
-
-		Dispute dispute = createAndSaveDispute();
-		Long disputeId = dispute.getDisputeId();
-		String noticeOfDisputeGuid = dispute.getNoticeOfDisputeGuid();
-
-		Long updateDisputantUpdateRequestId1 = createDisputantUpdateRequestWithStatusAndDisputeId(noticeOfDisputeGuid, DisputantUpdateRequestStatus.HOLD, disputeId);
-		updateRequestIds.add(updateDisputantUpdateRequestId1);
-		Long updateDisputantUpdateRequestId2 = createDisputantUpdateRequestWithStatusAndDisputeId(noticeOfDisputeGuid, DisputantUpdateRequestStatus.HOLD, disputeId);
-		updateRequestIds.add(updateDisputantUpdateRequestId2);
-		Long updateDisputantUpdateRequestId3 = createDisputantUpdateRequestWithStatusAndDisputeId(noticeOfDisputeGuid, DisputantUpdateRequestStatus.HOLD, disputeId);
-		updateRequestIds.add(updateDisputantUpdateRequestId3);
-
-		disputeService.updateDisputantUpdateRequestsStatusPending(updateRequestIds);
-
-		List<DisputantUpdateRequest> updateRequests = disputeService.findDisputantUpdateRequestByDisputeId(disputeId);
-
-		assertEquals(3, updateRequests.size());
-
-		for (DisputantUpdateRequest disputantUpdateRequest : updateRequests) {
-			assertEquals(DisputantUpdateRequestStatus.PENDING, disputantUpdateRequest.getStatus());
-		}
-	}
-
-	@Test
-	public void testUpdateDisputantUpdateRequestsStatusPending_404() throws Exception {
-		List<Long> updateRequestIds = new ArrayList<Long>();
-
-		Dispute dispute = createAndSaveDispute();
-		Long disputeId = dispute.getDisputeId();
-		String noticeOfDisputeGuid = dispute.getNoticeOfDisputeGuid();
-
-		Long updateDisputantUpdateRequestId1 = createDisputantUpdateRequestWithStatusAndDisputeId(noticeOfDisputeGuid, DisputantUpdateRequestStatus.HOLD, disputeId);
-		updateRequestIds.add(updateDisputantUpdateRequestId1);
-		updateRequestIds.add(Long.valueOf(987L));
-		updateRequestIds.add(Long.valueOf(985L));
-
-		assertThrows(NoSuchElementException.class, () -> {
-			disputeService.updateDisputantUpdateRequestsStatusPending(updateRequestIds);
-		});
-	}
-
-	@Test
-	public void testUpdateDisputantUpdateRequestsStatusPending_405() throws Exception {
-		List<Long> updateRequestIds = new ArrayList<Long>();
-
-		Dispute dispute = createAndSaveDispute();
-		Long disputeId = dispute.getDisputeId();
-		String noticeOfDisputeGuid = dispute.getNoticeOfDisputeGuid();
-
-		Long updateDisputantUpdateRequestId1 = createDisputantUpdateRequestWithStatusAndDisputeId(noticeOfDisputeGuid, DisputantUpdateRequestStatus.HOLD, disputeId);
-		updateRequestIds.add(updateDisputantUpdateRequestId1);
-		Long updateDisputantUpdateRequestId2 = createDisputantUpdateRequestWithStatusAndDisputeId(noticeOfDisputeGuid, DisputantUpdateRequestStatus.PENDING, disputeId);
-		updateRequestIds.add(updateDisputantUpdateRequestId2);
-
-		assertThrows(NotAllowedException.class, () -> {
-			disputeService.updateDisputantUpdateRequestsStatusPending(updateRequestIds);
-		});
-	}
-
 	private Long saveDispute(DisputeStatus disputeStatus) {
 		Dispute dispute = new Dispute();
 		dispute.setStatus(disputeStatus);
 
 		return disputeRepository.save(dispute).getDisputeId();
-	}
-
-	private Long createDisputantUpdateRequestWithStatusAndDisputeId(String noticeOfDisputeGuid, DisputantUpdateRequestStatus status, Long disputeId) {
-
-		String json = "{ \"address_line1\": \"123 Main Street\", \"address_line2\": \"\", \"address_line3\": \"\" }";
-		DisputantUpdateRequest updateRequest = new DisputantUpdateRequest();
-		updateRequest.setDisputeId(disputeId);
-		updateRequest.setStatus(status);
-		updateRequest.setUpdateType(DisputantUpdateRequestType.DISPUTANT_ADDRESS);
-		updateRequest.setUpdateJson(json);
-		DisputantUpdateRequest savedUpdateReq = disputeService.saveDisputantUpdateRequest(noticeOfDisputeGuid, updateRequest);
-
-		return savedUpdateReq.getDisputantUpdateRequestId();
 	}
 
 	private Dispute createAndSaveDispute() {


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- Removed DisputantUpdateRequestStatus.HOLD status since we are no longer using this enum value.
- Removed endpoint and service call that uses this deprecated HOLD value.
- Removed tests that test the removed endpoint and service call.
- Regenerated OpenAPI spec

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

mvn verify
dotnet test

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
