### PR TITLE
TCVP-2097 fix bug related to fetching metadata

### DIFF
--- a/src/backend/TrafficCourts/TrafficCourts.Coms.Client.Test/ClientTests/SearchObjectsAsync.cs
+++ b/src/backend/TrafficCourts/TrafficCourts.Coms.Client.Test/ClientTests/SearchObjectsAsync.cs
@@ -12,7 +12,7 @@ public class SearchObjectsAsync : ObjectManagementBase
 
     [Theory]
     [MemberData(nameof(TestCases))]
-    public async Task X(IDictionary<string, string>? meta, IList<Guid>? objIds, string? path, bool? active, bool? @public, string? mimeType, string? name, IDictionary<string, string>? tags)
+    public async Task calls_client_with_correct_parameters(Dictionary<string, string>? meta, IList<Guid>? objIds, string? path, bool? active, bool? @public, string? mimeType, string? name, Dictionary<string, string>? tags)
     {
         List<DBObject> expected = _fixture.CreateMany<DBObject>().ToList();
 

--- a/src/backend/TrafficCourts/TrafficCourts.Coms.Client.Test/IntegrationTest.cs
+++ b/src/backend/TrafficCourts/TrafficCourts.Coms.Client.Test/IntegrationTest.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Moq;
 using Xunit.Abstractions;
@@ -131,7 +131,12 @@ namespace TrafficCourts.Coms.Client.Test
                 expectedFile.Tags.Add(Guid.NewGuid().ToString("n")[0..6], Guid.NewGuid().ToString("n"));
             }
 
+            // expect the file id to be null before creation
+            Assert.Null(expectedFile.Id);
             var id = await _service.CreateFileAsync(expectedFile, _cancellationToken);
+
+            // expect the file id to set after creation
+            Assert.Equal(id, expectedFile.Id);
 
             using var actualFile = await _service.GetFileAsync(id, false, _cancellationToken);
 

--- a/src/backend/TrafficCourts/TrafficCourts.Coms.Client.Test/ServiceTests/CreateFileAsync.cs
+++ b/src/backend/TrafficCourts/TrafficCourts.Coms.Client.Test/ServiceTests/CreateFileAsync.cs
@@ -77,8 +77,8 @@ public class CreateFileAsync : ObjectManagementServiceTest
 
         // simulate success
         _mockClient.Setup(_ => _.CreateObjectsAsync(
-            It.IsAny<IDictionary<string, string>>(),
-            It.IsAny<IDictionary<string, string>>(),
+            It.IsAny<IReadOnlyDictionary<string, string>>(),
+            It.IsAny<IReadOnlyDictionary<string, string>>(),
             It.IsAny<FileParameter>(),
             It.IsAny<CancellationToken>()))
             .ReturnsAsync(() =>
@@ -99,8 +99,8 @@ public class CreateFileAsync : ObjectManagementServiceTest
         // verify the client called with correct values
         _mockClient.Verify(_ =>
             _.CreateObjectsAsync(
-                It.Is<IDictionary<string, string>>((_) => _ == file.Metadata),
-                It.Is<IDictionary<string, string>>((_) => _ == file.Tags),
+                It.Is<IReadOnlyDictionary<string, string>>((_) => _ == file.Metadata),
+                It.Is<IReadOnlyDictionary<string, string>>((_) => _ == file.Tags),
                 It.Is<FileParameter>((_) => _.Data == expectedStream && _.FileName == expectedFilename && _.ContentType == expectedContentType),
                 It.Is<CancellationToken>((cancellationToken) => cancellationToken == cts.Token))
             );

--- a/src/backend/TrafficCourts/TrafficCourts.Coms.Client.Test/ServiceTests/GetFileAsync.cs
+++ b/src/backend/TrafficCourts/TrafficCourts.Coms.Client.Test/ServiceTests/GetFileAsync.cs
@@ -13,12 +13,17 @@ public class GetFileAsync : ObjectManagementServiceTest
         Dictionary<string, IEnumerable<string>> headers = new()
         {
             { "x-amz-meta-id", new string[] { id.ToString("d") } },
-            { "x-amz-meta-name", new string[] { "filename.png" } },
-            { "x-amz-meta-type", new string[] { "picture" } }
+            { "x-amz-meta-name", new string[] { "filename.png" } }
+        };
+
+        List<MetadataItem> metadataItems = new List<MetadataItem>
+        {
+            new MetadataItem { Key = "type", Value = "picture" }
         };
 
         var stream = GetRandomStream();
         SetupReadObjectReturn(new FileResponse(200, headers, stream, null, null));
+        SetupGetObjectMetadataAsync(new[] { new ObjectMetadata { Id = id, Metadata = metadataItems } });
 
         CancellationTokenSource cts = new CancellationTokenSource();
 

--- a/src/backend/TrafficCourts/TrafficCourts.Coms.Client.Test/ServiceTests/ObjectManagementServiceTest.cs
+++ b/src/backend/TrafficCourts/TrafficCourts.Coms.Client.Test/ServiceTests/ObjectManagementServiceTest.cs
@@ -50,8 +50,16 @@ public abstract class ObjectManagementServiceTest
             .ReturnsAsync(() => response);
     }
 
