### PR TITLE
Fixed mapping of JJDisputeHearingType

### DIFF
--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/model/Auditable.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/model/Auditable.java
@@ -26,7 +26,8 @@ import lombok.Setter;
  */
 @TypeDefs({
 	@TypeDef(name = "disputantUpdateStatus", defaultForType = DisputantUpdateRequestStatus.class, typeClass = ShortNamedEnumType.class),
-	@TypeDef(name = "disputantUpdateType", defaultForType = DisputantUpdateRequestType.class, typeClass = ShortNamedEnumType.class)
+	@TypeDef(name = "disputantUpdateType", defaultForType = DisputantUpdateRequestType.class, typeClass = ShortNamedEnumType.class),
+	@TypeDef(name = "jjDisputeHearingType", defaultForType = JJDisputeHearingType.class, typeClass = ShortNamedEnumType.class)
 })
 @MappedSuperclass
 @Getter

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/model/JJDispute.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/model/JJDispute.java
@@ -48,7 +48,6 @@ public class JJDispute extends Auditable<String>{
     @Enumerated(EnumType.STRING)
 	private JJDisputeStatus status;
 
-    @Enumerated(EnumType.STRING)
     private JJDisputeHearingType hearingType;
 
     /**


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

Fixed a bug where the JJDisputeHearingType enum was modified to use a shortCode but forgot to also register the enum in a TypeDef so Hibernate knows how to convert the enum to/from the database.

`curl -X 'GET' 'http://localhost:5010/api/v1.0/jj/disputes'` works again.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

mvn verify

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
