### PR TITLE
Reset stream position when creating File, add docs

### DIFF
--- a/src/backend/TrafficCourts/TrafficCourts.Coms.Client.Test/ServiceTests/GetFileAsync.cs
+++ b/src/backend/TrafficCourts/TrafficCourts.Coms.Client.Test/ServiceTests/GetFileAsync.cs
@@ -51,6 +51,9 @@ public class GetFileAsync : ObjectManagementServiceTest
         Assert.Single(actualFile.Metadata);
         Assert.Equal("picture", actualFile.Metadata["type"]);
 
+        // expect the file position to be at the beginning of the stream
+        Assert.Equal(0L, actualFile.Data.Position);
+
         var expected = Assert.IsAssignableFrom<MemoryStream>(stream).ToArray();
         var actual = Assert.IsAssignableFrom<MemoryStream>(actualFile.Data).ToArray();
 

--- a/src/backend/TrafficCourts/TrafficCourts.Coms.Client/File.cs
+++ b/src/backend/TrafficCourts/TrafficCourts.Coms.Client/File.cs
@@ -7,26 +7,58 @@ public partial class File : IDisposable
     /// <summary>Does this instance own the memory stream and should dispose of it?</summary>
     private bool _ownsDataStream = true;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="File"/> class.
+    /// </summary>
+    /// <param name="data">The data stream containing the file data. The file stream will be rewound so the file position is at the beginning.</param>
     public File(Stream data)
         : this(data, null, null)
     {
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="File"/> class.
+    /// </summary>
+    /// <param name="data">The data stream containing the file data. The file stream will be rewound so the file position is at the beginning.</param>
+    /// <param name="fileName">The optional file name.</param>
     public File(Stream data, string? fileName)
         : this(data, fileName, null)
     {
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="File"/> class.
+    /// </summary>
+    /// <param name="data">The data stream containing the file data. The file stream will be rewound so the file position is at the beginning.</param>
+    /// <param name="fileName">The optional file name.</param>
+    /// <param name="contentType">The optional content type of the file</param>
     public File(Stream data, string? fileName, string? contentType)
         : this(data, fileName, contentType, null, null)
     {
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="File"/> class.
+    /// </summary>
+    /// <param name="data">The data stream containing the file data. The file stream will be rewound so the file position is at the beginning.</param>
+    /// <param name="fileName">The optional file name.</param>
+    /// <param name="contentType">The optional content type of the file</param>
+    /// <param name="metadata">The optional metadata properties</param>
+    /// <param name="tags">The optional tag properties</param>
     public File(Stream data, string? fileName, string? contentType, IDictionary<string, string>? metadata, IDictionary<string, string>? tags)
         : this(null, data, fileName, contentType, metadata, tags)
     {
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="File"/> class.
+    /// </summary>
+    /// <param name="id">The system generated file identifier.</param>
+    /// <param name="data">The data stream containing the file data. The file stream will be rewound so the file position is at the beginning.</param>
+    /// <param name="fileName">The optional file name.</param>
+    /// <param name="contentType">The optional content type of the file</param>
+    /// <param name="metadata">The optional metadata properties</param>
+    /// <param name="tags">The optional tag properties</param>
     public File(Guid? id, Stream data, string? fileName, string? contentType, IDictionary<string, string>? metadata, IDictionary<string, string>? tags)
     {
         Id = id;
@@ -36,6 +68,12 @@ public partial class File : IDisposable
 
         Metadata = Client.Metadata.Create(metadata);
         Tags = Factory.CreateTags(tags);
+
+        // data shouldn't be null, but to be on the safe side as there is no guard 
+        if (data is not null)
+        {
+            data.Position = 0; // rewind the stream so callers can consume the data
+        }
     }
 
     /// <summary>

--- a/src/backend/TrafficCourts/TrafficCourts.Coms.Client/IObjectManagementService.cs
+++ b/src/backend/TrafficCourts/TrafficCourts.Coms.Client/IObjectManagementService.cs
@@ -21,10 +21,10 @@ public interface IObjectManagementService
     /// <summary>
     /// Updates a file in the object management service.
     /// </summary>
-    /// <param name="id"></param>
-    /// <param name="file"></param>
-    /// <param name="cancellationToken"></param>
-    /// <returns></returns>
+    /// <param name="id">The system generated file identifier to update.</param>
+    /// <param name="file">The file object to update.</param>
+    /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+    /// <returns>A task that represents the asynchronous update operation.</returns>
     /// <exception cref="ArgumentNullException"><paramref name="file"/> is null.</exception>
     /// <exception cref="MetadataInvalidKeyException">A key contains an invalid character</exception>
     /// <exception cref="MetadataTooLongException">The total length of the metadata is too long</exception>
@@ -36,30 +36,30 @@ public interface IObjectManagementService
     Task UpdateFileAsync(Guid id, File file, CancellationToken cancellationToken);
 
     /// <summary>
-    /// Deletes a file from the object management service.
+    /// Deletes a file from the object management service. 
     /// </summary>
-    /// <param name="id"></param>
-    /// <param name="cancellationToken"></param>
-    /// <returns></returns>
+    /// <param name="id">The system generated file identifier to delete.</param>
+    /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+    /// <returns>A task that represents the asynchronous delete operation.</returns>
     /// <exception cref="ObjectManagementServiceException">Error executing the service call.</exception>
     Task DeleteFileAsync(Guid id, CancellationToken cancellationToken);
 
     /// <summary>
-    /// 
+    /// Gets the specified file from the object management service. 
     /// </summary>
-    /// <param name="id"></param>
+    /// <param name="id">The system generated file identifier to get.</param>
     /// <param name="includeTags"></param>
-    /// <param name="cancellationToken"></param>
-    /// <returns></returns>
+    /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+    /// <returns>The specified file.</returns>
     /// <exception cref="ObjectManagementServiceException"></exception>
     Task<File> GetFileAsync(Guid id, bool includeTags, CancellationToken cancellationToken);
 
     /// <summary>
-    /// 
+    /// Searches for files in the the object management service. 
     /// </summary>
-    /// <param name="parameters"></param>
-    /// <param name="cancellationToken"></param>
-    /// <returns></returns>
+    /// <param name="parameters">The search parameters used to search for matching files.</param>
+    /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+    /// <returns>The collection of found files.</returns>
     /// <exception cref="ArgumentNullException"><paramref name="parameters"/> is null.</exception>
     /// <exception cref="MetadataInvalidKeyException">An invalid metadata key was supplied.</exception>
     /// <exception cref="MetadataTooLongException">The total length of the metadata was too long.</exception>

--- a/src/backend/TrafficCourts/TrafficCourts.Coms.Client/ObjectManagementService.cs
+++ b/src/backend/TrafficCourts/TrafficCourts.Coms.Client/ObjectManagementService.cs
@@ -120,6 +120,15 @@ internal class ObjectManagementService : IObjectManagementService
             var file = new File(id, stream, fileName, contentType, metadata, tags);
             return file;
         }
+        catch (ApiException exception)
+        {
+            // Error calling the COMS service
+            // - ReadObjectAsync failed, or
+            // - GetMetadataAsync failed, or
+            // - GetTagsAsync failed
+            _logger.LogInformation(exception, "Could not get file by id, FileId={FileId}", id);
+            throw new ObjectManagementServiceException("API error getting file", exception);
+        }
         catch (Exception exception)
         {
             throw ExceptionHandler("getting file", exception);


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- When create a `File` object, the data stream passed will be rewound to the beginning.
- Add unit test to ensure ReadObjectAsync returns a stream with position = 0
- Added XML docs to IObjectManagementService
- 
## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [ ] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
