### PR TITLE
TCVP-2009 Added endpoint to fetch disputantUpdates by status

### DIFF
--- a/src/backend/TrafficCourts/Common/OpenAPIs/OracleDataAPI/v1_0/OracleDataApi.v1_0.json
+++ b/src/backend/TrafficCourts/Common/OpenAPIs/OracleDataAPI/v1_0/OracleDataApi.v1_0.json
@@ -1111,7 +1111,7 @@
     "/api/v1.0/dispute/{id}/updateRequest": {
       "get": {
         "tags": [ "dispute-controller" ],
-        "summary": "An endpoint that retrieves all DisputantUpdateRequest for a given Dispute.",
+        "summary": "An endpoint that retrieves all DisputantUpdateRequest for a given Dispute, optionally filtered by status.",
         "operationId": "getDisputantUpdateRequests",
         "parameters": [
           {
@@ -1123,6 +1123,17 @@
               "type": "integer",
               "format": "int64"
             }
+          },
+          {
+            "name": "status",
+            "in": "query",
+            "description": "If specified, filter request by status",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": [ "UNKNOWN", "ACCEPTED", "PENDING", "REJECTED" ]
+            },
+            "example": "PENDING"
           }
         ],
         "responses": {

--- a/src/backend/TrafficCourts/Common/OpenAPIs/OracleDataAPI/v1_0/OracleDataApiClient.g.cs
+++ b/src/backend/TrafficCourts/Common/OpenAPIs/OracleDataAPI/v1_0/OracleDataApiClient.g.cs
@@ -377,21 +377,23 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
         System.Threading.Tasks.Task UnassignDisputesAsync(System.Threading.CancellationToken cancellationToken);
 
         /// <summary>
-        /// An endpoint that retrieves all DisputantUpdateRequest for a given Dispute.
+        /// An endpoint that retrieves all DisputantUpdateRequest for a given Dispute, optionally filtered by status.
         /// </summary>
         /// <param name="id">The disputeId of the Dispute.</param>
+        /// <param name="status">If specified, filter request by status</param>
         /// <returns>Ok. DisputantUpdateRequest record saved.</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
-        System.Threading.Tasks.Task<System.Collections.Generic.ICollection<DisputantUpdateRequest>> GetDisputantUpdateRequestsAsync(long id);
+        System.Threading.Tasks.Task<System.Collections.Generic.ICollection<DisputantUpdateRequest>> GetDisputantUpdateRequestsAsync(long id, Status? status);
 
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <summary>
-        /// An endpoint that retrieves all DisputantUpdateRequest for a given Dispute.
+        /// An endpoint that retrieves all DisputantUpdateRequest for a given Dispute, optionally filtered by status.
         /// </summary>
         /// <param name="id">The disputeId of the Dispute.</param>
+        /// <param name="status">If specified, filter request by status</param>
         /// <returns>Ok. DisputantUpdateRequest record saved.</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
-        System.Threading.Tasks.Task<System.Collections.Generic.ICollection<DisputantUpdateRequest>> GetDisputantUpdateRequestsAsync(long id, System.Threading.CancellationToken cancellationToken);
+        System.Threading.Tasks.Task<System.Collections.Generic.ICollection<DisputantUpdateRequest>> GetDisputantUpdateRequestsAsync(long id, Status? status, System.Threading.CancellationToken cancellationToken);
 
         /// <summary>
         /// Finds Dispute statuses by TicketNumber and IssuedTime or noticeOfDisputeGuid if specified.
@@ -3583,31 +3585,38 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
         }
 
         /// <summary>
-        /// An endpoint that retrieves all DisputantUpdateRequest for a given Dispute.
+        /// An endpoint that retrieves all DisputantUpdateRequest for a given Dispute, optionally filtered by status.
         /// </summary>
         /// <param name="id">The disputeId of the Dispute.</param>
+        /// <param name="status">If specified, filter request by status</param>
         /// <returns>Ok. DisputantUpdateRequest record saved.</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
-        public virtual System.Threading.Tasks.Task<System.Collections.Generic.ICollection<DisputantUpdateRequest>> GetDisputantUpdateRequestsAsync(long id)
+        public virtual System.Threading.Tasks.Task<System.Collections.Generic.ICollection<DisputantUpdateRequest>> GetDisputantUpdateRequestsAsync(long id, Status? status)
         {
-            return GetDisputantUpdateRequestsAsync(id, System.Threading.CancellationToken.None);
+            return GetDisputantUpdateRequestsAsync(id, status, System.Threading.CancellationToken.None);
         }
 
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <summary>
-        /// An endpoint that retrieves all DisputantUpdateRequest for a given Dispute.
+        /// An endpoint that retrieves all DisputantUpdateRequest for a given Dispute, optionally filtered by status.
         /// </summary>
         /// <param name="id">The disputeId of the Dispute.</param>
+        /// <param name="status">If specified, filter request by status</param>
         /// <returns>Ok. DisputantUpdateRequest record saved.</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
