### PR TITLE
Fix exception thrown when no files found during search

### DIFF
--- a/src/backend/TrafficCourts/TrafficCourts.Coms.Client.Test/ServiceTests/FileSearchAsync.cs
+++ b/src/backend/TrafficCourts/TrafficCourts.Coms.Client.Test/ServiceTests/FileSearchAsync.cs
@@ -18,7 +18,7 @@ public class FileSearchAsync : ObjectManagementServiceTest
         ObjectManagementService sut = GetService();
 
         // act
-        List<FileSearchResult> results = await sut.FileSearchAsync(parameters, cts.Token);
+        IList<FileSearchResult> results = await sut.FileSearchAsync(parameters, cts.Token);
 
         // assert
         // verify the client called with correct values
@@ -51,7 +51,7 @@ public class FileSearchAsync : ObjectManagementServiceTest
         ObjectManagementService sut = GetService();
 
         // act
-        List<FileSearchResult> results = await sut.FileSearchAsync(parameters, cts.Token);
+        IList<FileSearchResult> results = await sut.FileSearchAsync(parameters, cts.Token);
 
         // verify the client called with correct values
         _mockClient.Verify(_ => _.SearchObjectsAsync(

--- a/src/backend/TrafficCourts/TrafficCourts.Coms.Client/FileSearchParameters.cs
+++ b/src/backend/TrafficCourts/TrafficCourts.Coms.Client/FileSearchParameters.cs
@@ -7,6 +7,11 @@ public class FileSearchParameters
     {
     }
 
+    public FileSearchParameters(Guid id)
+        : this(new List<Guid> { id }, null, null)
+    {
+    }
+
     public FileSearchParameters(IEnumerable<Guid>? ids, IDictionary<string, string>? metadata, IDictionary<string, string>? tags)
     {
         Ids = ids is not null

--- a/src/backend/TrafficCourts/TrafficCourts.Coms.Client/IObjectManagementService.cs
+++ b/src/backend/TrafficCourts/TrafficCourts.Coms.Client/IObjectManagementService.cs
@@ -10,13 +10,12 @@ public interface IObjectManagementService
     /// <returns></returns>
     /// <exception cref="ArgumentNullException"><paramref name="file"/> is null.</exception>
     /// <exception cref="ArgumentException"><paramref name="file"/> has a null data property.</exception>
-    /// <exception cref="MetadataInvalidKeyException">A key contains an invalid character</exception>
-    /// <exception cref="MetadataTooLongException">The total length of the metadata is too long</exception>
-    /// <exception cref="TagKeyEmptyException"></exception>
-    /// <exception cref="TagKeyTooLongException"></exception>
-    /// <exception cref="TagValueTooLongException"></exception>
-    /// <exception cref="TooManyTagsException"></exception>
-    /// <exception cref="ObjectManagementServiceException">Other error.</exception>
+    /// <exception cref="MetadataInvalidKeyException">An invalid metadata key was supplied.</exception>
+    /// <exception cref="MetadataTooLongException">The total length of the metadata was too long.</exception>
+    /// <exception cref="TooManyTagsException">Too many tags were supplied. Only 10 tags are allowed.</exception>
+    /// <exception cref="TagKeyTooLongException">A tag key was too long. Maximum length of a tag key is 128.</exception>
+    /// <exception cref="TagValueTooLongException">A tag value was too long. Maximum length of a tag value is 256.</exception>
+    /// <exception cref="ObjectManagementServiceException">Error executing the service call.</exception>
     Task<Guid> CreateFileAsync(File file, CancellationToken cancellationToken);
 
     /// <summary>
@@ -33,7 +32,7 @@ public interface IObjectManagementService
     /// <exception cref="TagKeyTooLongException"></exception>
     /// <exception cref="TagValueTooLongException"></exception>
     /// <exception cref="TooManyTagsException"></exception>
-    /// <exception cref="ObjectManagementServiceException">Other error.</exception>
+    /// <exception cref="ObjectManagementServiceException">Error executing the service call.</exception>
     Task UpdateFileAsync(Guid id, File file, CancellationToken cancellationToken);
 
     /// <summary>
@@ -42,7 +41,7 @@ public interface IObjectManagementService
     /// <param name="id"></param>
     /// <param name="cancellationToken"></param>
     /// <returns></returns>
-    /// <exception cref="ObjectManagementServiceException"></exception>
+    /// <exception cref="ObjectManagementServiceException">Error executing the service call.</exception>
     Task DeleteFileAsync(Guid id, CancellationToken cancellationToken);
 
     /// <summary>
@@ -62,6 +61,11 @@ public interface IObjectManagementService
     /// <param name="cancellationToken"></param>
     /// <returns></returns>
     /// <exception cref="ArgumentNullException"><paramref name="parameters"/> is null.</exception>
-    /// <exception cref="ObjectManagementServiceException"></exception>
-    Task<List<FileSearchResult>> FileSearchAsync(FileSearchParameters parameters, CancellationToken cancellationToken);
+    /// <exception cref="MetadataInvalidKeyException">An invalid metadata key was supplied.</exception>
+    /// <exception cref="MetadataTooLongException">The total length of the metadata was too long.</exception>
+    /// <exception cref="TooManyTagsException">Too many tags were supplied. Only 10 tags are allowed.</exception>
+    /// <exception cref="TagKeyTooLongException">A tag key was too long. Maximum length of a tag key is 128.</exception>
+    /// <exception cref="TagValueTooLongException">A tag value was too long. Maximum length of a tag value is 256.</exception>
+    /// <exception cref="ObjectManagementServiceException">Other error occured</exception>
+    Task<IList<FileSearchResult>> FileSearchAsync(FileSearchParameters parameters, CancellationToken cancellationToken);
 }

--- a/src/backend/TrafficCourts/TrafficCourts.Coms.Client/ObjectManagementService.cs
+++ b/src/backend/TrafficCourts/TrafficCourts.Coms.Client/ObjectManagementService.cs
@@ -126,7 +126,7 @@ internal class ObjectManagementService : IObjectManagementService
         }
     }
 
-    public async Task<List<FileSearchResult>> FileSearchAsync(FileSearchParameters parameters, CancellationToken cancellationToken)
+    public async Task<IList<FileSearchResult>> FileSearchAsync(FileSearchParameters parameters, CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(parameters);
 
@@ -147,6 +147,12 @@ internal class ObjectManagementService : IObjectManagementService
                 parameters.Name,
                 parameters.Tags,
                 cancellationToken).ConfigureAwait(false);
+
+            if (files.Count == 0)
+            {
+                _logger.LogDebug("No files found");
+                return Array.Empty<FileSearchResult>();
+            }
 
             _logger.LogDebug("Found {Count} files", files.Count);
 


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- does not try to fetch metadata if no files found
- switch to file search instead of get file when deleting file in staff portal

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [ ] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
