### PR TITLE
TCVP-2120 exposed ORDS TCO /v1/unassignDisputeVtc

### DIFF
--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/repository/JJDisputeRepository.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/repository/JJDisputeRepository.java
@@ -18,11 +18,15 @@ public interface JJDisputeRepository {
 	 */
 	public void assignJJDisputeVtc(String ticketNumber, String username);
 
+	/**
+	 * Unassigned JJDisputes older than the supplied datestamp (or just the one JJDispute if ticketNumber is supplied).
+	 * @param ticketNumber
+	 * @param assignedBeforeTs
+	 */
+	public void unassignJJDisputeVtc(String ticketNumber, Date assignedBeforeTs);
+
 	/** Fetch all records which have the specified jjAssigned. */
 	public List<JJDispute> findByJjAssignedToIgnoreCase(String jjAssigned);
-
-	/** Fetch all records whose assignedTs has a timestamp older than the given date. */
-	public Iterable<JJDispute> findByVtcAssignedTsBefore(Date olderThan);
 
 	/**
 	 * Deletes all entities managed by the repository.

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/repository/impl/h2/JJDisputeRepositoryImpl.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/repository/impl/h2/JJDisputeRepositoryImpl.java
@@ -1,5 +1,6 @@
 package ca.bc.gov.open.jag.tco.oracledataapi.repository.impl.h2;
 
+import java.util.Date;
 import java.util.List;
 
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -25,6 +26,11 @@ public interface JJDisputeRepositoryImpl extends JJDisputeRepository, JpaReposit
 	@Modifying(clearAutomatically = true)
 	@Query("update JJDispute jj set jj.vtcAssignedTo = :username, jj.vtcAssignedTs = CURRENT_TIMESTAMP() where jj.ticketNumber = :ticketNumber")
 	public void assignJJDisputeVtc(String ticketNumber, String username);
+
+	@Override
+	@Modifying(clearAutomatically = true)
+	@Query("update JJDispute jj set jj.vtcAssignedTo = null, jj.vtcAssignedTs = null where jj.vtcAssignedTs < :assignedBeforeTs and (:ticketNumber is null or jj.ticketNumber = :ticketNumber)")
+	public void unassignJJDisputeVtc(String ticketNumber, Date assignedBeforeTs);
 
 	@Override
 	@Query("select jj from JJDispute jj where jj.ticketNumber = :ticketNumber")

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/repository/impl/ords/JJDisputeRepositoryImpl.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/repository/impl/ords/JJDisputeRepositoryImpl.java
@@ -31,6 +31,7 @@ import ca.bc.gov.open.jag.tco.oracledataapi.ords.tco.api.model.DisputeResponseRe
 import ca.bc.gov.open.jag.tco.oracledataapi.ords.tco.api.model.JJDisputeListResponse;
 import ca.bc.gov.open.jag.tco.oracledataapi.ords.tco.api.model.ResponseResult;
 import ca.bc.gov.open.jag.tco.oracledataapi.repository.JJDisputeRepository;
+import ca.bc.gov.open.jag.tco.oracledataapi.util.DateUtil;
 
 @ConditionalOnProperty(name = "repository.jjdispute", havingValue = "ords", matchIfMissing = false)
 @Qualifier("jjDisputeRepository")
@@ -55,12 +56,12 @@ public class JJDisputeRepositoryImpl implements JJDisputeRepository {
 	}
 
 	@Override
-	public List<JJDispute> findByJjAssignedToIgnoreCase(String jjAssigned) {
-		throw new NotYetImplementedException();
+	public void unassignJJDisputeVtc(String ticketNumber, Date assignedBeforeTs) {
+		assertNoExceptionsGeneric(() -> jjDisputeApi.v1UnassignDisputeVtcPost(DateUtil.formatAsDateTimeUTC(assignedBeforeTs), ticketNumber));
 	}
 
 	@Override
-	public Iterable<JJDispute> findByVtcAssignedTsBefore(Date olderThan) {
+	public List<JJDispute> findByJjAssignedToIgnoreCase(String jjAssigned) {
 		throw new NotYetImplementedException();
 	}
 

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/service/JJDisputeService.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/service/JJDisputeService.java
@@ -101,19 +101,10 @@ public class JJDisputeService {
 	 * @return number of records modified.
 	 */
 	public void unassignJJDisputes() {
-		int count = 0;
-
 		// Find all Disputes with an assignedTs older than 1 hour ago.
 		Date hourAgo = DateUtils.addHours(new Date(), -1);
 		logger.debug("Unassigning all jj-disputes older than {}", hourAgo.toInstant());
-		for (JJDispute jjdispute : jjDisputeRepository.findByVtcAssignedTsBefore(hourAgo)) {
-			jjdispute.setVtcAssignedTo(null);
-			jjdispute.setVtcAssignedTs(null);
-			jjDisputeRepository.saveAndFlush(jjdispute);
-			count++;
-		}
-
-		logger.debug("Unassigned {} record(s)", count);
+		jjDisputeRepository.unassignJJDisputeVtc(null, hourAgo);
 	}
 
 	/**

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/util/DateUtil.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/util/DateUtil.java
@@ -19,4 +19,13 @@ public class DateUtil {
 		return DateFormatUtils.formatUTC(date, TIME_FORMAT);
 	}
 
+	/**
+	 * Returns the date in the format "yyyy-MM-dd'T'HH:mm:ss'Z'"
+	 * @param date
+	 * @return
+	 */
+	public static String formatAsDateTimeUTC(Date date) {
+		return DateFormatUtils.formatUTC(date, DATE_TIME_FORMAT);
+	}
+
 }

