### PR TITLE
Remove Red Hat Package Manager from Image

### DIFF
--- a/src/backend/TrafficCourts/Citizen.Service/Dockerfile.rhel8
+++ b/src/backend/TrafficCourts/Citizen.Service/Dockerfile.rhel8
@@ -36,6 +36,7 @@ EXPOSE 8080
 COPY --from=publish /app/publish .
 USER root
 RUN chgrp 0 entrypoint.sh && chmod a+rwx,o-rwx entrypoint.sh
+RUN rpm -e --nodeps $(rpm -qa '*rpm*' '*dnf*' '*libsolv*' '*hawkey*' 'yum*')
 # Run container by default as user with id 1001 (default)
 USER 1001
 ENTRYPOINT ["./entrypoint.sh", "dotnet", "TrafficCourts.Citizen.Service.dll"]

--- a/src/backend/TrafficCourts/Staff.Service/Dockerfile.rhel8
+++ b/src/backend/TrafficCourts/Staff.Service/Dockerfile.rhel8
@@ -35,6 +35,7 @@ EXPOSE 8080
 COPY --from=publish /app/publish .
 USER root
 RUN chgrp 0 entrypoint.sh && chmod a+rwx,o-rwx entrypoint.sh
+RUN rpm -e --nodeps $(rpm -qa '*rpm*' '*dnf*' '*libsolv*' '*hawkey*' 'yum*')
 # Run container by default as user with id 1001 (default)
 USER 1001
 ENTRYPOINT ["./entrypoint.sh", "dotnet", "TrafficCourts.Staff.Service.dll"]

--- a/src/backend/TrafficCourts/TrafficCourts.Arc.Dispute.Service/Dockerfile.rhel8
+++ b/src/backend/TrafficCourts/TrafficCourts.Arc.Dispute.Service/Dockerfile.rhel8
@@ -38,6 +38,7 @@ WORKDIR /opt/app-root/app
 COPY --from=publish /app/publish .
 USER root
 RUN chgrp 0 entrypoint.sh && chmod a+rwx,o-rwx entrypoint.sh
+RUN rpm -e --nodeps $(rpm -qa '*rpm*' '*dnf*' '*libsolv*' '*hawkey*' 'yum*')
 # Run container by default as user with id 1001 (default)
 USER 1001
 ENTRYPOINT ["./entrypoint.sh", "dotnet", "TrafficCourts.Arc.Dispute.Service.dll"]

--- a/src/backend/TrafficCourts/Workflow.Service/Dockerfile.rhel8
+++ b/src/backend/TrafficCourts/Workflow.Service/Dockerfile.rhel8
@@ -39,6 +39,7 @@ WORKDIR /opt/app-root/app
 COPY --from=publish /app/publish .
 USER root
 RUN chgrp 0 entrypoint.sh && chmod a+rwx,o-rwx entrypoint.sh
+RUN rpm -e --nodeps $(rpm -qa '*rpm*' '*dnf*' '*libsolv*' '*hawkey*' 'yum*')
 # Run container by default as user with id 1001 (default)
 USER 1001
 ENTRYPOINT ["./entrypoint.sh", "dotnet", "TrafficCourts.Workflow.Service.dll"]

--- a/src/backend/bc-gov-virus-scan/BCGov.VirusScan.Api/Dockerfile.rhel8
+++ b/src/backend/bc-gov-virus-scan/BCGov.VirusScan.Api/Dockerfile.rhel8
@@ -1,0 +1,25 @@
+ARG BUILD_IMAGE=image-registry.openshift-image-registry.svc:5000/0198bb-tools/dotnet-sdk
+ARG RUNTIME_IMAGE=image-registry.openshift-image-registry.svc:5000/0198bb-tools/dotnet-70-runtime:latest
+
+FROM $RUNTIME_IMAGE AS base
+WORKDIR /opt/app-root/app
+EXPOSE 8080
+
+FROM $BUILD_IMAGE:7.0 AS build
+WORKDIR /src
+COPY ["BCGov.VirusScan.Api/BCGov.VirusScan.Api.csproj", "BCGov.VirusScan.Api/"]
+RUN dotnet restore "BCGov.VirusScan.Api/BCGov.VirusScan.Api.csproj"
+COPY . .
+WORKDIR "/src/BCGov.VirusScan.Api"
+RUN dotnet build "BCGov.VirusScan.Api.csproj" -c Release -o /app/build
+
+FROM build AS publish
+RUN dotnet publish "BCGov.VirusScan.Api.csproj" -c Release -o /app/publish /p:UseAppHost=false
+
+FROM base AS final
+WORKDIR /opt/app-root/app
+COPY --from=publish /app/publish .
+USER root
+RUN rpm -e --nodeps $(rpm -qa '*rpm*' '*dnf*' '*libsolv*' '*hawkey*' 'yum*')
+
+ENTRYPOINT ["dotnet", "BCGov.VirusScan.Api.dll"]


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- Removes Red Hat/Fedora/CentOS package management system from built image as per this security recommendation.
- 
![image](https://user-images.githubusercontent.com/1844480/220447082-ba8b83ac-59e1-46bf-a3c6-2052620a5ce1.png)


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

