### PR TITLE
add fetching filename in file search

### DIFF
--- a/src/backend/TrafficCourts/TrafficCourts.Coms.Client.Test/ClientTests/ObjectManagementBase.cs
+++ b/src/backend/TrafficCourts/TrafficCourts.Coms.Client.Test/ClientTests/ObjectManagementBase.cs
@@ -35,7 +35,7 @@ public abstract class ObjectManagementBase
 
     protected Dictionary<string, string> CreateMetadata(int count = 0)
     {
-        Dictionary<string, string> items = Factory.CreateMetadata();
+        Dictionary<string, string> items = Metadata.Create();
         CreateItems(items, count);
         return items;
     }

--- a/src/backend/TrafficCourts/TrafficCourts.Coms.Client.Test/IntegrationTest.cs
+++ b/src/backend/TrafficCourts/TrafficCourts.Coms.Client.Test/IntegrationTest.cs
@@ -140,6 +140,18 @@ namespace TrafficCourts.Coms.Client.Test
 
             using var actualFile = await _service.GetFileAsync(id, false, _cancellationToken);
 
+            // search for the file by the first metadata property
+            FileSearchParameters parameters = new FileSearchParameters();
+            string key = expectedFile.Metadata.Keys.First();
+            parameters.Metadata.Add(key, expectedFile.Metadata[key]);
+
+            var fileSearchResults = await _service.FileSearchAsync(parameters, _cancellationToken);
+
+            FileSearchResult actualFound = Assert.Single(fileSearchResults);
+            Assert.Equal(id, actualFound.Id);
+            Assert.Equal(filename, actualFound.FileName);
+            Assert.Equal(expectedFile.Metadata.Count, actualFound.Metadata.Count);
+
             await _service.DeleteFileAsync(id, _cancellationToken);
 
             //Assert.Equal(expectedData.ToByteArray(), actualFile.Data);

--- a/src/backend/TrafficCourts/TrafficCourts.Coms.Client.Test/TrafficCourts.Coms.Client.Test.csproj
+++ b/src/backend/TrafficCourts/TrafficCourts.Coms.Client.Test/TrafficCourts.Coms.Client.Test.csproj
@@ -43,6 +43,6 @@
   </ItemGroup>
 
 	<ItemGroup>
-		<AssemblyAttribute Include="System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute"/>
+		<AssemblyAttribute Include="System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute" />
 	</ItemGroup>
 </Project>

--- a/src/backend/TrafficCourts/TrafficCourts.Coms.Client/ComsJsonContext.cs
+++ b/src/backend/TrafficCourts/TrafficCourts.Coms.Client/ComsJsonContext.cs
@@ -4,6 +4,8 @@ namespace TrafficCourts.Coms.Client;
 
 [JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
 [JsonSerializable(typeof(ObjectMetadataCollection))]
+//[JsonSerializable(typeof(ObjectMetadata))]
+//[JsonSerializable(typeof(MetadataItem))]
 internal partial class ComsJsonContext : JsonSerializerContext
 {
 }

--- a/src/backend/TrafficCourts/TrafficCourts.Coms.Client/Factory.cs
+++ b/src/backend/TrafficCourts/TrafficCourts.Coms.Client/Factory.cs
@@ -3,19 +3,6 @@
 internal static class Factory
 {
     /// <summary>
-    /// Creates the Metadata dictionary from the source with the correct <see cref="IEqualityComparer"/>.
-    /// </summary>
-    public static Dictionary<string, string> CreateMetadata(IEnumerable<KeyValuePair<string, string>>? source = null)
-    {
-        if (source is null)
-        {
-            return new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-        }
-
-        return new Dictionary<string, string>(source, StringComparer.OrdinalIgnoreCase);
-    }
-
-    /// <summary>
     /// Creates the Tags dictionary from the source with the correct <see cref="IEqualityComparer"/>.
     /// </summary>
     public static Dictionary<string, string> CreateTags(IEnumerable<KeyValuePair<string, string>>? source = null)

--- a/src/backend/TrafficCourts/TrafficCourts.Coms.Client/File.cs
+++ b/src/backend/TrafficCourts/TrafficCourts.Coms.Client/File.cs
@@ -34,7 +34,7 @@ public partial class File : IDisposable
         FileName = fileName;
         ContentType = contentType;
 
-        Metadata = Factory.CreateMetadata(metadata);
+        Metadata = Client.Metadata.Create(metadata);
         Tags = Factory.CreateTags(tags);
     }
 

--- a/src/backend/TrafficCourts/TrafficCourts.Coms.Client/FileSearchParameters.cs
+++ b/src/backend/TrafficCourts/TrafficCourts.Coms.Client/FileSearchParameters.cs
@@ -13,7 +13,7 @@ public class FileSearchParameters
             ? new List<Guid>(ids)
             : new List<Guid>();
 
-        Metadata = Factory.CreateMetadata(metadata);
+        Metadata = Client.Metadata.Create(metadata);
         Tags = Factory.CreateTags(tags);
     }
 

