### PR TITLE
TCVP-2304 add structured logs for oracle data api

### DIFF
--- a/src/backend/oracle-data-api/pom.xml
+++ b/src/backend/oracle-data-api/pom.xml
@@ -111,6 +111,12 @@
 			<artifactId>splunk-library-javalogging</artifactId>
 			<version>1.11.7</version>
 		</dependency>
+		
+		<dependency>
+		    <groupId>net.logstash.logback</groupId>
+		    <artifactId>logstash-logback-encoder</artifactId>
+		    <version>7.3</version>
+		</dependency>
 
 		<!-- Swagger UI -->
 		<dependency>

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/controller/v1_0/EmailHistoryController.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/controller/v1_0/EmailHistoryController.java
@@ -20,6 +20,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import net.logstash.logback.argument.StructuredArguments;
 
 @RestController(value = "EmailHistoryControllerV1_0")
 @RequestMapping("/api/v1.0")
@@ -40,7 +41,7 @@ public class EmailHistoryController {
 			@PathVariable
 			@Parameter(description = "Ticket number to retrieve related emails.")
 			String ticketNumber) {
-		logger.debug("getEmailHistoryForTicket called");
+		logger.debug("getEmailHistoryForTicket called for ticketNumber: {} ", StructuredArguments.value("ticketNumber", ticketNumber));
 
 		return emailHistoryService.getEmailHistoryByTicketNumber(ticketNumber);
 	}
@@ -59,7 +60,7 @@ public class EmailHistoryController {
 	@PostMapping("/emailHistory")
 	public ResponseEntity<Long> insertEmailHistory(
 			@RequestBody EmailHistory emailHistory) {
-		logger.debug("POST /emailHistory/{ticketNumber} called");
+		logger.debug("POST /emailHistory called to save emailHistory: {}", StructuredArguments.fields(emailHistory));
 		return new ResponseEntity<Long>(emailHistoryService.insertEmailHistory(emailHistory), HttpStatus.OK);
 	}
 }

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/controller/v1_0/FileHistoryController.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/controller/v1_0/FileHistoryController.java
@@ -20,6 +20,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import net.logstash.logback.argument.StructuredArguments;
 
 @RestController(value = "FileHistoryControllerV1_0")
 @RequestMapping("/api/v1.0")
@@ -40,14 +41,14 @@ public class FileHistoryController {
 			@PathVariable
 			@Parameter(description = "Ticket number to retrieve related file history.")
 			String ticketNumber) {
-		logger.debug("getFileHistoryForTicket called");
+		logger.debug("getFileHistoryForTicket called for ticketNumber: {} ", StructuredArguments.value("ticketNumber", ticketNumber));
 
 		return fileHistoryService.getFileHistoryByTicketNumber(ticketNumber);
 	}
 
 	/**
 	 * POST endpoint that inserts a file history record for given ticketnumber.
-	 * 
+	 *
 	 * @requestBody fileHistory
 	 * @return inserted {@link FileHistory}
 	 */
@@ -60,7 +61,7 @@ public class FileHistoryController {
 	@PostMapping("/fileHistory")
 	public ResponseEntity<Long> insertFileHistory(
 			@RequestBody FileHistory fileHistory) {
-		logger.debug("POST /fileHistory called");
+		logger.debug("POST /fileHistory called for saving fileHistory: {}", StructuredArguments.fields(fileHistory));
 		return new ResponseEntity<Long>(fileHistoryService.insertFileHistory(fileHistory), HttpStatus.OK);
 	}
 }

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/controller/v1_0/JJDisputeController.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/controller/v1_0/JJDisputeController.java
@@ -28,6 +28,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import net.logstash.logback.argument.StructuredArguments;
 
 @RestController(value = "JJDisputeControllerV1_0")
 @RequestMapping("/api/v1.0/jj")
