### PR TITLE
Update Helm Charts / entrypoint.sh for Vault

### DIFF
--- a/.gitops/charts/traffic-court-online/charts/arc-dispute-api/templates/deployment.yaml
+++ b/.gitops/charts/traffic-court-online/charts/arc-dispute-api/templates/deployment.yaml
@@ -19,6 +19,7 @@ spec:
         prometheus.io/port: "9090"
         vault.hashicorp.com/agent-inject: 'true'
         vault.hashicorp.com/agent-inject-token: 'true'
+        vault.hashicorp.com/agent-pre-populate-only: 'true'
         vault.hashicorp.com/auth-path: auth/k8s-silver
         vault.hashicorp.com/namespace: platform-services
         vault.hashicorp.com/role: {{ .Values.global.vault.role }}  # licenseplate-nonprod or licenseplate-prod are your options

--- a/.gitops/charts/traffic-court-online/charts/citizen-api/templates/deployment.yaml
+++ b/.gitops/charts/traffic-court-online/charts/citizen-api/templates/deployment.yaml
@@ -19,6 +19,7 @@ spec:
         prometheus.io/port: "9090"
         vault.hashicorp.com/agent-inject: 'true'
         vault.hashicorp.com/agent-inject-token: 'true'
+        vault.hashicorp.com/agent-pre-populate-only: 'true'
         vault.hashicorp.com/auth-path: auth/k8s-silver
         vault.hashicorp.com/namespace: platform-services
         vault.hashicorp.com/role: {{ .Values.global.vault.role }}  # licenseplate-nonprod or licenseplate-prod are your options

--- a/.gitops/charts/traffic-court-online/charts/oracle-data-api/templates/deployment.yaml
+++ b/.gitops/charts/traffic-court-online/charts/oracle-data-api/templates/deployment.yaml
@@ -19,6 +19,18 @@ spec:
       annotations:
         prometheus.io/scrape: 'true'
         prometheus.io/port: "9090"
+        vault.hashicorp.com/agent-inject: 'true'
+        vault.hashicorp.com/agent-inject-token: 'true'
+        vault.hashicorp.com/agent-pre-populate-only: 'true'
+        vault.hashicorp.com/auth-path: auth/k8s-silver
+        vault.hashicorp.com/namespace: platform-services
+        vault.hashicorp.com/role: {{ .Values.global.vault.role }}  # licenseplate-nonprod or licenseplate-prod are your options
+        vault.hashicorp.com/agent-inject-secret-secrets.env: {{ .Values.global.vault.role }}/{{ .Values.global.vault.path }}oracle-data-api
+        vault.hashicorp.com/agent-inject-template-secrets.env: |
+          {{`{{- with secret `}}"{{ .Values.global.vault.role }}/{{ .Values.global.vault.path }}arc-dispute-api"{{` }}
+          {{- range $k, $v := .Data.data }}
+          {{ $k }}='{{ $v }}'{{ end -}}
+          {{- end `}} }}
       labels:
         {{- include "oracle-data-api.selectorLabels" . | nindent 8 }}
     spec:

--- a/.gitops/charts/traffic-court-online/charts/oracle-data-api/templates/deployment.yaml
+++ b/.gitops/charts/traffic-court-online/charts/oracle-data-api/templates/deployment.yaml
@@ -27,7 +27,7 @@ spec:
         vault.hashicorp.com/role: {{ .Values.global.vault.role }}  # licenseplate-nonprod or licenseplate-prod are your options
         vault.hashicorp.com/agent-inject-secret-secrets.env: {{ .Values.global.vault.role }}/{{ .Values.global.vault.path }}oracle-data-api
         vault.hashicorp.com/agent-inject-template-secrets.env: |
-          {{`{{- with secret `}}"{{ .Values.global.vault.role }}/{{ .Values.global.vault.path }}arc-dispute-api"{{` }}
+          {{`{{- with secret `}}"{{ .Values.global.vault.role }}/{{ .Values.global.vault.path }}oracle-data-api"{{` }}
           {{- range $k, $v := .Data.data }}
           {{ $k }}='{{ $v }}'{{ end -}}
           {{- end `}} }}

--- a/.gitops/charts/traffic-court-online/charts/staff-api/templates/deployment.yaml
+++ b/.gitops/charts/traffic-court-online/charts/staff-api/templates/deployment.yaml
@@ -20,6 +20,7 @@ spec:
         prometheus.io/port: "9090"
         vault.hashicorp.com/agent-inject: 'true'
         vault.hashicorp.com/agent-inject-token: 'true'
+        vault.hashicorp.com/agent-pre-populate-only: 'true'
         vault.hashicorp.com/auth-path: auth/k8s-silver
         vault.hashicorp.com/namespace: platform-services
         vault.hashicorp.com/role: {{ .Values.global.vault.role }}  # licenseplate-nonprod or licenseplate-prod are your options

--- a/.gitops/charts/traffic-court-online/charts/workflow-service/templates/deployment.yaml
+++ b/.gitops/charts/traffic-court-online/charts/workflow-service/templates/deployment.yaml
@@ -19,6 +19,7 @@ spec:
         prometheus.io/port: "9090"
         vault.hashicorp.com/agent-inject: 'true'
         vault.hashicorp.com/agent-inject-token: 'true'
+        vault.hashicorp.com/agent-pre-populate-only: 'true'
         vault.hashicorp.com/auth-path: auth/k8s-silver
         vault.hashicorp.com/namespace: platform-services
         vault.hashicorp.com/role: {{ .Values.global.vault.role }}  # licenseplate-nonprod or licenseplate-prod are your options

--- a/src/backend/TrafficCourts/entrypoint.sh
+++ b/src/backend/TrafficCourts/entrypoint.sh
@@ -8,13 +8,6 @@ set -euo pipefail
 
 # shellcheck disable=SC1091
 
-# if the first two parameters are a sleep command,
-# execute the sleep and remove the parameters
-if [[ "$1" = "sleep" ]] ; then
-  sleep $2
-  shift 2
-fi
-
 VAULT_SECRETS_DIR=/vault/secrets
 
 if [ -d ${VAULT_SECRETS_DIR} ]; then

--- a/src/backend/oracle-data-api/entrypoint.sh
+++ b/src/backend/oracle-data-api/entrypoint.sh
@@ -8,13 +8,6 @@ set -euo pipefail
 
 # shellcheck disable=SC1091
 
-# if the first two parameters are a sleep command,
-# execute the sleep and remove the parameters
-if [[ "$1" = "sleep" ]] ; then
-  sleep $2
-  shift 2
-fi
-
 VAULT_SECRETS_DIR=/vault/secrets
 
 if [ -d ${VAULT_SECRETS_DIR} ]; then


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- Fixes TCVP-2208
- Removed unused `sleep` section in entry point scripts
- Add `vault.hashicorp.com/agent-pre-populate-only: 'true'` annotation that should prevent vault sidecar 
- Add injecting secrets for Oracle Data API to support the new ORDS credentials

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change
