### PR TITLE
quote boolean values in docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -239,7 +239,7 @@ services:
     ports:
       - 3000:3000
     environment:
-      BASICAUTH_ENABLED: true
+      BASICAUTH_ENABLED: "true"
       BASICAUTH_USERNAME: "username"
       BASICAUTH_PASSWORD: "password"
       OBJECTSTORAGE_ACCESSKEYID: ${OBJECTSTORAGE__ACCESSKEY:-username}
@@ -247,7 +247,7 @@ services:
       OBJECTSTORAGE_ENDPOINT: ${OBJECTSTORAGE__ENDPOINT:-http://minio:9000}
       OBJECTSTORAGE_KEY: "/"
       OBJECTSTORAGE_SECRETACCESSKEY: ${OBJECTSTORAGE__SECRETKEY:-password}
-      DB_ENABLED: true
+      DB_ENABLED: "true"
       DB_HOST: "coms-db"
       DB_USERNAME: "postgres"
       DB_PASSWORD: "password"
@@ -256,7 +256,7 @@ services:
   coms-init:
     image: bcgovimages/common-object-management-service:latest
     environment:
-      DB_ENABLED: true
+      DB_ENABLED: "true"
       DB_HOST: "coms-db"
       DB_USERNAME: "postgres"
       DB_PASSWORD: "password"


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- fixes boolean values in docker compose file that need to be quoted as per the [environment](https://docs.docker.com/compose/compose-file/compose-file-v3/#environment) documenation.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [ ] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
