### PR TITLE
Fixed getting filename from search

### DIFF
--- a/src/backend/TrafficCourts/Staff.Service/Services/ComsService.cs
+++ b/src/backend/TrafficCourts/Staff.Service/Services/ComsService.cs
@@ -83,13 +83,7 @@ public class ComsService : IComsService
 
         foreach (var result in searchResult)
         {
-            result.Metadata.TryGetValue("name", out string? filename);
-            if (string.IsNullOrEmpty(filename))
-            {
-                filename = "unknown";
-                _logger.LogDebug("name value from metadata is empty");
-            }
-            fileData.Add(result.Id, filename);
+            fileData.Add(result.Id, result.FileName);
         }
 
         return fileData;


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- Updated GetFilesBySearchAsync method to get filename directly from the FileSearchResult property instead of searching for internal metadata key.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
