### PR TITLE
TCVP-2048 Add service for citizen api upload documents

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,6 +35,9 @@ services:
       OBJECTSTORAGE__BUCKETNAME: ${OBJECTSTORAGE__ENDPOINT:-traffic-ticket-dev}
       OBJECTSTORAGE__SSL: ${OBJECTSTORAGE__SSL:-false}
       HASHIDS__SALT: ${HASHIDS__SALT:-00000000000000000000000000000000}
+      COMS__BASEURL: ${COMS__BASEURL:-http://coms:3000}
+      COMS__USERNAME: ${COMS__USERNAME:-username}
+      COMS__PASSWORD: ${COMS__PASSWORD:-password}
       SERILOG__USING__0: Serilog.Sinks.Console
       SERILOG__WRITETO__0__ARGS__OUTPUTTEMPLATE: "[{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj} <s:{SourceContext}>{NewLine}{Exception}"
       SERILOG__WRITETO__0__ARGS__THEME: Serilog.Sinks.SystemConsole.Themes.ConsoleTheme::None, Serilog.Sinks.Console

--- a/src/backend/TrafficCourts/Citizen.Service/Services/IComsService.cs
+++ b/src/backend/TrafficCourts/Citizen.Service/Services/IComsService.cs
@@ -1,0 +1,23 @@
+﻿using TrafficCourts.Coms.Client;
+
+namespace TrafficCourts.Citizen.Service.Services;
+
+public interface IComsService
+{
+    /// <summary>
+    /// Saves the given file object with optional content type and metadata to object store through COMS service
+    /// </summary>
+    /// <param name="file"></param>
+    /// <param name="metadata"></param>
+    /// <param name="cancellationToken"></param>
+    /// <returns>Id of newly inserted file to the object storage</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="file"/> is null.</exception>
+    /// <exception cref="ArgumentException"><paramref name="file"/> has a null data property.</exception>
+    /// <exception cref="MetadataInvalidKeyException">A key contains an invalid character</exception>
+    /// <exception cref="MetadataTooLongException">The total length of the metadata is too long</exception>
+    /// <exception cref="TagKeyTooLongException"></exception>
+    /// <exception cref="TagValueTooLongException"></exception>
+    /// <exception cref="TooManyTagsException"></exception>
+    /// <exception cref="ObjectManagementServiceException">Other error.</exception>
+    Task<Guid> SaveFileAsync(IFormFile file, Dictionary<string, string> metadata, CancellationToken cancellationToken);
+}

--- a/src/backend/TrafficCourts/Citizen.Service/Services/Impl/ComsService.cs
+++ b/src/backend/TrafficCourts/Citizen.Service/Services/Impl/ComsService.cs
@@ -1,0 +1,69 @@
+﻿using MassTransit;
+using TrafficCourts.Coms.Client;
+using TrafficCourts.Messaging.MessageContracts;
+
+namespace TrafficCourts.Citizen.Service.Services.Impl;
+
+/// <summary>
+/// A service for file operations utilizing common object management service client
+/// </summary>
+public class ComsService : IComsService
+{
+    private readonly IObjectManagementService _objectManagementService;
+    private readonly IMemoryStreamManager _memoryStreamManager;
+    private readonly IBus _bus;
+    private readonly ILogger<ComsService> _logger;
+
+    public ComsService(
+        IObjectManagementService objectManagementService,
+        IMemoryStreamManager memoryStreamManager,
+        IBus bus,
+        ILogger<ComsService> logger)
+    {
+        _objectManagementService = objectManagementService ?? throw new ArgumentNullException(nameof(objectManagementService));
+        _memoryStreamManager = memoryStreamManager ?? throw new ArgumentNullException(nameof(memoryStreamManager));
+        _bus = bus ?? throw new ArgumentNullException(nameof(bus));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<Guid> SaveFileAsync(IFormFile file, Dictionary<string, string> metadata, CancellationToken cancellationToken)
+    {
+        _logger.LogDebug("Saving file through COMS");
+
+        metadata.Add("staff-review-status", "pending");
+
+        using Coms.Client.File comsFile = new(GetStreamForFile(file), file.FileName, file.ContentType, metadata, null);
+
+        Guid id = await _objectManagementService.CreateFileAsync(comsFile, cancellationToken);
+
+        metadata.TryGetValue("ticket-number", out string? ticketNumber);
+        if (string.IsNullOrEmpty(ticketNumber))
+        {
+            ticketNumber = "unknown";
+            _logger.LogDebug("ticket-number value from metadata is empty");
+        }
+
+        // TODO: Publish a message to virus scan the uploaded document when the virus scan consumer would be added
+
+        // Save file upload event to file history
+        SaveFileHistoryRecord fileHistoryRecord = new();
+        fileHistoryRecord.TicketNumber = ticketNumber;
+        fileHistoryRecord.Description = $"File: {file.FileName} was uploaded by the Disputant.";
+        await _bus.PublishWithLog(_logger, fileHistoryRecord, cancellationToken);
+
+        return id;
+    }
+
+    private MemoryStream GetStreamForFile(IFormFile formFile)
+    {
+        MemoryStream memoryStream = _memoryStreamManager.GetStream();
+
+        using var fileStream = formFile.OpenReadStream();
+        fileStream.CopyTo(memoryStream);
+
+        // Reset position to the beginning of the stream
+        memoryStream.Position = 0;
+
+        return memoryStream;
+    }
+}

--- a/src/backend/TrafficCourts/Citizen.Service/Startup.cs
+++ b/src/backend/TrafficCourts/Citizen.Service/Startup.cs
@@ -76,6 +76,10 @@ public static class Startup
         builder.Services.AddLanguageLookup();
         builder.Services.AddStatuteLookup();
         builder.Services.AddTransient<IRedisCacheService, RedisCacheService>();
+        builder.Services.AddTransient<IComsService, ComsService>();
+
+        // Add COMS (Object Management Service) Client
+        builder.Services.AddObjectManagementService("COMS");
 
         // MassTransit
         builder.Services.AddMassTransit(Diagnostics.Source.Name, builder.Configuration, logger);

--- a/src/backend/TrafficCourts/Citizen.Service/TrafficCourts.Citizen.Service.csproj
+++ b/src/backend/TrafficCourts/Citizen.Service/TrafficCourts.Citizen.Service.csproj
@@ -52,6 +52,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Common\TrafficCourts.Common.csproj" />
     <ProjectReference Include="..\Messaging\TrafficCourts.Messaging.csproj" />
+    <ProjectReference Include="..\TrafficCourts.Coms.Client\TrafficCourts.Coms.Client.csproj" />
   </ItemGroup>
 	
 </Project>

--- a/src/backend/TrafficCourts/Citizen.Service/appsettings.Development.json
+++ b/src/backend/TrafficCourts/Citizen.Service/appsettings.Development.json
@@ -22,5 +22,11 @@
 
   "Swagger": {
     "Enabled": true
+  },
+
+  "COMS": {
+    "BaseUrl": "http://localhost:3000/",
+    "Username": "username",
+    "Password": "password"
   }
 }

--- a/src/backend/TrafficCourts/Messaging/MessageContracts/DisputantUpdateRequest.cs
+++ b/src/backend/TrafficCourts/Messaging/MessageContracts/DisputantUpdateRequest.cs
@@ -161,6 +161,14 @@ public class DisputantUpdateRequest
     /// </summary>
     public ICollection<Common.OpenAPIs.OracleDataApi.v1_0.DisputeCount>? DisputeCounts { get; set; } = null!;
 
-    // TODO: Add document request fields
+    /// <summary>
+    /// Id of the document uploaded by the disputant
+    /// </summary>
+    public Guid? DocumentId { get; set; }
+
+    /// <summary>
+    /// The type of the document uploaded by the disputant ('Other / Supporting Document' OR 'Application for Adjournment')
+    /// </summary>
+    public string? DocumentType { get; set; }
 }
 