--- a/src/backend/TrafficCourts/TrafficCourts.Coms.Client/FileSearchResult.cs
+++ b/src/backend/TrafficCourts/TrafficCourts.Coms.Client/FileSearchResult.cs
@@ -2,13 +2,14 @@
 
 public class FileSearchResult : TimestampUserData
 {
-    public FileSearchResult(Guid id, string path, bool active, bool @public, Guid createdBy, DateTimeOffset createdAt, Guid updatedBy, DateTimeOffset updatedAt)
-        : this(id, path, active, @public, createdBy, createdAt, updatedBy, updatedAt, null, null)
+    public FileSearchResult(Guid id, string filename, string path, bool active, bool @public, Guid createdBy, DateTimeOffset createdAt, Guid updatedBy, DateTimeOffset updatedAt)
+        : this(id, filename, path, active, @public, createdBy, createdAt, updatedBy, updatedAt, null, null)
     {
     }
 
     public FileSearchResult(
         Guid id, 
+        string filename,
         string path, 
         bool active, 
         bool @public, 
@@ -20,6 +21,7 @@ public class FileSearchResult : TimestampUserData
         IDictionary<string, string>? tags)
     {
         Id = id;
+        FileName = filename;
         Path = path;
         Active = active;
         Public = @public;
@@ -27,11 +29,12 @@ public class FileSearchResult : TimestampUserData
         CreatedAt = createdAt;
         UpdatedBy = updatedBy;
         UpdatedAt = updatedAt;
-        Metadata = Factory.CreateMetadata(metadata);
+        Metadata = Client.Metadata.Create(metadata);
         Tags = Factory.CreateTags(tags);
     }
 
     public Guid Id { get; set; }
+    public string FileName { get; set; }
     public string Path { get; set; }
     public bool Active { get; set; }
     public bool Public { get; set; }

--- a/src/backend/TrafficCourts/TrafficCourts.Coms.Client/Metadata.cs
+++ b/src/backend/TrafficCourts/TrafficCourts.Coms.Client/Metadata.cs
@@ -1,0 +1,30 @@
+﻿namespace TrafficCourts.Coms.Client;
+
+internal static class Metadata
+{
+    private const string Id = "id";
+    private const string Name = "name";
+    private static readonly StringComparer _comparer= StringComparer.OrdinalIgnoreCase;
+
+    public static bool IsInternal(string key)
+    {
+        return _comparer.Equals(key, Id) || _comparer.Equals(key, Name);
+    }
+
+    public static bool IsNotInternal(KeyValuePair<string, string> item) => !IsInternal(item.Key);
+    public static bool IsInternal(KeyValuePair<string, string> item) => IsInternal(item.Key);
+    public static bool IsName(KeyValuePair<string, string> item) => _comparer.Equals(item.Key, Name);
+
+    /// <summary>
+    /// Creates the Metadata dictionary from the source with the correct <see cref="IEqualityComparer"/>.
+    /// </summary>
+    public static Dictionary<string, string> Create(IEnumerable<KeyValuePair<string, string>>? source = null)
+    {
+        if (source is null)
+        {
+            return new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        }
+
+        return new Dictionary<string, string>(source.Where(IsNotInternal), StringComparer.OrdinalIgnoreCase);
+    }
+}

--- a/src/backend/TrafficCourts/TrafficCourts.Coms.Client/MetadataValidator.cs
+++ b/src/backend/TrafficCourts/TrafficCourts.Coms.Client/MetadataValidator.cs
@@ -41,7 +41,7 @@ public static class MetadataValidator
     /// <param name="items"></param>
     /// <exception cref="MetadataInvalidKeyException">A key contains an invalid character</exception>
     /// <exception cref="MetadataTooLongException">The total length of the metadata is too long</exception>
-    public static void Validate(IReadOnlyDictionary<string, string>? items)
+    public static void Validate(IReadOnlyDictionary<string, string>? items, bool allowInternal = false)
     {
         // no metadata is ok
         if (items is null)
@@ -49,17 +49,22 @@ public static class MetadataValidator
             return;
         }
 
-        ValidateKeys(items);
+        ValidateKeys(items, allowInternal);
         ValidateLength(items);
     }
 
-    private static void ValidateKeys(IReadOnlyDictionary<string, string> items)
+    private static void ValidateKeys(IReadOnlyDictionary<string, string> items, bool allowInternal)
     {
         foreach (var item in items)
         {
             string key = item.Key;
 
             if (string.IsNullOrWhiteSpace(key))
+            {
+                throw new MetadataInvalidKeyException(key);
+            }
+
+            if (!allowInternal && Metadata.IsInternal(key))
             {
                 throw new MetadataInvalidKeyException(key);
             }

--- a/src/backend/TrafficCourts/TrafficCourts.Coms.Client/Models.cs
+++ b/src/backend/TrafficCourts/TrafficCourts.Coms.Client/Models.cs
@@ -12,7 +12,6 @@ public class ObjectMetadata
     {
         Metadata = new List<MetadataItem>();
     }
-
     public string? VersionId { get; set; }
 
     [JsonPropertyName("objectId")]
@@ -30,12 +29,14 @@ public class ObjectMetadata
 
     public DateTime UpdatedAt { get; set; }
 
-    public List<MetadataItem> Metadata { get; set; }
+    [JsonPropertyName("metadata")]
+    public IList<MetadataItem> Metadata { get; set; }
 }
 
 public class MetadataItem
 {
+    [JsonPropertyName("key")]
     public string Key { get; set; } = string.Empty;
-
+    [JsonPropertyName("value")]
     public string Value { get; set; } = string.Empty;
 }

--- a/src/backend/TrafficCourts/TrafficCourts.Coms.Client/ObjectManagementClient.cs
+++ b/src/backend/TrafficCourts/TrafficCourts.Coms.Client/ObjectManagementClient.cs
@@ -14,7 +14,8 @@ public partial class ObjectManagementClient : IObjectManagementClient
     {
         get
         {
-            _jsonContext ??= new ComsJsonContext(JsonSerializerSettings);
+            var copy = new JsonSerializerOptions(JsonSerializerSettings);
+            _jsonContext ??= new ComsJsonContext(copy);
             return _jsonContext;
         }
     }


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- Returns the filename on file search.
- Filters out internal metadata from metadata returned
- Does not allow setting internal metadata via metadata dictionary

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [ ] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
