### PR TITLE
TCVP-2036 added /email/reset endpoint to oracle-data-api

### DIFF
--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/controller/v1_0/DisputeController.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/controller/v1_0/DisputeController.java
@@ -254,6 +254,27 @@ public class DisputeController {
 		return ResponseEntity.ok().build();
 	}
 
+	@Operation(summary = "Updates the email address of a particular Dispute.")
+	@ApiResponses({
+		@ApiResponse(responseCode = "200", description = "Ok. Email unverified."),
+		@ApiResponse(responseCode = "400", description = "If the email address is > 100 characters"),
+		@ApiResponse(responseCode = "404", description = "Dispute with specified id not found"),
+		@ApiResponse(responseCode = "500", description = "Internal server error occured.")
+	})
+	@PutMapping("/dispute/{id}/email/reset")
+	public ResponseEntity<Void> resetDisputeEmail(
+			@PathVariable(name="id")
+			@Parameter(description = "The id of the Dispute to update.")
+			Long id,
+			@RequestParam(name="email", required = false)
+			@Size(min = 1, max = 100)
+			@Parameter(description = "The new email address of the Disputant.")
+			String email) {
+		logger.debug("PUT /dispute/{}/email/reset called", id);
+		disputeService.resetEmail(id, email);
+		return ResponseEntity.ok().build();
+	}
+
 	/**
 	 * PUT endpoint that updates the dispute detail, setting the status to CANCELLED.
 	 *

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/service/DisputeService.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/service/DisputeService.java
@@ -295,6 +295,29 @@ public class DisputeService {
 	}
 
 	/**
+	 * Sets the email address of the specified Dispute
+	 *
+	 * @param id the Dispute record to update
+	 * @param emailAddress Dispute.emailAddress will be updated with this value
+	 * @throws NoSuchElementException if the Dispute could not be found.
+	 */
+	public void resetEmail(Long id, String emailAddress) {
+		Dispute dispute = disputeRepository.findById(id).orElseThrow();
+
+		// permit setting the emailAddress to null
+		if (StringUtils.isBlank(emailAddress)) {
+			dispute.setEmailAddress(null);
+			dispute.setEmailAddressVerified(Boolean.TRUE);
+		}
+		else {
+			dispute.setEmailAddress(emailAddress);
+			dispute.setEmailAddressVerified(Boolean.FALSE);
+		}
+
+		disputeRepository.update(dispute);
+	}
+
+	/**
 	 * Flips the Dispute.emailAddressVerified flag to true where on the target dispute if it exists
 	 * @param token the Dispute record to update
 	 */

--- a/src/backend/oracle-data-api/src/test/java/ca/bc/gov/open/jag/tco/oracledataapi/controller/v1_0/DisputeControllerTest.java
+++ b/src/backend/oracle-data-api/src/test/java/ca/bc/gov/open/jag/tco/oracledataapi/controller/v1_0/DisputeControllerTest.java
@@ -328,6 +328,69 @@ class DisputeControllerTest extends BaseTestSuite {
 	}
 
 	@Test
+	public void testResetEmail_200() throws Exception {
+		// Create a single Dispute
+		Dispute dispute = RandomUtil.createDispute();
+		dispute.setEmailAddress("oldaddress@somewhere.com");
+		dispute.setEmailAddressVerified(Boolean.TRUE);
+		Long disputeId = saveDispute(dispute);
+
+		// Load the dispute to confirm the database values are correct
+		dispute = getDispute(disputeId);
+		assertEquals("oldaddress@somewhere.com", dispute.getEmailAddress());
+		assertEquals(Boolean.TRUE, dispute.getEmailAddressVerified());
+
+		// attempt to reset the email address
+		mvc.perform(MockMvcRequestBuilders
+				.put("/api/v1.0/dispute/{id}/email/reset", disputeId)
+				.param("email", "newaddress@somewhere.com"))
+				.andExpect(status().isOk());
+
+		// reload the dispute to confirm the emailAddress has been updated.
+		Dispute updatedDispute = getDispute(disputeId);
+		assertEquals("newaddress@somewhere.com", updatedDispute.getEmailAddress());
+		assertEquals(Boolean.FALSE, updatedDispute.getEmailAddressVerified());
+	}
+
+	@Test
+	public void testResetEmail_400() throws Exception {
+		// Create a single Dispute
+		Dispute dispute = RandomUtil.createDispute();
+		dispute.setEmailAddress("oldaddress@somewhere.com");
+		dispute.setEmailAddressVerified(Boolean.TRUE);
+		Long disputeId = saveDispute(dispute);
+
+		// Load the dispute to confirm the database values are correct
+		dispute = getDispute(disputeId);
+		assertEquals("oldaddress@somewhere.com", dispute.getEmailAddress());
+		assertEquals(Boolean.TRUE, dispute.getEmailAddressVerified());
+
+		// attempt to reset with an overly long email address
+		mvc.perform(MockMvcRequestBuilders
+				.put("/api/v1.0/dispute/{id}/email/reset", disputeId)
+				.param("email", RandomUtil.randomAlphabetic(101))) // create a string 101 characters long - should fail.
+				.andExpect(status().isBadRequest());
+
+		// attempt to reset with a missing email address - should be permitted to set the email to blank.
+		mvc.perform(MockMvcRequestBuilders
+				.put("/api/v1.0/dispute/{id}/email/reset", disputeId))
+				.andExpect(status().isOk());
+
+		dispute = getDispute(disputeId);
+		assertNull(dispute.getEmailAddress());
+		assertEquals(Boolean.TRUE, dispute.getEmailAddressVerified());
+	}
+
+	@Test
+	public void testResetEmail_404() throws Exception {
+		// attempt to reset the email address on an invalid Dispute
+		mvc.perform(MockMvcRequestBuilders
+				.put("/api/v1.0/dispute/{id}/email/reset", Long.valueOf(1l))
+				.param("email", "newaddress@somewhere.com"))
+				.andExpect(status().isNotFound());
+	}
+
+	@Test
 	public void testVerifyEmail_200() throws Exception {
 		// Create a single Dispute
 		Dispute dispute = RandomUtil.createDispute();


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

TCVP-2036 
Added new endpoint to reset a Disputant's email address
- added junit test to confirm code coverage and functionality

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
