### PR TITLE
TCVP-2196 updated OCR to match changed Azure service

### DIFF
--- a/src/backend/TrafficCourts/Citizen.Service/Validators/Rules/OnlyMVAIsSelectedRule.cs
+++ b/src/backend/TrafficCourts/Citizen.Service/Validators/Rules/OnlyMVAIsSelectedRule.cs
@@ -4,7 +4,7 @@ namespace TrafficCourts.Citizen.Service.Validators.Rules;
 
 /// <summary>
 /// In the "Did commit offence(s) indicated, under the following act or its regulations" section, only 'MVA' can be selected.
-/// If any of the checkboxes in this section are unreadable (namely not "selected" or "unselected") then this rule cannot be verified.
+/// If any of the checkboxes in this section are unreadable (namely not ":selected:" or ":unselected:") then this rule cannot be verified.
 /// </summary>
 public class OnlyMVAIsSelectedRule : ValidationRule
 {

--- a/src/backend/TrafficCourts/Citizen.Service/Validators/ValidationMessages.cs
+++ b/src/backend/TrafficCourts/Citizen.Service/Validators/ValidationMessages.cs
@@ -8,7 +8,7 @@ public static class ValidationMessages
     public static readonly string DriversLicenceProvinceError = "Drivers Licence Province is not 'BC'. Could not validate Drivers Licence Number.";
     public static readonly string TicketTitleInvalid = @"Ticket title must be 'VIOLATION TICKET'.";
     public static readonly string TicketNumberInvalid = @"Violation ticket number must start with an A and be of the form 'AX00000000'.";
-    public static readonly string CheckboxInvalid = @"Checkbox '{0}' has an unknown value '{1}'. Expecting 'selected' or 'unselected'.";
+    public static readonly string CheckboxInvalid = @"Checkbox '{0}' has an unknown value '{1}'. Expecting ':selected:' or ':unselected:'.";
     public static readonly string CurrencyInvalid = @"Amount '{0}' is not a valid currency value.";
     public static readonly string MVAMustBeSelectedError = @"MVA must be selected under the 'Did commit the offence(s) indicated' section.";
     public static readonly string MVAMustBeCountValue = @"TCO only supports counts with MVA or MVR as the ACT/REG at this time. Read '{0}' for count {1}.";

--- a/src/backend/TrafficCourts/Common/Models/OcrViolationTicket.cs
+++ b/src/backend/TrafficCourts/Common/Models/OcrViolationTicket.cs
@@ -139,11 +139,11 @@ public class Field
     /// <summary>Returns true if the given field's value is "selected", false if "unselected", otherwise null (unknown) value.</summary> 
     public bool? IsCheckboxSelected()
     {
-        if (Value?.Equals("selected", StringComparison.OrdinalIgnoreCase) ?? false)
+        if (Value?.Equals(":selected:", StringComparison.OrdinalIgnoreCase) ?? false)
         {
             return true;
         }
-        if (Value?.Equals("unselected", StringComparison.OrdinalIgnoreCase) ?? false)
+        if (Value?.Equals(":unselected:", StringComparison.OrdinalIgnoreCase) ?? false)
         {
             return false;
         }

--- a/src/backend/TrafficCourts/Test/Citizen.Service/Validators/Rules/CheckboxIsValidRuleTest.cs
+++ b/src/backend/TrafficCourts/Test/Citizen.Service/Validators/Rules/CheckboxIsValidRuleTest.cs
@@ -1,7 +1,7 @@
 using System.Threading.Tasks;
-using TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0;
 using TrafficCourts.Citizen.Service.Validators;
 using TrafficCourts.Citizen.Service.Validators.Rules;
+using TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0;
 using Xunit;
 
 namespace TrafficCourts.Test.Citizen.Service.Validators.Rules;
@@ -41,8 +41,8 @@ public class CheckboxIsValidRuleTest
     {
         public TestData()
         {
-            Add(OcrViolationTicket.OffenceIsMVA, "selected", false);
-            Add(OcrViolationTicket.OffenceIsMVA, "unselected", false);
+            Add(OcrViolationTicket.OffenceIsMVA, ":selected:", false);
+            Add(OcrViolationTicket.OffenceIsMVA, ":unselected:", false);
             Add(OcrViolationTicket.OffenceIsMVA, "randomText", true);
             Add(OcrViolationTicket.OffenceIsMVA, null, true);
         }

--- a/src/backend/TrafficCourts/Test/Citizen.Service/Validators/Rules/OnlyMVAIsSelectedRuleTest.cs
+++ b/src/backend/TrafficCourts/Test/Citizen.Service/Validators/Rules/OnlyMVAIsSelectedRuleTest.cs
@@ -10,15 +10,15 @@ public class OnlyMVAIsSelectedRuleTest
 {
 
     [Theory]
-    [InlineData("selected", "unselected", "unselected", "unselected", "unselected", "unselected", "unselected", "unselected", null)]
-    [InlineData("unselected", "unselected", "unselected", "unselected", "unselected", "unselected", "unselected", "unselected", null)]
-    [InlineData("selected", "selected", "unselected", "unselected", "unselected", "unselected", "unselected", "unselected", @"^MVA must be the only selected.*")]
-    [InlineData("selected", "unselected", "selected", "unselected", "unselected", "unselected", "unselected", "unselected", @"^MVA must be the only selected.*")]
-    [InlineData("selected", "unselected", "unselected", "selected", "unselected", "unselected", "unselected", "unselected", @"^MVA must be the only selected.*")]
-    [InlineData("selected", "unselected", "unselected", "unselected", "selected", "unselected", "unselected", "unselected", @"^MVA must be the only selected.*")]
-    [InlineData("selected", "unselected", "unselected", "unselected", "unselected", "selected", "unselected", "unselected", @"^MVA must be the only selected.*")]
-    [InlineData("selected", "unselected", "unselected", "unselected", "unselected", "unselected", "selected", "unselected", @"^MVA must be the only selected.*")]
-    [InlineData("selected", "unselected", "unselected", "unselected", "unselected", "unselected", "unselected", "selected", @"^MVA must be the only selected.*")]
+    [InlineData(":selected:", ":unselected:", ":unselected:", ":unselected:", ":unselected:", ":unselected:", ":unselected:", ":unselected:", null)]
+    [InlineData(":unselected:", ":unselected:", ":unselected:", ":unselected:", ":unselected:", ":unselected:", ":unselected:", ":unselected:", null)]
+    [InlineData(":selected:", ":selected:", ":unselected:", ":unselected:", ":unselected:", ":unselected:", ":unselected:", ":unselected:", @"^MVA must be the only selected.*")]
+    [InlineData(":selected:", ":unselected:", ":selected:", ":unselected:", ":unselected:", ":unselected:", ":unselected:", ":unselected:", @"^MVA must be the only selected.*")]
+    [InlineData(":selected:", ":unselected:", ":unselected:", ":selected:", ":unselected:", ":unselected:", ":unselected:", ":unselected:", @"^MVA must be the only selected.*")]
+    [InlineData(":selected:", ":unselected:", ":unselected:", ":unselected:", ":selected:", ":unselected:", ":unselected:", ":unselected:", @"^MVA must be the only selected.*")]
+    [InlineData(":selected:", ":unselected:", ":unselected:", ":unselected:", ":unselected:", ":selected:", ":unselected:", ":unselected:", @"^MVA must be the only selected.*")]
+    [InlineData(":selected:", ":unselected:", ":unselected:", ":unselected:", ":unselected:", ":unselected:", ":selected:", ":unselected:", @"^MVA must be the only selected.*")]
+    [InlineData(":selected:", ":unselected:", ":unselected:", ":unselected:", ":unselected:", ":unselected:", ":unselected:", ":selected:", @"^MVA must be the only selected.*")]
     public async Task TestFieldsBlank(string? mva, string? mca, string? cta, string? wla, string? faa, string? lca, string? tcr, string? other, string? expectedPattern)
     {
         // Given


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

TCVP-2196 
Form Recognizer in Azure is returning different json than it did yesterday.
The PR is to update the citizen-api to match.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [x] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

dotnet test

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [x] No

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
