### PR TITLE
Change dev environment to use in memory version of H2.

### DIFF
--- a/.gitops/charts/traffic-court-dev-values.yaml
+++ b/.gitops/charts/traffic-court-dev-values.yaml
@@ -56,6 +56,7 @@ oracle-data-api:
     "DISPUTE_REPOSITORY_SRC": "ords"
     "JJDISPUTE_REPOSITORY_SRC": "h2"
     "HISTORY_REPOSITORY_SRC": "h2"
+    "H2_DATASOURCE": "jdbc:h2:mem:testdb"
 
 staff-api:
   image:


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- changes dev to use in memory for H2

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

I ran `helm template traffic-court-online --values traffic-court-dev-values.yaml` from the `.gitops\charts` directory and observed the environment variable in the deployment,

![image](https://user-images.githubusercontent.com/1844480/214953256-198d2731-e984-46aa-95ad-0ac4db83ad51.png)


## Does the change impact or break the Docker build?

- [ ] Yes
- [ ] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
