### PR TITLE
Updated mapping per changed ORDS serialization

### DIFF
--- a/src/backend/oracle-data-api/src/main/resources/tco-openapi-spec.yaml
+++ b/src/backend/oracle-data-api/src/main/resources/tco-openapi-spec.yaml
@@ -350,7 +350,7 @@ components:
         vtcAssignedDtm:
           type: string
           format: date-time
-          x-field-extra-annotation: "@com.fasterxml.jackson.annotation.JsonFormat(pattern=\"yyyy-MM-dd'T'HH:mm'Z'\")"
+          x-field-extra-annotation: "@com.fasterxml.jackson.annotation.JsonFormat(pattern=\"yyyy-MM-dd'T'HH:mm:ss'Z'\")"
         witnessNo:
           type: string
           format: nullable


### PR DESCRIPTION
Fixed mapping of a Date field due to a changed ORDS date-format serialization change.

Junit serialization test passes again.