### PR TITLE
TCVP-2324 Add delete endpoint for JJ Disputes

### DIFF
--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/controller/v1_0/JJDisputeController.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/controller/v1_0/JJDisputeController.java
@@ -6,11 +6,13 @@ import java.util.List;
 import javax.validation.constraints.Pattern;
 import javax.validation.constraints.Size;
 
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -263,5 +265,34 @@ public class JJDisputeController {
 		logger.debug("GET /dispute/ticketImage/{}/{} called", StructuredArguments.value("ticketNumber", ticketNumber), StructuredArguments.value("documentType", documentType));
 
 		return new ResponseEntity<TicketImageDataJustinDocument>(jjDisputeService.getTicketImageByTicketNumber(ticketNumber, documentType), HttpStatus.OK);
+	}
+
+	/**
+	 * DELETE endpoint that deletes a specified {@link JJDispute} as well as its associated data
+	 *
+	 * @param id of the {@link JJDispute} to be deleted
+	 */
+	@Operation(summary = "Deletes a particular JJDispute record.")
+	@ApiResponses({
+		@ApiResponse(responseCode = "200", description = "Ok. JJ Dispute record deleted."),
+		@ApiResponse(responseCode = "400", description = "Bad Request."),
+		@ApiResponse(responseCode = "404", description = "JJ Dispute record not found. Delete failed."),
+		@ApiResponse(responseCode = "500", description = "Internal Server Error. Delete failed.")
+	})
+	@DeleteMapping("/dispute")
+	public void deleteDispute(
+			@RequestParam(required = false)
+			@Parameter(description = "If specified, will delete the record of the specified jj dispute by this ID. JJ Dispute ID will take precedence if both ID and ticket number supplied")
+			Long jjDisputeId,
+			@RequestParam(required = false)
+			@Pattern(regexp = "[A-Z]{2}\\d{8}")
+			@Parameter(description = "If specified, will delete the record of the specified jj dispute by this TicketNumber. (Format is XX00000000)", example = "AX12345678")
+			String ticketNumber) {
+		logger.debug("DELETE /dispute called with jjDisputeId: {}, and ticketNumber: {}", StructuredArguments.value("jjDisputeId", jjDisputeId), StructuredArguments.value("ticketNumber", ticketNumber));
+		if (jjDisputeId == null && StringUtils.isBlank(ticketNumber)) {
+			throw new IllegalArgumentException("Either ticketNumber or jjDisputeId must be specified.");
+		}
+
+		jjDisputeService.delete(jjDisputeId, ticketNumber);
 	}
 }

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/repository/JJDisputeRepository.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/repository/JJDisputeRepository.java
@@ -49,7 +49,7 @@ public interface JJDisputeRepository {
 
 	/** Fetch all records that match by JJDispute.ticketNumber (should only ever be one). */
 	public List<JJDispute> findByTicketNumber(String ticketNumber);
-	
+
 	/**
 	 * Saves an entity and flushes changes instantly.
 	 *
@@ -73,5 +73,13 @@ public interface JJDisputeRepository {
 	 */
 	public void setStatus(Long disputeId, JJDisputeStatus disputeStatus, String userId, Long courtAppearanceId, YesNo seizedYn,
 			String adjudicatorPartId, JJDisputeCourtAppearanceAPP aattCd, JJDisputeCourtAppearanceDATT dattCd, String staffPartId);
+
+	/**
+	 * Deletes a JJ Dispute and all associated records for the given jjDisputeId or ticketNumber
+	 *
+	 * @param id
+	 * @param ticketNumber
+	 */
+	public void deleteByIdOrTicketNumber(Long id, String ticketNumber);
 
 }

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/repository/impl/ords/JJDisputeRepositoryImpl.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/repository/impl/ords/JJDisputeRepositoryImpl.java
@@ -149,6 +149,11 @@ public class JJDisputeRepositoryImpl implements JJDisputeRepository {
 				staffPartId));
 	}
 
+	@Override
+	public void deleteByIdOrTicketNumber(Long id, String ticketNumber) {
+		assertNoExceptionsGeneric(() -> jjDisputeApi.v1DeleteDisputeDelete(id, ticketNumber));
+	}
+
 	private JJDispute map(ca.bc.gov.open.jag.tco.oracledataapi.ords.tco.api.model.JJDispute jjDispute) {
 		return jjDisputeMapper.convert(jjDispute);
 	}

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/service/JJDisputeService.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/service/JJDisputeService.java
@@ -22,6 +22,7 @@ import org.springframework.stereotype.Service;
 
 import ca.bc.gov.open.jag.tco.oracledataapi.error.NotAllowedException;
 import ca.bc.gov.open.jag.tco.oracledataapi.model.CustomUserDetails;
+import ca.bc.gov.open.jag.tco.oracledataapi.model.Dispute;
 import ca.bc.gov.open.jag.tco.oracledataapi.model.JJDispute;
 import ca.bc.gov.open.jag.tco.oracledataapi.model.JJDisputeCourtAppearanceAPP;
 import ca.bc.gov.open.jag.tco.oracledataapi.model.JJDisputeCourtAppearanceDATT;
@@ -402,5 +403,15 @@ public class JJDisputeService {
 
 		JJDispute jjDispute = jjDisputes.get(0);
 		return Optional.of(jjDispute);
+	}
+
+	/**
+	 * Deletes a specific {@link Dispute} by using the jjDisputeId or TicketNumber
+	 *
+	 * @param id of the JJDispute to be deleted
+	 * @param ticketNumber of the JJDispute to be deleted
+	 */
+	public void delete(Long id, String ticketNumber) {
+		jjDisputeRepository.deleteByIdOrTicketNumber(id, ticketNumber);
 	}
 }

--- a/src/backend/oracle-data-api/src/main/resources/tco-openapi-spec.yaml
+++ b/src/backend/oracle-data-api/src/main/resources/tco-openapi-spec.yaml
@@ -269,6 +269,30 @@ paths:
           $ref: '#/components/responses/Unauthorized'
       tags:
         - JJDispute
+  /v1/deleteDispute:
+    delete:
+      parameters:
+        - name: disputeId
+          in: query
+          description: ''
+          schema:
+            type: integer
+            format: int64
+        - name: ticketNumber
+          in: query
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Ok
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResponseResult'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+      tags:
+        - JJDispute
 components:
   securitySchemes:
     basicAuth:


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- [TCVP-2324](https://justice.gov.bc.ca/jira/browse/TCVP-2324)
- Added functionality to delete a specific JJDispute and all its associated data within the TCO schema based on the provided JJDispute ID or violation ticket number.
- TCO dispute delete script and the ORDS endpoint has also been created so this endpoint is ready to be used in DEV.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Ran the apps through docker compose and managed to delete JJ Disputes by providing both disputeId and ticketNumber successfully.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
