### PR TITLE
TCVP-2352 retrieve dispute update requests

### DIFF
--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/controller/v1_0/DisputeController.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/controller/v1_0/DisputeController.java
@@ -442,7 +442,7 @@ public class DisputeController {
 			DisputeUpdateRequestStatus status) {
 		logger.debug("GET /dispute/updateRequests called with disputeId:{} and disputeUpdateRequestStatus:{} ",
 				StructuredArguments.value("disputeId", id),
-				StructuredArguments.value("disputeUpdateRequestStatus", status.toString()));
+				StructuredArguments.value("disputeUpdateRequestStatus", status != null ? status.toString() : ""));
 		return new ResponseEntity<List<DisputeUpdateRequest>>(disputeService.findDisputeUpdateRequestByDisputeIdAndStatus(id, status), HttpStatus.OK);
 	}
 

--- a/src/backend/oracle-data-api/src/test/java/ca/bc/gov/open/jag/tco/oracledataapi/controller/v1_0/DisputeControllerTest.java
+++ b/src/backend/oracle-data-api/src/test/java/ca/bc/gov/open/jag/tco/oracledataapi/controller/v1_0/DisputeControllerTest.java
@@ -572,7 +572,9 @@ class DisputeControllerTest extends BaseTestSuite {
 	public void testGetDisputeUpdateRequests_200() throws Exception {
 		// Setup - create a couple new random Disputes along with a few DisputeUpdateRequests
 		Dispute dispute1 = RandomUtil.createDispute();
+		saveDispute(dispute1);
 		Dispute dispute2 = RandomUtil.createDispute();
+		saveDispute(dispute2);
 		assertEquals(2, IterableUtils.toList(disputeRepository.findAll()).size());
 
 		DisputeUpdateRequest disputeUpdateRequest1 = RandomUtil.createDisputeUpdateRequest(dispute1.getDisputeId(), DisputeUpdateRequestStatus.PENDING, DisputeUpdateRequestType.DISPUTANT_NAME);

--- a/src/backend/oracle-data-api/src/test/java/ca/bc/gov/open/jag/tco/oracledataapi/controller/v1_0/DisputeControllerTest.java
+++ b/src/backend/oracle-data-api/src/test/java/ca/bc/gov/open/jag/tco/oracledataapi/controller/v1_0/DisputeControllerTest.java
@@ -593,6 +593,9 @@ class DisputeControllerTest extends BaseTestSuite {
 		assertEquals(controllerResponse.getStatusCode().value(), HttpStatus.OK.value());
 		
 		// Get all update requests with null params
+		results.add(disputeUpdateRequest1);
+		results.add(disputeUpdateRequest3);
+		results.add(disputeUpdateRequest4);
 		Mockito.when(service.findDisputeUpdateRequestByDisputeIdAndStatus(null, null)).thenReturn(results);
 		controllerResponse = disputeController.getDisputeUpdateRequests(null, null);
 	    resultList = controllerResponse.getBody();
@@ -600,13 +603,20 @@ class DisputeControllerTest extends BaseTestSuite {
 		assertEquals(resultList.size(),4);
 				
     	// Get all update requests with pending status
+		results.clear();
+		results.add(disputeUpdateRequest1);
+		results.add(disputeUpdateRequest3);
 		Mockito.when(service.findDisputeUpdateRequestByDisputeIdAndStatus(null, DisputeUpdateRequestStatus.PENDING)).thenReturn(results);
 		controllerResponse = disputeController.getDisputeUpdateRequests(null, DisputeUpdateRequestStatus.PENDING);
 		resultList = controllerResponse.getBody();
 		assertNotNull(resultList);
 		assertEquals(resultList.size(),2);
+		assertEquals(resultList.get(0).getStatus(), DisputeUpdateRequestStatus.PENDING);
 				
     	// Get all update requests for given dispute id
+		results.clear();
+		results.add(disputeUpdateRequest1);
+		results.add(disputeUpdateRequest2);
 		Mockito.when(service.findDisputeUpdateRequestByDisputeIdAndStatus(dispute1.getDisputeId(), null)).thenReturn(results);
 		controllerResponse = disputeController.getDisputeUpdateRequests(dispute1.getDisputeId(), null);
 	    resultList = controllerResponse.getBody();

--- a/src/backend/oracle-data-api/src/test/java/ca/bc/gov/open/jag/tco/oracledataapi/controller/v1_0/DisputeControllerTest.java
+++ b/src/backend/oracle-data-api/src/test/java/ca/bc/gov/open/jag/tco/oracledataapi/controller/v1_0/DisputeControllerTest.java
@@ -16,7 +16,6 @@ import org.apache.commons.collections4.IterableUtils;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.time.DateFormatUtils;
 import org.apache.commons.lang3.time.DateUtils;
-import org.hibernate.cfg.annotations.ResultsetMappingSecondPass;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -574,6 +573,7 @@ class DisputeControllerTest extends BaseTestSuite {
 		// Setup - create a couple new random Disputes along with a few DisputeUpdateRequests
 		Dispute dispute1 = RandomUtil.createDispute();
 		Dispute dispute2 = RandomUtil.createDispute();
+		assertEquals(2, IterableUtils.toList(disputeRepository.findAll()).size());
 
 		DisputeUpdateRequest disputeUpdateRequest1 = RandomUtil.createDisputeUpdateRequest(dispute1.getDisputeId(), DisputeUpdateRequestStatus.PENDING, DisputeUpdateRequestType.DISPUTANT_NAME);
 		DisputeUpdateRequest disputeUpdateRequest2 = RandomUtil.createDisputeUpdateRequest(dispute1.getDisputeId(), DisputeUpdateRequestStatus.ACCEPTED, DisputeUpdateRequestType.DISPUTANT_ADDRESS);
@@ -622,7 +622,7 @@ class DisputeControllerTest extends BaseTestSuite {
 	    resultList = controllerResponse.getBody();
 	    assertNotNull(resultList);
 		assertEquals(resultList.size(),2);
-		assertEquals(resultList.get(0).getDisputeId(), dispute1.getDisputeId());						
+		assertEquals(resultList.get(0).getDisputeId(), dispute1.getDisputeId());	
 	}
 
 	@Test


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- TCVP-2352 inability to retrieve individual dispute update request

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [ ] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