+    protected void SetupGetObjectMetadataAsync(IList<ObjectMetadata> response)
+    {
+        _mockClient.Setup(_ => _.GetObjectMetadataAsync(
+                It.IsAny<IList<Guid>>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() => response);
+    }
 
-    protected static bool Equal(IDictionary<string, string> expected, IDictionary<string, string> actual)
+
+    protected static bool Equal(IReadOnlyDictionary<string, string> expected, IReadOnlyDictionary<string, string> actual)
     {
         if (expected.Count != actual.Count)
         {

--- a/src/backend/TrafficCourts/TrafficCourts.Coms.Client.Test/ServiceTests/UpdateFileAsync.cs
+++ b/src/backend/TrafficCourts/TrafficCourts.Coms.Client.Test/ServiceTests/UpdateFileAsync.cs
@@ -17,9 +17,9 @@ public class UpdateFileAsync : ObjectManagementServiceTest
 
         // simulate success
         _mockClient.Setup(_ => _.UpdateObjectAsync(
-            It.IsAny<IDictionary<string, string>?>(),
+            It.IsAny<IReadOnlyDictionary<string, string>?>(),
             It.IsAny<Guid>(),
-            It.IsAny<IDictionary<string, string>?>(),
+            It.IsAny<IReadOnlyDictionary<string, string>?>(),
             It.IsAny<FileParameter>(),
             It.IsAny<CancellationToken>()))
             .ReturnsAsync(() =>
@@ -38,9 +38,9 @@ public class UpdateFileAsync : ObjectManagementServiceTest
         // verify the client called with correct values
         _mockClient.Verify(_ =>
             _.UpdateObjectAsync(
-                It.Is<IDictionary<string, string>>((_) => Equal(file.Metadata, _)),
+                It.Is<IReadOnlyDictionary<string, string>>((_) => Equal(file.Metadata, _)),
                 It.Is<Guid>((_) => _ == expectedId),
-                It.Is<IDictionary<string, string>>((_) => Equal(file.Tags, _)),
+                It.Is<IReadOnlyDictionary<string, string>>((_) => Equal(file.Tags, _)),
                 It.Is<FileParameter>((_) => _.Data == expectedStream && _.FileName == expectedFilename && _.ContentType == expectedContentType),
                 It.Is<CancellationToken>((cancellationToken) => cancellationToken == cts.Token))
             );

--- a/src/backend/TrafficCourts/TrafficCourts.Coms.Client/ComsJsonContext.cs
+++ b/src/backend/TrafficCourts/TrafficCourts.Coms.Client/ComsJsonContext.cs
@@ -1,0 +1,9 @@
+﻿using System.Text.Json.Serialization;
+
+namespace TrafficCourts.Coms.Client;
+
+[JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
+[JsonSerializable(typeof(ObjectMetadataCollection))]
+internal partial class ComsJsonContext : JsonSerializerContext
+{
+}

--- a/src/backend/TrafficCourts/TrafficCourts.Coms.Client/Factory.cs
+++ b/src/backend/TrafficCourts/TrafficCourts.Coms.Client/Factory.cs
@@ -5,7 +5,7 @@ internal static class Factory
     /// <summary>
     /// Creates the Metadata dictionary from the source with the correct <see cref="IEqualityComparer"/>.
     /// </summary>
-    public static Dictionary<string, string> CreateMetadata(IDictionary<string, string>? source = null)
+    public static Dictionary<string, string> CreateMetadata(IEnumerable<KeyValuePair<string, string>>? source = null)
     {
         if (source is null)
         {
@@ -18,7 +18,7 @@ internal static class Factory
     /// <summary>
     /// Creates the Tags dictionary from the source with the correct <see cref="IEqualityComparer"/>.
     /// </summary>
-    public static Dictionary<string, string> CreateTags(IDictionary<string, string>? source = null)
+    public static Dictionary<string, string> CreateTags(IEnumerable<KeyValuePair<string, string>>? source = null)
     {
         if (source is null)
         {

--- a/src/backend/TrafficCourts/TrafficCourts.Coms.Client/File.cs
+++ b/src/backend/TrafficCourts/TrafficCourts.Coms.Client/File.cs
@@ -23,7 +23,13 @@ public partial class File : IDisposable
     }
 
     public File(Stream data, string? fileName, string? contentType, IDictionary<string, string>? metadata, IDictionary<string, string>? tags)
+        : this(null, data, fileName, contentType, metadata, tags)
     {
+    }
+
+    public File(Guid? id, Stream data, string? fileName, string? contentType, IDictionary<string, string>? metadata, IDictionary<string, string>? tags)
+    {
+        Id = id;
         Data = data;
         FileName = fileName;
         ContentType = contentType;
@@ -31,6 +37,11 @@ public partial class File : IDisposable
         Metadata = Factory.CreateMetadata(metadata);
         Tags = Factory.CreateTags(tags);
     }
+
+    /// <summary>
+    /// The id of the document. Only set when getting documents.
+    /// </summary>
+    public Guid? Id { get; internal set; }
 
     public Stream Data { get; private set; }
 

--- a/src/backend/TrafficCourts/TrafficCourts.Coms.Client/IObjectManagementClient.cs
+++ b/src/backend/TrafficCourts/TrafficCourts.Coms.Client/IObjectManagementClient.cs
@@ -8,24 +8,24 @@ public interface IObjectManagementClient
     string BaseUrl { get; set; }
     bool ReadResponseAsString { get; set; }
 
-    Task AddMetadataAsync(IDictionary<string, string>? meta, Guid objId, string? versionId);
-    Task AddMetadataAsync(IDictionary<string, string>? meta, Guid objId, string? versionId, CancellationToken cancellationToken);
+    Task AddMetadataAsync(IReadOnlyDictionary<string, string>? meta, Guid objId, string? versionId);
+    Task AddMetadataAsync(IReadOnlyDictionary<string, string>? meta, Guid objId, string? versionId, CancellationToken cancellationToken);
     Task<List<DBObjectPermission>> AddPermissionsAsync(Guid objId, IEnumerable<RequestPermissionTuple>? body);
     Task<List<DBObjectPermission>> AddPermissionsAsync(Guid objId, IEnumerable<RequestPermissionTuple>? body, CancellationToken cancellationToken);
-    Task AddTaggingAsync(Guid objId, IDictionary<string, string>? tags, string? versionId);
-    Task AddTaggingAsync(Guid objId, IDictionary<string, string>? tags, string? versionId, CancellationToken cancellationToken);
-    Task<List<Anonymous>> CreateObjectsAsync(IDictionary<string, string>? meta, IDictionary<string, string>? tags, FileParameter anyKey);
-    Task<List<Anonymous>> CreateObjectsAsync(IDictionary<string, string>? meta, IDictionary<string, string>? tags, FileParameter anyKey, CancellationToken cancellationToken);
-    Task DeleteMetadataAsync(IDictionary<string, string>? meta, Guid objId, string? versionId);
-    Task DeleteMetadataAsync(IDictionary<string, string>? meta, Guid objId, string? versionId, CancellationToken cancellationToken);
+    Task AddTaggingAsync(Guid objId, IReadOnlyDictionary<string, string>? tags, string? versionId);
+    Task AddTaggingAsync(Guid objId, IReadOnlyDictionary<string, string>? tags, string? versionId, CancellationToken cancellationToken);
+    Task<List<Anonymous>> CreateObjectsAsync(IReadOnlyDictionary<string, string>? meta, IReadOnlyDictionary<string, string>? tags, FileParameter anyKey);
+    Task<List<Anonymous>> CreateObjectsAsync(IReadOnlyDictionary<string, string>? meta, IReadOnlyDictionary<string, string>? tags, FileParameter anyKey, CancellationToken cancellationToken);
+    Task DeleteMetadataAsync(IReadOnlyDictionary<string, string>? meta, Guid objId, string? versionId);
+    Task DeleteMetadataAsync(IReadOnlyDictionary<string, string>? meta, Guid objId, string? versionId, CancellationToken cancellationToken);
     Task<ResponseObjectDeleted> DeleteObjectAsync(Guid objId, string? versionId);
     Task<ResponseObjectDeleted> DeleteObjectAsync(Guid objId, string? versionId, CancellationToken cancellationToken);
-    Task DeleteTaggingAsync(Guid objId, IDictionary<string, string>? tags, string? versionId);
-    Task DeleteTaggingAsync(Guid objId, IDictionary<string, string>? tags, string? versionId, CancellationToken cancellationToken);
-    Task<List<S3TagSet>> GetMetadataAsync(IDictionary<string, string>? meta);
-    Task<List<S3TagSet>> GetMetadataAsync(IDictionary<string, string>? meta, CancellationToken cancellationToken);
-    Task<List<S3TagSet>> GetTaggingAsync(IDictionary<string, string>? tags);
-    Task<List<S3TagSet>> GetTaggingAsync(IDictionary<string, string>? tags, CancellationToken cancellationToken);
+    Task DeleteTaggingAsync(Guid objId, IReadOnlyDictionary<string, string>? tags, string? versionId);
+    Task DeleteTaggingAsync(Guid objId, IReadOnlyDictionary<string, string>? tags, string? versionId, CancellationToken cancellationToken);
+    Task<List<S3TagSet>> GetMetadataAsync(IReadOnlyDictionary<string, string>? meta);
+    Task<List<S3TagSet>> GetMetadataAsync(IReadOnlyDictionary<string, string>? meta, CancellationToken cancellationToken);
+    Task<List<S3TagSet>> GetTaggingAsync(IReadOnlyDictionary<string, string>? tags);
+    Task<List<S3TagSet>> GetTaggingAsync(IReadOnlyDictionary<string, string>? tags, CancellationToken cancellationToken);
     Task HeadObjectAsync(Guid objId, string? versionId);
     Task HeadObjectAsync(Guid objId, string? versionId, CancellationToken cancellationToken);
     Task<List<DBIdentityProvider>> ListIdpsAsync(bool? active);
@@ -38,18 +38,33 @@ public interface IObjectManagementClient
     Task<FileResponse> ReadObjectAsync(Guid objId, DownloadMode? download, int? expiresIn, string? versionId, CancellationToken cancellationToken);
     Task<List<DBObjectPermission>> RemovePermissionsAsync(Guid objId, Guid? userId, PermCode? permCode);
     Task<List<DBObjectPermission>> RemovePermissionsAsync(Guid objId, Guid? userId, PermCode? permCode, CancellationToken cancellationToken);
-    Task ReplaceMetadataAsync(IDictionary<string, string>? meta, Guid objId, string? versionId);
-    Task ReplaceMetadataAsync(IDictionary<string, string>? meta, Guid objId, string? versionId, CancellationToken cancellationToken);
-    Task ReplaceTaggingAsync(Guid objId, IDictionary<string, string>? tags, string? versionId);
-    Task ReplaceTaggingAsync(Guid objId, IDictionary<string, string>? tags, string? versionId, CancellationToken cancellationToken);
-    Task<List<DBObject>> SearchObjectsAsync(IDictionary<string, string>? meta, IList<Guid>? objIds, string? path, bool? active, bool? @public, string? mimeType, string? name, IDictionary<string, string>? tags);
-    Task<List<DBObject>> SearchObjectsAsync(IDictionary<string, string>? meta, IList<Guid>? objIds, string? path, bool? active, bool? @public, string? mimeType, string? name, IDictionary<string, string>? tags, CancellationToken cancellationToken);
+    Task ReplaceMetadataAsync(IReadOnlyDictionary<string, string>? meta, Guid objId, string? versionId);
+    Task ReplaceMetadataAsync(IReadOnlyDictionary<string, string>? meta, Guid objId, string? versionId, CancellationToken cancellationToken);
+    Task ReplaceTaggingAsync(Guid objId, IReadOnlyDictionary<string, string>? tags, string? versionId);
+    Task ReplaceTaggingAsync(Guid objId, IReadOnlyDictionary<string, string>? tags, string? versionId, CancellationToken cancellationToken);
+    Task<List<DBObject>> SearchObjectsAsync(IReadOnlyDictionary<string, string>? meta, IList<Guid>? objIds, string? path, bool? active, bool? @public, string? mimeType, string? name, IReadOnlyDictionary<string, string>? tags);
+    Task<List<DBObject>> SearchObjectsAsync(IReadOnlyDictionary<string, string>? meta, IList<Guid>? objIds, string? path, bool? active, bool? @public, string? mimeType, string? name, IReadOnlyDictionary<string, string>? tags, CancellationToken cancellationToken);
     Task<List<DBObjectPermission>> SearchPermissionsAsync(Guid? objId, Guid? userId, PermCode? permCode);
     Task<List<DBObjectPermission>> SearchPermissionsAsync(Guid? objId, Guid? userId, PermCode? permCode, CancellationToken cancellationToken);
     Task<List<DBUser>> SearchUsersAsync(Guid? userId, Guid? identityId, string? idp, string? username, string? email, string? firstName, string? fullName, string? lastName, bool? active, string? search);
     Task<List<DBUser>> SearchUsersAsync(Guid? userId, Guid? identityId, string? idp, string? username, string? email, string? firstName, string? fullName, string? lastName, bool? active, string? search, CancellationToken cancellationToken);
     Task<DBObject> TogglePublicAsync(Guid objId, bool? @public);
     Task<DBObject> TogglePublicAsync(Guid objId, bool? @public, CancellationToken cancellationToken);
-    Task<Response> UpdateObjectAsync(IDictionary<string, string>? meta, Guid objId, IDictionary<string, string>? tags, FileParameter anyKey);
-    Task<Response> UpdateObjectAsync(IDictionary<string, string>? meta, Guid objId, IDictionary<string, string>? tags, FileParameter anyKey, CancellationToken cancellationToken);
+    Task<Response> UpdateObjectAsync(IReadOnlyDictionary<string, string>? meta, Guid objId, IReadOnlyDictionary<string, string>? tags, FileParameter anyKey);
+    Task<Response> UpdateObjectAsync(IReadOnlyDictionary<string, string>? meta, Guid objId, IReadOnlyDictionary<string, string>? tags, FileParameter anyKey, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Get the metadata for a list of documents.
+    /// </summary>
+    /// <param name="ids">The list of documents to fetch metadata for</param>
+    /// <param name="cancellationToken"></param>
+    /// <returns></returns>
+    Task<IList<ObjectMetadata>> GetObjectMetadataAsync(IList<Guid> ids, CancellationToken cancellationToken);
+    /// <summary>
+    /// Get the metadata for a single document.
+    /// </summary>
+    /// <param name="id">The id of document to fetch metadata for</param>
+    /// <param name="cancellationToken"></param>
+    /// <returns></returns>
+    Task<ObjectMetadata?> GetObjectMetadataAsync(Guid id, CancellationToken cancellationToken);
 }

--- a/src/backend/TrafficCourts/TrafficCourts.Coms.Client/MetadataValidator.cs
+++ b/src/backend/TrafficCourts/TrafficCourts.Coms.Client/MetadataValidator.cs
@@ -41,7 +41,7 @@ public static class MetadataValidator
     /// <param name="items"></param>
     /// <exception cref="MetadataInvalidKeyException">A key contains an invalid character</exception>
     /// <exception cref="MetadataTooLongException">The total length of the metadata is too long</exception>
-    public static void Validate(IDictionary<string, string>? items)
+    public static void Validate(IReadOnlyDictionary<string, string>? items)
     {
         // no metadata is ok
         if (items is null)
@@ -53,7 +53,7 @@ public static class MetadataValidator
         ValidateLength(items);
     }
 
-    private static void ValidateKeys(IDictionary<string, string> items)
+    private static void ValidateKeys(IReadOnlyDictionary<string, string> items)
     {
         foreach (var item in items)
         {
@@ -77,7 +77,7 @@ public static class MetadataValidator
         }
     }
 
-    private static void ValidateLength(IDictionary<string, string> items)
+    private static void ValidateLength(IReadOnlyDictionary<string, string> items)
     {
         int prefixLength = "x-amz-meta-".Length;
 
@@ -103,7 +103,7 @@ public static class MetadataValidator
 
 public static class TagValidator
 {
-    public static void Validate(Dictionary<string, string>? items)
+    public static void Validate(IReadOnlyDictionary<string, string>? items)
     {
         if (items is null)
         {

--- a/src/backend/TrafficCourts/TrafficCourts.Coms.Client/Models.cs
+++ b/src/backend/TrafficCourts/TrafficCourts.Coms.Client/Models.cs
@@ -8,6 +8,11 @@ public class ObjectMetadataCollection : List<ObjectMetadata>
 
 public class ObjectMetadata
 {
+    public ObjectMetadata()
+    {
+        Metadata = new List<MetadataItem>();
+    }
+
     public string? VersionId { get; set; }
 
     [JsonPropertyName("objectId")]

--- a/src/backend/TrafficCourts/TrafficCourts.Coms.Client/Models.cs
+++ b/src/backend/TrafficCourts/TrafficCourts.Coms.Client/Models.cs
@@ -1,0 +1,36 @@
+﻿using System.Text.Json.Serialization;
+
+namespace TrafficCourts.Coms.Client;
+
+public class ObjectMetadataCollection : List<ObjectMetadata>
+{
+}
+
+public class ObjectMetadata
+{
+    public string? VersionId { get; set; }
+
+    [JsonPropertyName("objectId")]
+    public Guid Id { get; set; }
+
+    public string? MimeType { get; set; }
+
+    public bool DeleteMarker { get; set; }
+
+    public Guid CreatedBy { get; set; }
+
+    public DateTime CreatedAt { get; set; }
+
+    public Guid? UpdatedBy { get; set; }
+
+    public DateTime UpdatedAt { get; set; }
+
+    public List<MetadataItem> Metadata { get; set; }
+}
+
+public class MetadataItem
+{
+    public string Key { get; set; } = string.Empty;
+
+    public string Value { get; set; } = string.Empty;
+}

--- a/src/backend/TrafficCourts/TrafficCourts.Coms.Client/ObjectManagementClient.cs
+++ b/src/backend/TrafficCourts/TrafficCourts.Coms.Client/ObjectManagementClient.cs
@@ -1,5 +1,152 @@
-﻿namespace TrafficCourts.Coms.Client;
+﻿using System.Text.Json;
+using System.Text.Json.Serialization.Metadata;
+
+namespace TrafficCourts.Coms.Client;
 
 public partial class ObjectManagementClient : IObjectManagementClient
 {
+    public async Task<IList<ObjectMetadata>> GetObjectMetadataAsync(IList<Guid> ids, CancellationToken cancellationToken)
+    {
+        var urlBuilder_ = new System.Text.StringBuilder();
+        urlBuilder_.Append(BaseUrl != null ? BaseUrl.TrimEnd('/') : "").Append("/object/metadata?");
+
+        RequestBuilder.AppendQueryObjectId(urlBuilder_, ids);
+        urlBuilder_.Length--;
+
+        var client_ = _httpClient;
+        var disposeClient_ = false;
+        try
+        {
+            using (var request_ = new HttpRequestMessage())
+            {
+                request_.Method = HttpMethod.Get;
+                request_.Headers.Accept.Add(System.Net.Http.Headers.MediaTypeWithQualityHeaderValue.Parse("application/json"));
+
+                PrepareRequest(client_, request_, urlBuilder_);
+
+                var url_ = urlBuilder_.ToString();
+                request_.RequestUri = new Uri(url_, UriKind.RelativeOrAbsolute);
+
+                var response_ = await client_.SendAsync(request_, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+                var disposeResponse_ = true;
+
+                try
+                {
+                    var headers_ = Enumerable.ToDictionary(response_.Headers, h_ => h_.Key, h_ => h_.Value);
+                    if (response_.Content != null && response_.Content.Headers != null)
+                    {
+                        foreach (var item_ in response_.Content.Headers)
+                            headers_[item_.Key] = item_.Value;
+                    }
+
+                    ProcessResponse(client_, response_);
+
+                    var status_ = (int)response_.StatusCode;
+                    if (status_ == 200)
+                    {
+                        var objectResponse_ = await ReadObjectResponseAsync(response_, ComsJsonContext.Default.ObjectMetadataCollection, headers_, cancellationToken);
+                        if (objectResponse_.Object == null)
+                        {
+                            throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                        }
+                        return objectResponse_.Object;
+                    }
+                    else
+                    if (status_ == 401)
+                    {
+                        var objectResponse_ = await ReadObjectResponseAsync<ResponseUnauthorized>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                        if (objectResponse_.Object == null)
+                        {
+                            throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                        }
+                        throw new ApiException<ResponseUnauthorized>("Unauthorized", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                    }
+                    else
+                    if (status_ == 403)
+                    {
+                        var objectResponse_ = await ReadObjectResponseAsync<ResponseForbidden>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                        if (objectResponse_.Object == null)
+                        {
+                            throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                        }
+                        throw new ApiException<ResponseForbidden>("Forbidden", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                    }
+                    else
+                    {
+                        var objectResponse_ = await ReadObjectResponseAsync<ResponseError>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                        if (objectResponse_.Object == null)
+                        {
+                            throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                        }
+                        throw new ApiException<ResponseError>("Internal Server Error", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                    }
+                }
+                finally
+                {
+                    if (disposeResponse_)
+                        response_.Dispose();
+                }
+            }
+        }
+        finally
+        {
+            if (disposeClient_)
+                client_.Dispose();
+        }
+    }
+
+    public async Task<ObjectMetadata?> GetObjectMetadataAsync(Guid id, CancellationToken cancellationToken)
+    {
+        var response = await GetObjectMetadataAsync(new[] { id }, cancellationToken).ConfigureAwait(false);
+
+        if (response.Count == 0)
+        {            
+            return null; // not found
+        }
+
+        return response[0];
+    }
+
+    private async Task<ObjectResponseResult<T>> ReadObjectResponseAsync<T>(
+        HttpResponseMessage response, 
+        JsonTypeInfo<T> typeInfo,
+        IReadOnlyDictionary<string, IEnumerable<string>> headers,
+        CancellationToken cancellationToken)
+    {
+        if (response == null || response.Content == null)
+        {
+            return new ObjectResponseResult<T>(default(T)!, string.Empty);
+        }
+
+        if (ReadResponseAsString)
+        {
+            var responseText = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+            try
+            {
+                var typedBody = JsonSerializer.Deserialize(responseText, typeInfo);
+                return new ObjectResponseResult<T>(typedBody!, responseText);
+            }
+            catch (JsonException exception)
+            {
+                var message = "Could not deserialize the response body string as " + typeof(T).FullName + ".";
+                throw new ApiException(message, (int)response.StatusCode, responseText, headers, exception);
+            }
+        }
+        else
+        {
+            try
+            {
+                using (var responseStream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false))
+                {
+                    var typedBody = await JsonSerializer.DeserializeAsync<T>(responseStream, typeInfo, cancellationToken).ConfigureAwait(false);
+                    return new ObjectResponseResult<T>(typedBody!, string.Empty);
+                }
+            }
+            catch (JsonException exception)
+            {
+                var message = "Could not deserialize the response body stream as " + typeof(T).FullName + ".";
+                throw new ApiException(message, (int)response.StatusCode, string.Empty, headers, exception);
+            }
+        }
+    }
 }

--- a/src/backend/TrafficCourts/TrafficCourts.Coms.Client/ObjectManagementClient.cs
+++ b/src/backend/TrafficCourts/TrafficCourts.Coms.Client/ObjectManagementClient.cs
@@ -5,8 +5,23 @@ namespace TrafficCourts.Coms.Client;
 
 public partial class ObjectManagementClient : IObjectManagementClient
 {
+    private ComsJsonContext? _jsonContext = null;
+
+    /// <summary>
+    /// Gets the <see cref="JsonSerializerContext"/> with our JsonSerializerSettings
+    /// </summary>
+    private ComsJsonContext JsonSerializerContext
+    {
+        get
+        {
+            _jsonContext ??= new ComsJsonContext(JsonSerializerSettings);
+            return _jsonContext;
+        }
+    }
+    
     public async Task<IList<ObjectMetadata>> GetObjectMetadataAsync(IList<Guid> ids, CancellationToken cancellationToken)
     {
+        
         var urlBuilder_ = new System.Text.StringBuilder();
         urlBuilder_.Append(BaseUrl != null ? BaseUrl.TrimEnd('/') : "").Append("/object/metadata?");
 
@@ -44,7 +59,7 @@ public partial class ObjectManagementClient : IObjectManagementClient
                     var status_ = (int)response_.StatusCode;
                     if (status_ == 200)
                     {
-                        var objectResponse_ = await ReadObjectResponseAsync(response_, ComsJsonContext.Default.ObjectMetadataCollection, headers_, cancellationToken);
+                        var objectResponse_ = await ReadObjectResponseAsync(response_, JsonSerializerContext.ObjectMetadataCollection, headers_, cancellationToken);
                         if (objectResponse_.Object == null)
                         {
                             throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);

--- a/src/backend/TrafficCourts/TrafficCourts.Coms.Client/ObjectManagementClient.g.cs
+++ b/src/backend/TrafficCourts/TrafficCourts.Coms.Client/ObjectManagementClient.g.cs
@@ -45,7 +45,7 @@ public partial class ObjectManagementClient
     /// <param name="anyKey">This endpoint can accept an arbitrary number of form-data keys. There must be at least one key present, and every key must be unique. All keys shall contain a binary representation of the file to upload. In the response, each successfully uploaded file shall contain a 'fieldName' property corresponding to your custom defined keys.</param>
     /// <returns>Returns an array of created object data</returns>
     /// <exception cref="ApiException">A server side error occurred.</exception>
-    public virtual System.Threading.Tasks.Task<System.Collections.Generic.List<Anonymous>> CreateObjectsAsync(IDictionary<string, string>? meta, IDictionary<string, string>? tags, FileParameter anyKey)
+    public virtual System.Threading.Tasks.Task<System.Collections.Generic.List<Anonymous>> CreateObjectsAsync(IReadOnlyDictionary<string, string>? meta, IReadOnlyDictionary<string, string>? tags, FileParameter anyKey)
     {
         return CreateObjectsAsync(meta, tags, anyKey, System.Threading.CancellationToken.None);
     }
@@ -62,7 +62,7 @@ public partial class ObjectManagementClient
     /// <param name="anyKey">This endpoint can accept an arbitrary number of form-data keys. There must be at least one key present, and every key must be unique. All keys shall contain a binary representation of the file to upload. In the response, each successfully uploaded file shall contain a 'fieldName' property corresponding to your custom defined keys.</param>
     /// <returns>Returns an array of created object data</returns>
     /// <exception cref="ApiException">A server side error occurred.</exception>
-    public virtual async System.Threading.Tasks.Task<System.Collections.Generic.List<Anonymous>> CreateObjectsAsync(IDictionary<string, string>? meta, IDictionary<string, string>? tags, FileParameter anyKey, System.Threading.CancellationToken cancellationToken)
+    public virtual async System.Threading.Tasks.Task<System.Collections.Generic.List<Anonymous>> CreateObjectsAsync(IReadOnlyDictionary<string, string>? meta, IReadOnlyDictionary<string, string>? tags, FileParameter anyKey, System.Threading.CancellationToken cancellationToken)
     {
         var urlBuilder_ = new System.Text.StringBuilder();
         urlBuilder_.Append(BaseUrl != null ? BaseUrl.TrimEnd('/') : "").Append("/object?");
@@ -185,7 +185,7 @@ public partial class ObjectManagementClient
     /// <param name="tagset*">Tags for the object, defined as a Key/Value tag. The query must be formatted in deepObject style notation, where a tag-set made out of multiple tags would be encoded something similar to `tagset[Public]=a&amp;tagset[y]=b`. Only one value can exist for a given tag key.</param>
     /// <returns>Returns and array of objects</returns>
     /// <exception cref="ApiException">A server side error occurred.</exception>
-    public virtual System.Threading.Tasks.Task<System.Collections.Generic.List<DBObject>> SearchObjectsAsync(IDictionary<string, string>? meta, IList<Guid>? objIds, string? path, bool? active, bool? @public, string? mimeType, string? name, IDictionary<string, string>? tags)
+    public virtual System.Threading.Tasks.Task<System.Collections.Generic.List<DBObject>> SearchObjectsAsync(IReadOnlyDictionary<string, string>? meta, IList<Guid>? objIds, string? path, bool? active, bool? @public, string? mimeType, string? name, IReadOnlyDictionary<string, string>? tags)
     {
         return SearchObjectsAsync(meta, objIds, path, active, @public, mimeType, name, tags, System.Threading.CancellationToken.None);
     }
@@ -207,7 +207,7 @@ public partial class ObjectManagementClient
     /// <param name="tagset*">Tags for the object, defined as a Key/Value tag. The query must be formatted in deepObject style notation, where a tag-set made out of multiple tags would be encoded something similar to `tagset[Public]=a&amp;tagset[y]=b`. Only one value can exist for a given tag key.</param>
     /// <returns>Returns and array of objects</returns>
     /// <exception cref="ApiException">A server side error occurred.</exception>
-    public virtual async System.Threading.Tasks.Task<System.Collections.Generic.List<DBObject>> SearchObjectsAsync(IDictionary<string, string>? meta, IList<Guid>? objIds, string? path, bool? active, bool? @public, string? mimeType, string? name, IDictionary<string, string>? tags, System.Threading.CancellationToken cancellationToken)
+    public virtual async System.Threading.Tasks.Task<System.Collections.Generic.List<DBObject>> SearchObjectsAsync(IReadOnlyDictionary<string, string>? meta, IList<Guid>? objIds, string? path, bool? active, bool? @public, string? mimeType, string? name, IReadOnlyDictionary<string, string>? tags, System.Threading.CancellationToken cancellationToken)
     {
         var urlBuilder_ = new System.Text.StringBuilder();
         urlBuilder_.Append(BaseUrl != null ? BaseUrl.TrimEnd('/') : "").Append("/object?");
@@ -600,7 +600,7 @@ public partial class ObjectManagementClient
     /// <param name="anyKey">This endpoint will accept only one arbitrary form-data key. That key shall contain a binary representation of the file to upload. In the response, the successfully uploaded file shall contain a 'fieldName' property corresponding to your custom defined key.</param>
     /// <returns>Returns the updated object data</returns>
     /// <exception cref="ApiException">A server side error occurred.</exception>
-    public virtual System.Threading.Tasks.Task<Response> UpdateObjectAsync(IDictionary<string, string>? meta, System.Guid objId, IDictionary<string, string>? tags, FileParameter anyKey)
+    public virtual System.Threading.Tasks.Task<Response> UpdateObjectAsync(IReadOnlyDictionary<string, string>? meta, System.Guid objId, IReadOnlyDictionary<string, string>? tags, FileParameter anyKey)
     {
         return UpdateObjectAsync(meta, objId, tags, anyKey, System.Threading.CancellationToken.None);
     }
@@ -618,7 +618,7 @@ public partial class ObjectManagementClient
     /// <param name="anyKey">This endpoint will accept only one arbitrary form-data key. That key shall contain a binary representation of the file to upload. In the response, the successfully uploaded file shall contain a 'fieldName' property corresponding to your custom defined key.</param>
     /// <returns>Returns the updated object data</returns>
     /// <exception cref="ApiException">A server side error occurred.</exception>
-    public virtual async System.Threading.Tasks.Task<Response> UpdateObjectAsync(IDictionary<string, string>? meta, System.Guid objId, IDictionary<string, string>? tags, FileParameter anyKey, System.Threading.CancellationToken cancellationToken)
+    public virtual async System.Threading.Tasks.Task<Response> UpdateObjectAsync(IReadOnlyDictionary<string, string>? meta, System.Guid objId, IReadOnlyDictionary<string, string>? tags, FileParameter anyKey, System.Threading.CancellationToken cancellationToken)
     {
         var urlBuilder_ = new System.Text.StringBuilder();
         urlBuilder_.Append(BaseUrl != null ? BaseUrl.TrimEnd('/') : "").Append("/object/{objId}?");
@@ -1088,7 +1088,7 @@ public partial class ObjectManagementClient
     /// <param name="x_amz_meta_*">An arbitrary metadata key/value pair. Must contain the Public-amz-meta- prefix to be valid. Multiple metadata pairs can be defined. keys must be unique and will be converted to lowercase.</param>
     /// <returns>Returns an array of matching key/value pairs.</returns>
     /// <exception cref="ApiException">A server side error occurred.</exception>
-    public virtual System.Threading.Tasks.Task<System.Collections.Generic.List<S3TagSet>> GetMetadataAsync(IDictionary<string, string>? meta)
+    public virtual System.Threading.Tasks.Task<System.Collections.Generic.List<S3TagSet>> GetMetadataAsync(IReadOnlyDictionary<string, string>? meta)
     {
         return GetMetadataAsync(meta, System.Threading.CancellationToken.None);
     }
@@ -1103,7 +1103,7 @@ public partial class ObjectManagementClient
     /// <param name="x_amz_meta_*">An arbitrary metadata key/value pair. Must contain the Public-amz-meta- prefix to be valid. Multiple metadata pairs can be defined. keys must be unique and will be converted to lowercase.</param>
     /// <returns>Returns an array of matching key/value pairs.</returns>
     /// <exception cref="ApiException">A server side error occurred.</exception>
-    public virtual async System.Threading.Tasks.Task<System.Collections.Generic.List<S3TagSet>> GetMetadataAsync(IDictionary<string, string>? meta, System.Threading.CancellationToken cancellationToken)
+    public virtual async System.Threading.Tasks.Task<System.Collections.Generic.List<S3TagSet>> GetMetadataAsync(IReadOnlyDictionary<string, string>? meta, System.Threading.CancellationToken cancellationToken)
     {
         var urlBuilder_ = new System.Text.StringBuilder();
         urlBuilder_.Append(BaseUrl != null ? BaseUrl.TrimEnd('/') : "").Append("/object/metadata");
@@ -1193,7 +1193,7 @@ public partial class ObjectManagementClient
     /// <param name="versionId">Request a specified version</param>
     /// <returns>Accepted and no content</returns>
     /// <exception cref="ApiException">A server side error occurred.</exception>
-    public virtual System.Threading.Tasks.Task AddMetadataAsync(IDictionary<string, string>? meta, System.Guid objId, string? versionId)
+    public virtual System.Threading.Tasks.Task AddMetadataAsync(IReadOnlyDictionary<string, string>? meta, System.Guid objId, string? versionId)
     {
         return AddMetadataAsync(meta, objId, versionId, System.Threading.CancellationToken.None);
     }
@@ -1210,7 +1210,7 @@ public partial class ObjectManagementClient
     /// <param name="versionId">Request a specified version</param>
     /// <returns>Accepted and no content</returns>
     /// <exception cref="ApiException">A server side error occurred.</exception>
-    public virtual async System.Threading.Tasks.Task AddMetadataAsync(IDictionary<string, string>? meta, System.Guid objId, string? versionId, System.Threading.CancellationToken cancellationToken)
+    public virtual async System.Threading.Tasks.Task AddMetadataAsync(IReadOnlyDictionary<string, string>? meta, System.Guid objId, string? versionId, System.Threading.CancellationToken cancellationToken)
     {
         var urlBuilder_ = new System.Text.StringBuilder();
         urlBuilder_.Append(BaseUrl != null ? BaseUrl.TrimEnd('/') : "").Append("/object/{objId}/metadata?");
@@ -1322,7 +1322,7 @@ public partial class ObjectManagementClient
     /// <param name="versionId">Request a specified version</param>
     /// <returns>Accepted and no content</returns>
     /// <exception cref="ApiException">A server side error occurred.</exception>
-    public virtual System.Threading.Tasks.Task ReplaceMetadataAsync(IDictionary<string, string>? meta, System.Guid objId, string? versionId)
+    public virtual System.Threading.Tasks.Task ReplaceMetadataAsync(IReadOnlyDictionary<string, string>? meta, System.Guid objId, string? versionId)
     {
         return ReplaceMetadataAsync(meta, objId, versionId, System.Threading.CancellationToken.None);
     }
@@ -1339,7 +1339,7 @@ public partial class ObjectManagementClient
     /// <param name="versionId">Request a specified version</param>
     /// <returns>Accepted and no content</returns>
     /// <exception cref="ApiException">A server side error occurred.</exception>
-    public virtual async System.Threading.Tasks.Task ReplaceMetadataAsync(IDictionary<string, string>? meta, System.Guid objId, string? versionId, System.Threading.CancellationToken cancellationToken)
+    public virtual async System.Threading.Tasks.Task ReplaceMetadataAsync(IReadOnlyDictionary<string, string>? meta, System.Guid objId, string? versionId, System.Threading.CancellationToken cancellationToken)
     {
         var urlBuilder_ = new System.Text.StringBuilder();
         urlBuilder_.Append(BaseUrl != null ? BaseUrl.TrimEnd('/') : "").Append("/object/{objId}/metadata?");
@@ -1450,7 +1450,7 @@ public partial class ObjectManagementClient
     /// <param name="versionId">Request a specified version</param>
     /// <returns>Accepted and no content</returns>
     /// <exception cref="ApiException">A server side error occurred.</exception>
-    public virtual System.Threading.Tasks.Task DeleteMetadataAsync(IDictionary<string, string>? meta, System.Guid objId, string? versionId)
+    public virtual System.Threading.Tasks.Task DeleteMetadataAsync(IReadOnlyDictionary<string, string>? meta, System.Guid objId, string? versionId)
     {
         return DeleteMetadataAsync(meta, objId, versionId, System.Threading.CancellationToken.None);
     }
@@ -1467,7 +1467,7 @@ public partial class ObjectManagementClient
     /// <param name="versionId">Request a specified version</param>
     /// <returns>Accepted and no content</returns>
     /// <exception cref="ApiException">A server side error occurred.</exception>
-    public virtual async System.Threading.Tasks.Task DeleteMetadataAsync(IDictionary<string, string>? meta, System.Guid objId, string? versionId, System.Threading.CancellationToken cancellationToken)
+    public virtual async System.Threading.Tasks.Task DeleteMetadataAsync(IReadOnlyDictionary<string, string>? meta, System.Guid objId, string? versionId, System.Threading.CancellationToken cancellationToken)
     {
         var urlBuilder_ = new System.Text.StringBuilder();
         urlBuilder_.Append(BaseUrl != null ? BaseUrl.TrimEnd('/') : "").Append("/object/{objId}/metadata?");
@@ -1565,7 +1565,7 @@ public partial class ObjectManagementClient
     /// <param name="tagset*">Tags for the object, defined as a Key/Value tag. The query must be formatted in deepObject style notation, where a tag-set made out of multiple tags would be encoded something similar to `tagset[Public]=a&amp;tagset[y]=b`. Only one value can exist for a given tag key.</param>
     /// <returns>Returns an array of matching key/value pairs.</returns>
     /// <exception cref="ApiException">A server side error occurred.</exception>
-    public virtual System.Threading.Tasks.Task<System.Collections.Generic.List<S3TagSet>> GetTaggingAsync(IDictionary<string, string>? tags)
+    public virtual System.Threading.Tasks.Task<System.Collections.Generic.List<S3TagSet>> GetTaggingAsync(IReadOnlyDictionary<string, string>? tags)
     {
         return GetTaggingAsync(tags, System.Threading.CancellationToken.None);
     }
@@ -1580,7 +1580,7 @@ public partial class ObjectManagementClient
     /// <param name="tagset*">Tags for the object, defined as a Key/Value tag. The query must be formatted in deepObject style notation, where a tag-set made out of multiple tags would be encoded something similar to `tagset[Public]=a&amp;tagset[y]=b`. Only one value can exist for a given tag key.</param>
     /// <returns>Returns an array of matching key/value pairs.</returns>
     /// <exception cref="ApiException">A server side error occurred.</exception>
-    public virtual async System.Threading.Tasks.Task<System.Collections.Generic.List<S3TagSet>> GetTaggingAsync(IDictionary<string, string>? tags, System.Threading.CancellationToken cancellationToken)
+    public virtual async System.Threading.Tasks.Task<System.Collections.Generic.List<S3TagSet>> GetTaggingAsync(IReadOnlyDictionary<string, string>? tags, System.Threading.CancellationToken cancellationToken)
     {
         var urlBuilder_ = new System.Text.StringBuilder();
         urlBuilder_.Append(BaseUrl != null ? BaseUrl.TrimEnd('/') : "").Append("/object/tagging?");
@@ -1671,7 +1671,7 @@ public partial class ObjectManagementClient
     /// <param name="versionId">Request a specified version</param>
     /// <returns>Accepted and no content</returns>
     /// <exception cref="ApiException">A server side error occurred.</exception>
-    public virtual System.Threading.Tasks.Task AddTaggingAsync(System.Guid objId, IDictionary<string, string>? tags, string? versionId)
+    public virtual System.Threading.Tasks.Task AddTaggingAsync(System.Guid objId, IReadOnlyDictionary<string, string>? tags, string? versionId)
     {
         return AddTaggingAsync(objId, tags, versionId, System.Threading.CancellationToken.None);
     }
@@ -1688,7 +1688,7 @@ public partial class ObjectManagementClient
     /// <param name="versionId">Request a specified version</param>
     /// <returns>Accepted and no content</returns>
     /// <exception cref="ApiException">A server side error occurred.</exception>
-    public virtual async System.Threading.Tasks.Task AddTaggingAsync(System.Guid objId, IDictionary<string, string>? tags, string? versionId, System.Threading.CancellationToken cancellationToken)
+    public virtual async System.Threading.Tasks.Task AddTaggingAsync(System.Guid objId, IReadOnlyDictionary<string, string>? tags, string? versionId, System.Threading.CancellationToken cancellationToken)
     {
         var urlBuilder_ = new System.Text.StringBuilder();
         urlBuilder_.Append(BaseUrl != null ? BaseUrl.TrimEnd('/') : "").Append("/object/{objId}/tagging?");
@@ -1800,7 +1800,7 @@ public partial class ObjectManagementClient
     /// <param name="versionId">Request a specified version</param>
     /// <returns>Accepted and no content</returns>
     /// <exception cref="ApiException">A server side error occurred.</exception>
-    public virtual System.Threading.Tasks.Task ReplaceTaggingAsync(System.Guid objId, IDictionary<string, string>? tags, string? versionId)
+    public virtual System.Threading.Tasks.Task ReplaceTaggingAsync(System.Guid objId, IReadOnlyDictionary<string, string>? tags, string? versionId)
     {
         return ReplaceTaggingAsync(objId, tags, versionId, System.Threading.CancellationToken.None);
     }
@@ -1817,7 +1817,7 @@ public partial class ObjectManagementClient
     /// <param name="versionId">Request a specified version</param>
     /// <returns>Accepted and no content</returns>
     /// <exception cref="ApiException">A server side error occurred.</exception>
-    public virtual async System.Threading.Tasks.Task ReplaceTaggingAsync(System.Guid objId, IDictionary<string, string>? tags, string? versionId, System.Threading.CancellationToken cancellationToken)
+    public virtual async System.Threading.Tasks.Task ReplaceTaggingAsync(System.Guid objId, IReadOnlyDictionary<string, string>? tags, string? versionId, System.Threading.CancellationToken cancellationToken)
     {
         var urlBuilder_ = new System.Text.StringBuilder();
         urlBuilder_.Append(BaseUrl != null ? BaseUrl.TrimEnd('/') : "").Append("/object/{objId}/tagging?");
@@ -1928,7 +1928,7 @@ public partial class ObjectManagementClient
     /// <param name="versionId">Request a specified version</param>
     /// <returns>Accepted and no content</returns>
     /// <exception cref="ApiException">A server side error occurred.</exception>
-    public virtual System.Threading.Tasks.Task DeleteTaggingAsync(System.Guid objId, IDictionary<string, string>? tags, string? versionId)
+    public virtual System.Threading.Tasks.Task DeleteTaggingAsync(System.Guid objId, IReadOnlyDictionary<string, string>? tags, string? versionId)
     {
         return DeleteTaggingAsync(objId, tags, versionId, System.Threading.CancellationToken.None);
     }
@@ -1945,7 +1945,7 @@ public partial class ObjectManagementClient
     /// <param name="versionId">Request a specified version</param>
     /// <returns>Accepted and no content</returns>
     /// <exception cref="ApiException">A server side error occurred.</exception>
-    public virtual async System.Threading.Tasks.Task DeleteTaggingAsync(System.Guid objId, IDictionary<string, string>? tags, string? versionId, System.Threading.CancellationToken cancellationToken)
+    public virtual async System.Threading.Tasks.Task DeleteTaggingAsync(System.Guid objId, IReadOnlyDictionary<string, string>? tags, string? versionId, System.Threading.CancellationToken cancellationToken)
     {
         var urlBuilder_ = new System.Text.StringBuilder();
         urlBuilder_.Append(BaseUrl != null ? BaseUrl.TrimEnd('/') : "").Append("/object/{objId}/tagging?");

--- a/src/backend/TrafficCourts/TrafficCourts.Coms.Client/ObjectManagementService.cs
+++ b/src/backend/TrafficCourts/TrafficCourts.Coms.Client/ObjectManagementService.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Extensions.Logging;
+using System.Linq;
 
 namespace TrafficCourts.Coms.Client;
 
@@ -15,6 +16,14 @@ internal class ObjectManagementService : IObjectManagementService
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
+    /// <summary>
+    /// Creates a file. On successful creation, the file's <see cref="File.Id"/> will be set.
+    /// </summary>
+    /// <param name="file"></param>
+    /// <param name="cancellationToken"></param>
+    /// <returns></returns>
+    /// <exception cref="ArgumentException"></exception>
+    /// <exception cref="ObjectManagementServiceException"></exception>
     public async Task<Guid> CreateFileAsync(File file, CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(file);
@@ -48,6 +57,7 @@ internal class ObjectManagementService : IObjectManagementService
             }
 
             Guid id = created[0].Id;
+            file.Id = id;
             _logger.LogDebug("Created file {FileId}", id);
             return id;
         }
@@ -93,7 +103,9 @@ internal class ObjectManagementService : IObjectManagementService
             string? contentType = GetHeader(response.Headers, "Content-Type");
             string? fileName = GetHeader(response.Headers, "x-amz-meta-name");
 
-            IDictionary<string, string>? metadata = GetMetadata(response);
+            var metadataValues = await GetMetadataAsync(id, cancellationToken);
+            IDictionary<string, string>? metadata = Factory.CreateMetadata(metadataValues[id]);
+
             IDictionary<string, string>? tags = null;
 
             if (includeTags)
@@ -105,7 +117,7 @@ internal class ObjectManagementService : IObjectManagementService
             var stream = _memoryStreamFactory.GetStream();
             await response.Stream.CopyToAsync(stream, cancellationToken);
 
-            var file = new File(stream, fileName, contentType, metadata, tags);
+            var file = new File(id, stream, fileName, contentType, metadata, tags);
             return file;
         }
         catch (Exception exception)
@@ -138,12 +150,15 @@ internal class ObjectManagementService : IObjectManagementService
 
             _logger.LogDebug("Found {Count} files", files.Count);
 
+            // fetch all of the metadata for found files at once
+            var foundIds = files.Select(_ => _.Id).ToList();
+            var objectMetadataById = await GetMetadataAsync(foundIds, cancellationToken);
+
             List<FileSearchResult> results = new(files.Count);
 
             foreach (var file in files)
             {
-                // fetch the meta data and tags
-                var metadata = await GetMetadataAsync(file.Id, cancellationToken);
+                var metadata = new Dictionary<string, string>(objectMetadataById[file.Id]);
                 var tags = await GetTagsAsync(file.Id, cancellationToken);
 
                 var result = new FileSearchResult(
@@ -210,16 +225,15 @@ internal class ObjectManagementService : IObjectManagementService
         return value;
     }
 
-    private async Task<IDictionary<string, string>> GetMetadataAsync(Guid id, CancellationToken cancellationToken)
+    private async Task<ILookup<Guid, KeyValuePair<string, string>>> GetMetadataAsync(IList<Guid> ids, CancellationToken cancellationToken)
     {
         try
         {
-            // use the url mode to avoid downloading the file contents
-            FileResponse response = await _client.ReadObjectAsync(id, DownloadMode.Url, expiresIn: null, versionId: null, cancellationToken)
-                .ConfigureAwait(false);
-
-            IDictionary<string, string> metadata = GetMetadata(response);
-            return metadata;
+            IList<ObjectMetadata> objectsMetadata = await _client.GetObjectMetadataAsync(ids, cancellationToken).ConfigureAwait(false);
+            
+            // not great we have to flatten out the data, but it makes using a ILookup easier to process on the caller
+            var lookup = Flatten(objectsMetadata).ToLookup(_ => _.Item1, _ => _.Item2);
+            return lookup;
         }
         catch (Exception exception)
         {
@@ -227,32 +241,27 @@ internal class ObjectManagementService : IObjectManagementService
         }
     }
 
-    private IDictionary<string, string> GetMetadata(FileResponse response)
+    private async Task<ILookup<Guid, KeyValuePair<string, string>>> GetMetadataAsync(Guid id, CancellationToken cancellationToken)
     {
-        var metadata = new Dictionary<string,string>();
-
-        bool IsMetadataHeader(KeyValuePair<string, IEnumerable<string>> header)
-        {
-            return header.Key.StartsWith("x-amz-meta-", StringComparison.OrdinalIgnoreCase);
-        }
-
-        foreach (var header in response.Headers.Where(IsMetadataHeader))
-        {
-            // header is KeyValuePair<string, IEnumerable<string>>
-            // extract the meta data key without the prefix
-            var key = header.Key["x-amz-meta-".Length..];
-
-            if (key == "id" || key == "name")
-            {                
-                continue; // skip internal meta data properties
-            }
-
-            var value = header.Value.FirstOrDefault() ?? string.Empty;
-            metadata.Add(key, value);
-        }
-
-        return metadata;
+        return await GetMetadataAsync(new[] { id }, cancellationToken).ConfigureAwait(false);
     }
+
+    private IEnumerable<Tuple<Guid, KeyValuePair<string, string>>> Flatten(IList<ObjectMetadata> items)
+    {
+        foreach (var objectItem in items)
+        {
+            foreach (var metaDataItem in objectItem.Metadata)
+            {
+                // do not return internal metadata
+                if (!IsInternalMetadata(metaDataItem.Key))
+                {
+                    yield return Tuple.Create(objectItem.Id, new KeyValuePair<string, string>(metaDataItem.Key, metaDataItem.Value));
+                }
+            }
+        }
+    }
+
+    private static bool IsInternalMetadata(string key) => key == "id" || key == "name";
 
     private Task<IDictionary<string, string>> GetTagsAsync(Guid id, CancellationToken cancellationToken)
     {

--- a/src/backend/TrafficCourts/TrafficCourts.Coms.Client/ObjectManagementService.cs
+++ b/src/backend/TrafficCourts/TrafficCourts.Coms.Client/ObjectManagementService.cs
@@ -248,7 +248,7 @@ internal class ObjectManagementService : IObjectManagementService
 
     private IEnumerable<Tuple<Guid, KeyValuePair<string, string>>> Flatten(IList<ObjectMetadata> items)
     {
-        foreach (var objectItem in items)
+        foreach (var objectItem in items.Where(_ => _.Metadata != null))
         {
             foreach (var metaDataItem in objectItem.Metadata)
             {

--- a/src/backend/TrafficCourts/TrafficCourts.Coms.Client/RequestBuilder.cs
+++ b/src/backend/TrafficCourts/TrafficCourts.Coms.Client/RequestBuilder.cs
@@ -52,7 +52,7 @@ internal static class RequestBuilder
     /// <exception cref="TagKeyEmptyException"><paramref name="tags"/> one of the keys is an empty string.</exception>
     /// <exception cref="TagKeyTooLongException"><paramref name="tags"/> one of the keys is too long.</exception>
     /// <exception cref="TagValueTooLongException"><paramref name="tags"/> one of the key values is too long.</exception>
-    public static void AppendQueryTagSet(StringBuilder urlBuilder, IDictionary<string, string>? tags)
+    public static void AppendQueryTagSet(StringBuilder urlBuilder, IReadOnlyDictionary<string, string>? tags)
     {
         if (urlBuilder is null)
         {
@@ -93,7 +93,7 @@ internal static class RequestBuilder
     /// <param name="metadata"></param>
     /// <exception cref="ArgumentNullException"><paramref name="request"/> is null.</exception>
     /// <exception cref="MetadataInvalidKeyException"><paramref name="metadata"/> contains keys with invalid  values.</exception>
-    public static void AppendHeaderMetadata(HttpRequestMessage request, IDictionary<string, string>? metadata)
+    public static void AppendHeaderMetadata(HttpRequestMessage request, IReadOnlyDictionary<string, string>? metadata)
     {
         if (request is null)
         {


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- Fetches document metadata from the undocumented `/object/metadata` endpoint.
- Added nullable Guid File.Id property
- When creating a file, the File.Id is set with the created file id.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [ ] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
