### PR TITLE
TCVP-1999 Updated setStatus logic

### DIFF
--- a/src/backend/TrafficCourts/Common/OpenAPIs/OracleDataAPI/v1_0/OracleDataApi.v1_0.json
+++ b/src/backend/TrafficCourts/Common/OpenAPIs/OracleDataAPI/v1_0/OracleDataApi.v1_0.json
@@ -222,16 +222,6 @@
             "description": "Adjudicator's participant ID",
             "required": false,
             "schema": { "type": "string" }
-          },
-          {
-            "name": "courtAppearanceId",
-            "in": "query",
-            "description": "Court Appearance ID",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "format": "int64"
-            }
           }
         ],
         "responses": {
@@ -239,12 +229,12 @@
             "description": "JJDispute record not found. Update failed.",
             "content": { "*/*": { "schema": { "type": "object" } } }
           },
-          "400": {
-            "description": "Bad Request.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
           "405": {
             "description": "A JJDispute status can only be set to ACCEPTED iff status is CONFIRMED. Update failed.",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "400": {
+            "description": "Bad Request.",
             "content": { "*/*": { "schema": { "type": "object" } } }
           },
           "500": {

--- a/src/backend/TrafficCourts/Common/OpenAPIs/OracleDataAPI/v1_0/OracleDataApiClient.g.cs
+++ b/src/backend/TrafficCourts/Common/OpenAPIs/OracleDataAPI/v1_0/OracleDataApiClient.g.cs
@@ -86,20 +86,18 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
         /// Updates the status of a particular JJDispute record to ACCEPTED.
         /// </summary>
         /// <param name="partId">Adjudicator's participant ID</param>
-        /// <param name="courtAppearanceId">Court Appearance ID</param>
         /// <returns>Ok. Updated JJDispute record returned.</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
-        System.Threading.Tasks.Task<JJDispute> AcceptJJDisputeAsync(string ticketNumber, bool checkVTCAssigned, string partId, long? courtAppearanceId);
+        System.Threading.Tasks.Task<JJDispute> AcceptJJDisputeAsync(string ticketNumber, bool checkVTCAssigned, string partId);
 
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <summary>
         /// Updates the status of a particular JJDispute record to ACCEPTED.
         /// </summary>
         /// <param name="partId">Adjudicator's participant ID</param>
-        /// <param name="courtAppearanceId">Court Appearance ID</param>
         /// <returns>Ok. Updated JJDispute record returned.</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
-        System.Threading.Tasks.Task<JJDispute> AcceptJJDisputeAsync(string ticketNumber, bool checkVTCAssigned, string partId, long? courtAppearanceId, System.Threading.CancellationToken cancellationToken);
+        System.Threading.Tasks.Task<JJDispute> AcceptJJDisputeAsync(string ticketNumber, bool checkVTCAssigned, string partId, System.Threading.CancellationToken cancellationToken);
 
         /// <summary>
         /// Updates each JJ Dispute based on the passed in ticket numbers to assign them to a specific JJ or unassign them if JJ not specified.
@@ -1050,12 +1048,11 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
         /// Updates the status of a particular JJDispute record to ACCEPTED.
         /// </summary>
         /// <param name="partId">Adjudicator's participant ID</param>
-        /// <param name="courtAppearanceId">Court Appearance ID</param>
         /// <returns>Ok. Updated JJDispute record returned.</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
-        public virtual System.Threading.Tasks.Task<JJDispute> AcceptJJDisputeAsync(string ticketNumber, bool checkVTCAssigned, string partId, long? courtAppearanceId)
+        public virtual System.Threading.Tasks.Task<JJDispute> AcceptJJDisputeAsync(string ticketNumber, bool checkVTCAssigned, string partId)
         {
-            return AcceptJJDisputeAsync(ticketNumber, checkVTCAssigned, partId, courtAppearanceId, System.Threading.CancellationToken.None);
+            return AcceptJJDisputeAsync(ticketNumber, checkVTCAssigned, partId, System.Threading.CancellationToken.None);
         }
 
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
@@ -1063,10 +1060,9 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
         /// Updates the status of a particular JJDispute record to ACCEPTED.
         /// </summary>
         /// <param name="partId">Adjudicator's participant ID</param>
-        /// <param name="courtAppearanceId">Court Appearance ID</param>
         /// <returns>Ok. Updated JJDispute record returned.</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
-        public virtual async System.Threading.Tasks.Task<JJDispute> AcceptJJDisputeAsync(string ticketNumber, bool checkVTCAssigned, string partId, long? courtAppearanceId, System.Threading.CancellationToken cancellationToken)
+        public virtual async System.Threading.Tasks.Task<JJDispute> AcceptJJDisputeAsync(string ticketNumber, bool checkVTCAssigned, string partId, System.Threading.CancellationToken cancellationToken)
         {
             if (ticketNumber == null)
                 throw new System.ArgumentNullException("ticketNumber");
@@ -1081,10 +1077,6 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
             if (partId != null)
             {
                 urlBuilder_.Append(System.Uri.EscapeDataString("partId") + "=").Append(System.Uri.EscapeDataString(ConvertToString(partId, System.Globalization.CultureInfo.InvariantCulture))).Append("&");
-            }
-            if (courtAppearanceId != null)
-            {
-                urlBuilder_.Append(System.Uri.EscapeDataString("courtAppearanceId") + "=").Append(System.Uri.EscapeDataString(ConvertToString(courtAppearanceId, System.Globalization.CultureInfo.InvariantCulture))).Append("&");
             }
             urlBuilder_.Length--;
 
@@ -1129,16 +1121,6 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                             throw new ApiException<FileResponse>("JJDispute record not found. Update failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
-                        if (status_ == 400)
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            throw new ApiException<FileResponse>("Bad Request.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
-                        }
-                        else
                         if (status_ == 405)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
@@ -1147,6 +1129,16 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             throw new ApiException<FileResponse>("A JJDispute status can only be set to ACCEPTED iff status is CONFIRMED. Update failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 400)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<FileResponse>("Bad Request.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 500)

--- a/src/backend/TrafficCourts/Staff.Service/Services/JJDisputeService.cs
+++ b/src/backend/TrafficCourts/Staff.Service/Services/JJDisputeService.cs
@@ -122,7 +122,7 @@ public class JJDisputeService : IJJDisputeService
         // Get PartId from Keycloak
         string partId = await GetPartIdAsync(ticketNumber, cancellationToken);
 
-        JJDispute dispute = await _oracleDataApi.AcceptJJDisputeAsync(ticketNumber, checkVTC, partId, null, cancellationToken);
+        JJDispute dispute = await _oracleDataApi.AcceptJJDisputeAsync(ticketNumber, checkVTC, partId, cancellationToken);
 
         SaveFileHistoryRecord fileHistoryRecord = Mapper.ToFileHistory(
             dispute.OccamDisputeId,

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/controller/v1_0/JJDisputeController.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/controller/v1_0/JJDisputeController.java
@@ -211,16 +211,15 @@ public class JJDisputeController {
 	public ResponseEntity<JJDispute> acceptJJDispute(@PathVariable String ticketNumber,
 			boolean checkVTCAssigned,
 			Principal principal,
-			@RequestParam(required = false) @Parameter(description = "Adjudicator's participant ID") String partId,
-			@RequestParam(required = false) @Parameter(description = "Court Appearance ID") Long courtAppearanceId) {
-		
+			@RequestParam(required = false) @Parameter(description = "Adjudicator's participant ID") String partId) {
+
 		logger.debug("PUT /dispute/{}/accept called", ticketNumber);
 
 		if (checkVTCAssigned && !jjDisputeService.assignJJDisputeToVtc(ticketNumber, principal)) {
 			return new ResponseEntity<>(null, HttpStatus.CONFLICT);
 		}
 
-		return new ResponseEntity<JJDispute>(jjDisputeService.setStatus(ticketNumber, JJDisputeStatus.ACCEPTED, principal, null, partId, courtAppearanceId), HttpStatus.OK);
+		return new ResponseEntity<JJDispute>(jjDisputeService.setStatus(ticketNumber, JJDisputeStatus.ACCEPTED, principal, null, partId, null), HttpStatus.OK);
 	}
 
 	/**

--- a/src/backend/oracle-data-api/src/test/java/ca/bc/gov/open/jag/tco/oracledataapi/controller/v1_0/JJDisputeControllerTest.java
+++ b/src/backend/oracle-data-api/src/test/java/ca/bc/gov/open/jag/tco/oracledataapi/controller/v1_0/JJDisputeControllerTest.java
@@ -234,7 +234,7 @@ class JJDisputeControllerTest extends BaseTestSuite {
 		assertEquals(JJDisputeStatus.CONFIRMED, jjDispute.getStatus());
 
 		// Set the status to ACCEPTED
-		jjDisputeController.acceptJJDispute(ticketNumber, false, principal, null, null);
+		jjDisputeController.acceptJJDispute(ticketNumber, false, principal, null);
 
 		// Assert status is set correctly.
 		jjDispute = jjDisputeController.getJJDispute(ticketNumber, false, principal).getBody();


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

TCVP-1999
- removed courtAppearanceId from AcceptJJDispute endpoint since it was always null.
- added logic to retrieve the latest courtAppearance if courtAppearanceId not supplied (ie from AcceptJJDispute)
- updated tests

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

mvn test
dotnet test

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
