### PR TITLE
TCVP-2347 violation ticket issued time fix

### DIFF
--- a/src/backend/oracle-data-api/src/main/resources/occm-openapi-spec.yaml
+++ b/src/backend/oracle-data-api/src/main/resources/occm-openapi-spec.yaml
@@ -873,7 +873,7 @@ components:
         issuedDt:
           type: string
           format: date-time
-          x-field-extra-annotation: "@com.fasterxml.jackson.annotation.JsonFormat(pattern=\"yyyy-MM-dd'T'HH:mm'Z'\")"
+          x-field-extra-annotation: "@com.fasterxml.jackson.annotation.JsonFormat(pattern=\"yyyy-MM-dd HH:mm\")"
         jjAssignedTo:
           type: string
           format: nullable
@@ -1097,7 +1097,7 @@ components:
         issuedDt:
           type: string
           format: date-time
-          x-field-extra-annotation: "@com.fasterxml.jackson.annotation.JsonFormat(pattern=\"yyyy-MM-dd'T'HH:mm'Z'\")"
+          x-field-extra-annotation: "@com.fasterxml.jackson.annotation.JsonFormat(pattern=\"yyyy-MM-dd HH:mm\")"
         issuedOnRoadOrHighwayTxt:
           type: string
           format: nullable


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- [TCVP-2347](https://justice.gov.bc.ca/jira/browse/TCVP-2347)
- Updated `issuedTs` (issuedDt) field date/time format to save and retrieve the violation ticket date and time same as the provided ticket instead of UTC time.
- TODO: Once this will be deployed to dev environment, we must update the Oracle database packages to match the formatting.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Updated the issuedDt field formatting in the database temporarily and confirmed the issuedTs field retrieved by Oracle Data API was exactly same as the one written on the ticket.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