-        public virtual async System.Threading.Tasks.Task<System.Collections.Generic.ICollection<DisputantUpdateRequest>> GetDisputantUpdateRequestsAsync(long id, System.Threading.CancellationToken cancellationToken)
+        public virtual async System.Threading.Tasks.Task<System.Collections.Generic.ICollection<DisputantUpdateRequest>> GetDisputantUpdateRequestsAsync(long id, Status? status, System.Threading.CancellationToken cancellationToken)
         {
             if (id == null)
                 throw new System.ArgumentNullException("id");
 
             var urlBuilder_ = new System.Text.StringBuilder();
-            urlBuilder_.Append("api/v1.0/dispute/{id}/updateRequest");
+            urlBuilder_.Append("api/v1.0/dispute/{id}/updateRequest?");
             urlBuilder_.Replace("{id}", System.Uri.EscapeDataString(ConvertToString(id, System.Globalization.CultureInfo.InvariantCulture)));
+            if (status != null)
+            {
+                urlBuilder_.Append(System.Uri.EscapeDataString("status") + "=").Append(System.Uri.EscapeDataString(ConvertToString(status, System.Globalization.CultureInfo.InvariantCulture))).Append("&");
+            }
+            urlBuilder_.Length--;
 
             var client_ = _httpClient;
             var disposeClient_ = false;
@@ -5310,6 +5319,24 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
 
         [System.Runtime.Serialization.EnumMember(Value = @"CANCELLED")]
         CANCELLED = 5,
+
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "13.17.0.0 (NJsonSchema v10.8.0.0 (Newtonsoft.Json v13.0.0.0))")]
+    public enum Status
+    {
+
+        [System.Runtime.Serialization.EnumMember(Value = @"UNKNOWN")]
+        UNKNOWN = 0,
+
+        [System.Runtime.Serialization.EnumMember(Value = @"ACCEPTED")]
+        ACCEPTED = 1,
+
+        [System.Runtime.Serialization.EnumMember(Value = @"PENDING")]
+        PENDING = 2,
+
+        [System.Runtime.Serialization.EnumMember(Value = @"REJECTED")]
+        REJECTED = 3,
 
     }
 

--- a/src/backend/TrafficCourts/Workflow.Service/Services/IOracleDataApiService.cs
+++ b/src/backend/TrafficCourts/Workflow.Service/Services/IOracleDataApiService.cs
@@ -15,6 +15,7 @@ namespace TrafficCourts.Workflow.Service.Services
         Task<ICollection<JJDispute>> GetJJDisputesAsync(string jjAssignedTo, string ticketNumber, string violationTime, System.Threading.CancellationToken cancellationToken);
 
         // DisputantUpdateRequest endpoints
+        Task<ICollection<DisputantUpdateRequest>> GetDisputantUpdateRequestsAsync(long disputeId, Status? disputantUpdateRequestStatus, CancellationToken cancellationToken);
         Task<long> SaveDisputantUpdateRequestAsync(string guid, DisputantUpdateRequest disputantUpdateRequest, CancellationToken cancellationToken);
         Task<DisputantUpdateRequest> UpdateDisputantUpdateRequestStatusAsync(long disputantUpdateRequestId, DisputantUpdateRequestStatus disputantUpdateRequestStatus, CancellationToken cancellationToken);
     }

--- a/src/backend/TrafficCourts/Workflow.Service/Services/OracleDataApiService.cs
+++ b/src/backend/TrafficCourts/Workflow.Service/Services/OracleDataApiService.cs
@@ -1,5 +1,4 @@
-﻿using System.Threading;
-using TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0;
+﻿using TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0;
 
 namespace TrafficCourts.Workflow.Service.Services;
 
@@ -45,7 +44,7 @@ public class OracleDataApiService : IOracleDataApiService
         try
         {
             return await _client.InsertFileHistoryAsync(fileHistory.TicketNumber, fileHistory, cancellationToken);
-        } 
+        }
         catch (Exception)
         {
             throw;
@@ -129,7 +128,8 @@ public class OracleDataApiService : IOracleDataApiService
         }
     }
 
