### PR TITLE
TCVP-2044 Citizen API get uploaded documents list

### DIFF
--- a/src/backend/TrafficCourts/Citizen.Service/Services/IComsService.cs
+++ b/src/backend/TrafficCourts/Citizen.Service/Services/IComsService.cs
@@ -29,4 +29,20 @@ public interface IComsService
     /// <returns></returns>
     /// <exception cref="ObjectManagementServiceException">Unable to delete the file through COMS</exception>
     Task DeleteFileAsync(Guid fileId, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Returns a dictionary of IDs and file names of the documents found in object storage through COMS service based on the search parameters provided
+    /// </summary>
+    /// <param name="metadata"></param>
+    /// <param name="tags"></param>
+    /// <param name="cancellationToken"></param>
+    /// <exception cref="ArgumentNullException">Parameters is null.</exception>
+    /// <exception cref="MetadataInvalidKeyException">An invalid metadata key was supplied.</exception>
+    /// <exception cref="MetadataTooLongException">The total length of the metadata was too long.</exception>
+    /// <exception cref="TooManyTagsException">Too many tags were supplied. Only 10 tags are allowed.</exception>
+    /// <exception cref="TagKeyTooLongException">A tag key was too long. Maximum length of a tag key is 128.</exception>
+    /// <exception cref="TagValueTooLongException">A tag value was too long. Maximum length of a tag value is 256.</exception>
+    /// <exception cref="ObjectManagementServiceException">There was an error searching files in COMS</exception>
+    /// <returns></returns>
+    Task<Dictionary<Guid, string>> GetFilesBySearchAsync(IDictionary<string, string>? metadata, IDictionary<string, string>? tags, CancellationToken cancellationToken);
 }

--- a/src/backend/TrafficCourts/Citizen.Service/Services/Impl/ComsService.cs
+++ b/src/backend/TrafficCourts/Citizen.Service/Services/Impl/ComsService.cs
@@ -65,6 +65,20 @@ public class ComsService : IComsService
         await _bus.PublishWithLog(_logger, fileHistoryRecord, cancellationToken);
     }
 
+    public async Task<Dictionary<Guid, string>> GetFilesBySearchAsync(IDictionary<string, string>? metadata, IDictionary<string, string>? tags, CancellationToken cancellationToken)
+    {
+        _logger.LogDebug("Searching files through COMS");
+
+        FileSearchParameters searchParameters = new(null, metadata, tags);
+
+        IList<FileSearchResult> searchResult = await _objectManagementService.FileSearchAsync(searchParameters, cancellationToken);
+
+        Dictionary<Guid, string> fileData = searchResult
+            .ToDictionary(file => file.Id, file => file.FileName ?? "unknown");
+
+        return fileData;
+    }
+
     public async Task<Guid> SaveFileAsync(IFormFile file, Dictionary<string, string> metadata, CancellationToken cancellationToken)
     {
         _logger.LogDebug("Saving file through COMS");


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- [TCVP-2044](https://justice.gov.bc.ca/jira/browse/TCVP-2044)
- Added COMS service method in Citizen API to return all the related file IDs in a dictionary as keys while filenames as values of the uploaded documents based on search parameters (metadata) through COMS.
- TODO: A controller endpoint needs to be added to consume the service to return the list of documents after the BC Services Card authentication feature will be merged. Also the XUnit tests should be added for the endpoint.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
