### PR TITLE
TCVP-2087 Investigate COMS error when creating files

### DIFF
--- a/src/backend/TrafficCourts/TrafficCourts.Coms.Client.Test/ServiceTests/DeleteFileAsync.cs
+++ b/src/backend/TrafficCourts/TrafficCourts.Coms.Client.Test/ServiceTests/DeleteFileAsync.cs
@@ -1,4 +1,5 @@
 ﻿using Moq;
+using System;
 
 namespace TrafficCourts.Coms.Client.Test.ServiceTests;
 
@@ -21,5 +22,39 @@ public class DeleteFileAsync : ObjectManagementServiceTest
                 It.Is<string>((actual) => actual == null),
                 It.Is<CancellationToken>((actual) => actual == cts.Token)
             ));
+    }
+
+    [Fact]
+    public async Task should_not_throw_error_if_client_returns_not_found_error()
+    {
+        Guid id = Guid.NewGuid();
+        CancellationTokenSource cts = new CancellationTokenSource();
+
+        ResponseError error = new ResponseError { Detail = "NotFoundError" };
+        ApiException<ResponseError> exception = new ApiException<ResponseError>("", 502, null, null, error, null);
+
+        _mockClient.Setup(_ => _.DeleteObjectAsync(It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Throws(() => exception);
+
+        ObjectManagementService sut = GetService();
+
+        await sut.DeleteFileAsync(id, cts.Token);
+    }
+
+    [Fact]
+    public async Task should_ObjectManagementServiceException_when_other_erorr_thrown()
+    {
+        Guid id = Guid.NewGuid();
+        CancellationTokenSource cts = new CancellationTokenSource();
+
+        ResponseError error = new ResponseError { Detail = "OtherError" };
+        ApiException<ResponseError> exception = new ApiException<ResponseError>("", 502, null, null, error, null);
+
+        _mockClient.Setup(_ => _.DeleteObjectAsync(It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Throws(() => exception);
+
+        ObjectManagementService sut = GetService();
+
+        var actual = await Assert.ThrowsAsync<ObjectManagementServiceException>(() => sut.DeleteFileAsync(id, cts.Token));
     }
 }

--- a/src/backend/TrafficCourts/TrafficCourts.Coms.Client.Test/TrafficCourts.Coms.Client.Test.csproj
+++ b/src/backend/TrafficCourts/TrafficCourts.Coms.Client.Test/TrafficCourts.Coms.Client.Test.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>

--- a/src/backend/TrafficCourts/TrafficCourts.Coms.Client/File.cs
+++ b/src/backend/TrafficCourts/TrafficCourts.Coms.Client/File.cs
@@ -1,7 +1,12 @@
 ﻿namespace TrafficCourts.Coms.Client;
 
-public partial class File
+public partial class File : IDisposable
 {
+    /// <summary>Is this already disposed?</summary>
+    private bool _disposed;
+    /// <summary>Does this instance own the memory stream and should dispose of it?</summary>
+    private bool _ownsDataStream = true;
+
     public File(Stream data)
         : this(data, null, null)
     {
@@ -35,4 +40,31 @@ public partial class File
 
     public Dictionary<string, string> Metadata { get; private set; }
     public Dictionary<string, string> Tags { get; private set; }
+
+    public void Dispose()
+    {
+        Dispose(disposing: true);
+        // This object will be cleaned up by the Dispose method.
+        // Therefore, you should call GC.SuppressFinalize to
+        // take this object off the finalization queue
+        // and prevent finalization code for this object
+        // from executing a second time.
+        GC.SuppressFinalize(this);
+    }
+
+    protected virtual void Dispose(bool disposing)
+    {
+        if (!_disposed)
+        {
+            if (disposing)
+            {
+                if (_ownsDataStream)
+                {
+                    Data.Dispose();
+                }
+
+                _disposed = true;
+            }
+        }
+    }
 }

--- a/src/backend/TrafficCourts/TrafficCourts.Coms.Client/Models.g.cs
+++ b/src/backend/TrafficCourts/TrafficCourts.Coms.Client/Models.g.cs
@@ -173,7 +173,7 @@ namespace TrafficCourts.Coms.Client
 
         [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.Never)]   
         [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
-        public System.Guid UpdatedBy { get; set; } = default!;
+        public System.Guid? UpdatedBy { get; set; } = default!;
 
         /// <summary>
         /// Time when this record was last updated


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- Changes the UpdatedBy in the COMS generated code to nullable. Relates to bug [#87](https://github.com/bcgov/common-object-management-service/issues/87) in the COMS project
- The ObjectManagementService now handles not found on delete and does not throw error
- Adds integration test to validate ObjectManagementService calls work correctly

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