-    public async Task<ICollection<JJDispute>> GetJJDisputesAsync(string jjAssignedTo, string ticketNumber, string violationTime, System.Threading.CancellationToken cancellationToken) {
+    public async Task<ICollection<JJDispute>> GetJJDisputesAsync(string jjAssignedTo, string ticketNumber, string violationTime, System.Threading.CancellationToken cancellationToken)
+    {
         try
         {
             return await _client.GetJJDisputesAsync(jjAssignedTo, ticketNumber, violationTime, cancellationToken);
@@ -145,6 +145,18 @@ public class OracleDataApiService : IOracleDataApiService
         try
         {
             return await _client.UpdateDisputantUpdateRequestStatusAsync(disputantUpdateRequestId, disputantUpdateRequestStatus, cancellationToken);
+        }
+        catch (Exception)
+        {
+            throw;
+        }
+    }
+
+    public async Task<ICollection<DisputantUpdateRequest>> GetDisputantUpdateRequestsAsync(long disputeId, Status? disputantUpdateRequestStatus, CancellationToken cancellationToken)
+    {
+        try
+        {
+            return await _client.GetDisputantUpdateRequestsAsync(disputeId, disputantUpdateRequestStatus);
         }
         catch (Exception)
         {

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/controller/v1_0/DisputeController.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/controller/v1_0/DisputeController.java
@@ -399,15 +399,21 @@ public class DisputeController {
 	 * @return id of the saved {@link DisputantUpdateRequest}
 	 */
 	@GetMapping("/dispute/{id}/updateRequest")
-	@Operation(summary = "An endpoint that retrieves all DisputantUpdateRequest for a given Dispute.")
+	@Operation(summary = "An endpoint that retrieves all DisputantUpdateRequest for a given Dispute, optionally filtered by status.")
 	@ApiResponses({
 		@ApiResponse(responseCode = "200", description = "Ok. DisputantUpdateRequest record saved."),
 		@ApiResponse(responseCode = "404", description = "Dispute could not be found."),
 		@ApiResponse(responseCode = "500", description = "Internal Server Error. Save failed.")
 	})
-	public ResponseEntity<List<DisputantUpdateRequest>> getDisputantUpdateRequests(@PathVariable @Parameter(description = "The disputeId of the Dispute.") Long id) {
+	public ResponseEntity<List<DisputantUpdateRequest>> getDisputantUpdateRequests(
+			@PathVariable
+			@Parameter(description = "The disputeId of the Dispute.")
+			Long id,
+			@RequestParam(required = false)
+			@Parameter(description = "If specified, filter request by status", example = "PENDING")
+			DisputantUpdateRequestStatus status) {
 		logger.debug("GET /dispute/{}/updateRequest called", id);
-		return new ResponseEntity<List<DisputantUpdateRequest>>(disputeService.findDisputantUpdateRequestByDisputeId(id), HttpStatus.OK);
+		return new ResponseEntity<List<DisputantUpdateRequest>>(disputeService.findDisputantUpdateRequestByDisputeIdAndStatus(id, status), HttpStatus.OK);
 	}
 
 	/**

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/repository/DisputantUpdateRequestRepository.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/repository/DisputantUpdateRequestRepository.java
@@ -3,12 +3,15 @@ package ca.bc.gov.open.jag.tco.oracledataapi.repository;
 import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import ca.bc.gov.open.jag.tco.oracledataapi.model.DisputantUpdateRequest;
+import ca.bc.gov.open.jag.tco.oracledataapi.model.DisputantUpdateRequestStatus;
 
 public interface DisputantUpdateRequestRepository extends JpaRepository<DisputantUpdateRequest, Long> {
 
-	/** Fetch all records that matches the DisputeId. */
-	public List<DisputantUpdateRequest> findByDisputeId(Long disputeId);
+	/** Fetch all records that matches the DisputeId, optionally filtered by status. */
+	@Query("from DisputantUpdateRequest where disputeId = :disputeId and (:status is null or status = :status)")
+	public List<DisputantUpdateRequest> findByDisputeIdAndOptionalStatus(Long disputeId, DisputantUpdateRequestStatus status);
 
 }

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/service/DisputeService.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/service/DisputeService.java
@@ -384,8 +384,8 @@ public class DisputeService {
 	 * Retrieves all DisputantUpdateRequests by disputeId
 	 * @param disputeId must not be null
 	 */
-	public List<DisputantUpdateRequest> findDisputantUpdateRequestByDisputeId(Long disputeId) {
-		return disputantUpdateRequestRepository.findByDisputeId(disputeId);
+	public List<DisputantUpdateRequest> findDisputantUpdateRequestByDisputeIdAndStatus(Long disputeId, DisputantUpdateRequestStatus status) {
+		return disputantUpdateRequestRepository.findByDisputeIdAndOptionalStatus(disputeId, status);
 	}
 
 	/**

--- a/src/backend/oracle-data-api/src/test/java/ca/bc/gov/open/jag/tco/oracledataapi/service/DisputeServiceH2Test.java
+++ b/src/backend/oracle-data-api/src/test/java/ca/bc/gov/open/jag/tco/oracledataapi/service/DisputeServiceH2Test.java
@@ -124,7 +124,7 @@ class DisputeServiceH2Test extends BaseTestSuite {
 
 		assertNotNull(disputantUpdateRequestId);
 
-		List<DisputantUpdateRequest> updateRequests = disputeService.findDisputantUpdateRequestByDisputeId(dispute.getDisputeId());
+		List<DisputantUpdateRequest> updateRequests = disputeService.findDisputantUpdateRequestByDisputeIdAndStatus(dispute.getDisputeId(), null);
 
 		assertEquals(1, updateRequests.size());
 		savedUpdateReq = updateRequests.get(0);


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

TCVP-2009
- Added OracleAPI to fetch DisputantUpdateRequests by status
- Fixed TODO in EmailVerificationReceivedConsumer to send email iff there are update requests.

![image](https://user-images.githubusercontent.com/55215368/209230109-e732f3a7-85e8-433c-9571-38e9f790cc5c.png)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

mvn verify
dotnet test

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes