### PR TITLE
TCVP-2120 exposed ORDS TCO /v1/assignDisputeVtc

### DIFF
--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/repository/JJDisputeRepository.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/repository/JJDisputeRepository.java
@@ -11,6 +11,13 @@ import ca.bc.gov.open.jag.tco.oracledataapi.model.YesNo;
 
 public interface JJDisputeRepository {
 
+	/**
+	 * Assigns a particular JJDispute (by ticketNumber) to the supplied username.
+	 * @param ticketNumber
+	 * @param username
+	 */
+	public void assignJJDisputeVtc(String ticketNumber, String username);
+
 	/** Fetch all records which have the specified jjAssigned. */
 	public List<JJDispute> findByJjAssignedToIgnoreCase(String jjAssigned);
 

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/repository/impl/h2/JJDisputeRepositoryImpl.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/repository/impl/h2/JJDisputeRepositoryImpl.java
@@ -22,6 +22,11 @@ import ca.bc.gov.open.jag.tco.oracledataapi.repository.JJDisputeRepository;
 public interface JJDisputeRepositoryImpl extends JJDisputeRepository, JpaRepository<JJDispute, Long> {
 
 	@Override
+	@Modifying(clearAutomatically = true)
+	@Query("update JJDispute jj set jj.vtcAssignedTo = :username, jj.vtcAssignedTs = CURRENT_TIMESTAMP() where jj.ticketNumber = :ticketNumber")
+	public void assignJJDisputeVtc(String ticketNumber, String username);
+
+	@Override
 	@Query("select jj from JJDispute jj where jj.ticketNumber = :ticketNumber")
 	public List<JJDispute> findByTicketNumber(@Param(value = "ticketNumber") String ticketNumber);
 

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/repository/impl/ords/JJDisputeRepositoryImpl.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/repository/impl/ords/JJDisputeRepositoryImpl.java
@@ -27,6 +27,7 @@ import ca.bc.gov.open.jag.tco.oracledataapi.model.JJDisputeStatus;
 import ca.bc.gov.open.jag.tco.oracledataapi.model.YesNo;
 import ca.bc.gov.open.jag.tco.oracledataapi.ords.occam.api.handler.ApiException;
 import ca.bc.gov.open.jag.tco.oracledataapi.ords.tco.api.JjDisputeApi;
+import ca.bc.gov.open.jag.tco.oracledataapi.ords.tco.api.model.DisputeResponseResult;
 import ca.bc.gov.open.jag.tco.oracledataapi.ords.tco.api.model.JJDisputeListResponse;
 import ca.bc.gov.open.jag.tco.oracledataapi.ords.tco.api.model.ResponseResult;
 import ca.bc.gov.open.jag.tco.oracledataapi.repository.JJDisputeRepository;
@@ -46,6 +47,11 @@ public class JJDisputeRepositoryImpl implements JJDisputeRepository {
 
 	public JJDisputeRepositoryImpl(JjDisputeApi jjDisputeApi) {
 		this.jjDisputeApi = jjDisputeApi;
+	}
+
+	@Override
+	public void assignJJDisputeVtc(String ticketNumber, String username) {
+		assertNoExceptionsGeneric(() -> jjDisputeApi.v1AssignDisputeVtcPost(username, ticketNumber));
 	}
 
 	@Override
@@ -88,7 +94,7 @@ public class JJDisputeRepositoryImpl implements JJDisputeRepository {
 	@Override
 	public JJDispute saveAndFlush(JJDispute jjDispute) {
 		try {
-			ResponseResult responseResult = assertNoExceptions(() -> {
+			DisputeResponseResult responseResult = assertNoExceptions(() -> {
 				ca.bc.gov.open.jag.tco.oracledataapi.ords.tco.api.model.JJDispute convert = jjDisputeMapper.convert(jjDispute);
 				return jjDisputeApi.v1UpdateDisputePut(convert);
 			});
@@ -137,8 +143,29 @@ public class JJDisputeRepositoryImpl implements JJDisputeRepository {
 	 * A helper method that will throw an appropriate InternalServerErrorException based on the ResponseResult. Any RuntimeExceptions throw will propagate up to caller.
 	 * @return
 	 */
-	private ResponseResult assertNoExceptions(Supplier<ResponseResult> m) {
+	private ResponseResult assertNoExceptionsGeneric(Supplier<ResponseResult> m) {
 		ResponseResult result = m.get();
+
+		if (result == null) {
+			// Missing response object.
+			throw new InternalServerErrorException("Invalid ResponseResult object");
+		} else if (result.getException() != null) {
+			// Exception in response exists
+			throw new InternalServerErrorException(result.getException());
+		} else if (!"1".equals(result.getStatus())) {
+			// Status is not 1 (success)
+			throw new InternalServerErrorException("Status is not 1 (success)");
+		} else {
+			return result;
+		}
+	}
+
+	/**
+	 * A helper method that will throw an appropriate InternalServerErrorException based on the ResponseResult. Any RuntimeExceptions throw will propagate up to caller.
+	 * @return
+	 */
+	private DisputeResponseResult assertNoExceptions(Supplier<DisputeResponseResult> m) {
+		DisputeResponseResult result = m.get();
 
 		if (result == null) {
 			// Missing response object.

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/service/JJDisputeService.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/service/JJDisputeService.java
@@ -86,11 +86,7 @@ public class JJDisputeService {
 		JJDispute jjDispute = findByTicketNumberUnique(ticketNumber).orElseThrow();
 
 		if (StringUtils.isBlank(jjDispute.getVtcAssignedTo()) || jjDispute.getVtcAssignedTo().equals(principal.getName())) {
-
-			// FIXME: setting vtcAssignedTo doesn't work in ORDS, rather call the {{JUSTIN-TCO}}/v1/assignDisputeVtc endpoint
-			jjDispute.setVtcAssignedTo(principal.getName());
-			jjDispute.setVtcAssignedTs(new Date());
-			jjDisputeRepository.saveAndFlush(jjDispute);
+			jjDisputeRepository.assignJJDisputeVtc(ticketNumber, principal.getName());
 
 			logger.debug("JJDispute with ticket Number {} has been assigned to {}", ticketNumber, principal.getName());
 

--- a/src/backend/oracle-data-api/src/main/resources/tco-openapi-spec.yaml
+++ b/src/backend/oracle-data-api/src/main/resources/tco-openapi-spec.yaml
@@ -57,6 +57,28 @@ paths:
           content:
             application/json:
               schema:
+                $ref: '#/components/schemas/DisputeResponseResult'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+      tags:
+        - JJDispute
+  /v1/assignDisputeVtc:
+    post:
+      parameters:
+        - name: userId
+          in: query
+          schema:
+            type: string
+        - name: ticketNumber
+          in: query
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Ok
+          content:
+            application/json:
+              schema:
                 $ref: '#/components/schemas/ResponseResult'
         '401':
           $ref: '#/components/responses/Unauthorized'
@@ -154,7 +176,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ResponseResult'
+                $ref: '#/components/schemas/DisputeResponseResult'
         '401':
           $ref: '#/components/responses/Unauthorized'
       tags:
@@ -542,6 +564,14 @@ components:
           type: string
           format: date-time
     ResponseResult:
+      type: object
+      properties:
+        status:
+          type: string
+        exception:
+          type: string
+          format: nullable
+    DisputeResponseResult:
       type: object
       properties:
         status:

--- a/src/backend/oracle-data-api/src/test/java/ca/bc/gov/open/jag/tco/oracledataapi/BaseTestSuite.java
+++ b/src/backend/oracle-data-api/src/test/java/ca/bc/gov/open/jag/tco/oracledataapi/BaseTestSuite.java
@@ -127,7 +127,7 @@ public class BaseTestSuite {
 	}
 
 	/** Helper method to return an instance of Principal */
-	private Principal getPrincipal(String name) {
+	public Principal getPrincipal(String name) {
 		return new Principal() {
 			@Override
 			public String getName() {


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

TCVP-2120
- exposed /v1/assignDisputeVtc in OpenAPI spec
- added junit test to confirm actual persistence in ORDs
- renamed `ResponseResult `to `DisputeResponseResult `to make room for the generic new `ResponseResult `

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

mvn verify

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
