### PR TITLE
Add timeoutSeconds for readinessProbe

### DIFF
--- a/.gitops/charts/virus-scan/templates/deployment.yaml
+++ b/.gitops/charts/virus-scan/templates/deployment.yaml
@@ -50,6 +50,7 @@ spec:
               value: application/json
           initialDelaySeconds: 10
           periodSeconds: 5
+          timeoutSeconds: 10
         resources:
           {{- toYaml .Values.resources | nindent 12 }}
         env:


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- Change timeoutSeconds for readinessProbe to 10 seconds. Default is 1 second.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [ ] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
