### PR TITLE
TCVP-2120 Implemented setStatus for JJDispute

### DIFF
--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/mapper/JJDisputeMapper.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/mapper/JJDisputeMapper.java
@@ -119,6 +119,7 @@ public abstract class JJDisputeMapper {
 	@Mapping(source = "accUpdUserId", target = "jjDisputedCountRoP.modifiedBy")
 	public abstract JJDisputedCount convert(ca.bc.gov.open.jag.tco.oracledataapi.ords.tco.api.model.JJDisputeCount jjDisputeCount);
 
+	/** Convert TCO ORDS -> Oracle Data API */
 	@Mapping(source = "disputeRemarkId", target = "id")
 	@Mapping(source = "disputeId", target = "jjDispute.id")
 	@Mapping(source = "disputeRemarkTxt", target = "note")
@@ -129,6 +130,17 @@ public abstract class JJDisputeMapper {
 	@Mapping(source = "updDtm", target = "modifiedTs")
 	@Mapping(source = "updUserId", target = "modifiedBy")
 	public abstract JJDisputeRemark convert(ca.bc.gov.open.jag.tco.oracledataapi.ords.tco.api.model.JJDisputeRemark jjDisputeRemark);
+
+	@Mapping(source = "id", target = "disputeRemarkId")
+	@Mapping(source = "jjDispute.id", target = "disputeId")
+	@Mapping(source = "note", target = "disputeRemarkTxt")
+	@Mapping(source = "userFullName", target = "fullUserNameTxt")
+	@Mapping(source = "remarksMadeTs", target = "remarksMadeDtm")
+	@Mapping(source = "createdBy", target = "entDtm")
+	@Mapping(source = "createdTs", target = "entUserId")
+	@Mapping(source = "modifiedBy", target = "updUserId")
+	@Mapping(source = "modifiedTs", target = "updDtm")
+	public abstract ca.bc.gov.open.jag.tco.oracledataapi.ords.tco.api.model.JJDisputeRemark convert(JJDisputeRemark jjDisputeRemark);
 
 	@Mapping(source = "appearanceDtm", target = "appearanceTs")
 	@Mapping(source = "appearanceReasonTxt", target = "reason")

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/model/JJDispute.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/model/JJDispute.java
@@ -369,17 +369,22 @@ public class JJDispute extends Auditable<String> {
 	@OneToMany(targetEntity = JJDisputeRemark.class, cascade = CascadeType.ALL, fetch = FetchType.LAZY, orphanRemoval = true, mappedBy = "jjDispute")
 	public List<JJDisputeRemark> remarks = new ArrayList<JJDisputeRemark>();
 
-	public void addRemarks(List<JJDisputeRemark> remarks) {
-		for (JJDisputeRemark remark : remarks) {
-			remark.setJjDispute(this);
-		}
-		this.remarks.addAll(remarks);
-	}
-
 	@JsonManagedReference(value = "jj_dispute_count_reference")
 	@OneToMany(targetEntity = JJDisputedCount.class, cascade = CascadeType.ALL, fetch = FetchType.LAZY, orphanRemoval = true)
 	@JoinColumn(name = "jjdispute_id")
 	public List<JJDisputedCount> jjDisputedCounts = new ArrayList<JJDisputedCount>();
+
+	@JsonManagedReference(value = "jj_dispute_court_appearance_rop_reference")
+	@OneToMany(targetEntity = JJDisputeCourtAppearanceRoP.class, cascade = CascadeType.ALL, fetch = FetchType.LAZY, orphanRemoval = true)
+	@JoinColumn(name = "jjdispute_id")
+	public List<JJDisputeCourtAppearanceRoP> jjDisputeCourtAppearanceRoPs = new ArrayList<JJDisputeCourtAppearanceRoP>();
+
+	/**
+	 * Simple constructor to create a blank JJDispute with the id.
+	 */
+	public JJDispute(Long jjDisputeId) {
+		this.id = jjDisputeId;
+	}
 
 	public void addJJDisputedCounts(List<JJDisputedCount> disputedCounts) {
 		for (JJDisputedCount disputedCount : disputedCounts) {
@@ -388,10 +393,12 @@ public class JJDispute extends Auditable<String> {
 		this.jjDisputedCounts.addAll(disputedCounts);
 	}
 
-	@JsonManagedReference(value = "jj_dispute_court_appearance_rop_reference")
-	@OneToMany(targetEntity = JJDisputeCourtAppearanceRoP.class, cascade = CascadeType.ALL, fetch = FetchType.LAZY, orphanRemoval = true)
-	@JoinColumn(name = "jjdispute_id")
-	public List<JJDisputeCourtAppearanceRoP> jjDisputeCourtAppearanceRoPs = new ArrayList<JJDisputeCourtAppearanceRoP>();
+	public void addRemarks(List<JJDisputeRemark> remarks) {
+		for (JJDisputeRemark remark : remarks) {
+			remark.setJjDispute(this);
+		}
+		this.remarks.addAll(remarks);
+	}
 
 	public void addJJDisputeCourtAppearances(List<JJDisputeCourtAppearanceRoP> disputeCourtAppearanceRoPs) {
 		for (JJDisputeCourtAppearanceRoP disputeCourtAppearanceRoP : disputeCourtAppearanceRoPs) {

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/model/JJDisputeRemark.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/model/JJDisputeRemark.java
@@ -58,7 +58,7 @@ public class JJDisputeRemark extends Auditable<String> {
 
 	@JsonBackReference
 	@ManyToOne(targetEntity=JJDispute.class, fetch = FetchType.LAZY)
-	@JoinColumn(name = "ticket_number")
+	@JoinColumn(name = "jj_dispute_id")
 	@Schema(hidden = true)
 	private JJDispute jjDispute;
 

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/repository/JJDisputeRemarkRepository.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/repository/JJDisputeRemarkRepository.java
@@ -1,0 +1,16 @@
+package ca.bc.gov.open.jag.tco.oracledataapi.repository;
+
+import ca.bc.gov.open.jag.tco.oracledataapi.model.JJDisputeRemark;
+
+public interface JJDisputeRemarkRepository {
+
+	/**
+	 * Saves a given entity. Use the returned instance for further operations as the save operation might have changed the entity instance completely.
+	 *
+	 * @param entity must not be {@literal null}.
+	 * @return the saved entity; will never be {@literal null}.
+	 * @throws IllegalArgumentException in case the given {@literal entity} is {@literal null}.
+	 */
+	public JJDisputeRemark saveAndFlush(JJDisputeRemark entity);
+
+}

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/repository/JJDisputeRepository.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/repository/JJDisputeRepository.java
@@ -5,7 +5,10 @@ import java.util.List;
 import java.util.Optional;
 
 import ca.bc.gov.open.jag.tco.oracledataapi.model.JJDispute;
+import ca.bc.gov.open.jag.tco.oracledataapi.model.JJDisputeCourtAppearanceAPP;
+import ca.bc.gov.open.jag.tco.oracledataapi.model.JJDisputeCourtAppearanceDATT;
 import ca.bc.gov.open.jag.tco.oracledataapi.model.JJDisputeStatus;
+import ca.bc.gov.open.jag.tco.oracledataapi.model.YesNo;
 
 public interface JJDisputeRepository {
 
@@ -59,11 +62,17 @@ public interface JJDisputeRepository {
 	/**
 	 * Sets the status field on the given JJDispute.
 	 *
-	 * @param ticketNumber
-	 * @param jjDisputeStatus
-	 * @param userName
-	 * @param partId
+	 * @param disputeId
+	 * @param disputeStatus
+	 * @param userId
 	 * @param courtAppearanceId
+	 * @param seizedYn
+	 * @param adjudicatorPartId
+	 * @param aattCd
+	 * @param dattCd
+	 * @param staffPartId
 	 */
-	public void setStatus(String ticketNumber, JJDisputeStatus jjDisputeStatus, String userName, String partId, Long courtAppearanceId);
+	public void setStatus(Long disputeId, JJDisputeStatus disputeStatus, String userId, Long courtAppearanceId, YesNo seizedYn,
+			String adjudicatorPartId, JJDisputeCourtAppearanceAPP aattCd, JJDisputeCourtAppearanceDATT dattCd, String staffPartId);
+
 }

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/repository/impl/h2/JJDisputeRemarkRepositoryImpl.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/repository/impl/h2/JJDisputeRemarkRepositoryImpl.java
@@ -1,0 +1,14 @@
+package ca.bc.gov.open.jag.tco.oracledataapi.repository.impl.h2;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import ca.bc.gov.open.jag.tco.oracledataapi.model.JJDisputeRemark;
+import ca.bc.gov.open.jag.tco.oracledataapi.repository.JJDisputeRemarkRepository;
+
+@ConditionalOnProperty(name = "repository.jjdispute", havingValue = "h2", matchIfMissing = true)
+@Qualifier("jjDisputeRemarkRepository")
+public interface JJDisputeRemarkRepositoryImpl extends JJDisputeRemarkRepository, JpaRepository<JJDisputeRemark, Long> {
+
+}

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/repository/impl/h2/JJDisputeRepositoryImpl.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/repository/impl/h2/JJDisputeRepositoryImpl.java
@@ -11,7 +11,10 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.transaction.annotation.Transactional;
 
 import ca.bc.gov.open.jag.tco.oracledataapi.model.JJDispute;
+import ca.bc.gov.open.jag.tco.oracledataapi.model.JJDisputeCourtAppearanceAPP;
+import ca.bc.gov.open.jag.tco.oracledataapi.model.JJDisputeCourtAppearanceDATT;
 import ca.bc.gov.open.jag.tco.oracledataapi.model.JJDisputeStatus;
+import ca.bc.gov.open.jag.tco.oracledataapi.model.YesNo;
 import ca.bc.gov.open.jag.tco.oracledataapi.repository.JJDisputeRepository;
 
 @ConditionalOnProperty(name = "repository.jjdispute", havingValue = "h2", matchIfMissing = true)
@@ -24,11 +27,21 @@ public interface JJDisputeRepositoryImpl extends JJDisputeRepository, JpaReposit
 
 	@Override
 	@Modifying(clearAutomatically = true)
-	@Query("update JJDispute jj set jj.status = :jjDisputeStatus, jj.modifiedBy = :userName, jj.modifiedTs = CURRENT_TIMESTAMP() where jj.ticketNumber = :ticketNumber and :partId = null and :courtAppearanceId = null")
+	@Query("update JJDispute jj set jj.status = :jjDisputeStatus, jj.modifiedBy = :userId, jj.modifiedTs = CURRENT_TIMESTAMP() "
+			+ "where jj.id = :jjDisputeId "
+
+			// NOTE: this query does nothing with courtAppearanceId, seized, ... staffPartId as these are not fields in the JJDispute record.
+			+ "and (1=1 or :courtAppearanceId is null or :seizedYn is null or :adjudicatorPartId is null or :aattCd is null or :dattCd is null or :staffPartId is null)")
 	@Transactional
 	public void setStatus(
-			@Param(value = "ticketNumber") String ticketNumber,
-			@Param(value = "jjDisputeStatus") JJDisputeStatus jjDisputeStatus,
-			@Param(value = "userName") String userName, @Param(value = "partId") String partId, @Param(value = "courtAppearanceId") Long courtAppearanceId);
+			@Param(value = "jjDisputeId") Long disputeId,
+			@Param(value = "jjDisputeStatus") JJDisputeStatus disputeStatus,
+			@Param(value = "userId") String userId,
+			@Param(value = "courtAppearanceId") Long courtAppearanceId,
+			@Param(value = "seizedYn") YesNo seizedYn,
+			@Param(value = "adjudicatorPartId") String adjudicatorPartId,
+			@Param(value = "aattCd") JJDisputeCourtAppearanceAPP aattCd,
+			@Param(value = "dattCd") JJDisputeCourtAppearanceDATT dattCd,
+			@Param(value = "staffPartId") String staffPartId);
 
 }

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/repository/impl/ords/JJDisputeRemarkRepositoryImpl.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/repository/impl/ords/JJDisputeRemarkRepositoryImpl.java
@@ -1,0 +1,60 @@
+package ca.bc.gov.open.jag.tco.oracledataapi.repository.impl.ords;
+
+import java.util.function.Supplier;
+
+import javax.ws.rs.InternalServerErrorException;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Repository;
+
+import ca.bc.gov.open.jag.tco.oracledataapi.mapper.JJDisputeMapper;
+import ca.bc.gov.open.jag.tco.oracledataapi.model.JJDisputeRemark;
+import ca.bc.gov.open.jag.tco.oracledataapi.ords.tco.api.JjDisputeApi;
+import ca.bc.gov.open.jag.tco.oracledataapi.ords.tco.api.model.RemarkResponseResult;
+import ca.bc.gov.open.jag.tco.oracledataapi.repository.JJDisputeRemarkRepository;
+
+@ConditionalOnProperty(name = "repository.jjdispute", havingValue = "ords", matchIfMissing = false)
+@Qualifier("jjDisputeRemarkRepository")
+@Repository
+public class JJDisputeRemarkRepositoryImpl implements JJDisputeRemarkRepository {
+
+	// Delegate, OpenAPI generated client
+	private final JjDisputeApi jjDisputeApi;
+
+	@Autowired
+	private JJDisputeMapper jjDisputeMapper;
+
+	public JJDisputeRemarkRepositoryImpl(JjDisputeApi jjDisputeApi) {
+		this.jjDisputeApi = jjDisputeApi;
+	}
+
+	@Override
+	public JJDisputeRemark saveAndFlush(JJDisputeRemark jjDisputeRemark) {
+		assertNoExceptions(() -> jjDisputeApi.v1ProcessDisputeRemarkPost(jjDisputeMapper.convert(jjDisputeRemark)));
+		return null; // There is no TCO ORDS endpoint that will fetch a JJDisputeRemark by id so we can't return the newly saved record.
+	}
+
+	/**
+	 * A helper method that will throw an appropriate InternalServerErrorException based on the ResponseResult. Any RuntimeExceptions throw will propagate up to caller.
+	 * @return
+	 */
+	private RemarkResponseResult assertNoExceptions(Supplier<RemarkResponseResult> m) {
+		RemarkResponseResult result = m.get();
+
+		if (result == null) {
+			// Missing response object.
+			throw new InternalServerErrorException("Invalid ResponseResult object");
+		} else if (result.getException() != null) {
+			// Exception in response exists
+			throw new InternalServerErrorException(result.getException());
+		} else if (!"1".equals(result.getStatus())) {
+			// Status is not 1 (success)
+			throw new InternalServerErrorException("Status is not 1 (success)");
+		} else {
+			return result;
+		}
+	}
+
+}

--- a/src/backend/oracle-data-api/src/main/resources/tco-openapi-spec.yaml
+++ b/src/backend/oracle-data-api/src/main/resources/tco-openapi-spec.yaml
@@ -105,16 +105,26 @@ paths:
                 $ref: '#/components/schemas/ResponseResult'
       tags:
         - JJDispute
+  /v1/processDisputeRemark:
+    post:
+      requestBody:
+        description: body
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/JJDisputeRemark'
+        required: true
+      responses:
+        '200':
+          description: Ok
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RemarkResponseResult'
+      tags:
+        - JJDispute
 components:
   schemas:
-    ResponseResult:
-      type: object
-      properties:
-        status:
-          type: string
-        exception:
-          type: string
-          format: nullable
     AuditBase:
       type: object
       properties:
@@ -453,3 +463,25 @@ components:
         currentTimestamp:
           type: string
           format: date-time
+    ResponseResult:
+      type: object
+      properties:
+        status:
+          type: string
+        disputeId:
+          type: string
+          format: nullable
+        exception:
+          type: string
+          format: nullable
+    RemarkResponseResult:
+      type: object
+      properties:
+        status:
+          type: string
+        disputeRemarkId:
+          type: string
+          format: nullable
+        exception:
+          type: string
+          format: nullable

--- a/src/backend/oracle-data-api/src/test/java/ca/bc/gov/open/jag/tco/oracledataapi/controller/v1_0/JJDisputeControllerTest.java
+++ b/src/backend/oracle-data-api/src/test/java/ca/bc/gov/open/jag/tco/oracledataapi/controller/v1_0/JJDisputeControllerTest.java
@@ -206,10 +206,9 @@ class JJDisputeControllerTest extends BaseTestSuite {
 		assertEquals(JJDisputeStatus.CONFIRMED, jjDispute.getStatus());
 
 		// Set the status to REVIEW
-		jjDisputeController.reviewJJDispute(ticketNumber, "Test Remark", false, principal);
+		jjDispute = jjDisputeController.reviewJJDispute(ticketNumber, "Test Remark", false, principal).getBody();
 
 		// Assert status and remark are set.
-		jjDispute = jjDisputeController.getJJDispute(ticketNumber, false, principal).getBody();
 		assertEquals(JJDisputeStatus.REVIEW, jjDispute.getStatus());
 		assertEquals("Test Remark", jjDispute.getRemarks().get(0).getNote());
 		assertEquals("testUser", jjDispute.getRemarks().get(0).getUserFullName());

--- a/src/backend/oracle-data-api/src/test/java/ca/bc/gov/open/jag/tco/oracledataapi/service/DisputeServiceOrdsOccamTest.java
+++ b/src/backend/oracle-data-api/src/test/java/ca/bc/gov/open/jag/tco/oracledataapi/service/DisputeServiceOrdsOccamTest.java
@@ -35,7 +35,7 @@ class DisputeServiceOrdsOccamTest extends BaseTestSuite {
 	private HealthApi ordsOccamHealthApi;
 
 	@Test
-	void testPingOrdsOccam() throws Exception {
+	public void testPingOrdsOccam() throws Exception {
 		PingResult pingResult = ordsOccamHealthApi.ping();
 		assertNotNull(pingResult);
 		assertEquals("success", pingResult.getStatus());

--- a/src/backend/oracle-data-api/src/test/java/ca/bc/gov/open/jag/tco/oracledataapi/service/DisputeServiceOrdsTcoTest.java
+++ b/src/backend/oracle-data-api/src/test/java/ca/bc/gov/open/jag/tco/oracledataapi/service/DisputeServiceOrdsTcoTest.java
@@ -3,14 +3,13 @@ package ca.bc.gov.open.jag.tco.oracledataapi.service;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-import java.util.List;
-
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import ca.bc.gov.open.jag.tco.oracledataapi.BaseTestSuite;
 import ca.bc.gov.open.jag.tco.oracledataapi.model.JJDispute;
+import ca.bc.gov.open.jag.tco.oracledataapi.model.JJDisputeStatus;
 import ca.bc.gov.open.jag.tco.oracledataapi.ords.tco.api.HealthApi;
 import ca.bc.gov.open.jag.tco.oracledataapi.ords.tco.api.model.PingResult;
 
@@ -34,11 +33,23 @@ class DisputeServiceOrdsTcoTest extends BaseTestSuite {
 	public void testJjDispute_GET() throws Exception {
 		// TODO: replace this test with a POST/GET/PUT/DELETE to confirm CRUD
 		// Hard-coded TicketNumber for now since there are no POST/DELETE endpoints yet.
-		List<JJDispute> jjDisputes = jjDisputeService.getJJDisputes(null, "EA90100004");
+		String ticketNumber = "EA90100004";
 
-		assertNotNull(jjDisputes);
-		assertEquals(1, jjDisputes.size());
-		assertEquals("EA90100004", jjDisputes.get(0).getTicketNumber());
+		JJDispute jjDispute = jjDisputeService.getJJDisputeByTicketNumber(ticketNumber);
+		assertNotNull(jjDispute);
+		assertEquals(ticketNumber, jjDispute.getTicketNumber());
+
+		// Try setting the status to IN_PROGRESS
+		JJDispute jjDisputeDb = jjDisputeService.setStatus(
+				ticketNumber,
+				JJDisputeStatus.IN_PROGRESS,
+				getPrincipal(),
+				"A custom remark 3. Setting status to IN_PROGRESS ...",
+				"1",
+				Long.valueOf(1l));
+		assertNotNull(jjDisputeDb);
+		assertEquals(ticketNumber, jjDisputeDb.getTicketNumber());
+		assertEquals(JJDisputeStatus.IN_PROGRESS, jjDisputeDb.getStatus());
 	}
 
 }


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

TCVP-2120

Implemented setStatus with remarks for JJDisputes TCO ORDS endpoint.
- added JJDisputeRemark mapper
- added JJDisputeRemarkRepository to save entities
- updated tco OpenApi spec to include remarks
- added junit tests
- 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

mvn verify

Ran a test that commits a status change (with comments) to the actual TCO ORDS instance.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
