### PR TITLE
TCVP-2075 Audit log entries (file history) ords support

### DIFF
--- a/src/backend/TrafficCourts/Common/OpenAPIs/OracleDataAPI/v1_0/OracleDataApi.v1_0.json
+++ b/src/backend/TrafficCourts/Common/OpenAPIs/OracleDataAPI/v1_0/OracleDataApi.v1_0.json
@@ -6,7 +6,7 @@
   },
   "servers": [
     {
-      "url": "http://localhost:5010",
+      "url": "http://localhost:8080",
       "description": "Generated server url"
     }
   ],
@@ -36,10 +36,6 @@
           "required": true
         },
         "responses": {
-          "404": {
-            "description": "JJDispute record not found. Update failed.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
           "400": {
             "description": "Bad Request.",
             "content": { "*/*": { "schema": { "type": "object" } } }
@@ -50,6 +46,10 @@
           },
           "500": {
             "description": "Internal Server Error",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "404": {
+            "description": "JJDispute record not found. Update failed.",
             "content": { "*/*": { "schema": { "type": "object" } } }
           },
           "200": {
@@ -91,10 +91,6 @@
           "required": true
         },
         "responses": {
-          "404": {
-            "description": "JJDispute record not found. Update failed.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
           "400": {
             "description": "Bad Request.",
             "content": { "*/*": { "schema": { "type": "object" } } }
@@ -105,6 +101,10 @@
           },
           "500": {
             "description": "Internal server error occured.",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "404": {
+            "description": "JJDispute record not found. Update failed.",
             "content": { "*/*": { "schema": { "type": "object" } } }
           },
           "200": {
@@ -138,10 +138,6 @@
           }
         ],
         "responses": {
-          "404": {
-            "description": "JJDispute record not found. Update failed.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
           "400": {
             "description": "Bad Request.",
             "content": { "*/*": { "schema": { "type": "object" } } }
@@ -152,6 +148,10 @@
           },
           "500": {
             "description": "Internal server error occured.",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "404": {
+            "description": "JJDispute record not found. Update failed.",
             "content": { "*/*": { "schema": { "type": "object" } } }
           },
           "200": {
@@ -175,10 +175,6 @@
           }
         ],
         "responses": {
-          "404": {
-            "description": "JJDispute record not found. Update failed.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
           "400": {
             "description": "Bad Request.",
             "content": { "*/*": { "schema": { "type": "object" } } }
@@ -189,6 +185,10 @@
           },
           "500": {
             "description": "Internal server error occured.",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "404": {
+            "description": "JJDispute record not found. Update failed.",
             "content": { "*/*": { "schema": { "type": "object" } } }
           },
           "200": {
@@ -235,10 +235,6 @@
           }
         ],
         "responses": {
-          "404": {
-            "description": "JJDispute record not found. Update failed.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
           "400": {
             "description": "Bad Request.",
             "content": { "*/*": { "schema": { "type": "object" } } }
@@ -249,6 +245,10 @@
           },
           "500": {
             "description": "Internal server error occured.",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "404": {
+            "description": "JJDispute record not found. Update failed.",
             "content": { "*/*": { "schema": { "type": "object" } } }
           },
           "200": {
@@ -281,10 +281,6 @@
           }
         ],
         "responses": {
-          "404": {
-            "description": "JJDispute record(s) not found. Update failed.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
           "400": {
             "description": "Bad Request.",
             "content": { "*/*": { "schema": { "type": "object" } } }
@@ -295,6 +291,10 @@
           },
           "500": {
             "description": "Internal server error occured.",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "404": {
+            "description": "JJDispute record(s) not found. Update failed.",
             "content": { "*/*": { "schema": { "type": "object" } } }
           },
           "200": { "description": "Ok" }
@@ -317,10 +317,6 @@
           }
         ],
         "responses": {
-          "404": {
-            "description": "Not Found",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
           "400": {
             "description": "Bad Request",
             "content": { "*/*": { "schema": { "type": "object" } } }
@@ -331,6 +327,10 @@
           },
           "500": {
             "description": "Internal Server Error",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "404": {
+            "description": "Not Found",
             "content": { "*/*": { "schema": { "type": "object" } } }
           },
           "200": {
@@ -359,10 +359,6 @@
           "required": true
         },
         "responses": {
-          "404": {
-            "description": "Dispute record not found. Update failed.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
           "400": {
             "description": "Bad Request.",
             "content": { "*/*": { "schema": { "type": "object" } } }
@@ -373,6 +369,10 @@
           },
           "500": {
             "description": "Internal Server Error",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "404": {
+            "description": "Dispute record not found. Update failed.",
             "content": { "*/*": { "schema": { "type": "object" } } }
           },
           "409": {
@@ -401,10 +401,6 @@
           }
         ],
         "responses": {
-          "404": {
-            "description": "Dispute record not found. Delete failed.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
           "400": {
             "description": "Bad Request.",
             "content": { "*/*": { "schema": { "type": "object" } } }
@@ -415,6 +411,10 @@
           },
           "500": {
             "description": "Internal Server Error. Delete failed.",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "404": {
+            "description": "Dispute record not found. Delete failed.",
             "content": { "*/*": { "schema": { "type": "object" } } }
           },
           "200": { "description": "Ok. Dispute record deleted." }
@@ -438,10 +438,6 @@
           }
         ],
         "responses": {
-          "404": {
-            "description": "Dispute record not found. Update failed.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
           "400": {
             "description": "Bad Request.",
             "content": { "*/*": { "schema": { "type": "object" } } }
@@ -452,6 +448,10 @@
           },
           "500": {
             "description": "Internal Server Error",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "404": {
+            "description": "Dispute record not found. Update failed.",
             "content": { "*/*": { "schema": { "type": "object" } } }
           },
           "200": {
@@ -482,10 +482,6 @@
           }
         ],
         "responses": {
-          "404": {
-            "description": "Dispute record not found. Update failed.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
           "400": {
             "description": "Bad Request.",
             "content": { "*/*": { "schema": { "type": "object" } } }
@@ -496,6 +492,10 @@
           },
           "500": {
             "description": "Internal Server Error",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "404": {
+            "description": "Dispute record not found. Update failed.",
             "content": { "*/*": { "schema": { "type": "object" } } }
           },
           "200": {
@@ -538,10 +538,6 @@
           "required": true
         },
         "responses": {
-          "404": {
-            "description": "Dispute record not found. Update failed.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
           "400": {
             "description": "Bad Request.",
             "content": { "*/*": { "schema": { "type": "object" } } }
@@ -552,6 +548,10 @@
           },
           "500": {
             "description": "Internal Server Error",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "404": {
+            "description": "Dispute record not found. Update failed.",
             "content": { "*/*": { "schema": { "type": "object" } } }
           },
           "200": {
@@ -583,10 +583,6 @@
           }
         ],
         "responses": {
-          "404": {
-            "description": "Dispute with specified id not found",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
           "400": {
             "description": "Bad Request",
             "content": { "*/*": { "schema": { "type": "object" } } }
@@ -597,6 +593,10 @@
           },
           "500": {
             "description": "Internal server error occured.",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "404": {
+            "description": "Dispute with specified id not found",
             "content": { "*/*": { "schema": { "type": "object" } } }
           },
           "200": { "description": "Ok. Email verified." }
@@ -632,10 +632,6 @@
           }
         ],
         "responses": {
-          "404": {
-            "description": "Dispute with specified id not found",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
           "400": {
             "description": "If the email address is > 100 characters",
             "content": { "*/*": { "schema": { "type": "object" } } }
@@ -646,6 +642,10 @@
           },
           "500": {
             "description": "Internal server error occured.",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "404": {
+            "description": "Dispute with specified id not found",
             "content": { "*/*": { "schema": { "type": "object" } } }
           },
           "200": {
@@ -672,10 +672,6 @@
           }
         ],
         "responses": {
-          "404": {
-            "description": "Dispute record not found. Update failed.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
           "400": {
             "description": "Bad Request.",
             "content": { "*/*": { "schema": { "type": "object" } } }
@@ -686,6 +682,10 @@
           },
           "500": {
             "description": "Internal Server Error",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "404": {
+            "description": "Dispute record not found. Update failed.",
             "content": { "*/*": { "schema": { "type": "object" } } }
           },
           "200": {
@@ -728,10 +728,6 @@
           }
         ],
         "responses": {
-          "404": {
-            "description": "DisputeUpdateRequest could not be found.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
           "400": {
             "description": "Bad Request",
             "content": { "*/*": { "schema": { "type": "object" } } }
@@ -744,6 +740,10 @@
             "description": "Internal Server Error. Save failed.",
             "content": { "*/*": { "schema": { "type": "object" } } }
           },
+          "404": {
+            "description": "DisputeUpdateRequest could not be found.",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
           "200": {
             "description": "Ok. DisputeUpdateRequest updated.",
             "content": { "*/*": { "schema": { "$ref": "#/components/schemas/DisputeUpdateRequest" } } }
@@ -751,70 +751,16 @@
         }
       }
     },
-    "/api/v1.0/fileHistory/{ticketNumber}": {
-      "get": {
-        "tags": [ "file-history-controller" ],
-        "operationId": "getFileHistoryByTicketNumber",
-        "parameters": [
-          {
-            "name": "ticketNumber",
-            "in": "path",
-            "description": "Ticket number to retrieve related file history.",
-            "required": true,
-            "schema": { "type": "string" }
-          }
-        ],
-        "responses": {
-          "404": {
-            "description": "Not Found",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "400": {
-            "description": "Bad Request",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "405": {
-            "description": "Method Not Allowed",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "500": {
-            "description": "Internal Server Error",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "200": {
-            "description": "OK",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "type": "array",
-                  "items": { "$ref": "#/components/schemas/FileHistory" }
-                }
-              }
-            }
-          }
-        }
-      },
+    "/api/v1.0/fileHistory": {
       "post": {
         "tags": [ "file-history-controller" ],
         "summary": "Inserts a file history record for the given ticket number.",
         "operationId": "insertFileHistory",
-        "parameters": [
-          {
-            "name": "ticketNumber",
-            "in": "path",
-            "required": true,
-            "schema": { "type": "string" }
-          }
-        ],
         "requestBody": {
           "content": { "application/json": { "schema": { "$ref": "#/components/schemas/FileHistory" } } },
           "required": true
         },
         "responses": {
-          "404": {
-            "description": "An invalid file history record provided. Insert failed.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
           "400": {
             "description": "Bad Request.",
             "content": { "*/*": { "schema": { "type": "object" } } }
@@ -825,6 +771,10 @@
           },
           "500": {
             "description": "Internal Server Error",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "404": {
+            "description": "An invalid file history record provided. Insert failed.",
             "content": { "*/*": { "schema": { "type": "object" } } }
           },
           "200": {
@@ -855,10 +805,6 @@
           }
         ],
         "responses": {
-          "404": {
-            "description": "Not Found",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
           "400": {
             "description": "Bad Request",
             "content": { "*/*": { "schema": { "type": "object" } } }
@@ -869,6 +815,10 @@
           },
           "500": {
             "description": "Internal Server Error",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "404": {
+            "description": "Not Found",
             "content": { "*/*": { "schema": { "type": "object" } } }
           },
           "200": {
@@ -901,10 +851,6 @@
           "required": true
         },
         "responses": {
-          "404": {
-            "description": "An invalid email history record provided. Insert failed.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
           "400": {
             "description": "Bad Request.",
             "content": { "*/*": { "schema": { "type": "object" } } }
@@ -915,6 +861,10 @@
           },
           "500": {
             "description": "Internal Server Error",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "404": {
+            "description": "An invalid email history record provided. Insert failed.",
             "content": { "*/*": { "schema": { "type": "object" } } }
           },
           "200": {
@@ -940,10 +890,6 @@
           "required": true
         },
         "responses": {
-          "404": {
-            "description": "Not Found",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
           "400": {
             "description": "Bad Request",
             "content": { "*/*": { "schema": { "type": "object" } } }
@@ -954,6 +900,10 @@
           },
           "500": {
             "description": "Internal Server Error",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "404": {
+            "description": "Not Found",
             "content": { "*/*": { "schema": { "type": "object" } } }
           },
           "200": {
@@ -989,10 +939,6 @@
           "required": true
         },
         "responses": {
-          "404": {
-            "description": "Dispute could not be found.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
           "400": {
             "description": "Bad Request",
             "content": { "*/*": { "schema": { "type": "object" } } }
@@ -1003,6 +949,10 @@
           },
           "500": {
             "description": "Internal Server Error. Save failed.",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "404": {
+            "description": "Dispute could not be found.",
             "content": { "*/*": { "schema": { "type": "object" } } }
           },
           "200": {
@@ -1044,10 +994,6 @@
           }
         ],
         "responses": {
-          "404": {
-            "description": "Not Found",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
           "400": {
             "description": "Bad Request",
             "content": { "*/*": { "schema": { "type": "object" } } }
@@ -1058,6 +1004,10 @@
           },
           "500": {
             "description": "Internal Server Error",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "404": {
+            "description": "Not Found",
             "content": { "*/*": { "schema": { "type": "object" } } }
           },
           "200": {
@@ -1094,10 +1044,6 @@
           }
         ],
         "responses": {
-          "404": {
-            "description": "Not Found",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
           "400": {
             "description": "Bad Request",
             "content": { "*/*": { "schema": { "type": "object" } } }
@@ -1110,9 +1056,57 @@
             "description": "Internal Server Error",
             "content": { "*/*": { "schema": { "type": "object" } } }
           },
+          "404": {
+            "description": "Not Found",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
           "200": {
             "description": "OK",
             "content": { "*/*": { "schema": { "$ref": "#/components/schemas/JJDispute" } } }
+          }
+        }
+      }
+    },
+    "/api/v1.0/fileHistory/{ticketNumber}": {
+      "get": {
+        "tags": [ "file-history-controller" ],
+        "operationId": "getFileHistoryByTicketNumber",
+        "parameters": [
+          {
+            "name": "ticketNumber",
+            "in": "path",
+            "description": "Ticket number to retrieve related file history.",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "400": {
+            "description": "Bad Request",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "405": {
+            "description": "Method Not Allowed",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "array",
+                  "items": { "$ref": "#/components/schemas/FileHistory" }
+                }
+              }
+            }
           }
         }
       }
@@ -1147,10 +1141,6 @@
           }
         ],
         "responses": {
-          "404": {
-            "description": "Not Found",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
           "400": {
             "description": "Bad Request.",
             "content": { "*/*": { "schema": { "type": "object" } } }
@@ -1161,6 +1151,10 @@
           },
           "500": {
             "description": "Internal Server Error. Getting disputes failed.",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "404": {
+            "description": "Not Found",
             "content": { "*/*": { "schema": { "type": "object" } } }
           },
           "200": {
@@ -1184,10 +1178,6 @@
         "description": "A Dispute can be assigned to a specific user that \"locks\" the record for others. This endpoing manually triggers the Unassign Dispute job that clears the assignment of all Disputes that were assigned for more than 1 hour.",
         "operationId": "unassignDisputes",
         "responses": {
-          "404": {
-            "description": "Not Found",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
           "400": {
             "description": "Bad Request",
             "content": { "*/*": { "schema": { "type": "object" } } }
@@ -1198,6 +1188,10 @@
           },
           "500": {
             "description": "Internal Server Error. Unassigned failed.",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "404": {
+            "description": "Not Found",
             "content": { "*/*": { "schema": { "type": "object" } } }
           },
           "200": { "description": "Ok. Dispute record unassigned." }
@@ -1233,10 +1227,6 @@
           }
         ],
         "responses": {
-          "404": {
-            "description": "Not Found",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
           "400": {
             "description": "Bad Request",
             "content": { "*/*": { "schema": { "type": "object" } } }
@@ -1247,6 +1237,10 @@
           },
           "500": {
             "description": "Internal Server Error. Save failed.",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "404": {
+            "description": "Not Found",
             "content": { "*/*": { "schema": { "type": "object" } } }
           },
           "200": {
@@ -1297,10 +1291,6 @@
           }
         ],
         "responses": {
-          "404": {
-            "description": "Not Found",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
           "400": {
             "description": "Bad Request, check parameters.",
             "content": { "*/*": { "schema": { "type": "object" } } }
@@ -1311,6 +1301,10 @@
           },
           "500": {
             "description": "Internal Server Error. Search failed.",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "404": {
+            "description": "Not Found",
             "content": { "*/*": { "schema": { "type": "object" } } }
           },
           "200": {
@@ -1342,10 +1336,6 @@
           }
         ],
         "responses": {
-          "404": {
-            "description": "Dispute could not be found.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
           "400": {
             "description": "Bad Request",
             "content": { "*/*": { "schema": { "type": "object" } } }
@@ -1356,6 +1346,10 @@
           },
           "500": {
             "description": "Internal server error occured.",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "404": {
+            "description": "Dispute could not be found.",
             "content": { "*/*": { "schema": { "type": "object" } } }
           },
           "200": {
@@ -1372,10 +1366,6 @@
         "description": "The codetables in redis are cached copies of data pulled from Oracle to ensure TCO remains stable. This data is periodically refreshed, but can be forced by hitting this endpoint.",
         "operationId": "codeTableRefresh",
         "responses": {
-          "404": {
-            "description": "Not Found",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
           "400": {
             "description": "Bad Request",
             "content": { "*/*": { "schema": { "type": "object" } } }
@@ -1386,6 +1376,10 @@
           },
           "500": {
             "description": "Internal Server Error",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "404": {
+            "description": "Not Found",
             "content": { "*/*": { "schema": { "type": "object" } } }
           },
           "200": { "description": "OK" }
@@ -1500,8 +1494,8 @@
             "nullable": true
           },
           "occamDisputeId": {
-            "type": "string",
-            "nullable": true
+            "type": "integer",
+            "format": "int64"
           },
           "occamViolationTicketUpldId": {
             "type": "string",
@@ -2597,6 +2591,7 @@
         }
       },
       "FileHistory": {
+        "required": [ "auditLogEntryType", "disputeId" ],
         "type": "object",
         "properties": {
           "createdBy": { "type": "string" },
@@ -2619,7 +2614,14 @@
             "format": "int64",
             "readOnly": true
           },
-          "ticketNumber": { "type": "string" },
+          "disputeId": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "auditLogEntryType": {
+            "type": "string",
+            "enum": [ "UNKNOWN", "ARFL", "CAIN", "CAWT", "CCAN", "CCON", "CCWR", "CLEG", "CUEM", "CUEV", "CUIN", "CULG", "CUPD", "CUWR", "CUWT", "EMCA", "EMCF", "EMCR", "EMDC", "EMFD", "EMPR", "EMRJ", "EMRV", "EMST", "EMUP", "EMVF", "INIT", "JASG", "JCNF", "JDIV", "JPRG", "RECN", "SCAN", "SPRC", "SREJ", "SUB", "SUPL", "SVAL", "VREV", "VSUB" ]
+          },
           "description": {
             "type": "string",
             "nullable": true

--- a/src/backend/TrafficCourts/Common/OpenAPIs/OracleDataAPI/v1_0/OracleDataApiClient.g.cs
+++ b/src/backend/TrafficCourts/Common/OpenAPIs/OracleDataAPI/v1_0/OracleDataApiClient.g.cs
@@ -270,23 +270,12 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
         /// <exception cref="ApiException">A server side error occurred.</exception>
         System.Threading.Tasks.Task<DisputeUpdateRequest> UpdateDisputeUpdateRequestStatusAsync(long id, DisputeUpdateRequestStatus disputeUpdateRequestStatus, System.Threading.CancellationToken cancellationToken);
 
-        /// <param name="ticketNumber">Ticket number to retrieve related file history.</param>
-        /// <returns>OK</returns>
-        /// <exception cref="ApiException">A server side error occurred.</exception>
-        System.Threading.Tasks.Task<System.Collections.Generic.ICollection<FileHistory>> GetFileHistoryByTicketNumberAsync(string ticketNumber);
-
-        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
-        /// <param name="ticketNumber">Ticket number to retrieve related file history.</param>
-        /// <returns>OK</returns>
-        /// <exception cref="ApiException">A server side error occurred.</exception>
-        System.Threading.Tasks.Task<System.Collections.Generic.ICollection<FileHistory>> GetFileHistoryByTicketNumberAsync(string ticketNumber, System.Threading.CancellationToken cancellationToken);
-
         /// <summary>
         /// Inserts a file history record for the given ticket number.
         /// </summary>
         /// <returns>Ok</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
-        System.Threading.Tasks.Task<long> InsertFileHistoryAsync(string ticketNumber, FileHistory body);
+        System.Threading.Tasks.Task<long> InsertFileHistoryAsync(FileHistory body);
 
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <summary>
@@ -294,7 +283,7 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
         /// </summary>
         /// <returns>Ok</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
-        System.Threading.Tasks.Task<long> InsertFileHistoryAsync(string ticketNumber, FileHistory body, System.Threading.CancellationToken cancellationToken);
+        System.Threading.Tasks.Task<long> InsertFileHistoryAsync(FileHistory body, System.Threading.CancellationToken cancellationToken);
 
         /// <param name="ticketNumber">Ticket number to retrieve related emails.</param>
         /// <returns>OK</returns>
@@ -371,6 +360,17 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
         /// <returns>OK</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
         System.Threading.Tasks.Task<JJDispute> GetJJDisputeAsync(string ticketNumber, bool assignVTC, System.Threading.CancellationToken cancellationToken);
+
+        /// <param name="ticketNumber">Ticket number to retrieve related file history.</param>
+        /// <returns>OK</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        System.Threading.Tasks.Task<System.Collections.Generic.ICollection<FileHistory>> GetFileHistoryByTicketNumberAsync(string ticketNumber);
+
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <param name="ticketNumber">Ticket number to retrieve related file history.</param>
+        /// <returns>OK</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        System.Threading.Tasks.Task<System.Collections.Generic.ICollection<FileHistory>> GetFileHistoryByTicketNumberAsync(string ticketNumber, System.Threading.CancellationToken cancellationToken);
 
         /// <summary>
         /// Returns all Dispute records based on the specified optional parameters.
@@ -586,16 +586,6 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                         ProcessResponse(client_, response_);
 
                         var status_ = (int)response_.StatusCode;
-                        if (status_ == 404)
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            throw new ApiException<FileResponse>("JJDispute record not found. Update failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
-                        }
-                        else
                         if (status_ == 400)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
@@ -624,6 +614,16 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             throw new ApiException<FileResponse>("Internal Server Error", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 404)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<FileResponse>("JJDispute record not found. Update failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 200)
@@ -722,16 +722,6 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                         ProcessResponse(client_, response_);
 
                         var status_ = (int)response_.StatusCode;
-                        if (status_ == 404)
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            throw new ApiException<FileResponse>("JJDispute record not found. Update failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
-                        }
-                        else
                         if (status_ == 400)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
@@ -760,6 +750,16 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             throw new ApiException<FileResponse>("Internal server error occured.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 404)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<FileResponse>("JJDispute record not found. Update failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 200)
@@ -852,16 +852,6 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                         ProcessResponse(client_, response_);
 
                         var status_ = (int)response_.StatusCode;
-                        if (status_ == 404)
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            throw new ApiException<FileResponse>("JJDispute record not found. Update failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
-                        }
-                        else
                         if (status_ == 400)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
@@ -890,6 +880,16 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             throw new ApiException<FileResponse>("Internal server error occured.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 404)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<FileResponse>("JJDispute record not found. Update failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 200)
@@ -977,16 +977,6 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                         ProcessResponse(client_, response_);
 
                         var status_ = (int)response_.StatusCode;
-                        if (status_ == 404)
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            throw new ApiException<FileResponse>("JJDispute record not found. Update failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
-                        }
-                        else
                         if (status_ == 400)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
@@ -1015,6 +1005,16 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             throw new ApiException<FileResponse>("Internal server error occured.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 404)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<FileResponse>("JJDispute record not found. Update failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 200)
@@ -1119,16 +1119,6 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                         ProcessResponse(client_, response_);
 
                         var status_ = (int)response_.StatusCode;
-                        if (status_ == 404)
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            throw new ApiException<FileResponse>("JJDispute record not found. Update failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
-                        }
-                        else
                         if (status_ == 400)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
@@ -1157,6 +1147,16 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             throw new ApiException<FileResponse>("Internal server error occured.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 404)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<FileResponse>("JJDispute record not found. Update failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 200)
@@ -1248,16 +1248,6 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                         ProcessResponse(client_, response_);
 
                         var status_ = (int)response_.StatusCode;
-                        if (status_ == 404)
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            throw new ApiException<FileResponse>("JJDispute record(s) not found. Update failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
-                        }
-                        else
                         if (status_ == 400)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
@@ -1286,6 +1276,16 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             throw new ApiException<FileResponse>("Internal server error occured.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 404)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<FileResponse>("JJDispute record(s) not found. Update failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 200)
@@ -1361,16 +1361,6 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                         ProcessResponse(client_, response_);
 
                         var status_ = (int)response_.StatusCode;
-                        if (status_ == 404)
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            throw new ApiException<FileResponse>("Not Found", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
-                        }
-                        else
                         if (status_ == 400)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
@@ -1399,6 +1389,16 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             throw new ApiException<FileResponse>("Internal Server Error", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 404)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<FileResponse>("Not Found", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 200)
@@ -1492,16 +1492,6 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                         ProcessResponse(client_, response_);
 
                         var status_ = (int)response_.StatusCode;
-                        if (status_ == 404)
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            throw new ApiException<FileResponse>("Dispute record not found. Update failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
-                        }
-                        else
                         if (status_ == 400)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
@@ -1530,6 +1520,16 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             throw new ApiException<FileResponse>("Internal Server Error", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 404)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<FileResponse>("Dispute record not found. Update failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 409)
@@ -1625,16 +1625,6 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                         ProcessResponse(client_, response_);
 
                         var status_ = (int)response_.StatusCode;
-                        if (status_ == 404)
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            throw new ApiException<FileResponse>("Dispute record not found. Delete failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
-                        }
-                        else
                         if (status_ == 400)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
@@ -1663,6 +1653,16 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             throw new ApiException<FileResponse>("Internal Server Error. Delete failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 404)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<FileResponse>("Dispute record not found. Delete failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 200)
@@ -1745,16 +1745,6 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                         ProcessResponse(client_, response_);
 
                         var status_ = (int)response_.StatusCode;
-                        if (status_ == 404)
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            throw new ApiException<FileResponse>("Dispute record not found. Update failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
-                        }
-                        else
                         if (status_ == 400)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
@@ -1783,6 +1773,16 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             throw new ApiException<FileResponse>("Internal Server Error", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 404)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<FileResponse>("Dispute record not found. Update failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 200)
@@ -1880,16 +1880,6 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                         ProcessResponse(client_, response_);
 
                         var status_ = (int)response_.StatusCode;
-                        if (status_ == 404)
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            throw new ApiException<FileResponse>("Dispute record not found. Update failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
-                        }
-                        else
                         if (status_ == 400)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
@@ -1918,6 +1908,16 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             throw new ApiException<FileResponse>("Internal Server Error", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 404)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<FileResponse>("Dispute record not found. Update failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 200)
@@ -2021,16 +2021,6 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                         ProcessResponse(client_, response_);
 
                         var status_ = (int)response_.StatusCode;
-                        if (status_ == 404)
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            throw new ApiException<FileResponse>("Dispute record not found. Update failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
-                        }
-                        else
                         if (status_ == 400)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
@@ -2059,6 +2049,16 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             throw new ApiException<FileResponse>("Internal Server Error", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 404)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<FileResponse>("Dispute record not found. Update failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 200)
@@ -2157,16 +2157,6 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                         ProcessResponse(client_, response_);
 
                         var status_ = (int)response_.StatusCode;
-                        if (status_ == 404)
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            throw new ApiException<FileResponse>("Dispute with specified id not found", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
-                        }
-                        else
                         if (status_ == 400)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
@@ -2195,6 +2185,16 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             throw new ApiException<FileResponse>("Internal server error occured.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 404)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<FileResponse>("Dispute with specified id not found", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 200)
@@ -2286,16 +2286,6 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                         ProcessResponse(client_, response_);
 
                         var status_ = (int)response_.StatusCode;
-                        if (status_ == 404)
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            throw new ApiException<FileResponse>("Dispute with specified id not found", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
-                        }
-                        else
                         if (status_ == 400)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
@@ -2324,6 +2314,16 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             throw new ApiException<FileResponse>("Internal server error occured.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 404)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<FileResponse>("Dispute with specified id not found", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 200)
@@ -2411,16 +2411,6 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                         ProcessResponse(client_, response_);
 
                         var status_ = (int)response_.StatusCode;
-                        if (status_ == 404)
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            throw new ApiException<FileResponse>("Dispute record not found. Update failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
-                        }
-                        else
                         if (status_ == 400)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
@@ -2449,6 +2439,16 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             throw new ApiException<FileResponse>("Internal Server Error", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 404)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<FileResponse>("Dispute record not found. Update failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 200)
@@ -2555,16 +2555,6 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                         ProcessResponse(client_, response_);
 
                         var status_ = (int)response_.StatusCode;
-                        if (status_ == 404)
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            throw new ApiException<FileResponse>("DisputeUpdateRequest could not be found.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
-                        }
-                        else
                         if (status_ == 400)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
@@ -2593,6 +2583,16 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             throw new ApiException<FileResponse>("Internal Server Error. Save failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 404)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<FileResponse>("DisputeUpdateRequest could not be found.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 200)
@@ -2624,134 +2624,14 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
             }
         }
 
-        /// <param name="ticketNumber">Ticket number to retrieve related file history.</param>
-        /// <returns>OK</returns>
-        /// <exception cref="ApiException">A server side error occurred.</exception>
-        public virtual System.Threading.Tasks.Task<System.Collections.Generic.ICollection<FileHistory>> GetFileHistoryByTicketNumberAsync(string ticketNumber)
-        {
-            return GetFileHistoryByTicketNumberAsync(ticketNumber, System.Threading.CancellationToken.None);
-        }
-
-        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
-        /// <param name="ticketNumber">Ticket number to retrieve related file history.</param>
-        /// <returns>OK</returns>
-        /// <exception cref="ApiException">A server side error occurred.</exception>
-        public virtual async System.Threading.Tasks.Task<System.Collections.Generic.ICollection<FileHistory>> GetFileHistoryByTicketNumberAsync(string ticketNumber, System.Threading.CancellationToken cancellationToken)
-        {
-            if (ticketNumber == null)
-                throw new System.ArgumentNullException("ticketNumber");
-
-            var urlBuilder_ = new System.Text.StringBuilder();
-            urlBuilder_.Append("api/v1.0/fileHistory/{ticketNumber}");
-            urlBuilder_.Replace("{ticketNumber}", System.Uri.EscapeDataString(ConvertToString(ticketNumber, System.Globalization.CultureInfo.InvariantCulture)));
-
-            var client_ = _httpClient;
-            var disposeClient_ = false;
-            try
-            {
-                using (var request_ = new System.Net.Http.HttpRequestMessage())
-                {
-                    request_.Method = new System.Net.Http.HttpMethod("GET");
-                    request_.Headers.Accept.Add(System.Net.Http.Headers.MediaTypeWithQualityHeaderValue.Parse("*/*"));
-
-                    PrepareRequest(client_, request_, urlBuilder_);
-
-                    var url_ = urlBuilder_.ToString();
-                    request_.RequestUri = new System.Uri(url_, System.UriKind.RelativeOrAbsolute);
-
-                    PrepareRequest(client_, request_, url_);
-
-                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
-                    var disposeResponse_ = true;
-                    try
-                    {
-                        var headers_ = System.Linq.Enumerable.ToDictionary(response_.Headers, h_ => h_.Key, h_ => h_.Value);
-                        if (response_.Content != null && response_.Content.Headers != null)
-                        {
-                            foreach (var item_ in response_.Content.Headers)
-                                headers_[item_.Key] = item_.Value;
-                        }
-
-                        ProcessResponse(client_, response_);
-
-                        var status_ = (int)response_.StatusCode;
-                        if (status_ == 404)
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            throw new ApiException<FileResponse>("Not Found", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
-                        }
-                        else
-                        if (status_ == 400)
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            throw new ApiException<FileResponse>("Bad Request", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
-                        }
-                        else
-                        if (status_ == 405)
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            throw new ApiException<FileResponse>("Method Not Allowed", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
-                        }
-                        else
-                        if (status_ == 500)
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            throw new ApiException<FileResponse>("Internal Server Error", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
-                        }
-                        else
-                        if (status_ == 200)
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<System.Collections.Generic.ICollection<FileHistory>>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            return objectResponse_.Object;
-                        }
-                        else
-                        {
-                            var responseData_ = response_.Content == null ? null : await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
-                            throw new ApiException("The HTTP status code of the response was not expected (" + status_ + ").", status_, responseData_, headers_, null);
-                        }
-                    }
-                    finally
-                    {
-                        if (disposeResponse_)
-                            response_.Dispose();
-                    }
-                }
-            }
-            finally
-            {
-                if (disposeClient_)
-                    client_.Dispose();
-            }
-        }
-
         /// <summary>
         /// Inserts a file history record for the given ticket number.
         /// </summary>
         /// <returns>Ok</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
-        public virtual System.Threading.Tasks.Task<long> InsertFileHistoryAsync(string ticketNumber, FileHistory body)
+        public virtual System.Threading.Tasks.Task<long> InsertFileHistoryAsync(FileHistory body)
         {
-            return InsertFileHistoryAsync(ticketNumber, body, System.Threading.CancellationToken.None);
+            return InsertFileHistoryAsync(body, System.Threading.CancellationToken.None);
         }
 
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
@@ -2760,17 +2640,13 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
         /// </summary>
         /// <returns>Ok</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
-        public virtual async System.Threading.Tasks.Task<long> InsertFileHistoryAsync(string ticketNumber, FileHistory body, System.Threading.CancellationToken cancellationToken)
+        public virtual async System.Threading.Tasks.Task<long> InsertFileHistoryAsync(FileHistory body, System.Threading.CancellationToken cancellationToken)
         {
-            if (ticketNumber == null)
-                throw new System.ArgumentNullException("ticketNumber");
-
             if (body == null)
                 throw new System.ArgumentNullException("body");
 
             var urlBuilder_ = new System.Text.StringBuilder();
-            urlBuilder_.Append("api/v1.0/fileHistory/{ticketNumber}");
-            urlBuilder_.Replace("{ticketNumber}", System.Uri.EscapeDataString(ConvertToString(ticketNumber, System.Globalization.CultureInfo.InvariantCulture)));
+            urlBuilder_.Append("api/v1.0/fileHistory");
 
             var client_ = _httpClient;
             var disposeClient_ = false;
@@ -2806,16 +2682,6 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                         ProcessResponse(client_, response_);
 
                         var status_ = (int)response_.StatusCode;
-                        if (status_ == 404)
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            throw new ApiException<FileResponse>("An invalid file history record provided. Insert failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
-                        }
-                        else
                         if (status_ == 400)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
@@ -2844,6 +2710,16 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             throw new ApiException<FileResponse>("Internal Server Error", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 404)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<FileResponse>("An invalid file history record provided. Insert failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 200)
@@ -2926,16 +2802,6 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                         ProcessResponse(client_, response_);
 
                         var status_ = (int)response_.StatusCode;
-                        if (status_ == 404)
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            throw new ApiException<FileResponse>("Not Found", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
-                        }
-                        else
                         if (status_ == 400)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
@@ -2964,6 +2830,16 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             throw new ApiException<FileResponse>("Internal Server Error", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 404)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<FileResponse>("Not Found", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 200)
@@ -3057,16 +2933,6 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                         ProcessResponse(client_, response_);
 
                         var status_ = (int)response_.StatusCode;
-                        if (status_ == 404)
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            throw new ApiException<FileResponse>("An invalid email history record provided. Insert failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
-                        }
-                        else
                         if (status_ == 400)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
@@ -3095,6 +2961,16 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             throw new ApiException<FileResponse>("Internal Server Error", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 404)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<FileResponse>("An invalid email history record provided. Insert failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 200)
@@ -3178,16 +3054,6 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                         ProcessResponse(client_, response_);
 
                         var status_ = (int)response_.StatusCode;
-                        if (status_ == 404)
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            throw new ApiException<FileResponse>("Not Found", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
-                        }
-                        else
                         if (status_ == 400)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
@@ -3216,6 +3082,16 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             throw new ApiException<FileResponse>("Internal Server Error", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 404)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<FileResponse>("Not Found", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 200)
@@ -3311,16 +3187,6 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                         ProcessResponse(client_, response_);
 
                         var status_ = (int)response_.StatusCode;
-                        if (status_ == 404)
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            throw new ApiException<FileResponse>("Dispute could not be found.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
-                        }
-                        else
                         if (status_ == 400)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
@@ -3349,6 +3215,16 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             throw new ApiException<FileResponse>("Internal Server Error. Save failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 404)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<FileResponse>("Dispute could not be found.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 200)
@@ -3438,16 +3314,6 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                         ProcessResponse(client_, response_);
 
                         var status_ = (int)response_.StatusCode;
-                        if (status_ == 404)
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            throw new ApiException<FileResponse>("Not Found", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
-                        }
-                        else
                         if (status_ == 400)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
@@ -3476,6 +3342,16 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             throw new ApiException<FileResponse>("Internal Server Error", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 404)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<FileResponse>("Not Found", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 200)
@@ -3562,16 +3438,6 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                         ProcessResponse(client_, response_);
 
                         var status_ = (int)response_.StatusCode;
-                        if (status_ == 404)
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            throw new ApiException<FileResponse>("Not Found", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
-                        }
-                        else
                         if (status_ == 400)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
@@ -3602,9 +3468,139 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                             throw new ApiException<FileResponse>("Internal Server Error", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
+                        if (status_ == 404)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<FileResponse>("Not Found", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
                         if (status_ == 200)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<JJDispute>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            return objectResponse_.Object;
+                        }
+                        else
+                        {
+                            var responseData_ = response_.Content == null ? null : await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
+                            throw new ApiException("The HTTP status code of the response was not expected (" + status_ + ").", status_, responseData_, headers_, null);
+                        }
+                    }
+                    finally
+                    {
+                        if (disposeResponse_)
+                            response_.Dispose();
+                    }
+                }
+            }
+            finally
+            {
+                if (disposeClient_)
+                    client_.Dispose();
+            }
+        }
+
+        /// <param name="ticketNumber">Ticket number to retrieve related file history.</param>
+        /// <returns>OK</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        public virtual System.Threading.Tasks.Task<System.Collections.Generic.ICollection<FileHistory>> GetFileHistoryByTicketNumberAsync(string ticketNumber)
+        {
+            return GetFileHistoryByTicketNumberAsync(ticketNumber, System.Threading.CancellationToken.None);
+        }
+
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <param name="ticketNumber">Ticket number to retrieve related file history.</param>
+        /// <returns>OK</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        public virtual async System.Threading.Tasks.Task<System.Collections.Generic.ICollection<FileHistory>> GetFileHistoryByTicketNumberAsync(string ticketNumber, System.Threading.CancellationToken cancellationToken)
+        {
+            if (ticketNumber == null)
+                throw new System.ArgumentNullException("ticketNumber");
+
+            var urlBuilder_ = new System.Text.StringBuilder();
+            urlBuilder_.Append("api/v1.0/fileHistory/{ticketNumber}");
+            urlBuilder_.Replace("{ticketNumber}", System.Uri.EscapeDataString(ConvertToString(ticketNumber, System.Globalization.CultureInfo.InvariantCulture)));
+
+            var client_ = _httpClient;
+            var disposeClient_ = false;
+            try
+            {
+                using (var request_ = new System.Net.Http.HttpRequestMessage())
+                {
+                    request_.Method = new System.Net.Http.HttpMethod("GET");
+                    request_.Headers.Accept.Add(System.Net.Http.Headers.MediaTypeWithQualityHeaderValue.Parse("*/*"));
+
+                    PrepareRequest(client_, request_, urlBuilder_);
+
+                    var url_ = urlBuilder_.ToString();
+                    request_.RequestUri = new System.Uri(url_, System.UriKind.RelativeOrAbsolute);
+
+                    PrepareRequest(client_, request_, url_);
+
+                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+                    var disposeResponse_ = true;
+                    try
+                    {
+                        var headers_ = System.Linq.Enumerable.ToDictionary(response_.Headers, h_ => h_.Key, h_ => h_.Value);
+                        if (response_.Content != null && response_.Content.Headers != null)
+                        {
+                            foreach (var item_ in response_.Content.Headers)
+                                headers_[item_.Key] = item_.Value;
+                        }
+
+                        ProcessResponse(client_, response_);
+
+                        var status_ = (int)response_.StatusCode;
+                        if (status_ == 400)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<FileResponse>("Bad Request", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 405)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<FileResponse>("Method Not Allowed", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 500)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<FileResponse>("Internal Server Error", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 404)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<FileResponse>("Not Found", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 200)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<System.Collections.Generic.ICollection<FileHistory>>(response_, headers_, cancellationToken).ConfigureAwait(false);
                             if (objectResponse_.Object == null)
                             {
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
@@ -3695,16 +3691,6 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                         ProcessResponse(client_, response_);
 
                         var status_ = (int)response_.StatusCode;
-                        if (status_ == 404)
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            throw new ApiException<FileResponse>("Not Found", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
-                        }
-                        else
                         if (status_ == 400)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
@@ -3733,6 +3719,16 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             throw new ApiException<FileResponse>("Internal Server Error. Getting disputes failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 404)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<FileResponse>("Not Found", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 200)
@@ -3820,16 +3816,6 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                         ProcessResponse(client_, response_);
 
                         var status_ = (int)response_.StatusCode;
-                        if (status_ == 404)
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            throw new ApiException<FileResponse>("Not Found", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
-                        }
-                        else
                         if (status_ == 400)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
@@ -3858,6 +3844,16 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             throw new ApiException<FileResponse>("Internal Server Error. Unassigned failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 404)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<FileResponse>("Not Found", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 200)
@@ -3948,16 +3944,6 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                         ProcessResponse(client_, response_);
 
                         var status_ = (int)response_.StatusCode;
-                        if (status_ == 404)
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            throw new ApiException<FileResponse>("Not Found", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
-                        }
-                        else
                         if (status_ == 400)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
@@ -3986,6 +3972,16 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             throw new ApiException<FileResponse>("Internal Server Error. Save failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 404)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<FileResponse>("Not Found", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 200)
@@ -4087,16 +4083,6 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                         ProcessResponse(client_, response_);
 
                         var status_ = (int)response_.StatusCode;
-                        if (status_ == 404)
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            throw new ApiException<FileResponse>("Not Found", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
-                        }
-                        else
                         if (status_ == 400)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
@@ -4125,6 +4111,16 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             throw new ApiException<FileResponse>("Internal Server Error. Search failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 404)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<FileResponse>("Not Found", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 200)
@@ -4213,16 +4209,6 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                         ProcessResponse(client_, response_);
 
                         var status_ = (int)response_.StatusCode;
-                        if (status_ == 404)
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            throw new ApiException<FileResponse>("Dispute could not be found.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
-                        }
-                        else
                         if (status_ == 400)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
@@ -4251,6 +4237,16 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             throw new ApiException<FileResponse>("Internal server error occured.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 404)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<FileResponse>("Dispute could not be found.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 200)
@@ -4338,16 +4334,6 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                         ProcessResponse(client_, response_);
 
                         var status_ = (int)response_.StatusCode;
-                        if (status_ == 404)
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            throw new ApiException<FileResponse>("Not Found", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
-                        }
-                        else
                         if (status_ == 400)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
@@ -4376,6 +4362,16 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             throw new ApiException<FileResponse>("Internal Server Error", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 404)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<FileResponse>("Not Found", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 200)
@@ -4592,8 +4588,8 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
         [Newtonsoft.Json.JsonProperty("occamDisputantSurnameNm", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string OccamDisputantSurnameNm { get; set; }
 
-        [Newtonsoft.Json.JsonProperty("occamDisputeId", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public string OccamDisputeId { get; set; }
+        [Newtonsoft.Json.JsonProperty("occamDisputeId", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public long OccamDisputeId { get; set; }
 
         [Newtonsoft.Json.JsonProperty("occamViolationTicketUpldId", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string OccamViolationTicketUpldId { get; set; }
@@ -5560,8 +5556,13 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
         [Newtonsoft.Json.JsonProperty("fileHistoryId", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public long FileHistoryId { get; set; }
 
-        [Newtonsoft.Json.JsonProperty("ticketNumber", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public string TicketNumber { get; set; }
+        [Newtonsoft.Json.JsonProperty("disputeId", Required = Newtonsoft.Json.Required.Always)]
+        public long DisputeId { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("auditLogEntryType", Required = Newtonsoft.Json.Required.Always)]
+        [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
+        [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
+        public FileHistoryAuditLogEntryType AuditLogEntryType { get; set; }
 
         [Newtonsoft.Json.JsonProperty("description", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Description { get; set; }
@@ -6425,6 +6426,132 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
 
         [System.Runtime.Serialization.EnumMember(Value = @"COURT_OPTIONS")]
         COURT_OPTIONS = 7,
+
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "13.18.2.0 (NJsonSchema v10.8.0.0 (Newtonsoft.Json v13.0.0.0))")]
+    public enum FileHistoryAuditLogEntryType
+    {
+
+        [System.Runtime.Serialization.EnumMember(Value = @"UNKNOWN")]
+        UNKNOWN = 0,
+
+        [System.Runtime.Serialization.EnumMember(Value = @"ARFL")]
+        ARFL = 1,
+
+        [System.Runtime.Serialization.EnumMember(Value = @"CAIN")]
+        CAIN = 2,
+
+        [System.Runtime.Serialization.EnumMember(Value = @"CAWT")]
+        CAWT = 3,
+
+        [System.Runtime.Serialization.EnumMember(Value = @"CCAN")]
+        CCAN = 4,
+
+        [System.Runtime.Serialization.EnumMember(Value = @"CCON")]
+        CCON = 5,
+
+        [System.Runtime.Serialization.EnumMember(Value = @"CCWR")]
+        CCWR = 6,
+
+        [System.Runtime.Serialization.EnumMember(Value = @"CLEG")]
+        CLEG = 7,
+
+        [System.Runtime.Serialization.EnumMember(Value = @"CUEM")]
+        CUEM = 8,
+
+        [System.Runtime.Serialization.EnumMember(Value = @"CUEV")]
+        CUEV = 9,
+
+        [System.Runtime.Serialization.EnumMember(Value = @"CUIN")]
+        CUIN = 10,
+
+        [System.Runtime.Serialization.EnumMember(Value = @"CULG")]
+        CULG = 11,
+
+        [System.Runtime.Serialization.EnumMember(Value = @"CUPD")]
+        CUPD = 12,
+
+        [System.Runtime.Serialization.EnumMember(Value = @"CUWR")]
+        CUWR = 13,
+
+        [System.Runtime.Serialization.EnumMember(Value = @"CUWT")]
+        CUWT = 14,
+
+        [System.Runtime.Serialization.EnumMember(Value = @"EMCA")]
+        EMCA = 15,
+
+        [System.Runtime.Serialization.EnumMember(Value = @"EMCF")]
+        EMCF = 16,
+
+        [System.Runtime.Serialization.EnumMember(Value = @"EMCR")]
+        EMCR = 17,
+
+        [System.Runtime.Serialization.EnumMember(Value = @"EMDC")]
+        EMDC = 18,
+
+        [System.Runtime.Serialization.EnumMember(Value = @"EMFD")]
+        EMFD = 19,
+
+        [System.Runtime.Serialization.EnumMember(Value = @"EMPR")]
+        EMPR = 20,
+
+        [System.Runtime.Serialization.EnumMember(Value = @"EMRJ")]
+        EMRJ = 21,
+
+        [System.Runtime.Serialization.EnumMember(Value = @"EMRV")]
+        EMRV = 22,
+
+        [System.Runtime.Serialization.EnumMember(Value = @"EMST")]
+        EMST = 23,
+
+        [System.Runtime.Serialization.EnumMember(Value = @"EMUP")]
+        EMUP = 24,
+
+        [System.Runtime.Serialization.EnumMember(Value = @"EMVF")]
+        EMVF = 25,
+
+        [System.Runtime.Serialization.EnumMember(Value = @"INIT")]
+        INIT = 26,
+
+        [System.Runtime.Serialization.EnumMember(Value = @"JASG")]
+        JASG = 27,
+
+        [System.Runtime.Serialization.EnumMember(Value = @"JCNF")]
+        JCNF = 28,
+
+        [System.Runtime.Serialization.EnumMember(Value = @"JDIV")]
+        JDIV = 29,
+
+        [System.Runtime.Serialization.EnumMember(Value = @"JPRG")]
+        JPRG = 30,
+
+        [System.Runtime.Serialization.EnumMember(Value = @"RECN")]
+        RECN = 31,
+
+        [System.Runtime.Serialization.EnumMember(Value = @"SCAN")]
+        SCAN = 32,
+
+        [System.Runtime.Serialization.EnumMember(Value = @"SPRC")]
+        SPRC = 33,
+
+        [System.Runtime.Serialization.EnumMember(Value = @"SREJ")]
+        SREJ = 34,
+
+        [System.Runtime.Serialization.EnumMember(Value = @"SUB")]
+        SUB = 35,
+
+        [System.Runtime.Serialization.EnumMember(Value = @"SUPL")]
+        SUPL = 36,
+
+        [System.Runtime.Serialization.EnumMember(Value = @"SVAL")]
+        SVAL = 37,
+
+        [System.Runtime.Serialization.EnumMember(Value = @"VREV")]
+        VREV = 38,
+
+        [System.Runtime.Serialization.EnumMember(Value = @"VSUB")]
+        VSUB = 39,
 
     }
 

--- a/src/backend/TrafficCourts/Messaging/MessageContracts/SaveFileHistory.cs
+++ b/src/backend/TrafficCourts/Messaging/MessageContracts/SaveFileHistory.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0;
 
 namespace TrafficCourts.Messaging.MessageContracts
 {
@@ -11,7 +12,9 @@ namespace TrafficCourts.Messaging.MessageContracts
     /// </summary>
     public class SaveFileHistoryRecord
     {
-        public string Description { get; set; } = String.Empty;
-        public string TicketNumber { get; set; } = String.Empty;
+        public FileHistoryAuditLogEntryType AuditLogEntryType { get; set; }
+        public long? DisputeId { get; set; }
+        public string? NoticeOfDisputeId { get; set; }
+        public string? TicketNumber { get; set; }
     }
 }

--- a/src/backend/TrafficCourts/Staff.Service/Mappers/Mapper.cs
+++ b/src/backend/TrafficCourts/Staff.Service/Mappers/Mapper.cs
@@ -88,15 +88,31 @@ public class Mapper
         return disputeRejected;
     }
 
-    public static SaveFileHistoryRecord ToFileHistory(string ticketNumber, string description)
+    public static SaveFileHistoryRecord ToFileHistory(long disputeId, FileHistoryAuditLogEntryType auditLogEntryType)
     {
         SaveFileHistoryRecord fileHistoryRecord = new();
-        fileHistoryRecord.TicketNumber = ticketNumber;
-        fileHistoryRecord.Description = description;
+        fileHistoryRecord.DisputeId = disputeId;
+        fileHistoryRecord.AuditLogEntryType = auditLogEntryType;
         return fileHistoryRecord;
     }
 
-   
+    public static SaveFileHistoryRecord ToFileHistoryWithNoticeOfDisputeId(string noticeOfDisputeId, FileHistoryAuditLogEntryType auditLogEntryType)
+    {
+        SaveFileHistoryRecord fileHistoryRecord = new();
+        fileHistoryRecord.NoticeOfDisputeId = noticeOfDisputeId;
+        fileHistoryRecord.AuditLogEntryType = auditLogEntryType;
+        return fileHistoryRecord;
+    }
+
+    public static SaveFileHistoryRecord ToFileHistoryWithTicketNumber(string ticketNumber, FileHistoryAuditLogEntryType auditLogEntryType)
+    {
+        SaveFileHistoryRecord fileHistoryRecord = new();
+        fileHistoryRecord.TicketNumber = ticketNumber;
+        fileHistoryRecord.AuditLogEntryType = auditLogEntryType;
+        return fileHistoryRecord;
+    }
+
+
     public static EmailVerificationSend ToEmailVerification(Guid guid)
     {
         EmailVerificationSend emailVerificationSend = new(guid);

--- a/src/backend/TrafficCourts/Staff.Service/Services/DisputeService.cs
+++ b/src/backend/TrafficCourts/Staff.Service/Services/DisputeService.cs
@@ -168,7 +168,9 @@ public class DisputeService : IDisputeService
         Dispute dispute = await _oracleDataApi.ValidateDisputeAsync(disputeId, cancellationToken);
 
         // Publish file history
-        SaveFileHistoryRecord fileHistoryRecord = Mapper.ToFileHistory(dispute.TicketNumber, "Handwritten ticket OCR details validated by staff.");
+        SaveFileHistoryRecord fileHistoryRecord = Mapper.ToFileHistory(
+            dispute.DisputeId, 
+            FileHistoryAuditLogEntryType.SVAL); // Handwritten ticket OCR details validated by staff
         await _bus.PublishWithLog(_logger, fileHistoryRecord, cancellationToken);
     }
 
@@ -179,7 +181,9 @@ public class DisputeService : IDisputeService
         Dispute dispute = await _oracleDataApi.CancelDisputeAsync(disputeId, cancellationToken);
 
         // Publish file history
-        SaveFileHistoryRecord fileHistoryRecord = Mapper.ToFileHistory(dispute.TicketNumber, "Dispute cancelled by staff.");
+        SaveFileHistoryRecord fileHistoryRecord = Mapper.ToFileHistory(
+            dispute.DisputeId, 
+            FileHistoryAuditLogEntryType.SCAN); // Dispute canceled by staff
         await _bus.PublishWithLog(_logger, fileHistoryRecord, cancellationToken);
 
         // Publish submit event (consumer(s) will generate email, etc)
@@ -197,7 +201,9 @@ public class DisputeService : IDisputeService
         Dispute dispute = await _oracleDataApi.RejectDisputeAsync(disputeId, rejectedReason, cancellationToken);
 
         // Publish file history
-        SaveFileHistoryRecord fileHistoryRecord = Mapper.ToFileHistory(dispute.TicketNumber, "Dispute rejected by staff.");
+        SaveFileHistoryRecord fileHistoryRecord = Mapper.ToFileHistory(
+            dispute.DisputeId, 
+            FileHistoryAuditLogEntryType.SREJ); // Dispute rejected by staff
         await _bus.PublishWithLog(_logger, fileHistoryRecord, cancellationToken);
 
         // Publish submit event (consumer(s) will generate email, etc)
@@ -216,7 +222,9 @@ public class DisputeService : IDisputeService
         Dispute dispute = await _oracleDataApi.SubmitDisputeAsync(disputeId, cancellationToken);
 
         // Publish file history
-        SaveFileHistoryRecord fileHistoryRecord = Mapper.ToFileHistory(dispute.TicketNumber, "Dispute submitted to ARC by staff.");
+        SaveFileHistoryRecord fileHistoryRecord = Mapper.ToFileHistory(
+            dispute.DisputeId, 
+            FileHistoryAuditLogEntryType.SPRC); // Dispute submitted to ARC by staff
         await _bus.PublishWithLog(_logger, fileHistoryRecord, cancellationToken);
 
         // Publish submit event (consumer(s) will push event to ARC and generate email)

--- a/src/backend/TrafficCourts/Staff.Service/Services/FileHistoryService.cs
+++ b/src/backend/TrafficCourts/Staff.Service/Services/FileHistoryService.cs
@@ -37,6 +37,6 @@ public class FileHistoryService : IFileHistoryService
 
     public async Task<long> SaveFileHistoryAsync(FileHistory fileHistory, CancellationToken cancellationToken)
     {
-        return await _oracleDataApi.InsertFileHistoryAsync(fileHistory.TicketNumber, fileHistory, cancellationToken);
+        return await _oracleDataApi.InsertFileHistoryAsync(fileHistory, cancellationToken);
     }
 }

--- a/src/backend/TrafficCourts/Staff.Service/Services/JJDisputeService.cs
+++ b/src/backend/TrafficCourts/Staff.Service/Services/JJDisputeService.cs
@@ -50,12 +50,16 @@ public class JJDisputeService : IJJDisputeService
 
         if (dispute.Status == JJDisputeStatus.IN_PROGRESS)
         {
-            SaveFileHistoryRecord fileHistoryRecord = Mapper.ToFileHistory(ticketNumber, "Dispute decision details updated.");
+            SaveFileHistoryRecord fileHistoryRecord = Mapper.ToFileHistory(
+                jjDispute.OccamDisputeId,
+                FileHistoryAuditLogEntryType.JPRG); // Dispute decision details saved for later
             await _bus.PublishWithLog(_logger, fileHistoryRecord, cancellationToken);
         }
         else if (dispute.Status == JJDisputeStatus.CONFIRMED)
         {
-            SaveFileHistoryRecord fileHistoryRecord = Mapper.ToFileHistory(ticketNumber, "Dispute decision details confirmed / submitted by JJ.");
+            SaveFileHistoryRecord fileHistoryRecord = Mapper.ToFileHistory(
+                jjDispute.OccamDisputeId,
+                FileHistoryAuditLogEntryType.JCNF); // Dispute decision confirmed/submitted by JJ
             await _bus.PublishWithLog(_logger, fileHistoryRecord, cancellationToken);
         }
 
@@ -69,7 +73,11 @@ public class JJDisputeService : IJJDisputeService
         // Publish file history
         foreach (string ticketNumber in ticketNumbers)
         {
-            SaveFileHistoryRecord fileHistoryRecord = Mapper.ToFileHistory(ticketNumber, "Dispute assigned to JJ.");
+            JJDispute dispute = await _oracleDataApi.GetJJDisputeAsync(ticketNumber, false, cancellationToken);
+
+            SaveFileHistoryRecord fileHistoryRecord = Mapper.ToFileHistory(
+                dispute.OccamDisputeId,
+                FileHistoryAuditLogEntryType.JASG); // Dispute assigned to JJ
             await _bus.PublishWithLog(_logger, fileHistoryRecord, cancellationToken);
         }
     }
@@ -78,7 +86,9 @@ public class JJDisputeService : IJJDisputeService
     {
         JJDispute dispute = await _oracleDataApi.ReviewJJDisputeAsync(ticketNumber, checkVTC, remark, cancellationToken);
 
-        SaveFileHistoryRecord fileHistoryRecord = Mapper.ToFileHistory(ticketNumber, "Dispute returned to JJ for review.");
+        SaveFileHistoryRecord fileHistoryRecord = Mapper.ToFileHistory(
+            dispute.OccamDisputeId,
+            FileHistoryAuditLogEntryType.VREV); // Dispute returned to JJ for review
         await _bus.PublishWithLog(_logger, fileHistoryRecord, cancellationToken);
 
         return dispute;
@@ -90,7 +100,9 @@ public class JJDisputeService : IJJDisputeService
         {
             JJDispute dispute = await _oracleDataApi.RequireCourtHearingJJDisputeAsync(ticketNumber, remark, cancellationToken);
 
-            SaveFileHistoryRecord fileHistoryRecord = Mapper.ToFileHistory(ticketNumber, "JJ requires a court hearing for this dispute.");
+            SaveFileHistoryRecord fileHistoryRecord = Mapper.ToFileHistory(
+                dispute.OccamDisputeId, 
+                FileHistoryAuditLogEntryType.JDIV); // Dispute change of plea required / Divert to court appearance
             await _bus.PublishWithLog(_logger, fileHistoryRecord, cancellationToken);
 
             return dispute;
@@ -108,7 +120,9 @@ public class JJDisputeService : IJJDisputeService
     {
         JJDispute dispute = await _oracleDataApi.AcceptJJDisputeAsync(ticketNumber, checkVTC, null, null, cancellationToken);
 
-        SaveFileHistoryRecord fileHistoryRecord = Mapper.ToFileHistory(ticketNumber, "Dispute approved for resulting by staff.");
+        SaveFileHistoryRecord fileHistoryRecord = Mapper.ToFileHistory(
+            dispute.OccamDisputeId,
+            FileHistoryAuditLogEntryType.VSUB); // Dispute approved for resulting by staff
         await _bus.PublishWithLog(_logger, fileHistoryRecord, cancellationToken);
 
         return dispute;
@@ -118,7 +132,9 @@ public class JJDisputeService : IJJDisputeService
     {
         JJDispute dispute = await _oracleDataApi.ConfirmJJDisputeAsync(ticketNumber, cancellationToken);
 
-        SaveFileHistoryRecord fileHistoryRecord = Mapper.ToFileHistory(ticketNumber, "Dispute confirmed for resulting by JJ.");
+        SaveFileHistoryRecord fileHistoryRecord = Mapper.ToFileHistory(
+            dispute.OccamDisputeId, 
+            FileHistoryAuditLogEntryType.JCNF); // Dispute decision confirmed/submitted by JJ
         await _bus.PublishWithLog(_logger, fileHistoryRecord, cancellationToken);
 
         return dispute;

--- a/src/backend/TrafficCourts/Staff.Service/Services/StaffDocumentService.cs
+++ b/src/backend/TrafficCourts/Staff.Service/Services/StaffDocumentService.cs
@@ -2,6 +2,7 @@
 using Minio.DataModel.Tags;
 using System.Linq;
 using TrafficCourts.Common.Models;
+using TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0;
 using TrafficCourts.Coms.Client;
 using TrafficCourts.Messaging.MessageContracts;
 using TrafficCourts.Staff.Service.Mappers;
@@ -80,7 +81,12 @@ public class StaffDocumentService : IStaffDocumentService
         await _objectManagementService.DeleteFileAsync(fileId, cancellationToken);
 
         // Save file delete event to file history
-        SaveFileHistoryRecord fileHistoryRecord = Mapper.ToFileHistory(ticketNumber, $"File: {file.FileName} was deleted by the Staff.");
+        SaveFileHistoryRecord fileHistoryRecord = Mapper.ToFileHistoryWithTicketNumber(
+            ticketNumber,
+            // TODO: This entry type is currently set to: "Document uploaded by Staff (VTC & Court)"
+            // since the original description: "File was deleted by Staff." is missing from the database.
+            // When the description is added to the databse change this
+            FileHistoryAuditLogEntryType.SUPL);
         await _bus.PublishWithLog(_logger, fileHistoryRecord, cancellationToken);
     }
 
@@ -131,7 +137,12 @@ public class StaffDocumentService : IStaffDocumentService
         }
         
         // Save file upload event to file history
-        SaveFileHistoryRecord fileHistoryRecord = Mapper.ToFileHistory(ticketNumber, $"File: {file.FileName} was uploaded by the Staff.");
+        SaveFileHistoryRecord fileHistoryRecord = Mapper.ToFileHistoryWithTicketNumber(
+            ticketNumber,
+            // TODO: This entry type is currently set to: "Document uploaded by Staff (VTC & Court)"
+            // since the original description: "File was uploaded by Staff." is missing from the database.
+            // When the description is added to the databse change this
+            FileHistoryAuditLogEntryType.SUPL);
         await _bus.PublishWithLog(_logger, fileHistoryRecord, cancellationToken);
 
         return id;

--- a/src/backend/TrafficCourts/TrafficCourts.Staff.Service.Test/Controllers/FileHistoryControllerTest.cs
+++ b/src/backend/TrafficCourts/TrafficCourts.Staff.Service.Test/Controllers/FileHistoryControllerTest.cs
@@ -29,10 +29,10 @@ public class FileHistoryControllerTest
         // Arrange
         FileHistory fileHistory1 = new();
         fileHistory1.FileHistoryId = 1;
-        fileHistory1.TicketNumber = "TestTicket01";
+        fileHistory1.DisputeId = 3;
         FileHistory fileHistory2 = new();
         fileHistory2.FileHistoryId =2;
-        fileHistory2.TicketNumber = "TestTicket01";
+        fileHistory2.DisputeId = 4;
         List<FileHistory> fileHistories = new() { fileHistory1, fileHistory2 };
         var fileHistoryService = new Mock<IFileHistoryService>();
         fileHistoryService

--- a/src/backend/TrafficCourts/Workflow.Service/Consumers/DisputeUpdateRequestAcceptedConsumer.cs
+++ b/src/backend/TrafficCourts/Workflow.Service/Consumers/DisputeUpdateRequestAcceptedConsumer.cs
@@ -145,8 +145,11 @@ public class DisputeUpdateRequestAcceptedConsumer : IConsumer<DisputeUpdateReque
     {
         SaveFileHistoryRecord fileHistoryRecord = new()
         {
-            TicketNumber = dispute.TicketNumber,
-            Description = "Dispute update request accepted."
+            DisputeId = dispute.DisputeId,
+            // TODO: This entry type is currently set to: "Dispute contact info updated by citizen"
+            // since the original description: "Dispute update request accepted." is missing from the database.
+            // When the description is added to the databse change this
+            AuditLogEntryType = FileHistoryAuditLogEntryType.CCON
         };
         await context.PublishWithLog(_logger, fileHistoryRecord, context.CancellationToken);
     }

--- a/src/backend/TrafficCourts/Workflow.Service/Consumers/DisputeUpdateRequestRejectedConsumer.cs
+++ b/src/backend/TrafficCourts/Workflow.Service/Consumers/DisputeUpdateRequestRejectedConsumer.cs
@@ -64,8 +64,11 @@ public class DisputeUpdateRequestRejectedConsumer : IConsumer<DisputeUpdateReque
     {
         SaveFileHistoryRecord fileHistoryRecord = new()
         {
-            TicketNumber = dispute.TicketNumber,
-            Description = "Disputant update request rejected."
+            DisputeId = dispute.DisputeId,
+            // TODO: This entry type is currently set to: "Dispute rejected by staff"
+            // since the original description: "Dispute update request rejected." is missing from the database.
+            // When the description is added to the databse change this
+            AuditLogEntryType = FileHistoryAuditLogEntryType.SREJ
         };
         await context.PublishWithLog(_logger, fileHistoryRecord, context.CancellationToken);
     }

--- a/src/backend/TrafficCourts/Workflow.Service/Consumers/EmailVerificationReceivedConsumer.cs
+++ b/src/backend/TrafficCourts/Workflow.Service/Consumers/EmailVerificationReceivedConsumer.cs
@@ -46,14 +46,16 @@ public class SetEmailVerifiedOnDisputeInDatabase : IConsumer<EmailVerificationSu
 
             // File History 
             SaveFileHistoryRecord fileHistoryRecord = new SaveFileHistoryRecord();
-            fileHistoryRecord.TicketNumber = dispute.TicketNumber;
-            fileHistoryRecord.Description = !message.IsUpdateEmailVerification ? "Email verification complete" : "Email update verification complete";
+            fileHistoryRecord.DisputeId = dispute.DisputeId;
+            fileHistoryRecord.AuditLogEntryType = !message.IsUpdateEmailVerification ? 
+                FileHistoryAuditLogEntryType.EMVF : // Email verification complete
+                FileHistoryAuditLogEntryType.CUEV; // Email re-verification complete
             await context.PublishWithLog(_logger, fileHistoryRecord, context.CancellationToken);
 
             if (!message.IsUpdateEmailVerification)
             {
                 // File History 
-                fileHistoryRecord.Description = "Dispute submitted for staff review";
+                fileHistoryRecord.AuditLogEntryType = FileHistoryAuditLogEntryType.SUB; // Dispute submitted for staff review
                 await context.PublishWithLog(_logger, fileHistoryRecord, context.CancellationToken);
             }
 

--- a/src/backend/TrafficCourts/Workflow.Service/Consumers/SendUpdateRequestReceivedEmailConsumer.cs
+++ b/src/backend/TrafficCourts/Workflow.Service/Consumers/SendUpdateRequestReceivedEmailConsumer.cs
@@ -42,13 +42,19 @@ public class SendUpdateRequestReceivedEmailConsumer : IConsumer<UpdateRequestRec
             // File History 
             SaveFileHistoryRecord fileHistoryRecord = new()
             {
-                TicketNumber = dispute.TicketNumber,
-                Description = "Email sent to notify Disputant regarding their update request(s) received"
+                DisputeId = dispute.DisputeId,
+                // TODO: This entry type is currently set to: "Automated notification sent to citizen to verify the updates/changes to their dispute"
+                // The original description: "Email sent to notify Disputant regarding their update request(s) received".
+                // Confirm if this is the correct matching description, if not add the correct one to the database and update this 
+                AuditLogEntryType = FileHistoryAuditLogEntryType.EMVF
             };
             await context.PublishWithLog(_logger, fileHistoryRecord, context.CancellationToken);
 
             // File History 
-            fileHistoryRecord.Description = "Update request(s) submitted for staff review";
+            // TODO: This entry type is currently set to: "Dispute contact info updated by citizen"
+            // since the original description: "Update request(s) submitted for staff review." is missing from the database.
+            // When the description is added to the databse change this
+            fileHistoryRecord.AuditLogEntryType = FileHistoryAuditLogEntryType.CCON;
             await context.PublishWithLog(_logger, fileHistoryRecord, context.CancellationToken);
 
             // Send email to disputant to confirm disputant's update request(s) are received and will be reviewed

--- a/src/backend/TrafficCourts/Workflow.Service/Services/FileHistoryService.cs
+++ b/src/backend/TrafficCourts/Workflow.Service/Services/FileHistoryService.cs
@@ -28,6 +28,20 @@ namespace TrafficCourts.Workflow.Service.Services
             try
             {
                 // prepare file history record
+                if (!string.IsNullOrEmpty(fileHistoryRecord.NoticeOfDisputeId))
+                {
+                    Guid guid = new(fileHistoryRecord.NoticeOfDisputeId);
+                    Dispute? dispute = await _oracleDataApiService.GetDisputeByNoticeOfDisputeGuidAsync(guid, cancellationToken);
+                    if (dispute != null)
+                    {
+                        fileHistoryRecord.DisputeId = dispute.DisputeId;
+                    }
+                }
+                else if (!string.IsNullOrEmpty(fileHistoryRecord.TicketNumber))
+                {
+                    JJDispute dispute = await _oracleDataApiService.GetJJDisputeAsync(fileHistoryRecord.TicketNumber, false, cancellationToken);
+                    fileHistoryRecord.DisputeId = dispute.OccamDisputeId;
+                }
                 FileHistory fileHistory = _mapper.Map<FileHistory>(fileHistoryRecord);
                 long id = await _oracleDataApiService.CreateFileHistoryAsync(fileHistory, cancellationToken);
                 return id;

--- a/src/backend/TrafficCourts/Workflow.Service/Services/IOracleDataApiService.cs
+++ b/src/backend/TrafficCourts/Workflow.Service/Services/IOracleDataApiService.cs
@@ -14,6 +14,7 @@ namespace TrafficCourts.Workflow.Service.Services
         Task<Dispute> GetDisputeByIdAsync(long disputeId, CancellationToken cancellationToken);
         Task<Dispute> UpdateDisputeAsync(long disputeId, Dispute dispute, CancellationToken cancellationToken);
         Task<ICollection<JJDispute>> GetJJDisputesAsync(string jjAssignedTo, string ticketNumber, System.Threading.CancellationToken cancellationToken);
+        Task<JJDispute> GetJJDisputeAsync(string ticketNumber, bool assignVTC, CancellationToken cancellationToken);
 
         // DisputeUpdateRequest endpoints
         Task<ICollection<DisputeUpdateRequest>> GetDisputeUpdateRequestsAsync(long disputeId, Status? disputeUpdateRequestStatus, CancellationToken cancellationToken);

--- a/src/backend/TrafficCourts/Workflow.Service/Services/OracleDataApiService.cs
+++ b/src/backend/TrafficCourts/Workflow.Service/Services/OracleDataApiService.cs
@@ -43,7 +43,7 @@ public class OracleDataApiService : IOracleDataApiService
     {
         try
         {
-            return await _client.InsertFileHistoryAsync(fileHistory.TicketNumber, fileHistory, cancellationToken);
+            return await _client.InsertFileHistoryAsync(fileHistory, cancellationToken);
         }
         catch (Exception)
         {
@@ -138,6 +138,18 @@ public class OracleDataApiService : IOracleDataApiService
         try
         {
             return await _client.GetJJDisputesAsync(jjAssignedTo, ticketNumber, cancellationToken);
+        }
+        catch (Exception)
+        {
+            throw;
+        }
+    }
+
+    public async Task<JJDispute> GetJJDisputeAsync(string ticketNumber, bool assignVTC, CancellationToken cancellationToken)
+    {
+        try
+        {
+            return await _client.GetJJDisputeAsync(ticketNumber, assignVTC, cancellationToken);
         }
         catch (Exception)
         {

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/config/OrdsOccamApiClientConfiguration.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/config/OrdsOccamApiClientConfiguration.java
@@ -5,6 +5,7 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import ca.bc.gov.open.jag.tco.oracledataapi.ords.occam.api.AuditLogEntryApi;
 import ca.bc.gov.open.jag.tco.oracledataapi.ords.occam.api.DisputeUpdateRequestApi;
 import ca.bc.gov.open.jag.tco.oracledataapi.ords.occam.api.HealthApi;
 import ca.bc.gov.open.jag.tco.oracledataapi.ords.occam.api.LookupValuesApi;
@@ -55,6 +56,11 @@ public class OrdsOccamApiClientConfiguration {
 	@Bean
 	public DisputeUpdateRequestApi disputeUpdateRequestApi(ApiClient ordsOccamApiClient) {
 		return new DisputeUpdateRequestApi(ordsOccamApiClient);
+	}
+
+	@Bean
+	public AuditLogEntryApi auditLogEntryApi(ApiClient ordsOccamApiClient) {
+		return new AuditLogEntryApi(ordsOccamApiClient);
 	}
 
 }

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/controller/v1_0/FileHistoryController.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/controller/v1_0/FileHistoryController.java
@@ -15,7 +15,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import ca.bc.gov.open.jag.tco.oracledataapi.model.FileHistory;
-import ca.bc.gov.open.jag.tco.oracledataapi.model.JJDispute;
 import ca.bc.gov.open.jag.tco.oracledataapi.service.FileHistoryService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -45,11 +44,10 @@ public class FileHistoryController {
 
 		return fileHistoryService.getFileHistoryByTicketNumber(ticketNumber);
 	}
-		
+
 	/**
 	 * POST endpoint that inserts a file history record for given ticketnumber.
 	 *
-	 * @param id (ticket number) of the saved {@link JJDispute} to update
 	 * @return inserted {@link FileHistory}
 	 */
 	@Operation(summary = "Inserts a file history record for the given ticket number.")
@@ -58,11 +56,10 @@ public class FileHistoryController {
 		@ApiResponse(responseCode = "400", description = "Bad Request."),
 		@ApiResponse(responseCode = "404", description = "An invalid file history record provided. Insert failed.")
 	})
-	@PostMapping("/fileHistory/{ticketNumber}")
+	@PostMapping("/fileHistory")
 	public ResponseEntity<Long> insertFileHistory(
-			@PathVariable("ticketNumber") String ticketNumber, 
 			@RequestBody FileHistory fileHistory) {
 		logger.debug("POST /fileHistory/{ticketNumber} called");
-		return new ResponseEntity<Long>(fileHistoryService.insertFileHistory(ticketNumber, fileHistory), HttpStatus.OK);
+		return new ResponseEntity<Long>(fileHistoryService.insertFileHistory(fileHistory), HttpStatus.OK);
 	}
 }

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/controller/v1_0/FileHistoryController.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/controller/v1_0/FileHistoryController.java
@@ -59,7 +59,7 @@ public class FileHistoryController {
 	@PostMapping("/fileHistory")
 	public ResponseEntity<Long> insertFileHistory(
 			@RequestBody FileHistory fileHistory) {
-		logger.debug("POST /fileHistory/{ticketNumber} called");
+		logger.debug("POST /fileHistory called");
 		return new ResponseEntity<Long>(fileHistoryService.insertFileHistory(fileHistory), HttpStatus.OK);
 	}
 }

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/mapper/AuditLogEntryMapper.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/mapper/AuditLogEntryMapper.java
@@ -1,0 +1,38 @@
+package ca.bc.gov.open.jag.tco.oracledataapi.mapper;
+
+import org.mapstruct.InjectionStrategy;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.factory.Mappers;
+
+import ca.bc.gov.open.jag.tco.oracledataapi.model.FileHistory;
+
+/**
+ * This mapper maps from ORDS AuditLogEntry model to Oracle Data API FileHistory model and vice versa
+ */
+@Mapper
+(componentModel = "spring", injectionStrategy = InjectionStrategy.CONSTRUCTOR) // This is required for tests to work
+public interface AuditLogEntryMapper {
+
+	AuditLogEntryMapper INSTANCE = Mappers.getMapper(AuditLogEntryMapper.class);
+
+	// Map AuditLogEntry data from ORDS to Oracle Data API FileHistory model
+	@Mapping(source = "auditLogEntryId", target = "fileHistoryId")
+	@Mapping(source = "auditLogEntryTypeCd", target = "auditLogEntryType")
+	@Mapping(source = "auditLogEntryTypeDsc", target = "description")
+	@Mapping(source = "entUserId", target = "createdBy")
+	@Mapping(source = "entDtm", target = "createdTs")
+	@Mapping(source = "updUserId", target = "modifiedBy")
+	@Mapping(source = "updDtm", target = "modifiedTs")
+	FileHistory convert(ca.bc.gov.open.jag.tco.oracledataapi.ords.occam.api.model.AuditLogEntry auditLogEntry);
+
+	// Map Oracle Data API FileHistory model to ORDS AuditLogEntry data
+	@Mapping(target = "auditLogEntryId", source = "fileHistoryId")
+	@Mapping(target = "auditLogEntryTypeCd", source = "auditLogEntryType")
+	@Mapping(target = "auditLogEntryTypeDsc", source = "description")
+	@Mapping(target = "entUserId", source = "createdBy")
+	@Mapping(target = "entDtm", source = "createdTs")
+	@Mapping(target = "updUserId", source = "modifiedBy")
+	@Mapping(target = "updDtm", source = "modifiedTs")
+	ca.bc.gov.open.jag.tco.oracledataapi.ords.occam.api.model.AuditLogEntry convert(FileHistory fileHistory);
+}

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/model/AuditLogEntryType.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/model/AuditLogEntryType.java
@@ -1,0 +1,49 @@
+package ca.bc.gov.open.jag.tco.oracledataapi.model;
+
+/**
+ * An enumeration of file history (audit log) types that represents a specific description for the log
+ * @author 237563
+ */
+public enum AuditLogEntryType {
+	/** Unknown type (undefined). Must be index 0. */
+	UNKNOWN,
+	ARFL,
+	CAIN,
+	CAWT,
+	CCAN,
+	CCON,
+	CCWR,
+	CLEG,
+	CUEM,
+	CUEV,
+	CUIN,
+	CULG,
+	CUPD,
+	CUWR,
+	CUWT,
+	EMCA,
+	EMCF,
+	EMCR,
+	EMDC,
+	EMFD,
+	EMPR,
+	EMRJ,
+	EMRV,
+	EMST,
+	EMUP,
+	EMVF,
+	INIT,
+	JASG,
+	JCNF,
+	JDIV,
+	JPRG,
+	RECN,
+	SCAN,
+	SPRC,
+	SREJ,
+	SUB,
+	SUPL,
+	SVAL,
+	VREV,
+	VSUB
+}

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/model/FileHistory.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/model/FileHistory.java
@@ -5,6 +5,7 @@ import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.Table;
+import javax.validation.constraints.NotNull;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
@@ -19,7 +20,7 @@ import lombok.Setter;
 @Setter
 @NoArgsConstructor
 public class FileHistory extends Auditable<String> {
-	
+
 	/**
 	 * Primary key
 	 */
@@ -27,18 +28,27 @@ public class FileHistory extends Auditable<String> {
 	@Id
 	@GeneratedValue
 	private Long fileHistoryId;
-		
-    /**
-     * The violation ticket number.
-     */
-    @Column(length = 50)
-    @Schema(nullable = false)
-    private String ticketNumber;
-    
-    /**
+
+	/**
+	 * The occam dispute id.
+	 */
+	@Column
+	@Schema(nullable = false)
+	@NotNull
+	private Long disputeId;
+
+	/**
+	 * File history entry type
+	 */
+	@Column(length = 4)
+	@Schema(nullable = false)
+	@NotNull
+	private AuditLogEntryType auditLogEntryType;
+
+	/**
 	 * description
 	 */
 	@Column(length = 500)
 	@Schema(nullable = true)
-	private String description;    
+	private String description;
 }

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/model/JJDispute.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/model/JJDispute.java
@@ -170,9 +170,8 @@ public class JJDispute extends Auditable<String> {
 	@Schema(nullable = true)
 	private String occamDisputantSurnameNm;
 
-	@Column(length = 15)
-	@Schema(nullable = true)
-	private String occamDisputeId;
+	@Schema(nullable = false)
+	private Long occamDisputeId;
 
 	@Column(length = 15)
 	@Schema(nullable = true)

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/repository/FileHistoryRepository.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/repository/FileHistoryRepository.java
@@ -2,12 +2,25 @@ package ca.bc.gov.open.jag.tco.oracledataapi.repository;
 
 import java.util.List;
 
-import org.springframework.data.jpa.repository.JpaRepository;
 import ca.bc.gov.open.jag.tco.oracledataapi.model.FileHistory;
 
-public interface FileHistoryRepository extends JpaRepository<FileHistory, Long> {
+public interface FileHistoryRepository {
 
-	/** Fetch all records older than the given date. */
-    public List<FileHistory> findByTicketNumber(String ticketNumber);
+
+	/**
+	 * Fetches all fileHistory records for the given ticketNumber through ORDS.
+	 *
+	 * @param ticketNumber
+	 * @return List of {@link FileHistory}
+	 */
+	public List<FileHistory> findByTicketNumber(String ticketNumber);
+
+	/**
+	 * Saves a fileHistory entity through ORDS.
+	 *
+	 * @param fileHistory entity to be saved. Must not be {@literal null}.
+	 * @return id of the saved entity
+	 */
+	public Long save(FileHistory fileHistory);
 
 }

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/repository/impl/ords/FileHistoryRepositoryImpl.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/repository/impl/ords/FileHistoryRepositoryImpl.java
@@ -1,0 +1,95 @@
+package ca.bc.gov.open.jag.tco.oracledataapi.repository.impl.ords;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+import javax.ws.rs.InternalServerErrorException;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Repository;
+
+import ca.bc.gov.open.jag.tco.oracledataapi.mapper.AuditLogEntryMapper;
+import ca.bc.gov.open.jag.tco.oracledataapi.model.FileHistory;
+import ca.bc.gov.open.jag.tco.oracledataapi.ords.occam.api.AuditLogEntryApi;
+import ca.bc.gov.open.jag.tco.oracledataapi.ords.occam.api.handler.ApiException;
+import ca.bc.gov.open.jag.tco.oracledataapi.ords.occam.api.model.AuditLogEntryListResponse;
+import ca.bc.gov.open.jag.tco.oracledataapi.ords.occam.api.model.AuditLogEntryResponseResult;
+import ca.bc.gov.open.jag.tco.oracledataapi.repository.FileHistoryRepository;
+
+@Qualifier("fileHistoryRepository")
+@Repository
+public class FileHistoryRepositoryImpl implements FileHistoryRepository{
+
+	private static Logger logger = LoggerFactory.getLogger(FileHistoryRepositoryImpl.class);
+
+	// Delegate, OpenAPI generated client
+	private final AuditLogEntryApi auditLogEntryApi;
+
+	public FileHistoryRepositoryImpl(AuditLogEntryApi auditLogEntryApi) {
+		this.auditLogEntryApi = auditLogEntryApi;
+	}
+
+	@Override
+	public List<FileHistory> findByTicketNumber(String ticketNumber) {
+
+		AuditLogEntryListResponse response = auditLogEntryApi.v1AuditLogEntryListGet(ticketNumber);
+
+		List<FileHistory> fileHistoriesToReturn = new ArrayList<FileHistory>();
+		if (response != null && !response.getAuditLogEntries().isEmpty()) {
+			logger.debug("Successfully returned audit log entries from ORDS");
+
+			fileHistoriesToReturn = response.getAuditLogEntries().stream()
+					.map(auditLog -> AuditLogEntryMapper.INSTANCE.convert(auditLog))
+					.collect(Collectors.toList());
+		}
+
+		return fileHistoriesToReturn;
+	}
+
+	@Override
+	public Long save(FileHistory fileHistory) {
+		if (fileHistory == null) {
+			throw new IllegalArgumentException("FileHistory body is null.");
+		}
+
+		ca.bc.gov.open.jag.tco.oracledataapi.ords.occam.api.model.AuditLogEntry auditLogEntry = AuditLogEntryMapper.INSTANCE.convert(fileHistory);
+		try {
+			AuditLogEntryResponseResult result = assertNoExceptions(() -> auditLogEntryApi.v1ProcessAuditLogEntryPost(auditLogEntry));
+			if (result.getAuditLogEntryId() != null) {
+				logger.debug("Successfully saved the audit log entry through ORDS");
+				return Long.valueOf(result.getAuditLogEntryId()).longValue();
+			}
+		} catch (ApiException e) {
+			logger.error("ERROR inserting FileHistory to ORDS with data: {}", fileHistory.toString(), e);
+			throw new InternalServerErrorException(e);
+		}
+
+		return null;
+	}
+
+	/**
+	 * A helper method that will throw an appropriate InternalServerErrorException based on the AuditLogEntryResponseResult. Any RuntimeExceptions throw will propagate up to caller.
+	 * @return
+	 */
+	private AuditLogEntryResponseResult assertNoExceptions(Supplier<AuditLogEntryResponseResult> m) {
+		AuditLogEntryResponseResult result = m.get();
+
+		if (result == null) {
+			// Missing response object.
+			throw new InternalServerErrorException("Invalid AuditLogEntryResponseResult object");
+		} else if (result.getException() != null) {
+			// Exception in response exists
+			throw new InternalServerErrorException(result.getException());
+		} else if (!"1".equals(result.getStatus())) {
+			// Status is not 1 (success)
+			throw new InternalServerErrorException("Status is not 1 (success)");
+		} else {
+			return result;
+		}
+	}
+
+}

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/service/FileHistoryService.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/service/FileHistoryService.java
@@ -17,10 +17,10 @@ public class FileHistoryService {
 
 	@Autowired
 	FileHistoryRepository fileHistoryRepository;
-	
+
 	@PersistenceContext
-    private EntityManager entityManager;
-	
+	private EntityManager entityManager;
+
 	/**
 	 * Retrieves {@link FileHistory} records by Ticket Number, delegating to CrudRepository
 	 * @param ticketNumber the id for which to retrieve file history records
@@ -29,19 +29,17 @@ public class FileHistoryService {
 	public List<FileHistory> getFileHistoryByTicketNumber(String ticketNumber) {
 		return fileHistoryRepository.findByTicketNumber(ticketNumber);
 	}
-	
+
 	/**
-	 * Inserts an email history record
+	 * Inserts a file history record
 	 *
-	 * @param ticketNumber
 	 * @param {@link FileHistory}
 	 * @return
 	 */
 	@Transactional
-	public Long insertFileHistory(String ticketNumber, FileHistory fileHistory) {
-		
+	public Long insertFileHistory(FileHistory fileHistory) {
+
 		fileHistory.setFileHistoryId(null);
-		fileHistory.setTicketNumber(ticketNumber);
 		fileHistoryRepository.saveAndFlush(fileHistory);
 		return fileHistory.getFileHistoryId();
 	}

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/service/FileHistoryService.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/service/FileHistoryService.java
@@ -38,9 +38,6 @@ public class FileHistoryService {
 	 */
 	@Transactional
 	public Long insertFileHistory(FileHistory fileHistory) {
-
-		fileHistory.setFileHistoryId(null);
-		fileHistoryRepository.saveAndFlush(fileHistory);
-		return fileHistory.getFileHistoryId();
+		return fileHistoryRepository.save(fileHistory);
 	}
 }

--- a/src/backend/oracle-data-api/src/main/resources/occm-openapi-spec.yaml
+++ b/src/backend/oracle-data-api/src/main/resources/occm-openapi-spec.yaml
@@ -466,6 +466,45 @@ paths:
           $ref: '#/components/responses/Unauthorized'
       tags:
         - Dispute Update Request
+  /v1/processAuditLogEntry:
+    post:
+      requestBody:
+        description: body
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AuditLogEntry'
+        required: true
+      responses:
+        '200':
+          description: Ok
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AuditLogEntryResponseResult'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+      tags:
+        - Audit Log Entry
+  /v1/auditLogEntryList:
+    get:
+      parameters:
+        - name: ticketNumber
+          in: query
+          description: ''
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Ok
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AuditLogEntryListResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+      tags:
+        - Audit Log Entry
 components:
   securitySchemes:
     basicAuth:
@@ -627,6 +666,24 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/ViolationTicket'
+    AuditLogEntryResponseResult:
+      type: object
+      properties:
+        status:
+          type: string
+        auditLogEntryId:
+          type: string
+          format: nullable
+        exception:
+          type: string
+          format: nullable
+    AuditLogEntryListResponse:
+      type: object
+      properties:
+        auditLogEntries:
+          type: array
+          items:
+            $ref: '#/components/schemas/AuditLogEntry'
     AuditBase:
       type: object
       properties:
@@ -1044,6 +1101,19 @@ components:
         disputeUpdateReqTypeCd:
           type: string
         requestJsonTxt:
+          type: string
+      allOf:
+        - $ref: '#/components/schemas/AuditBase'
+    AuditLogEntry:
+      type: object
+      properties:
+        auditLogEntryId:
+          type: string
+        disputeId:
+          type: string
+        auditLogEntryTypeCd:
+          type: string
+        auditLogEntryTypeDsc:
           type: string
       allOf:
         - $ref: '#/components/schemas/AuditBase'

--- a/src/backend/oracle-data-api/src/test/java/ca/bc/gov/open/jag/tco/oracledataapi/controller/v1_0/FileHistoryControllerTest.java
+++ b/src/backend/oracle-data-api/src/test/java/ca/bc/gov/open/jag/tco/oracledataapi/controller/v1_0/FileHistoryControllerTest.java
@@ -1,13 +1,16 @@
 package ca.bc.gov.open.jag.tco.oracledataapi.controller.v1_0;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import ca.bc.gov.open.jag.tco.oracledataapi.repository.FileHistoryRepository;
+
 import java.util.List;
+
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
+
 import ca.bc.gov.open.jag.tco.oracledataapi.BaseTestSuite;
 import ca.bc.gov.open.jag.tco.oracledataapi.model.FileHistory;
+import ca.bc.gov.open.jag.tco.oracledataapi.repository.FileHistoryRepository;
 import ca.bc.gov.open.jag.tco.oracledataapi.util.RandomUtil;
 
 class FileHistoryControllerTest extends BaseTestSuite {
@@ -15,29 +18,29 @@ class FileHistoryControllerTest extends BaseTestSuite {
 	@Autowired
 	@Qualifier("FileHistoryControllerV1_0")
 	private FileHistoryController fileHistoryController;
-	
+
 	@Autowired
 	private FileHistoryRepository fileHistoryRepository;
 
 	@Test
 	public void testSaveFileHistory() {
 		// Assert db is empty and clean
-		List<FileHistory> allFileHistory = fileHistoryRepository.findAll(); 
+		List<FileHistory> allFileHistory = fileHistoryRepository.findAll();
 		assertEquals(0, allFileHistory.size());
 
 		// Create a single FileHistory record
 		FileHistory fileHistory = RandomUtil.createFileHistory();
-		Long fileHistoryId = fileHistoryController.insertFileHistory(fileHistory.getTicketNumber(), fileHistory).getBody();
+		Long fileHistoryId = fileHistoryController.insertFileHistory(fileHistory).getBody();
 
 		// Assert db contains the single created record
-		allFileHistory = fileHistoryRepository.findAll(); 
+		allFileHistory = fileHistoryRepository.findAll();
 		assertEquals(1, allFileHistory.size());
 		assertEquals(fileHistoryId, allFileHistory.get(0).getFileHistoryId());
 		assertEquals(fileHistory.getDescription(), allFileHistory.get(0).getDescription());
 
 		// Delete record
 		fileHistoryRepository.deleteById(fileHistoryId);
-	
+
 		// Assert db is empty again
 		allFileHistory = fileHistoryRepository.findAll();
 		assertEquals(0, allFileHistory.size());

--- a/src/backend/oracle-data-api/src/test/java/ca/bc/gov/open/jag/tco/oracledataapi/controller/v1_0/FileHistoryControllerTest.java
+++ b/src/backend/oracle-data-api/src/test/java/ca/bc/gov/open/jag/tco/oracledataapi/controller/v1_0/FileHistoryControllerTest.java
@@ -1,48 +1,40 @@
 package ca.bc.gov.open.jag.tco.oracledataapi.controller.v1_0;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-
-import java.util.List;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 
 import ca.bc.gov.open.jag.tco.oracledataapi.BaseTestSuite;
 import ca.bc.gov.open.jag.tco.oracledataapi.model.FileHistory;
-import ca.bc.gov.open.jag.tco.oracledataapi.repository.FileHistoryRepository;
+import ca.bc.gov.open.jag.tco.oracledataapi.service.FileHistoryService;
 import ca.bc.gov.open.jag.tco.oracledataapi.util.RandomUtil;
 
 class FileHistoryControllerTest extends BaseTestSuite {
 
-	@Autowired
-	@Qualifier("FileHistoryControllerV1_0")
+	@InjectMocks
 	private FileHistoryController fileHistoryController;
 
-	@Autowired
-	private FileHistoryRepository fileHistoryRepository;
+	@Mock
+	private FileHistoryService service;
 
 	@Test
-	public void testSaveFileHistory() {
-		// Assert db is empty and clean
-		List<FileHistory> allFileHistory = fileHistoryRepository.findAll();
-		assertEquals(0, allFileHistory.size());
-
+	public void testSaveFileHistory_200() {
 		// Create a single FileHistory record
 		FileHistory fileHistory = RandomUtil.createFileHistory();
-		Long fileHistoryId = fileHistoryController.insertFileHistory(fileHistory).getBody();
+		// Mock underlying saveDisputeUpdateRequest service
+		Mockito.when(service.insertFileHistory(fileHistory)).thenReturn(fileHistory.getFileHistoryId());
 
-		// Assert db contains the single created record
-		allFileHistory = fileHistoryRepository.findAll();
-		assertEquals(1, allFileHistory.size());
-		assertEquals(fileHistoryId, allFileHistory.get(0).getFileHistoryId());
-		assertEquals(fileHistory.getDescription(), allFileHistory.get(0).getDescription());
-
-		// Delete record
-		fileHistoryRepository.deleteById(fileHistoryId);
-
-		// Assert db is empty again
-		allFileHistory = fileHistoryRepository.findAll();
-		assertEquals(0, allFileHistory.size());
+		// issue a POST request, expect 200
+		ResponseEntity<Long> controllerResponse = fileHistoryController.insertFileHistory(fileHistory);
+		Mockito.verify(service).insertFileHistory(fileHistory);
+		Long resultId = controllerResponse.getBody();
+		assertNotNull(resultId);
+		assertEquals(controllerResponse.getStatusCode().value(), HttpStatus.OK.value());
 	}
 }

--- a/src/backend/oracle-data-api/src/test/java/ca/bc/gov/open/jag/tco/oracledataapi/mapper/JJDisputeMapperTest.java
+++ b/src/backend/oracle-data-api/src/test/java/ca/bc/gov/open/jag/tco/oracledataapi/mapper/JJDisputeMapperTest.java
@@ -198,7 +198,7 @@ public class JJDisputeMapperTest extends BaseTestSuite {
 		assertEquals(occamDisputantGiven2Nm, target.getOccamDisputantGiven2Nm());
 		assertEquals(occamDisputantGiven3Nm, target.getOccamDisputantGiven3Nm());
 		assertEquals(occamDisputantSurnameNm, target.getOccamDisputantSurnameNm());
-		assertEquals(occamDisputeId, target.getOccamDisputeId());
+		assertEquals(Long.valueOf(occamDisputeId), target.getOccamDisputeId());
 		assertEquals(occamViolationTicketUpldId, target.getOccamViolationTicketUpldId());
 		assertEquals(offenceLocationTxt, target.getOffenceLocation());
 		assertEquals(requestCourtAppearanceYn, target.getAppearInCourt());

--- a/src/backend/oracle-data-api/src/test/java/ca/bc/gov/open/jag/tco/oracledataapi/util/RandomUtil.java
+++ b/src/backend/oracle-data-api/src/test/java/ca/bc/gov/open/jag/tco/oracledataapi/util/RandomUtil.java
@@ -228,7 +228,6 @@ public class RandomUtil {
 
 	public static FileHistory createFileHistory() {
 		FileHistory fileHistory = new FileHistory();
-		fileHistory.setTicketNumber(UUID.randomUUID().toString());
 		fileHistory.setDescription(UUID.randomUUID().toString());
 		return fileHistory;
 	}

--- a/src/backend/oracle-data-api/src/test/java/ca/bc/gov/open/jag/tco/oracledataapi/util/RandomUtil.java
+++ b/src/backend/oracle-data-api/src/test/java/ca/bc/gov/open/jag/tco/oracledataapi/util/RandomUtil.java
@@ -13,6 +13,7 @@ import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.time.DateFormatUtils;
 import org.apache.commons.lang3.time.DateUtils;
 
+import ca.bc.gov.open.jag.tco.oracledataapi.model.AuditLogEntryType;
 import ca.bc.gov.open.jag.tco.oracledataapi.model.ContactType;
 import ca.bc.gov.open.jag.tco.oracledataapi.model.Dispute;
 import ca.bc.gov.open.jag.tco.oracledataapi.model.DisputeCount;
@@ -228,7 +229,9 @@ public class RandomUtil {
 
 	public static FileHistory createFileHistory() {
 		FileHistory fileHistory = new FileHistory();
-		fileHistory.setDescription(UUID.randomUUID().toString());
+		fileHistory.setFileHistoryId(3L);
+		fileHistory.setDisputeId(5L);
+		fileHistory.setAuditLogEntryType(AuditLogEntryType.INIT);
 		return fileHistory;
 	}
 


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- [TCVP-2075](https://justice.gov.bc.ca/jira/browse/TCVP-2075)
- Added mappers and functionality to insert and get audit log entries (file history) through the ORDS endpoints.
- Added new `AuditLogEntryType` enum.
- Added repository for saving and getting list of audit log entries through ORDS endpoints.
- Refactored file history controller to receive only `fileHistory` in the body of the request for inserting file history record.
- Refactored unit tests.
- Updated JJDispute to make occamDisputeId to be not nullable and updated .net code accordingly.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Ran oracle data api locally, inserted and retrieved audit log entries successfully using Swagger UI.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