--- a/src/backend/TrafficCourts/Workflow.Service/Consumers/DisputantUpdateRequestConsumer.cs
+++ b/src/backend/TrafficCourts/Workflow.Service/Consumers/DisputantUpdateRequestConsumer.cs
@@ -137,8 +137,14 @@ public class DisputantUpdateRequestConsumer : IConsumer<DisputantUpdateRequest>
             await _oracleDataApiService.SaveDisputantUpdateRequestAsync(message.NoticeOfDisputeGuid.ToString(), disputantUpdateRequest, context.CancellationToken);
         }
 
+        // If the message contains a documentId, send a DISPUTANT_DOCUMENT request
+        if (message.DocumentId is not null && message.DocumentId != Guid.Empty)
+        {
+            disputantUpdateRequest.UpdateType = DisputantUpdateRequestUpdateType.DISPUTANT_DOCUMENT;
+            await _oracleDataApiService.SaveDisputantUpdateRequestAsync(message.NoticeOfDisputeGuid.ToString(), disputantUpdateRequest, context.CancellationToken);
+        }
+
         // TODO: ensure security so only requests authenticated with BCSC can do COURT_OPTIONS, COUNT, DOCUMENTS
-        // TODO: add document updates requests
 
         // If at least one disputantUpdateRequest was saved ...
         if (disputantUpdateRequest.UpdateType != DisputantUpdateRequestUpdateType.UNKNOWN)


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- [TCVP-2048](https://justice.gov.bc.ca/jira/browse/TCVP-2048)
- Added COMS service to Citizen API to consume object management service client.
- Updated disputant update request consumer to send a DISPUTANT_DOCUMENT type request.
- Updated configuration and docker-compose file to add COMS service for Citizen API.
- Added functionality to update file history when a disputant uploads a document.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [x] Yes
- [ ] No

If Yes: Has Docker been updated accordingly?

- [x] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
