### PR TITLE
TCVP-2000 - Get Document IDs when Staff API Get JJDispute called

### DIFF
--- a/src/backend/TrafficCourts/Common/Models/JJDispute.cs
+++ b/src/backend/TrafficCourts/Common/Models/JJDispute.cs
@@ -3,12 +3,12 @@
 namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0;
 
 /// <summary>
-/// An extension of the JJDispute object to include list of IDs (Unique identifiers for the files in COMS) of the saved files for this JJDispute.
+/// An extension of the JJDispute object to include dictionary of KEY IDs (Unique identifiers for the files in COMS) and filenames as VALUE of the saved files for this JJDispute.
 /// </summary>
 public partial class JJDispute
 {
     /// <summary>
-    /// List of IDs of all the uploaded documents related to this particular JJDispute
+    /// Dictionary of IDs and Filenames of all the uploaded documents related to this particular JJDispute
     /// </summary>
-    public List<Guid>? FileIds { get; set; }
+    public Dictionary<Guid, string>? FileData { get; set; }
 }

--- a/src/backend/TrafficCourts/Common/Models/JJDispute.cs
+++ b/src/backend/TrafficCourts/Common/Models/JJDispute.cs
@@ -1,0 +1,14 @@
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0;
+
+/// <summary>
+/// An extension of the JJDispute object to include list of IDs (Unique identifiers for the files in COMS) of the saved files for this JJDispute.
+/// </summary>
+public partial class JJDispute
+{
+    /// <summary>
+    /// List of IDs of all the uploaded documents related to this particular JJDispute
+    /// </summary>
+    public List<Guid>? FileIds { get; set; }
+}

