### PR TITLE
Fixed merged act/reg - section text from a poor OCR scan

### DIFF
--- a/src/backend/TrafficCourts/Common/Models/OcrViolationTicket.cs
+++ b/src/backend/TrafficCourts/Common/Models/OcrViolationTicket.cs
@@ -249,7 +249,7 @@ public class Field
 
     public bool IsPopulated()
     {
-        return !String.IsNullOrEmpty(Value);
+        return !string.IsNullOrEmpty(Value);
     }
 }
 

--- a/src/backend/TrafficCourts/Test/Citizen.Service/Validators/Rules/CountActRegMustBeMVATest.cs
+++ b/src/backend/TrafficCourts/Test/Citizen.Service/Validators/Rules/CountActRegMustBeMVATest.cs
@@ -1,4 +1,5 @@
 ﻿using System.Threading.Tasks;
+using TrafficCourts.Citizen.Service.Validators;
 using TrafficCourts.Citizen.Service.Validators.Rules;
 using TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0;
 using Xunit;
@@ -12,7 +13,7 @@ public class CountActRegMustBeMVATest
     [InlineData("MVA", true)]
     [InlineData("CTA", false)]
     [InlineData("", false)]
-    public async Task TestACTREGsFields(string countAct, bool expectValid)
+    public async Task TestACTREGsFields1(string countAct, bool expectValid)
     {
         // Given
         Field field = new(countAct);
@@ -21,6 +22,37 @@ public class CountActRegMustBeMVATest
         CountActRegMustBeMVA rule = new(field, 1);
 
         // When
+        await rule.RunAsync();
+
+        // Then.
+        if (expectValid)
+        {
+            Assert.Empty(rule.Field.ValidationErrors);
+        }
+        else
+        {
+            Assert.NotEmpty(rule.Field.ValidationErrors);
+        }
+
+    }
+
+    [Theory]
+    [InlineData("MVA", "45(a)", true)]
+    [InlineData("", "MVA 45(a)", true)]
+    [InlineData(null, "MVA 45(a)", true)]
+    public async Task TestACTREGsFields2(string? actReg, string? section, bool expectValid)
+    {
+        // Given
+        Field actRegField = new(actReg);
+        Field sectionField = new(section);
+
+        OcrViolationTicket violationTicket = new();
+        violationTicket.Fields.Add(OcrViolationTicket.Count1ActRegs, actRegField);
+        violationTicket.Fields.Add(OcrViolationTicket.Count1Section, sectionField);
+        CountActRegMustBeMVA rule = new(actRegField, 1);
+
+        // When
+        FormRecognizerValidator.Sanitize(violationTicket);
         await rule.RunAsync();
 
         // Then.


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

It can happen that text is too close to the shared border between two adjacent fields. The OCR may incorrectly think one field is blank and the other populate with the blank field's text.

In this example, the OCR thought the ACT/REGS was blank and the SECTION text read "MVA 67(b)".

![image](https://user-images.githubusercontent.com/55215368/210436612-d0270494-7d6a-4036-b9c7-b11a8974838c.png)

This PR addresses this particular poor OCR scan result by moving the expected MVA text to the correct field.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

dotnet test

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