@@ -52,7 +53,7 @@ public class JJDisputeController {
 			@PathVariable("ticketNumber") String ticketNumber,
 			@PathVariable("assignVTC") boolean checkVTCAssigned,
 			Principal principal) {
-		logger.debug("GET /dispute/{}/{} called", ticketNumber, checkVTCAssigned);
+		logger.debug("GET /dispute/{}/{} called", StructuredArguments.value("ticketNumber", ticketNumber), StructuredArguments.value("checkVTCAssigned", checkVTCAssigned));
 
 		if (checkVTCAssigned && !jjDisputeService.assignJJDisputeToVtc(ticketNumber, principal)) {
 			return new ResponseEntity<>(null, HttpStatus.CONFLICT);
@@ -103,7 +104,7 @@ public class JJDisputeController {
 			boolean checkVTCAssigned,
 			Principal principal,
 			@RequestBody JJDispute jjDispute) {
-		logger.debug("PUT /dispute/{} called", ticketNumber);
+		logger.debug("PUT /dispute/{} called", StructuredArguments.value("ticketNumber", ticketNumber));
 
 		if (checkVTCAssigned && !jjDisputeService.assignJJDisputeToVtc(ticketNumber, principal)) {
 			return new ResponseEntity<>(null, HttpStatus.CONFLICT);
@@ -158,7 +159,7 @@ public class JJDisputeController {
 			@RequestBody @Size(max = 256) String remark,
 			boolean checkVTCAssigned,
 			Principal principal) {
-		logger.debug("PUT /dispute/{}/review called", ticketNumber);
+		logger.debug("PUT /dispute/{}/review called", StructuredArguments.value("ticketNumber", ticketNumber));
 
 		if (checkVTCAssigned && !jjDisputeService.assignJJDisputeToVtc(ticketNumber, principal)) {
 			return new ResponseEntity<>(null, HttpStatus.CONFLICT);
@@ -188,7 +189,7 @@ public class JJDisputeController {
 	public ResponseEntity<JJDispute> requireCourtHearingJJDispute(@PathVariable String ticketNumber,
 			@RequestParam (required = false) @Size(max = 256) String remark,
 			Principal principal) {
-		logger.debug("PUT /dispute/{}/requirecourthearing called", ticketNumber);
+		logger.debug("PUT /dispute/{}/requirecourthearing called", StructuredArguments.value("ticketNumber", ticketNumber));
 
 		return new ResponseEntity<JJDispute>(jjDisputeService.requireCourtHearing(ticketNumber, principal, remark), HttpStatus.OK);
 	}
@@ -215,7 +216,7 @@ public class JJDisputeController {
 			Principal principal,
 			@RequestParam(required = false) @Parameter(description = "Adjudicator's participant ID") String partId) {
 
-		logger.debug("PUT /dispute/{}/accept called", ticketNumber);
+		logger.debug("PUT /dispute/{}/accept called", StructuredArguments.value("ticketNumber", ticketNumber));
 
 		if (checkVTCAssigned && !jjDisputeService.assignJJDisputeToVtc(ticketNumber, principal)) {
 			return new ResponseEntity<>(null, HttpStatus.CONFLICT);
@@ -242,7 +243,7 @@ public class JJDisputeController {
 	})
 	@PutMapping("/dispute/{ticketNumber}/confirm")
 	public ResponseEntity<JJDispute> confirmJJDispute(@PathVariable String ticketNumber, Principal principal) {
-		logger.debug("PUT /dispute/{}/confirm called", ticketNumber);
+		logger.debug("PUT /dispute/{}/confirm called", StructuredArguments.value("ticketNumber", ticketNumber));
 
 		return new ResponseEntity<JJDispute>(jjDisputeService.setStatus(ticketNumber, JJDisputeStatus.CONFIRMED, principal, null, null), HttpStatus.OK);
 	}
@@ -259,7 +260,7 @@ public class JJDisputeController {
 			@PathVariable("ticketNumber") String ticketNumber,
 			@PathVariable("documentType") TicketImageDataDocumentType documentType,
 			Principal principal) {
-		logger.debug("GET /dispute/ticketImage/{}/{} called", ticketNumber, documentType);
+		logger.debug("GET /dispute/ticketImage/{}/{} called", StructuredArguments.value("ticketNumber", ticketNumber), StructuredArguments.value("documentType", documentType));
 
 		return new ResponseEntity<TicketImageDataJustinDocument>(jjDisputeService.getTicketImageByTicketNumber(ticketNumber, documentType), HttpStatus.OK);
 	}

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/repository/impl/ords/DisputeUpdateRequestRepositoryImpl.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/repository/impl/ords/DisputeUpdateRequestRepositoryImpl.java
@@ -21,6 +21,7 @@ import ca.bc.gov.open.jag.tco.oracledataapi.ords.occam.api.handler.ApiException;
 import ca.bc.gov.open.jag.tco.oracledataapi.ords.occam.api.model.UpdateRequestListResponse;
 import ca.bc.gov.open.jag.tco.oracledataapi.ords.occam.api.model.UpdateRequestResponseResult;
 import ca.bc.gov.open.jag.tco.oracledataapi.repository.DisputeUpdateRequestRepository;
+import net.logstash.logback.argument.StructuredArguments;
 
 @Qualifier("disputantUpdateRequestRepository")
 @Repository
@@ -63,11 +64,11 @@ public class DisputeUpdateRequestRepositoryImpl implements DisputeUpdateRequestR
 		try {
 			UpdateRequestResponseResult result = assertNoExceptions(() -> disputeUpdateRequestApi.v1ProcessDisputeUpdateRequestPost(updateRequest));
 			if (result.getDisputeUpdateRequestId() != null) {
-				logger.debug("Successfully saved the dispute update request through ORDS for dispute id {}", result.getDisputeId());
+				logger.debug("Successfully saved the dispute update request through ORDS for dispute id {}", StructuredArguments.value("disputeId", result.getDisputeId()));
 				return findById(Long.valueOf(result.getDisputeUpdateRequestId()).longValue()).orElse(null);
 			}
 		} catch (ApiException e) {
-			logger.error("ERROR inserting DisputeUpdateRequest to ORDS with update request data: {}", updateRequest.toString(), e);
+			logger.error("ERROR inserting DisputeUpdateRequest to ORDS with update request data: {}", StructuredArguments.fields(updateRequest), e);
 			throw new InternalServerErrorException(e);
 		}
 
@@ -85,13 +86,13 @@ public class DisputeUpdateRequestRepositoryImpl implements DisputeUpdateRequestR
 				return Optional.empty();
 			}
 			else {
-				logger.debug("Successfully returned the dispute update request from ORDS with id {}", id);
+				logger.debug("Successfully returned the dispute update request from ORDS with id {}", StructuredArguments.value("disputeUpdateRequestId", id));
 				DisputeUpdateRequest disputeUpdateRequest = DisputeUpdateRequestMapper.INSTANCE.convert(updateRequest);
 
 				return Optional.ofNullable(disputeUpdateRequest);
 			}
 		} catch (ApiException e) {
-			logger.error("ERROR retrieving dispute update request from ORDS with id {}", id, e);
+			logger.error("ERROR retrieving dispute update request from ORDS with id {}", StructuredArguments.value("disputeId", id), e);
 			throw new InternalServerErrorException(e);
 		}
 	}
@@ -106,11 +107,11 @@ public class DisputeUpdateRequestRepositoryImpl implements DisputeUpdateRequestR
 		try {
 			UpdateRequestResponseResult result = assertNoExceptions(() -> disputeUpdateRequestApi.v1UpdateDisputeUpdateRequestPut(updateRequest));
 			if (result.getDisputeUpdateRequestId() != null) {
-				logger.debug("Successfully updated the dispute update request through ORDS for dispute id {}", result.getDisputeId());
+				logger.debug("Successfully updated the dispute update request through ORDS for dispute id {}", StructuredArguments.value("disputeId", result.getDisputeId()));
 				return findById(Long.valueOf(result.getDisputeUpdateRequestId()).longValue()).orElse(null);
 			}
 		} catch (ApiException e) {
-			logger.error("ERROR updating DisputeUpdateRequest through ORDS with update request data: {}", updateRequest.toString(), e);
+			logger.error("ERROR updating DisputeUpdateRequest through ORDS with update request data: {}", StructuredArguments.fields(updateRequest), e);
 			throw new InternalServerErrorException(e);
 		}
 
@@ -125,10 +126,10 @@ public class DisputeUpdateRequestRepositoryImpl implements DisputeUpdateRequestR
 
 		try {
 			UpdateRequestResponseResult result = assertNoExceptions(() -> disputeUpdateRequestApi.v1DeleteDisputeUpdateRequestDelete(id, null));
-			logger.debug("Successfully deleted the dispute update request through ORDS with id {}", result.getDisputeUpdateRequestId());
+			logger.debug("Successfully deleted the dispute update request through ORDS with id {}", StructuredArguments.value("disputeUpdateRequestId", id));
 
 		} catch (ApiException e) {
-			logger.error("ERROR deleting DisputeUpdateRequest through ORDS with id: {}", id, e);
+			logger.error("ERROR deleting DisputeUpdateRequest through ORDS with id: {}", StructuredArguments.value("disputeUpdateRequestId", id), e);
 			throw new InternalServerErrorException(e);
 		}
 	}

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/repository/impl/ords/EmailHistoryRepositoryImpl.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/repository/impl/ords/EmailHistoryRepositoryImpl.java
@@ -19,6 +19,7 @@ import ca.bc.gov.open.jag.tco.oracledataapi.ords.occam.api.handler.ApiException;
 import ca.bc.gov.open.jag.tco.oracledataapi.ords.occam.api.model.OutgoingEmailListResponse;
 import ca.bc.gov.open.jag.tco.oracledataapi.ords.occam.api.model.OutgoingEmailResponseResult;
 import ca.bc.gov.open.jag.tco.oracledataapi.repository.EmailHistoryRepository;
+import net.logstash.logback.argument.StructuredArguments;
 
 @Qualifier("disputeRepository")
 @Repository
@@ -63,7 +64,7 @@ public class EmailHistoryRepositoryImpl implements EmailHistoryRepository {
 				return Long.valueOf(result.getOutgoingEmailId()).longValue();
 			}
 		} catch (ApiException e) {
-			logger.error("ERROR inserting EmailHistory to ORDS with data: {}", emailHistory.toString(), e);
+			logger.error("ERROR inserting EmailHistory to ORDS with data: {}", StructuredArguments.fields(emailHistory), e);
 			throw new InternalServerErrorException(e);
 		}
 

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/repository/impl/ords/FileHistoryRepositoryImpl.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/repository/impl/ords/FileHistoryRepositoryImpl.java
@@ -19,6 +19,7 @@ import ca.bc.gov.open.jag.tco.oracledataapi.ords.occam.api.handler.ApiException;
 import ca.bc.gov.open.jag.tco.oracledataapi.ords.occam.api.model.AuditLogEntryListResponse;
 import ca.bc.gov.open.jag.tco.oracledataapi.ords.occam.api.model.AuditLogEntryResponseResult;
 import ca.bc.gov.open.jag.tco.oracledataapi.repository.FileHistoryRepository;
+import net.logstash.logback.argument.StructuredArguments;
 
 @Qualifier("fileHistoryRepository")
 @Repository
@@ -64,7 +65,7 @@ public class FileHistoryRepositoryImpl implements FileHistoryRepository{
 				return Long.valueOf(result.getAuditLogEntryId()).longValue();
 			}
 		} catch (ApiException e) {
-			logger.error("ERROR inserting FileHistory to ORDS with data: {}", fileHistory.toString(), e);
+			logger.error("ERROR inserting FileHistory to ORDS with data: {}", StructuredArguments.fields(fileHistory), e);
 			throw new InternalServerErrorException(e);
 		}
 

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/repository/impl/ords/JJDisputeRepositoryImpl.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/repository/impl/ords/JJDisputeRepositoryImpl.java
@@ -32,6 +32,7 @@ import ca.bc.gov.open.jag.tco.oracledataapi.ords.tco.api.model.JJDisputeListResp
 import ca.bc.gov.open.jag.tco.oracledataapi.ords.tco.api.model.ResponseResult;
 import ca.bc.gov.open.jag.tco.oracledataapi.repository.JJDisputeRepository;
 import ca.bc.gov.open.jag.tco.oracledataapi.util.DateUtil;
+import net.logstash.logback.argument.StructuredArguments;
 
 @ConditionalOnProperty(name = "repository.jjdispute", havingValue = "ords", matchIfMissing = true)
 @Qualifier("jjDisputeRepository")
@@ -45,7 +46,7 @@ public class JJDisputeRepositoryImpl implements JJDisputeRepository {
 
 	@Autowired
 	private JJDisputeMapper jjDisputeMapper;
-	
+
 	public JJDisputeRepositoryImpl(JjDisputeApi jjDisputeApi) {
 		this.jjDisputeApi = jjDisputeApi;
 	}
@@ -103,7 +104,7 @@ public class JJDisputeRepositoryImpl implements JJDisputeRepository {
 		}
 		return new ArrayList<JJDispute>();
 	}
-	
+
 	@Override
 	public JJDispute saveAndFlush(JJDispute jjDispute) {
 		try {
@@ -112,7 +113,7 @@ public class JJDisputeRepositoryImpl implements JJDisputeRepository {
 				return jjDisputeApi.v1UpdateDisputePut(convert);
 			});
 			if (responseResult.getDisputeId() != null) {
-				logger.debug("Successfully updated the jjDispute through ORDS with dispute id {}", responseResult.getDisputeId());
+				logger.debug("Successfully updated the jjDispute through ORDS with dispute id {}", StructuredArguments.value("disputeId", responseResult.getDisputeId()));
 
 				// There is no endpoint to retrieve a JJDispute by id, so we'll use the ticketNumber that was in the update request (hopefully it wasn't changed)
 				//return findById(Long.valueOf(result.getDisputeId()).longValue()).orElse(null);
@@ -122,12 +123,12 @@ public class JJDisputeRepositoryImpl implements JJDisputeRepository {
 					throw new InternalServerErrorException("Update was successful, but retrieving the same record failed");
 				}
 				else if (jjDisputes.size() > 1) {
-					logger.error("More than on JJDispute found with the [supposedly-unique] ticketNumber: {}", jjDispute.getTicketNumber());
+					logger.error("More than on JJDispute found with the [supposedly-unique] ticketNumber: {}", StructuredArguments.value("ticketNumber", jjDispute.getTicketNumber()));
 				}
 				return jjDisputes.get(0);
 			}
 		} catch (ApiException e) {
-			logger.error("ERROR updating JJDispute to ORDS with data: {}", jjDispute.toString(), e);
+			logger.error("ERROR updating JJDispute to ORDS with data: {}", StructuredArguments.fields(jjDispute), e);
 			throw new InternalServerErrorException(e);
 		}
 

--- a/src/backend/oracle-data-api/src/main/resources/logback-spring.xml
+++ b/src/backend/oracle-data-api/src/main/resources/logback-spring.xml
@@ -17,9 +17,14 @@
 		<disableCertificateValidation>true</disableCertificateValidation>
 		<batch_size_count>1</batch_size_count>
 		<connectTimeout>5000</connectTimeout>
-		<layout class="ch.qos.logback.classic.PatternLayout">
-			<pattern>%msg</pattern>
-		</layout>
+		<messageFormat>json</messageFormat>
+		<layout class="net.logstash.logback.layout.LogstashLayout">
+	        <customFields>
+	        	{
+	        		"Application":"TrafficCourts.OracleDataApi"
+	        	}
+	        </customFields>
+	    </layout>
 	</appender>
 
 	<springProfile name="!test">


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- [TCVP-2304](https://justice.gov.bc.ca/jira/browse/TCVP-2304)
- Added required dependencies and configuration to publish structured logs to Splunk through logback in JSON format.
- Using [Logstash Logback Encoder](https://github.com/logfellow/logstash-logback-encoder) dependency to provide logback layouts to log in JSON.
- Updated all logs in controllers, services and repositories to use structured logging in order to pass structured parameters to Splunk for dashboard view.
![splunk log](https://user-images.githubusercontent.com/98848668/228663130-378fd890-528c-4a73-af14-f685c135490a.png)


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Ran splunk and oracle data api locally, sent some request to the endpoints and confirmed the structured logs published to Splunk.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