--- a/src/backend/TrafficCourts/Staff.Service/Controllers/ComsController.cs
+++ b/src/backend/TrafficCourts/Staff.Service/Controllers/ComsController.cs
@@ -41,8 +41,7 @@ public class ComsController : StaffControllerBase<ComsController>
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    //[KeycloakAuthorize(Resources.JJDispute, Scopes.Update)]
-    [AllowAnonymous]
+    [KeycloakAuthorize(Resources.JJDispute, Scopes.Update)]
     public async Task<IActionResult> UploadDocumentAsync([FromForm] FileUploadRequest fileUploadRequest, CancellationToken cancellationToken)
     {
         _logger.LogDebug("Uploading the document to the object storage");

--- a/src/backend/TrafficCourts/Staff.Service/Controllers/ComsController.cs
+++ b/src/backend/TrafficCourts/Staff.Service/Controllers/ComsController.cs
@@ -46,12 +46,12 @@ public class ComsController : StaffControllerBase<ComsController>
     {
         _logger.LogDebug("Uploading the document to the object storage");
 
-        if (!fileUploadRequest.Metadata.ContainsKey("ticketnumber"))
+        if (!fileUploadRequest.Metadata.ContainsKey("ticket-number"))
         {
-            _logger.LogError("Could not upload a document because metadata does not contain the key: ticketnumber");
+            _logger.LogError("Could not upload a document because metadata does not contain the key: ticket-number");
             ProblemDetails problemDetails = new();
             problemDetails.Status = (int)HttpStatusCode.BadRequest;
-            problemDetails.Title = "Exception Invoking COMS - Metadata Key does not contain ticketnumber";
+            problemDetails.Title = "Exception Invoking COMS - Metadata Key does not contain ticket-number";
             problemDetails.Instance = HttpContext?.Request?.Path;
 
             return new ObjectResult(problemDetails);

--- a/src/backend/TrafficCourts/Staff.Service/Services/ComsService.cs
+++ b/src/backend/TrafficCourts/Staff.Service/Services/ComsService.cs
@@ -71,6 +71,27 @@ public class ComsService : IComsService
         await _bus.PublishWithLog(_logger, fileHistoryRecord, cancellationToken);
     }
 
+    public async Task<List<Guid>> GetFilesBySearchAsync(IDictionary<string, string>? metadata, IDictionary<string, string>? tags, CancellationToken cancellationToken)
+    {
+        _logger.LogDebug("Searching files through COMS");
+
+        List<Guid> documentIds = new();
+
+        FileSearchParameters searchParameters = new(null, metadata, tags);
+
+        List<FileSearchResult> searchResult = await _objectManagementService.FileSearchAsync(searchParameters, cancellationToken);
+
+        if(searchResult != null && searchResult.Any())
+        {
+            foreach (var result in searchResult)
+            {
+                documentIds.Add(result.Id);
+            }
+        }
+
+        return documentIds;
+    }
+
     public async Task<Guid> SaveFileAsync(IFormFile file, Dictionary<string, string> metadata, CancellationToken cancellationToken)
     {
         _logger.LogDebug("Saving file through COMS");

--- a/src/backend/TrafficCourts/Staff.Service/Services/ComsService.cs
+++ b/src/backend/TrafficCourts/Staff.Service/Services/ComsService.cs
@@ -57,11 +57,11 @@ public class ComsService : IComsService
 
         Coms.Client.File file = await _objectManagementService.GetFileAsync(fileId, false, cancellationToken);
 
-        file.Metadata.TryGetValue("ticketnumber", out string? ticketNumber);
+        file.Metadata.TryGetValue("ticket-number", out string? ticketNumber);
         if (string.IsNullOrEmpty(ticketNumber))
         {
             ticketNumber = "unknown";
-            _logger.LogDebug("ticketnumber value from metadata is empty");
+            _logger.LogDebug("ticket-number value from metadata is empty");
         }
 
         await _objectManagementService.DeleteFileAsync(fileId, cancellationToken);
@@ -108,11 +108,11 @@ public class ComsService : IComsService
 
         Guid id = await _objectManagementService.CreateFileAsync(comsFile, cancellationToken);
 
-        metadata.TryGetValue("ticketnumber", out string? ticketNumber);
+        metadata.TryGetValue("ticket-number", out string? ticketNumber);
         if (string.IsNullOrEmpty(ticketNumber))
         {
             ticketNumber = "unknown";
-            _logger.LogDebug("ticketnumber value from metadata is empty");
+            _logger.LogDebug("ticket-number value from metadata is empty");
         }
         
         // Save file upload event to file history

--- a/src/backend/TrafficCourts/Staff.Service/Services/ComsService.cs
+++ b/src/backend/TrafficCourts/Staff.Service/Services/ComsService.cs
@@ -81,18 +81,15 @@ public class ComsService : IComsService
 
         List<FileSearchResult> searchResult = await _objectManagementService.FileSearchAsync(searchParameters, cancellationToken);
 
-        if (searchResult != null && searchResult.Any())
+        foreach (var result in searchResult)
         {
-            foreach (var result in searchResult)
+            result.Metadata.TryGetValue("name", out string? filename);
+            if (string.IsNullOrEmpty(filename))
             {
-                result.Metadata.TryGetValue("name", out string? filename);
-                if (string.IsNullOrEmpty(filename))
-                {
-                    filename = "unknown";
-                    _logger.LogDebug("name value from metadata is empty");
-                }
-                fileData.Add(result.Id, filename);
+                filename = "unknown";
+                _logger.LogDebug("name value from metadata is empty");
             }
+            fileData.Add(result.Id, filename);
         }
 
         return fileData;

--- a/src/backend/TrafficCourts/Staff.Service/Services/IComsService.cs
+++ b/src/backend/TrafficCourts/Staff.Service/Services/IComsService.cs
@@ -48,5 +48,5 @@ public interface IComsService
     /// <param name="cancellationToken"></param>
     /// <exception cref="ObjectManagementServiceException">There was an error searching files in COMS</exception>
     /// <returns></returns>
-    Task<List<Guid>> GetFilesBySearchAsync(IDictionary<string, string>? metadata, IDictionary<string, string>? tags, CancellationToken cancellationToken);
+    Task<Dictionary<Guid, string>> GetFilesBySearchAsync(IDictionary<string, string>? metadata, IDictionary<string, string>? tags, CancellationToken cancellationToken);
 }

--- a/src/backend/TrafficCourts/Staff.Service/Services/IComsService.cs
+++ b/src/backend/TrafficCourts/Staff.Service/Services/IComsService.cs
@@ -39,4 +39,14 @@ public interface IComsService
     /// <returns></returns>
     /// <exception cref="ObjectManagementServiceException">Unable to delete the file through COMS</exception>
     Task DeleteFileAsync(Guid fileId, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Returns the IDs of the documents found in object storage through COMS service based on the search parameters provided
+    /// </summary>
+    /// <param name="metadata"></param>
+    /// <param name="tags"></param>
+    /// <param name="cancellationToken"></param>
+    /// <exception cref="ObjectManagementServiceException">There was an error searching files in COMS</exception>
+    /// <returns></returns>
+    Task<List<Guid>> GetFilesBySearchAsync(IDictionary<string, string>? metadata, IDictionary<string, string>? tags, CancellationToken cancellationToken);
 }

--- a/src/backend/TrafficCourts/Staff.Service/Services/JJDisputeService.cs
+++ b/src/backend/TrafficCourts/Staff.Service/Services/JJDisputeService.cs
@@ -34,7 +34,7 @@ public class JJDisputeService : IJJDisputeService
         JJDispute dispute = await _oracleDataApi.GetJJDisputeAsync(disputeId, assignVTC, cancellationToken);
 
         Dictionary<string, string> documentSearchParam = new();
-        documentSearchParam.Add("ticketnumber", disputeId);
+        documentSearchParam.Add("ticket-number", disputeId);
 
         // TODO: Add search parameter "notice-of-dispute-id" for returning other documents for the associated dispute that were uploaded by the citizen
         // when there will be an endpoint to return disputes by ticket number.

--- a/src/backend/TrafficCourts/Staff.Service/Services/JJDisputeService.cs
+++ b/src/backend/TrafficCourts/Staff.Service/Services/JJDisputeService.cs
@@ -39,7 +39,7 @@ public class JJDisputeService : IJJDisputeService
         // TODO: Add search parameter "notice-of-dispute-id" for returning other documents for the associated dispute that were uploaded by the citizen
         // when there will be an endpoint to return disputes by ticket number.
 
-        dispute.FileIds = await _comsService.GetFilesBySearchAsync(documentSearchParam, null, cancellationToken);
+        dispute.FileData = await _comsService.GetFilesBySearchAsync(documentSearchParam, null, cancellationToken);
 
         return dispute;
     }

--- a/src/backend/TrafficCourts/Staff.Service/Services/JJDisputeService.cs
+++ b/src/backend/TrafficCourts/Staff.Service/Services/JJDisputeService.cs
@@ -13,12 +13,14 @@ public class JJDisputeService : IJJDisputeService
 {
     private readonly IOracleDataApiClient _oracleDataApi;
     private readonly IBus _bus;
+    private readonly IComsService _comsService;
     private readonly ILogger<JJDisputeService> _logger;
 
-    public JJDisputeService(IOracleDataApiClient oracleDataApi, IBus bus, ILogger<JJDisputeService> logger)
+    public JJDisputeService(IOracleDataApiClient oracleDataApi, IBus bus, IComsService comsService, ILogger<JJDisputeService> logger)
     {
         _oracleDataApi = oracleDataApi ?? throw new ArgumentNullException(nameof(oracleDataApi));
         _bus = bus ?? throw new ArgumentNullException(nameof(bus));
+        _comsService = comsService ?? throw new ArgumentNullException(nameof(comsService));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
@@ -30,6 +32,14 @@ public class JJDisputeService : IJJDisputeService
     public async Task<JJDispute> GetJJDisputeAsync(string disputeId, bool assignVTC, CancellationToken cancellationToken)
     {
         JJDispute dispute = await _oracleDataApi.GetJJDisputeAsync(disputeId, assignVTC, cancellationToken);
+
+        Dictionary<string, string> documentSearchParam = new();
+        documentSearchParam.Add("ticketnumber", disputeId);
+
+        // TODO: Add search parameter "notice-of-dispute-id" for returning other documents for the associated dispute that were uploaded by the citizen
+        // when there will be an endpoint to return disputes by ticket number.
+
+        dispute.FileIds = await _comsService.GetFilesBySearchAsync(documentSearchParam, null, cancellationToken);
 
         return dispute;
     }

--- a/src/backend/TrafficCourts/TrafficCourts.Staff.Service.Test/Controllers/ComsControllerTest.cs
+++ b/src/backend/TrafficCourts/TrafficCourts.Staff.Service.Test/Controllers/ComsControllerTest.cs
@@ -24,7 +24,7 @@ public class ComsControllerTest
         var mockFileUploadRequest = new Mock<FileUploadRequest>();
         var comsService = new Mock<IComsService>();
         Guid guid = Guid.NewGuid();
-        mockFileUploadRequest.Object.Metadata.Add("ticketnumber", "AO38375804");
+        mockFileUploadRequest.Object.Metadata.Add("ticket-number", "AO38375804");
         comsService
             .Setup(_ => _.SaveFileAsync(It.IsAny<IFormFile>(), It.IsAny<Dictionary<string, string>>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(guid);
@@ -56,7 +56,7 @@ public class ComsControllerTest
         var objectResult = Assert.IsType<ObjectResult>(result);
         var problemDetails = Assert.IsType<ProblemDetails>(objectResult.Value);
         Assert.Equal((int)HttpStatusCode.BadRequest, problemDetails.Status);
-        Assert.True(problemDetails?.Title?.Contains("Metadata Key does not contain ticketnumber"));
+        Assert.True(problemDetails?.Title?.Contains("Metadata Key does not contain ticket-number"));
     }
 
     [Fact]
@@ -66,7 +66,7 @@ public class ComsControllerTest
         var mockFileUploadRequest = new Mock<FileUploadRequest>();
         var comsService = new Mock<IComsService>();
         Guid guid = Guid.NewGuid();
-        mockFileUploadRequest.Object.Metadata.Add("ticketnumber", "AO38375804");
+        mockFileUploadRequest.Object.Metadata.Add("ticket-number", "AO38375804");
         comsService
             .Setup(_ => _.SaveFileAsync(It.IsAny<IFormFile>(), It.IsAny<Dictionary<string, string>>(), It.IsAny<CancellationToken>()))
             .Throws(new MetadataInvalidKeyException(It.IsAny<string>()));
@@ -90,7 +90,7 @@ public class ComsControllerTest
         var mockFileUploadRequest = new Mock<FileUploadRequest>();
         var comsService = new Mock<IComsService>();
         Guid guid = Guid.NewGuid();
-        mockFileUploadRequest.Object.Metadata.Add("ticketnumber", "AO38375804");
+        mockFileUploadRequest.Object.Metadata.Add("ticket-number", "AO38375804");
         comsService
             .Setup(_ => _.SaveFileAsync(It.IsAny<IFormFile>(), It.IsAny<Dictionary<string, string>>(), It.IsAny<CancellationToken>()))
             .Throws(new MetadataTooLongException());
@@ -114,7 +114,7 @@ public class ComsControllerTest
         var mockFileUploadRequest = new Mock<FileUploadRequest>();
         var comsService = new Mock<IComsService>();
         Guid guid = Guid.NewGuid();
-        mockFileUploadRequest.Object.Metadata.Add("ticketnumber", "AO38375804");
+        mockFileUploadRequest.Object.Metadata.Add("ticket-number", "AO38375804");
         comsService
             .Setup(_ => _.SaveFileAsync(It.IsAny<IFormFile>(), It.IsAny<Dictionary<string, string>>(), It.IsAny<CancellationToken>()))
             .Throws(new TagKeyEmptyException(It.IsAny<string>()));
@@ -138,7 +138,7 @@ public class ComsControllerTest
         var mockFileUploadRequest = new Mock<FileUploadRequest>();
         var comsService = new Mock<IComsService>();
         Guid guid = Guid.NewGuid();
-        mockFileUploadRequest.Object.Metadata.Add("ticketnumber", "AO38375804");
+        mockFileUploadRequest.Object.Metadata.Add("ticket-number", "AO38375804");
         comsService
             .Setup(_ => _.SaveFileAsync(It.IsAny<IFormFile>(), It.IsAny<Dictionary<string, string>>(), It.IsAny<CancellationToken>()))
             .Throws(new TagKeyTooLongException(It.IsAny<string>()));
@@ -162,7 +162,7 @@ public class ComsControllerTest
         var mockFileUploadRequest = new Mock<FileUploadRequest>();
         var comsService = new Mock<IComsService>();
         Guid guid = Guid.NewGuid();
-        mockFileUploadRequest.Object.Metadata.Add("ticketnumber", "AO38375804");
+        mockFileUploadRequest.Object.Metadata.Add("ticket-number", "AO38375804");
         comsService
             .Setup(_ => _.SaveFileAsync(It.IsAny<IFormFile>(), It.IsAny<Dictionary<string, string>>(), It.IsAny<CancellationToken>()))
             .Throws(new TagValueTooLongException(It.IsAny<string>(), It.IsAny<string>()));
@@ -186,7 +186,7 @@ public class ComsControllerTest
         var mockFileUploadRequest = new Mock<FileUploadRequest>();
         var comsService = new Mock<IComsService>();
         Guid guid = Guid.NewGuid();
-        mockFileUploadRequest.Object.Metadata.Add("ticketnumber", "AO38375804");
+        mockFileUploadRequest.Object.Metadata.Add("ticket-number", "AO38375804");
         comsService
             .Setup(_ => _.SaveFileAsync(It.IsAny<IFormFile>(), It.IsAny<Dictionary<string, string>>(), It.IsAny<CancellationToken>()))
             .Throws(new TooManyTagsException(It.IsAny<int>()));
@@ -210,7 +210,7 @@ public class ComsControllerTest
         var mockFileUploadRequest = new Mock<FileUploadRequest>();
         var comsService = new Mock<IComsService>();
         Guid guid = Guid.NewGuid();
-        mockFileUploadRequest.Object.Metadata.Add("ticketnumber", "AO38375804");
+        mockFileUploadRequest.Object.Metadata.Add("ticket-number", "AO38375804");
         comsService
             .Setup(_ => _.SaveFileAsync(It.IsAny<IFormFile>(), It.IsAny<Dictionary<string, string>>(), It.IsAny<CancellationToken>()))
             .Throws(new ObjectManagementServiceException(It.IsAny<string>()));
@@ -235,7 +235,7 @@ public class ComsControllerTest
         Coms.Client.File mockFile = new(fileStream, "testFile");
         var comsService = new Mock<IComsService>();
         Guid guid = Guid.NewGuid();
-        mockFile.Metadata.Add("ticketnumber", "AO38375804");
+        mockFile.Metadata.Add("ticket-number", "AO38375804");
         mockFile.Metadata.Add("virus-scan-status", "clean");
         var filename = mockFile.FileName;
         comsService
@@ -260,7 +260,7 @@ public class ComsControllerTest
         Coms.Client.File mockFile = new(fileStream, "testFile");
         var comsService = new Mock<IComsService>();
         Guid guid = Guid.NewGuid();
-        mockFile.Metadata.Add("ticketnumber", "AO38375804");
+        mockFile.Metadata.Add("ticket-number", "AO38375804");
         var filename = mockFile.FileName;
         comsService
             .Setup(_ => _.GetFileAsync(guid, It.IsAny<CancellationToken>()))
@@ -286,7 +286,7 @@ public class ComsControllerTest
         Coms.Client.File mockFile = new(fileStream, "testFile");
         var comsService = new Mock<IComsService>();
         Guid guid = Guid.NewGuid();
-        mockFile.Metadata.Add("ticketnumber", "AO38375804");
+        mockFile.Metadata.Add("ticket-number", "AO38375804");
         mockFile.Metadata.Add("virus-scan-status", "unscanned");
         var filename = mockFile.FileName;
         comsService

--- a/src/backend/TrafficCourts/TrafficCourts.Staff.Service.Test/Controllers/JJControllerTest.cs
+++ b/src/backend/TrafficCourts/TrafficCourts.Staff.Service.Test/Controllers/JJControllerTest.cs
@@ -1,20 +1,16 @@
-﻿using FluentAssertions;
-using FluentAssertions.Types;
-using Microsoft.AspNetCore.Authorization;
-using Microsoft.AspNetCore.Http;
+﻿using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using Moq;
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Reflection;
+using System.Net;
 using System.Threading;
-using TrafficCourts.Common.Authorization;
 using TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0;
+using TrafficCourts.Coms.Client;
 using TrafficCourts.Staff.Service.Controllers;
 using TrafficCourts.Staff.Service.Services;
 using Xunit;
+using ApiException = TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0.ApiException;
 
 namespace TrafficCourts.Staff.Service.Test.Controllers;
 
@@ -280,5 +276,124 @@ public class JJControllerTest
         // Assert
         var methodNotAllowedResult = Assert.IsType<HttpError>(result);
         Assert.Equal(StatusCodes.Status405MethodNotAllowed, methodNotAllowedResult.StatusCode);
+    }
+
+    [Fact]
+    public async void TestGetJJDispute200Result()
+    {
+        // Arrange
+        JJDispute dispute = new();
+        string ticketnumber = "AJ201092461";
+        dispute.TicketNumber = ticketnumber;
+        var jjDisputeService = new Mock<IJJDisputeService>();
+
+        jjDisputeService
+            .Setup(_ => _.GetJJDisputeAsync(ticketnumber, false, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(dispute);
+        var mockLogger = new Mock<ILogger<JJController>>();
+        JJController jjDisputeController = new(jjDisputeService.Object, mockLogger.Object);
+
+        // Act
+        IActionResult? result = await jjDisputeController.GetJJDisputeAsync(ticketnumber, false, CancellationToken.None);
+
+        // Assert
+        var okResult = Assert.IsType<OkObjectResult>(result);
+        Assert.Equal(dispute, okResult.Value);
+    }
+
+    [Fact]
+    public async void TestGetJJDispute400Result()
+    {
+        // Arrange
+        JJDispute dispute = new();
+        string ticketnumber = "AJ201092461";
+        dispute.TicketNumber = ticketnumber;
+        var jjDisputeService = new Mock<IJJDisputeService>();
+
+        jjDisputeService
+            .Setup(_ => _.GetJJDisputeAsync(null!, false, It.IsAny<CancellationToken>()))
+            .Throws(new ApiException("msg", StatusCodes.Status400BadRequest, "rsp", null, null));
+        var mockLogger = new Mock<ILogger<JJController>>();
+        JJController jjDisputeController = new(jjDisputeService.Object, mockLogger.Object);
+
+        // Act
+        IActionResult? result = await jjDisputeController.GetJJDisputeAsync(null!, false, CancellationToken.None);
+
+        // Assert
+        var badRequestResult = Assert.IsType<HttpError>(result);
+        Assert.Equal(StatusCodes.Status400BadRequest, badRequestResult.StatusCode);
+    }
+
+    [Fact]
+    public async void TestGetJJDispute404Result()
+    {
+        // Arrange
+        JJDispute dispute = new();
+        string ticketnumber = "AJ201092461";
+        dispute.TicketNumber = ticketnumber;
+        var jjDisputeService = new Mock<IJJDisputeService>();
+
+        jjDisputeService
+            .Setup(_ => _.GetJJDisputeAsync(ticketnumber, false, It.IsAny<CancellationToken>()))
+            .Throws(new ApiException("msg", StatusCodes.Status404NotFound, "rsp", null, null));
+        var mockLogger = new Mock<ILogger<JJController>>();
+        JJController jjDisputeController = new(jjDisputeService.Object, mockLogger.Object);
+
+        // Act
+        IActionResult? result = await jjDisputeController.GetJJDisputeAsync(ticketnumber, false, CancellationToken.None);
+
+        // Assert
+        var notFoundResult = Assert.IsType<HttpError>(result);
+        Assert.Equal(StatusCodes.Status404NotFound, notFoundResult.StatusCode);
+    }
+
+    [Fact]
+    public async void TestGetJJDisputeDisputeAssigned409Result()
+    {
+        // Arrange
+        JJDispute dispute = new();
+        string ticketnumber = "AJ201092461";
+        dispute.TicketNumber = ticketnumber;
+        var jjDisputeService = new Mock<IJJDisputeService>();
+
+        jjDisputeService
+            .Setup(_ => _.GetJJDisputeAsync(ticketnumber, true, It.IsAny<CancellationToken>()))
+            .Throws(new ApiException("msg", StatusCodes.Status409Conflict, "rsp", null, null));
+        var mockLogger = new Mock<ILogger<JJController>>();
+        JJController jjDisputeController = new(jjDisputeService.Object, mockLogger.Object);
+
+        // Act
+        IActionResult? result = await jjDisputeController.GetJJDisputeAsync(ticketnumber, true, CancellationToken.None);
+
+        // Assert
+        var objectResult = Assert.IsType<ObjectResult>(result);
+        var problemDetails = Assert.IsType<ProblemDetails>(objectResult.Value);
+        Assert.Equal((int)HttpStatusCode.Conflict, problemDetails.Status);
+        Assert.True(problemDetails?.Title?.Contains("JJ Dispute Already Assigned"));
+    }
+
+    [Fact]
+    public async void TestGetJJDisputeThrowsObjectManagementServiceException500Result()
+    {
+        // Arrange
+        JJDispute dispute = new();
+        string ticketnumber = "AJ201092461";
+        dispute.TicketNumber = ticketnumber;
+        var jjDisputeService = new Mock<IJJDisputeService>();
+
+        jjDisputeService
+            .Setup(_ => _.GetJJDisputeAsync(ticketnumber, true, It.IsAny<CancellationToken>()))
+            .Throws(new ObjectManagementServiceException(It.IsAny<string>()));
+        var mockLogger = new Mock<ILogger<JJController>>();
+        JJController jjDisputeController = new(jjDisputeService.Object, mockLogger.Object);
+
+        // Act
+        IActionResult? result = await jjDisputeController.GetJJDisputeAsync(ticketnumber, true, CancellationToken.None);
+
+        // Assert
+        var objectResult = Assert.IsType<ObjectResult>(result);
+        var problemDetails = Assert.IsType<ProblemDetails>(objectResult.Value);
+        Assert.Equal((int)HttpStatusCode.InternalServerError, problemDetails.Status);
+        Assert.True(problemDetails?.Title?.Contains("Error Invoking COMS"));
     }
 }


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- [TCVP-2000](https://justice.gov.bc.ca/jira/browse/TCVP-2000)
- Added functionality to return all the related file IDs in a dictionary as keys while filenames as values of the uploaded documents through COMS when returning a single JJDispute.
- Added XUnit tests for the controller endpoint.
- Fixed a small bug with authorization for the COMS file upload endpoint.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