--- a/src/backend/oracle-data-api/src/main/resources/tco-openapi-spec.yaml
+++ b/src/backend/oracle-data-api/src/main/resources/tco-openapi-spec.yaml
@@ -84,6 +84,28 @@ paths:
           $ref: '#/components/responses/Unauthorized'
       tags:
         - JJDispute
+  /v1/unassignDisputeVtc:
+    post:
+      parameters:
+        - name: assignedBeforeTs
+          in: query
+          schema:
+            type: string
+        - name: ticketNumber
+          in: query
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Ok
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResponseResult'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+      tags:
+        - JJDispute
   /v1/jjDisputeList:
     get:
       parameters:

--- a/src/backend/oracle-data-api/src/test/java/ca/bc/gov/open/jag/tco/oracledataapi/service/DisputeServiceOrdsTcoTest.java
+++ b/src/backend/oracle-data-api/src/test/java/ca/bc/gov/open/jag/tco/oracledataapi/service/DisputeServiceOrdsTcoTest.java
@@ -3,6 +3,7 @@ package ca.bc.gov.open.jag.tco.oracledataapi.service;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Date;
@@ -129,6 +130,26 @@ class DisputeServiceOrdsTcoTest extends BaseTestSuite {
 		assertEquals(username, jjDispute.getVtcAssignedTo());
 		// vtcAssignedTs should have been set by the stored procedure so we don't know the exact time, but it should have happened in the last 5 minutes.
 		assertTrue(jjDispute.getVtcAssignedTs().after(DateUtils.addMinutes(new Date(), -5)));
+	}
+
+	@Test
+	public void testJjDisputeUnAssignVtc_POST() throws Exception {
+		String ticketNumber = "EA90100004";
+		String username = RandomUtil.randomGivenName().charAt(0) + RandomUtil.randomSurname();
+
+		// Ensure JJDispute is assigned.
+		jjDisputeRepository.assignJJDisputeVtc(ticketNumber, username);
+		JJDispute jjDispute = jjDisputeService.getJJDisputeByTicketNumber(ticketNumber);
+		assertNotNull(jjDispute.getVtcAssignedTo());
+		assertNotNull(jjDispute.getVtcAssignedTs());
+
+		Thread.sleep(1000);
+
+		// Attempt to unassign JJDispute, assert
+		jjDisputeRepository.unassignJJDisputeVtc(ticketNumber, new Date());
+		jjDispute = jjDisputeService.getJJDisputeByTicketNumber(ticketNumber);
+		assertNull(jjDispute.getVtcAssignedTo());
+		assertNull(jjDispute.getVtcAssignedTs());
 	}
 
 }


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

TCVP-2120
- exposed /v1/unassignDisputeVtc in OpenAPI spec
- added junit test to confirm actual persistence in ORDs
- removed findByVtcAssignedTsBefore() as we are now using the endpoint directly to unassign rather than iterating over records.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

mvn verify

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
