### PR TITLE
TCVP-2109 publish message for virus scan

### DIFF
--- a/src/backend/TrafficCourts/Citizen.Service/Services/IComsService.cs
+++ b/src/backend/TrafficCourts/Citizen.Service/Services/IComsService.cs
@@ -1,4 +1,5 @@
-﻿using TrafficCourts.Coms.Client;
+﻿using TrafficCourts.Common.Models;
+using TrafficCourts.Coms.Client;
 
 namespace TrafficCourts.Citizen.Service.Services;
 
@@ -44,5 +45,5 @@ public interface IComsService
     /// <exception cref="TagValueTooLongException">A tag value was too long. Maximum length of a tag value is 256.</exception>
     /// <exception cref="ObjectManagementServiceException">There was an error searching files in COMS</exception>
     /// <returns></returns>
-    Task<Dictionary<Guid, string>> GetFilesBySearchAsync(IDictionary<string, string>? metadata, IDictionary<string, string>? tags, CancellationToken cancellationToken);
+    Task<List<FileMetadata>> GetFilesBySearchAsync(IDictionary<string, string>? metadata, IDictionary<string, string>? tags, CancellationToken cancellationToken);
 }

--- a/src/backend/TrafficCourts/Common/Models/FileMetadata.cs
+++ b/src/backend/TrafficCourts/Common/Models/FileMetadata.cs
@@ -1,0 +1,20 @@
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace TrafficCourts.Common.Models;
+
+/// <summary>
+/// A class that contains metadata for a file that was uploaded through COMS
+/// </summary>
+[ExcludeFromCodeCoverage]
+public class FileMetadata
+{
+    /// <summary>
+    /// Unique identifier for a file in COMS
+    /// </summary>
+    public Guid FileId { get; set; }
+
+    /// <summary>
+    /// The file name of the uploaded file
+    /// </summary>
+    public string FileName { get; set; } = String.Empty;
+}

--- a/src/backend/TrafficCourts/Common/Models/JJDispute.cs
+++ b/src/backend/TrafficCourts/Common/Models/JJDispute.cs
@@ -1,14 +1,15 @@
 ﻿using System.Diagnostics.CodeAnalysis;
+using TrafficCourts.Common.Models;
 
 namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0;
 
 /// <summary>
-/// An extension of the JJDispute object to include dictionary of KEY IDs (Unique identifiers for the files in COMS) and filenames as VALUE of the saved files for this JJDispute.
+/// An extension of the JJDispute object to include list of file metadata that contain ID (Unique identifiers for the files in COMS) and filename of the saved files for this JJDispute.
 /// </summary>
 public partial class JJDispute
 {
     /// <summary>
-    /// Dictionary of IDs and Filenames of all the uploaded documents related to this particular JJDispute
+    /// List of file metadata that contain ID and Filename of all the uploaded documents related to this particular JJDispute
     /// </summary>
-    public Dictionary<Guid, string>? FileData { get; set; }
+    public List<FileMetadata>? FileData { get; set; }
 }

--- a/src/backend/TrafficCourts/Staff.Service/Controllers/ComsController.cs
+++ b/src/backend/TrafficCourts/Staff.Service/Controllers/ComsController.cs
@@ -1,5 +1,4 @@
-﻿using Microsoft.AspNetCore.Authorization;
-using Microsoft.AspNetCore.Mvc;
+﻿using Microsoft.AspNetCore.Mvc;
 using System.Net;
 using TrafficCourts.Common.Authorization;
 using TrafficCourts.Staff.Service.Authentication;

--- a/src/backend/TrafficCourts/Staff.Service/Services/IComsService.cs
+++ b/src/backend/TrafficCourts/Staff.Service/Services/IComsService.cs
@@ -1,4 +1,5 @@
-﻿using TrafficCourts.Coms.Client;
+﻿using TrafficCourts.Common.Models;
+using TrafficCourts.Coms.Client;
 
 namespace TrafficCourts.Staff.Service.Services;
 
@@ -48,5 +49,5 @@ public interface IComsService
     /// <param name="cancellationToken"></param>
     /// <exception cref="ObjectManagementServiceException">There was an error searching files in COMS</exception>
     /// <returns></returns>
-    Task<Dictionary<Guid, string>> GetFilesBySearchAsync(IDictionary<string, string>? metadata, IDictionary<string, string>? tags, CancellationToken cancellationToken);
+    Task<List<FileMetadata>> GetFilesBySearchAsync(IDictionary<string, string>? metadata, IDictionary<string, string>? tags, CancellationToken cancellationToken);
 }

--- a/src/backend/TrafficCourts/Workflow.Service/Consumers/VirusScanDocumentConsumer.cs
+++ b/src/backend/TrafficCourts/Workflow.Service/Consumers/VirusScanDocumentConsumer.cs
@@ -1,7 +1,4 @@
 ﻿using MassTransit;
-using Microsoft.AspNetCore.Mvc;
-using Newtonsoft.Json.Linq;
-using System.Net;
 using TrafficCourts.Common.OpenAPIs.VirusScan.V1;
 using TrafficCourts.Coms.Client;
 using TrafficCourts.Messaging.MessageContracts;

--- a/src/backend/TrafficCourts/Workflow.Service/Services/VirusScanService.cs
+++ b/src/backend/TrafficCourts/Workflow.Service/Services/VirusScanService.cs
@@ -24,7 +24,7 @@ namespace TrafficCourts.Workflow.Service.Services
             catch (ApiException ex)
             {
                 _logger.LogError(ex, "Could not scan the file for viruses");
-                throw ex;
+                throw;
             }
         }
     }


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- [TCVP-2109](https://justice.gov.bc.ca/jira/browse/TCVP-2109)
- Added functionality to kick off a virus scan message to the workflow service on successful document upload. 
- Changed response type to be a list of file metadata object on document search instead of dictionary. 
- Fixed some minor issues.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
