### PR TITLE
TCVP-2054 staff remove single document

### DIFF
--- a/src/backend/TrafficCourts/Staff.Service/Controllers/ComsController.cs
+++ b/src/backend/TrafficCourts/Staff.Service/Controllers/ComsController.cs
@@ -216,7 +216,61 @@ public class ComsController : StaffControllerBase<ComsController>
         }
         catch (Exception e)
         {
-            _logger.LogError(e, "Error downloading the document");
+            _logger.LogError(e, "Error retrieving the document");
+            return new HttpError(StatusCodes.Status500InternalServerError, e.Message);
+        }
+    }
+
+    /// <summary>
+    /// Removes the specified document for the given unique file ID.
+    /// </summary>
+    /// <param name="fileId">Unique identifier for a specific document.</param>
+    /// <param name="cancellationToken"></param>
+    /// <response code="200">The document is successfully removed.</response>
+    /// <response code="400">The request was not well formed. Check the parameters.</response>
+    /// <response code="401">Unauthenticated.</response>
+    /// <response code="403">Forbidden, requires jjdispute:delete permission.</response>
+    /// <response code="500">There was a server error that prevented the file to be removed successfully.</response>
+    /// <returns></returns>
+    [HttpGet("RemoveDocument")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+    [KeycloakAuthorize(Resources.JJDispute, Scopes.Delete)]
+    public async Task<IActionResult> RemoveDocumentAsync(Guid fileId, CancellationToken cancellationToken)
+    {
+        _logger.LogDebug("Removing the document from the object storage");
+
+        try
+        {
+            await _comsService.DeleteFileAsync(fileId, cancellationToken);
+
+            return Ok();
+        }
+        catch (Coms.Client.ObjectManagementServiceException e)
+        {
+            _logger.LogError(e, "Could not remove the document because of ObjectManagementServiceException");
+            ProblemDetails problemDetails = new();
+            problemDetails.Status = (int)HttpStatusCode.InternalServerError;
+            problemDetails.Title = e.Source + ": Error removing file from COMS";
+            problemDetails.Instance = HttpContext?.Request?.Path;
+            string? innerExceptionMessage = e.InnerException?.Message;
+            if (innerExceptionMessage is not null)
+            {
+                problemDetails.Extensions.Add("errors", new string[] { e.Message, innerExceptionMessage });
+            }
+            else
+            {
+                problemDetails.Extensions.Add("errors", new string[] { e.Message });
+            }
+
+            return new ObjectResult(problemDetails);
+        }
+        catch (Exception e)
+        {
+            _logger.LogError(e, "Error removing the document");
             return new HttpError(StatusCodes.Status500InternalServerError, e.Message);
         }
     }

--- a/src/backend/TrafficCourts/Staff.Service/Services/ComsService.cs
+++ b/src/backend/TrafficCourts/Staff.Service/Services/ComsService.cs
@@ -51,6 +51,11 @@ public class ComsService : IComsService
         return comsFile;
     }
 
+    public Task DeleteFileAsync(Guid fileId, CancellationToken cancellationToken)
+    {
+        throw new NotImplementedException();
+    }
+
     public async Task<Guid> SaveFileAsync(IFormFile file, Dictionary<string, string> metadata, CancellationToken cancellationToken)
     {
         _logger.LogDebug("Saving file through COMS");

--- a/src/backend/TrafficCourts/Staff.Service/Services/IComsService.cs
+++ b/src/backend/TrafficCourts/Staff.Service/Services/IComsService.cs
@@ -31,4 +31,12 @@ public interface IComsService
     /// <exception cref="ObjectManagementServiceException">Unable to return file through COMS</exception>
     Task<Coms.Client.File> GetFileAsync(Guid fileId, CancellationToken cancellationToken);
 
+    /// <summary>
+    /// Deletes the specified file through COMS service for the given unique file ID
+    /// </summary>
+    /// <param name="fileId"></param>
+    /// <param name="cancellationToken"></param>
+    /// <returns></returns>
+    /// <exception cref="ObjectManagementServiceException">Unable to delete the file through COMS</exception>
+    Task DeleteFileAsync(Guid fileId, CancellationToken cancellationToken);
 }


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- [TCVP-2054](https://justice.gov.bc.ca/jira/browse/TCVP-2054)
- Added functionality to remove a document for the given unique file ID and track file deletion in file history.
- Added XUnit tests.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Ran the services locally and uploaded a file using swagger ui and called the new endpoint to remove the file and confirmed that the file has been deleted successfully.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
