### PR TITLE
TCVP-2089 Citizen API remove uploaded document

### DIFF
--- a/src/backend/TrafficCourts/Citizen.Service/Services/IComsService.cs
+++ b/src/backend/TrafficCourts/Citizen.Service/Services/IComsService.cs
@@ -20,4 +20,13 @@ public interface IComsService
     /// <exception cref="TooManyTagsException"></exception>
     /// <exception cref="ObjectManagementServiceException">Other error.</exception>
     Task<Guid> SaveFileAsync(IFormFile file, Dictionary<string, string> metadata, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Deletes the specified file through COMS service for the given unique file ID
+    /// </summary>
+    /// <param name="fileId"></param>
+    /// <param name="cancellationToken"></param>
+    /// <returns></returns>
+    /// <exception cref="ObjectManagementServiceException">Unable to delete the file through COMS</exception>
+    Task DeleteFileAsync(Guid fileId, CancellationToken cancellationToken);
 }

--- a/src/backend/TrafficCourts/Citizen.Service/Services/Impl/ComsService.cs
+++ b/src/backend/TrafficCourts/Citizen.Service/Services/Impl/ComsService.cs
@@ -30,7 +30,7 @@ public class ComsService : IComsService
     {
         _logger.LogDebug("Deleting the file through COMS");
 
-        // find the file so we can get the ticket number
+        // find the file so we can get the ticket number and notice of dispute id
         FileSearchParameters searchParameters = new(fileId);
 
         IList<FileSearchResult> searchResults = await _objectManagementService.FileSearchAsync(searchParameters, cancellationToken);


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- [TCVP-2089](https://justice.gov.bc.ca/jira/browse/TCVP-2089)
- Added COMS service method to remove a disputant uploaded document for the given unique file ID and track file deletion in file history.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
