### PR TITLE
TCVP-2120 exposed ORDS TCO /v1/assignDisputeJj

### DIFF
--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/repository/JJDisputeRepository.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/repository/JJDisputeRepository.java
@@ -12,14 +12,21 @@ import ca.bc.gov.open.jag.tco.oracledataapi.model.YesNo;
 public interface JJDisputeRepository {
 
 	/**
-	 * Assigns a particular JJDispute (by ticketNumber) to the supplied username.
+	 * Assigns a particular JJDispute (by ticketNumber) to the supplied username (sets jjAssignedTo).
+	 * @param ticketNumber
+	 * @param username
+	 */
+	public void assignJJDisputeJj(String ticketNumber, String username);
+
+	/**
+	 * Assigns a particular JJDispute (by ticketNumber) to the supplied username (sets vtcAssignedTo/vtcAssignedTs).
 	 * @param ticketNumber
 	 * @param username
 	 */
 	public void assignJJDisputeVtc(String ticketNumber, String username);
 
 	/**
-	 * Unassigned JJDisputes older than the supplied datestamp (or just the one JJDispute if ticketNumber is supplied).
+	 * Unassigned JJDisputes older than the supplied datestamp (or just the one JJDispute if ticketNumber is supplied), (clears vtcAssignedTo/vtcAssignedTs).
 	 * @param ticketNumber
 	 * @param assignedBeforeTs
 	 */

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/repository/impl/h2/JJDisputeRepositoryImpl.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/repository/impl/h2/JJDisputeRepositoryImpl.java
@@ -24,6 +24,11 @@ public interface JJDisputeRepositoryImpl extends JJDisputeRepository, JpaReposit
 
 	@Override
 	@Modifying(clearAutomatically = true)
+	@Query("update JJDispute jj set jj.jjAssignedTo = :username where jj.ticketNumber = :ticketNumber")
+	public void assignJJDisputeJj(String ticketNumber, String username);
+
+	@Override
+	@Modifying(clearAutomatically = true)
 	@Query("update JJDispute jj set jj.vtcAssignedTo = :username, jj.vtcAssignedTs = CURRENT_TIMESTAMP() where jj.ticketNumber = :ticketNumber")
 	public void assignJJDisputeVtc(String ticketNumber, String username);
 

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/repository/impl/ords/JJDisputeRepositoryImpl.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/repository/impl/ords/JJDisputeRepositoryImpl.java
@@ -51,6 +51,11 @@ public class JJDisputeRepositoryImpl implements JJDisputeRepository {
 	}
 
 	@Override
+	public void assignJJDisputeJj(String ticketNumber, String username) {
+		assertNoExceptionsGeneric(() -> jjDisputeApi.v1AssignDisputeJjPost(username, ticketNumber));
+	}
+
+	@Override
 	public void assignJJDisputeVtc(String ticketNumber, String username) {
 		assertNoExceptionsGeneric(() -> jjDisputeApi.v1AssignDisputeVtcPost(username, ticketNumber));
 	}
@@ -61,8 +66,15 @@ public class JJDisputeRepositoryImpl implements JJDisputeRepository {
 	}
 
 	@Override
-	public List<JJDispute> findByJjAssignedToIgnoreCase(String jjAssigned) {
-		throw new NotYetImplementedException();
+	public List<JJDispute> findByJjAssignedToIgnoreCase(String jjAssignedTo) {
+		JJDisputeListResponse response = jjDisputeApi.v1JjDisputeListGet(null, null, null, jjAssignedTo);
+		if (response == null)
+			return new ArrayList<JJDispute>();
+
+		// convert a list of TCO ORDS JJDisputes to Oracle Data JJDisputes
+		return response.getJjDisputes().stream()
+				.map(jjDispute -> map(jjDispute))
+				.collect(Collectors.toList());
 	}
 
 	@Override
@@ -72,7 +84,7 @@ public class JJDisputeRepositoryImpl implements JJDisputeRepository {
 
 	@Override
 	public List<JJDispute> findAll() {
-		JJDisputeListResponse response = jjDisputeApi.v1JjDisputeListGet(null, null, null);
+		JJDisputeListResponse response = jjDisputeApi.v1JjDisputeListGet(null, null, null, null);
 		if (response == null)
 			return new ArrayList<JJDispute>();
 

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/service/JJDisputeService.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/service/JJDisputeService.java
@@ -182,18 +182,10 @@ public class JJDisputeService {
 				throw new NoSuchElementException("Could not find JJDispute to be assigned to the JJ for the given ticket number: " + ticketNumber);
 			}
 
+			jjDisputeRepository.assignJJDisputeJj(ticketNumber, username);
 			if (!StringUtils.isBlank(username)) {
-
-				// FIXME: setting JjAssignedTo doesn't work in ORDS, rather call the {{JUSTIN-TCO}}/v1/assignDisputeJj endpoint
-				jjDispute.setJjAssignedTo(username);
-				jjDisputeRepository.saveAndFlush(jjDispute);
-
 				logger.debug("JJDispute with ticket number {} has been assigned to JJ {}", ticketNumber, username);
 			} else {
-				// FIXME: setting JjAssignedTo doesn't work in ORDS, rather call the {{JUSTIN-TCO}}/v1/unassignDisputeJj endpoint
-				jjDispute.setJjAssignedTo(null);
-				jjDisputeRepository.saveAndFlush(jjDispute);
-
 				logger.debug("Unassigned JJDispute with ticket number {} ", ticketNumber);
 			}
 		}

--- a/src/backend/oracle-data-api/src/main/resources/tco-openapi-spec.yaml
+++ b/src/backend/oracle-data-api/src/main/resources/tco-openapi-spec.yaml
@@ -62,6 +62,28 @@ paths:
           $ref: '#/components/responses/Unauthorized'
       tags:
         - JJDispute
+  /v1/assignDisputeJj:
+    post:
+      parameters:
+        - name: userId
+          in: query
+          schema:
+            type: string
+        - name: ticketNumber
+          in: query
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Ok
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResponseResult'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+      tags:
+        - JJDispute
   /v1/assignDisputeVtc:
     post:
       parameters:
@@ -118,6 +140,10 @@ paths:
           schema:
             type: string
         - name: violationTicketId
+          in: query
+          schema:
+            type: string
+        - name: jjAssignedTo
           in: query
           schema:
             type: string

--- a/src/backend/oracle-data-api/src/test/java/ca/bc/gov/open/jag/tco/oracledataapi/service/DisputeServiceOrdsTcoTest.java
+++ b/src/backend/oracle-data-api/src/test/java/ca/bc/gov/open/jag/tco/oracledataapi/service/DisputeServiceOrdsTcoTest.java
@@ -117,6 +117,35 @@ class DisputeServiceOrdsTcoTest extends BaseTestSuite {
 	}
 
 	@Test
+	public void testJjDisputeAssignJj_POST() throws Exception {
+		String ticketNumber = "EA90100004";
+		JJDispute jjDispute = jjDisputeService.getJJDisputeByTicketNumber(ticketNumber);
+		String jjAssignedTo = jjDispute.getJjAssignedTo();
+
+		String username = RandomUtil.randomGivenName().charAt(0) + RandomUtil.randomSurname();
+		assertNotEquals(jjAssignedTo, username); // confirm jjAssignedTo is not already set to the random name.
+		jjDisputeRepository.assignJJDisputeJj(ticketNumber, username);
+
+		jjDispute = jjDisputeService.getJJDisputeByTicketNumber(ticketNumber);
+		assertEquals(username, jjDispute.getJjAssignedTo());
+	}
+
+	@Test
+	public void testJjDisputeUnassignJj_POST() throws Exception {
+		String ticketNumber = "EA90100004";
+		String username = RandomUtil.randomGivenName().charAt(0) + RandomUtil.randomSurname();
+
+		jjDisputeRepository.assignJJDisputeJj(ticketNumber, username);
+		JJDispute jjDispute = jjDisputeService.getJJDisputeByTicketNumber(ticketNumber);
+		assertNotNull(jjDispute.getJjAssignedTo());
+
+		// Setting the username to null should "unassign" JJDispute
+		jjDisputeRepository.assignJJDisputeJj(ticketNumber, null);
+		jjDispute = jjDisputeService.getJJDisputeByTicketNumber(ticketNumber);
+		assertNull(jjDispute.getJjAssignedTo());
+	}
+
+	@Test
 	public void testJjDisputeAssignVtc_POST() throws Exception {
 		String ticketNumber = "EA90100004";
 		JJDispute jjDispute = jjDisputeService.getJJDisputeByTicketNumber(ticketNumber);


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

TCVP-2120
- exposed /v1/assignDisputeJj in OpenAPI spec
- added jjAssignedTo parameter /v1/jjDisputeList to match Postman collection
- added junit test to confirm actual persistence in ORDs

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

mvn verify

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
