### PR TITLE
TCVP-2124 Use PartId from Keycloak

### DIFF
--- a/src/backend/TrafficCourts/TrafficCourts.Staff.Service.Test/Controllers/JJControllerTest.cs
+++ b/src/backend/TrafficCourts/TrafficCourts.Staff.Service.Test/Controllers/JJControllerTest.cs
@@ -18,6 +18,29 @@ namespace TrafficCourts.Staff.Service.Test.Controllers;
 public class JJControllerTest
 {
     [Fact]
+    public async void TestAcceptJJDispute200Result()
+    {
+        // Arrange
+        JJDispute dispute = new();
+        string ticketNumber = "AJ201092461";
+        bool checkVTC = false;
+        dispute.TicketNumber = ticketNumber;
+        List<string> ticketNumbers = new();
+        ticketNumbers.Add(ticketNumber);
+        var jjDisputeService = new Mock<IJJDisputeService>();
+        jjDisputeService
+            .Setup(_ => _.AcceptJJDisputeAsync(ticketNumber, It.IsAny<bool>(), It.IsAny<CancellationToken>()));
+        var mockLogger = new Mock<ILogger<JJController>>();
+        JJController jjDisputeController = new(jjDisputeService.Object, mockLogger.Object);
+
+        // Act
+        IActionResult? result = await jjDisputeController.AcceptJJDisputeAsync(ticketNumber, checkVTC, CancellationToken.None);
+
+        // Assert
+        var okResult = Assert.IsType<OkResult>(result);
+    }
+
+    [Fact]
     public async void TestAssignJJDisputesToJJ200Result()
     {
         // Mock the OracleDataApi to update a specific JJDispute with ticket number (AJ201092461) to assign it to a JJ, confirm controller updates and assigns the JJ.

--- a/src/backend/TrafficCourts/TrafficCourts.Staff.Service.Test/Services/JJDisputeServiceTest.cs
+++ b/src/backend/TrafficCourts/TrafficCourts.Staff.Service.Test/Services/JJDisputeServiceTest.cs
@@ -1,0 +1,112 @@
+﻿using MassTransit;
+using Microsoft.Extensions.Logging;
+using Moq;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using TrafficCourts.Common.OpenAPIs.KeycloakAdminApi.v18_0;
+using TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0;
+using TrafficCourts.Staff.Service.Services;
+using Xunit;
+
+namespace TrafficCourts.Staff.Service.Test.Services;
+
+public class JJDisputeServiceTest
+{
+
+    [Fact]
+    public void TestGetPartId_JJAssignedToNull()
+    {
+        // Arrange
+        var _oracleDataApiClient = new Mock<IOracleDataApiClient>();
+        var _bus = new Mock<IBus>();
+        var _staffDocumentService = new Mock<IStaffDocumentService>();
+        var _keycloakService = new Mock<IKeycloakService>();
+        var _logger = new Mock<ILogger<JJDisputeService>>();
+        JJDisputeService jJDisputeService = new(_oracleDataApiClient.Object, _bus.Object, _staffDocumentService.Object, _keycloakService.Object, _logger.Object);
+        JJDispute dispute = new();
+        dispute.TicketNumber = "AJ201092461";
+
+        _oracleDataApiClient.Setup(_ => _.GetJJDisputeAsync(dispute.TicketNumber, It.IsAny<bool>(), CancellationToken.None)).ReturnsAsync(dispute);
+
+        // Assert/Act
+        Assert.ThrowsAsync<ArgumentNullException>(() => jJDisputeService.GetPartIdAsync(dispute.TicketNumber, CancellationToken.None));
+    }
+
+    [Fact]
+    public void TestGetPartId_HearingTypeNull()
+    {
+        // Arrange
+        var _oracleDataApiClient = new Mock<IOracleDataApiClient>();
+        var _bus = new Mock<IBus>();
+        var _staffDocumentService = new Mock<IStaffDocumentService>();
+        var _keycloakService = new Mock<IKeycloakService>();
+        var _logger = new Mock<ILogger<JJDisputeService>>();
+        JJDisputeService jJDisputeService = new(_oracleDataApiClient.Object, _bus.Object, _staffDocumentService.Object, _keycloakService.Object, _logger.Object);
+        JJDispute dispute = new();
+        dispute.JjAssignedTo = "ckent";
+        dispute.TicketNumber = "AJ201092461";
+
+        _oracleDataApiClient.Setup(_ => _.GetJJDisputeAsync(dispute.TicketNumber, It.IsAny<bool>(), CancellationToken.None)).ReturnsAsync(dispute);
+
+        // Assert/Act
+        Assert.ThrowsAsync<ArgumentException>(() => jJDisputeService.GetPartIdAsync(dispute.TicketNumber, CancellationToken.None));
+    }
+
+    [Fact]
+    public void TestGetPartId_EmptyKeycloak()
+    {
+        // Arrange
+        var _oracleDataApiClient = new Mock<IOracleDataApiClient>();
+        var _bus = new Mock<IBus>();
+        var _staffDocumentService = new Mock<IStaffDocumentService>();
+        var _keycloakService = new Mock<IKeycloakService>();
+        var _logger = new Mock<ILogger<JJDisputeService>>();
+        var _userReps = new Mock<ICollection<UserRepresentation>>();
+        JJDisputeService jJDisputeService = new(_oracleDataApiClient.Object, _bus.Object, _staffDocumentService.Object, _keycloakService.Object, _logger.Object);
+        JJDispute dispute = new();
+        dispute.JjAssignedTo = "ckent";
+        dispute.TicketNumber = "AJ201092461";
+        dispute.HearingType = JJDisputeHearingType.WRITTEN_REASONS;
+
+        _oracleDataApiClient.Setup(_ => _.GetJJDisputeAsync(dispute.TicketNumber, It.IsAny<bool>(), CancellationToken.None)).ReturnsAsync(dispute);
+        _keycloakService.Setup(_ => _.UsersByIdirAsync(dispute.JjAssignedTo, CancellationToken.None)).ReturnsAsync(_userReps.Object);
+
+        // Assert/Act
+        Assert.ThrowsAsync<ArgumentNullException>(() => jJDisputeService.GetPartIdAsync(dispute.TicketNumber, CancellationToken.None));
+    }
+
+    [Fact]
+    public async void TestGetPartId()
+    {
+        // Arrange
+        var _oracleDataApiClient = new Mock<IOracleDataApiClient>();
+        var _bus = new Mock<IBus>();
+        var _staffDocumentService = new Mock<IStaffDocumentService>();
+        var _keycloakService = new Mock<IKeycloakService>();
+        var _logger = new Mock<ILogger<JJDisputeService>>();
+        var _userReps = new List<UserRepresentation>();
+        var _userRep = new Mock<UserRepresentation>();
+        var _expectedPartIds = new List<string>();
+        JJDisputeService jJDisputeService = new(_oracleDataApiClient.Object, _bus.Object, _staffDocumentService.Object, _keycloakService.Object, _logger.Object);
+        JJDispute dispute = new();
+        dispute.JjAssignedTo = "ckent";
+        dispute.TicketNumber = "AJ201092461";
+        dispute.HearingType = JJDisputeHearingType.WRITTEN_REASONS;
+        _userRep.Object.Username = dispute.JjAssignedTo;
+        _userReps.Add(_userRep.Object);
+        _expectedPartIds.Add("1234.5678");
+
+        _oracleDataApiClient.Setup(_ => _.GetJJDisputeAsync(dispute.TicketNumber, It.IsAny<bool>(), CancellationToken.None)).ReturnsAsync(dispute);
+        _keycloakService.Setup(_ => _.UsersByIdirAsync(dispute.JjAssignedTo, CancellationToken.None)).ReturnsAsync(_userReps);
+        _keycloakService.Setup(_ => _.TryGetPartIds(_userRep.Object)).Returns(_expectedPartIds);
+
+        // Act
+        string _actualPartId = await jJDisputeService.GetPartIdAsync(dispute.TicketNumber, CancellationToken.None);
+
+        // Assert
+        Assert.Equal(_expectedPartIds.First(), _actualPartId);
+    }
+
+}


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

TCVP-2124
- Supplied partId from Keycloak when accepting a JJDispute
- Added xUnit tests

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

dotnet test

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [x] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
