### PR TITLE
Exposed 8000 as a debugging port in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -213,6 +213,7 @@ services:
       - redis
     ports:
       - "5010:8080"
+      - "8000:8000"
     volumes:
       - data-oracle:/data
 

--- a/src/backend/oracle-data-api/Dockerfile
+++ b/src/backend/oracle-data-api/Dockerfile
@@ -44,6 +44,7 @@ ENV GIT_SHA=$GIT_SHA
 
 WORKDIR /app
 EXPOSE 8080
+EXPOSE 8000
 
 ADD https://repo1.maven.org/maven2/io/prometheus/jmx/jmx_prometheus_javaagent/${PROMETHEUS_AGENT_VERSION}/jmx_prometheus_javaagent-${PROMETHEUS_AGENT_VERSION}.jar /app/jmx_prometheus_javaagent.jar
 RUN printf "Generate jmx_prometheus_javaagent_config.yaml\n" & \


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

Exposed 8000 as a debugging port so developers can remote debug the oracle-data-api application running in docker-compose.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
