### PR TITLE
Remove injecting vault token

### DIFF
--- a/.gitops/charts/traffic-court-online/charts/arc-dispute-api/templates/deployment.yaml
+++ b/.gitops/charts/traffic-court-online/charts/arc-dispute-api/templates/deployment.yaml
@@ -18,7 +18,6 @@ spec:
         prometheus.io/scrape: 'true'
         prometheus.io/port: "9090"
         vault.hashicorp.com/agent-inject: 'true'
-        vault.hashicorp.com/agent-inject-token: 'true'
         vault.hashicorp.com/agent-pre-populate-only: 'true'
         vault.hashicorp.com/auth-path: auth/k8s-silver
         vault.hashicorp.com/namespace: platform-services

--- a/.gitops/charts/traffic-court-online/charts/citizen-api/templates/deployment.yaml
+++ b/.gitops/charts/traffic-court-online/charts/citizen-api/templates/deployment.yaml
@@ -18,7 +18,6 @@ spec:
         prometheus.io/scrape: 'true'
         prometheus.io/port: "9090"
         vault.hashicorp.com/agent-inject: 'true'
-        vault.hashicorp.com/agent-inject-token: 'true'
         vault.hashicorp.com/agent-pre-populate-only: 'true'
         vault.hashicorp.com/auth-path: auth/k8s-silver
         vault.hashicorp.com/namespace: platform-services

--- a/.gitops/charts/traffic-court-online/charts/oracle-data-api/templates/deployment.yaml
+++ b/.gitops/charts/traffic-court-online/charts/oracle-data-api/templates/deployment.yaml
@@ -20,7 +20,6 @@ spec:
         prometheus.io/scrape: 'true'
         prometheus.io/port: "9090"
         # vault.hashicorp.com/agent-inject: 'true'
-        vault.hashicorp.com/agent-inject-token: 'true'
         vault.hashicorp.com/agent-pre-populate-only: 'true'
         vault.hashicorp.com/auth-path: auth/k8s-silver
         vault.hashicorp.com/namespace: platform-services

--- a/.gitops/charts/traffic-court-online/charts/staff-api/templates/deployment.yaml
+++ b/.gitops/charts/traffic-court-online/charts/staff-api/templates/deployment.yaml
@@ -19,7 +19,6 @@ spec:
         prometheus.io/scrape: 'true'
         prometheus.io/port: "9090"
         vault.hashicorp.com/agent-inject: 'true'
-        vault.hashicorp.com/agent-inject-token: 'true'
         vault.hashicorp.com/agent-pre-populate-only: 'true'
         vault.hashicorp.com/auth-path: auth/k8s-silver
         vault.hashicorp.com/namespace: platform-services

--- a/.gitops/charts/traffic-court-online/charts/workflow-service/templates/deployment.yaml
+++ b/.gitops/charts/traffic-court-online/charts/workflow-service/templates/deployment.yaml
@@ -18,7 +18,6 @@ spec:
         prometheus.io/scrape: 'true'
         prometheus.io/port: "9090"
         vault.hashicorp.com/agent-inject: 'true'
-        vault.hashicorp.com/agent-inject-token: 'true'
         vault.hashicorp.com/agent-pre-populate-only: 'true'
         vault.hashicorp.com/auth-path: auth/k8s-silver
         vault.hashicorp.com/namespace: platform-services


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- Vault token is required if the application wants to connect to vault. Our application only gets injected secrets and does not call vault. The vault token is not required to be injected.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring / Documentation
- [ ] Version change

