### PR TITLE
TCVP-2337 Get hearing duration from Justin

### DIFF
--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/mapper/JJDisputeMapper.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/mapper/JJDisputeMapper.java
@@ -1,10 +1,12 @@
 package ca.bc.gov.open.jag.tco.oracledataapi.mapper;
 
+import org.apache.commons.lang3.StringUtils;
 import org.mapstruct.AfterMapping;
 import org.mapstruct.InjectionStrategy;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.MappingTarget;
+import org.mapstruct.Named;
 
 import ca.bc.gov.open.jag.tco.oracledataapi.model.JJDispute;
 import ca.bc.gov.open.jag.tco.oracledataapi.model.JJDisputeCourtAppearanceRoP;
@@ -258,6 +260,7 @@ public abstract class JJDisputeMapper extends BaseMapper {
 	@Mapping(source = "disputeId", target = "jjDispute.id")
 	@Mapping(source = "disputantPresenceCd", target = "appCd")
 	@Mapping(source = "disputantNotPresentDtm", target = "noAppTs")
+	@Mapping(source = ".", target = "duration", qualifiedByName="getDurationInMinutes")
 	@Mapping(source = "entDtm", target = "createdTs")
 	@Mapping(source = "entUserId", target = "createdBy")
 	@Mapping(source = "judgeOrJjNameTxt", target = "adjudicator")
@@ -278,6 +281,8 @@ public abstract class JJDisputeMapper extends BaseMapper {
 	@Mapping(source = "jjDispute.id", target = "disputeId")
 	@Mapping(source = "appCd", target = "disputantPresenceCd")
 	@Mapping(source = "noAppTs", target = "disputantNotPresentDtm")
+	@Mapping(target = "durationHoursTxt", ignore = true) // ignore back reference mapping
+	@Mapping(target = "durationMinutesTxt", ignore = true) // ignore back reference mapping
 	@Mapping(source = "createdTs", target = "entDtm")
 	@Mapping(source = "createdBy", target = "entUserId")
 	@Mapping(source = "adjudicator", target = "judgeOrJjNameTxt")
@@ -286,6 +291,21 @@ public abstract class JJDisputeMapper extends BaseMapper {
 	@Mapping(source = "modifiedTs", target = "updDtm")
 	@Mapping(source = "modifiedBy", target = "updUserId")
 	public abstract ca.bc.gov.open.jag.tco.oracledataapi.ords.tco.api.model.JJCourtAppearance convert(JJDisputeCourtAppearanceRoP jjCourtAppearance);
+
+	@Named("getDurationInMinutes")
+	public short getDurationInMinutes(ca.bc.gov.open.jag.tco.oracledataapi.ords.tco.api.model.JJCourtAppearance jjCourtAppearance) {
+		short duration = (short)0;
+		if (!StringUtils.isBlank(jjCourtAppearance.getDurationHoursTxt())) {
+			short hours = Short.parseShort(jjCourtAppearance.getDurationHoursTxt());
+			duration = (short) (hours * 60);
+		}
+		if (!StringUtils.isBlank(jjCourtAppearance.getDurationMinutesTxt())) {
+			short minutes = Short.parseShort(jjCourtAppearance.getDurationMinutesTxt());
+			duration += minutes;
+		}
+		return duration;
+	}
+
 	@AfterMapping
 	public void afterMapping(ca.bc.gov.open.jag.tco.oracledataapi.ords.tco.api.model.JJDisputeCount jjDisputeCount, @MappingTarget JJDisputedCount jjDisputedCount) {
 		if (jjDisputedCount.getJjDisputedCountRoP() != null && jjDisputedCount.getJjDisputedCountRoP().getId() == null) {

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/mapper/JJDisputeMapper.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/mapper/JJDisputeMapper.java
@@ -1,6 +1,5 @@
 package ca.bc.gov.open.jag.tco.oracledataapi.mapper;
 
-import org.apache.commons.lang3.StringUtils;
 import org.mapstruct.AfterMapping;
 import org.mapstruct.InjectionStrategy;
 import org.mapstruct.Mapper;
@@ -281,8 +280,8 @@ public abstract class JJDisputeMapper extends BaseMapper {
 	@Mapping(source = "jjDispute.id", target = "disputeId")
 	@Mapping(source = "appCd", target = "disputantPresenceCd")
 	@Mapping(source = "noAppTs", target = "disputantNotPresentDtm")
-	@Mapping(target = "durationHoursTxt", ignore = true) // ignore back reference mapping
-	@Mapping(target = "durationMinutesTxt", ignore = true) // ignore back reference mapping
+	@Mapping(target = "durationHours", ignore = true) // ignore back reference mapping
+	@Mapping(target = "durationMinutes", ignore = true) // ignore back reference mapping
 	@Mapping(source = "createdTs", target = "entDtm")
 	@Mapping(source = "createdBy", target = "entUserId")
 	@Mapping(source = "adjudicator", target = "judgeOrJjNameTxt")
@@ -295,12 +294,12 @@ public abstract class JJDisputeMapper extends BaseMapper {
 	@Named("getDurationInMinutes")
 	public short getDurationInMinutes(ca.bc.gov.open.jag.tco.oracledataapi.ords.tco.api.model.JJCourtAppearance jjCourtAppearance) {
 		short duration = (short)0;
-		if (!StringUtils.isBlank(jjCourtAppearance.getDurationHoursTxt())) {
-			short hours = Short.parseShort(jjCourtAppearance.getDurationHoursTxt());
+		if (jjCourtAppearance.getDurationHours() != null && jjCourtAppearance.getDurationHours() > 0) {
+			short hours = jjCourtAppearance.getDurationHours().shortValue();
 			duration = (short) (hours * 60);
 		}
-		if (!StringUtils.isBlank(jjCourtAppearance.getDurationMinutesTxt())) {
-			short minutes = Short.parseShort(jjCourtAppearance.getDurationMinutesTxt());
+		if (jjCourtAppearance.getDurationMinutes() != null && jjCourtAppearance.getDurationMinutes() > 0) {
+			short minutes = jjCourtAppearance.getDurationMinutes().shortValue();
 			duration += minutes;
 		}
 		return duration;

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/model/JJDisputeCourtAppearanceRoP.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/model/JJDisputeCourtAppearanceRoP.java
@@ -24,7 +24,7 @@ import lombok.Setter;
 //mark class as an Entity
 /**
  * @author 237563
- * 
+ *
  * Represents JJ Written Reasons for each count
  *
  */
@@ -38,7 +38,7 @@ public class JJDisputeCourtAppearanceRoP extends Auditable<String> {
 
 	@Schema(description = "ID", accessMode = Schema.AccessMode.READ_ONLY)
 	@Id
-    private Long id;
+	private Long id;
 
 	/**
 	 * The court appearance timestamp.
@@ -53,52 +53,52 @@ public class JJDisputeCourtAppearanceRoP extends Auditable<String> {
 	 */
 	@Column
 	@Schema(nullable = true)
-    private String room;
-	
+	private String room;
+
 	/**
 	 * Expected Duration in minutes
 	 */
 	@Column
 	@Schema(nullable = true)
 	private short duration;
-	
+
 	/**
-     * Reason
-     */
-    @Column
-    @Schema(nullable = true)
-    private String reason;
-    
-    /**
+	 * Reason
+	 */
+	@Column
+	@Schema(nullable = true)
+	private String reason;
+
+	/**
 	 * APP -- whether or not disputant appeared (agent = A, not present = N, present = P).
 	 */
 	@Column
 	@Schema(nullable = true)
 	@Enumerated(EnumType.STRING)
 	private JJDisputeCourtAppearanceAPP appCd;
-	
+
 	/**
-     * No app -- timestamp when it was decided disputant did not appear
-     */
-    @Column
-    @Schema(nullable = true)
-    @Temporal(TemporalType.TIMESTAMP)
-    private Date noAppTs;
-    
-    /**
+	 * No app -- timestamp when it was decided disputant did not appear
+	 */
+	@Column
+	@Schema(nullable = true)
+	@Temporal(TemporalType.TIMESTAMP)
+	private Date noAppTs;
+
+	/**
 	 * Clerk Rec
 	 */
 	@Column
 	@Schema(nullable = true)
-    private String clerkRecord;
-	
+	private String clerkRecord;
+
 	/**
 	 * Defense Counsel
 	 */
 	@Column
 	@Schema(nullable = true)
-    private String defenceCounsel;
-	
+	private String defenceCounsel;
+
 	/**
 	 * Defense Counsel Attendance
 	 */
@@ -106,7 +106,7 @@ public class JJDisputeCourtAppearanceRoP extends Auditable<String> {
 	@Schema(nullable = true)
 	@Enumerated(EnumType.STRING)
 	private JJDisputeCourtAppearanceDATT dattCd;
-	
+
 	/**
 	 * Crown present (P) or not present (N)
 	 */
@@ -114,24 +114,24 @@ public class JJDisputeCourtAppearanceRoP extends Auditable<String> {
 	@Schema(nullable = true)
 	@Enumerated(EnumType.STRING)
 	private JJDisputeCourtAppearanceCrown crown;
-	
+
 	/**
 	 * JJ Seized
 	 */
 	@Column
 	@Enumerated(EnumType.STRING)
 	@Schema(nullable = true)
-    private YesNo jjSeized;
-	
+	private YesNo jjSeized;
+
 	/**
 	 * Adjudicator
 	 */
 	@Column
 	@Schema(nullable = true)
 	private String adjudicator;
-	
+
 	/**
-	 * JJ's comments about court appearance 
+	 * JJ's comments about court appearance
 	 */
 	@Size(max = 500)
 	@Column(length = 500)

--- a/src/backend/oracle-data-api/src/main/resources/tco-openapi-spec.yaml
+++ b/src/backend/oracle-data-api/src/main/resources/tco-openapi-spec.yaml
@@ -627,6 +627,10 @@ components:
           type: string
           format: date-time
           x-field-extra-annotation: "@com.fasterxml.jackson.annotation.JsonFormat(pattern=\"yyyy-MM-dd'T'HH:mm:ss'Z'\")"
+        durationHoursTxt:
+          type: string
+        durationMinutesTxt:
+          type: string
         judgeOrJjNameTxt:
           type: string
         recordingClerkNameTxt:

--- a/src/backend/oracle-data-api/src/main/resources/tco-openapi-spec.yaml
+++ b/src/backend/oracle-data-api/src/main/resources/tco-openapi-spec.yaml
@@ -627,10 +627,10 @@ components:
           type: string
           format: date-time
           x-field-extra-annotation: "@com.fasterxml.jackson.annotation.JsonFormat(pattern=\"yyyy-MM-dd'T'HH:mm:ss'Z'\")"
-        durationHoursTxt:
-          type: string
-        durationMinutesTxt:
-          type: string
+        durationHours:
+          type: Integer
+        durationMinutes:
+          type: Integer
         judgeOrJjNameTxt:
           type: string
         recordingClerkNameTxt:

--- a/src/backend/oracle-data-api/src/test/java/ca/bc/gov/open/jag/tco/oracledataapi/mapper/JJDisputeMapperTest.java
+++ b/src/backend/oracle-data-api/src/test/java/ca/bc/gov/open/jag/tco/oracledataapi/mapper/JJDisputeMapperTest.java
@@ -436,8 +436,8 @@ public class JJDisputeMapperTest extends BaseTestSuite {
 		String courtAppearanceCreatedBy = "5";
 		Date courtAppearanceModifedTs =  RandomUtil.randomDate();
 		String courtAppearanceModifiedBy = "6";
-		String durationHoursTxt = "1";
-		String durationMinutesTxt = "15";
+		Integer durationHours = 1;
+		Integer durationMinutes = 15;
 
 		ca.bc.gov.open.jag.tco.oracledataapi.ords.tco.api.model.JJDispute source = new ca.bc.gov.open.jag.tco.oracledataapi.ords.tco.api.model.JJDispute();
 
@@ -453,8 +453,8 @@ public class JJDisputeMapperTest extends BaseTestSuite {
 		courtAppearance.setDefenceCounselPresenceCd(defenceCounselPresenceCd.toString());
 		courtAppearance.setDisputantNotPresentDtm(disputantNotPresentDtm);
 		courtAppearance.setDisputantPresenceCd(disputantPresenceCd.toString());
-		courtAppearance.setDurationHoursTxt(durationHoursTxt);
-		courtAppearance.setDurationMinutesTxt(durationMinutesTxt);
+		courtAppearance.setDurationHours(durationHours);
+		courtAppearance.setDurationMinutes(durationMinutes);
 		courtAppearance.setEntDtm(courtAppearanceTs);
 		courtAppearance.setEntUserId(courtAppearanceCreatedBy);
 		courtAppearance.setJudgeOrJjNameTxt(judgeOrJjNameTxt);

--- a/src/backend/oracle-data-api/src/test/java/ca/bc/gov/open/jag/tco/oracledataapi/mapper/JJDisputeMapperTest.java
+++ b/src/backend/oracle-data-api/src/test/java/ca/bc/gov/open/jag/tco/oracledataapi/mapper/JJDisputeMapperTest.java
@@ -28,7 +28,7 @@ public class JJDisputeMapperTest extends BaseTestSuite {
 
 	@Autowired
 	private JJDisputeMapper jjDisputeMapper;
-	
+
 	@Autowired
 	private TicketImageDataMapper ticketImageDataMapper;
 
@@ -388,17 +388,17 @@ public class JJDisputeMapperTest extends BaseTestSuite {
 		assertEquals(remarkModifedTs, jjDisputeRemark.getModifiedTs());
 		assertEquals(remarkModifiedBy, jjDisputeRemark.getModifiedBy());
 	}
-	
+
 	@Test
 	public void testTicketImageData() throws Exception {
-		
+
 		String reportType = "NOTICE_OF_DISPUTE";
 		String index = RandomUtil.randomAlphabetic(5);
 		String partId = RandomUtil.randomAlphanumeric(10);
 		String participantName = RandomUtil.randomGivenName() + " " + RandomUtil.randomSurname();
 		String reportFormat = RandomUtil.randomAlphabetic(5);
 		String data = RandomUtil.randomAlphanumeric(1000);
-		
+
 		ca.bc.gov.open.jag.tco.oracledataapi.ords.tco.api.model.TicketImageDataJustinDocument justinDocument = new ca.bc.gov.open.jag.tco.oracledataapi.ords.tco.api.model.TicketImageDataJustinDocument();
 		justinDocument.setReportType(reportType);
 		justinDocument.setIndex(index);
@@ -406,9 +406,9 @@ public class JJDisputeMapperTest extends BaseTestSuite {
 		justinDocument.setParticipantName(participantName);
 		justinDocument.setReportFormat(reportFormat);
 		justinDocument.setData(data);
-		
+
 		ca.bc.gov.open.jag.tco.oracledataapi.model.TicketImageDataJustinDocument doc = ticketImageDataMapper.convert(justinDocument);
-		
+
 		assertEquals(reportType, doc.getReportType().getShortName());
 		assertEquals(index, doc.getIndex());
 		assertEquals(partId, doc.getPartId());
@@ -436,6 +436,8 @@ public class JJDisputeMapperTest extends BaseTestSuite {
 		String courtAppearanceCreatedBy = "5";
 		Date courtAppearanceModifedTs =  RandomUtil.randomDate();
 		String courtAppearanceModifiedBy = "6";
+		String durationHoursTxt = "1";
+		String durationMinutesTxt = "15";
 
 		ca.bc.gov.open.jag.tco.oracledataapi.ords.tco.api.model.JJDispute source = new ca.bc.gov.open.jag.tco.oracledataapi.ords.tco.api.model.JJDispute();
 
@@ -451,6 +453,8 @@ public class JJDisputeMapperTest extends BaseTestSuite {
 		courtAppearance.setDefenceCounselPresenceCd(defenceCounselPresenceCd.toString());
 		courtAppearance.setDisputantNotPresentDtm(disputantNotPresentDtm);
 		courtAppearance.setDisputantPresenceCd(disputantPresenceCd.toString());
+		courtAppearance.setDurationHoursTxt(durationHoursTxt);
+		courtAppearance.setDurationMinutesTxt(durationMinutesTxt);
 		courtAppearance.setEntDtm(courtAppearanceTs);
 		courtAppearance.setEntUserId(courtAppearanceCreatedBy);
 		courtAppearance.setJudgeOrJjNameTxt(judgeOrJjNameTxt);
@@ -462,6 +466,8 @@ public class JJDisputeMapperTest extends BaseTestSuite {
 
 		JJDispute target = jjDisputeMapper.convert(source);
 		JJDisputeCourtAppearanceRoP courtAppearanceRoP = target.getJjDisputeCourtAppearanceRoPs().get(0);
+		// Expected duration value is set to 75 minutes because initial duration values expected to be mapped above are set to 1 hour and 15 minutes
+		short duration = (short)75;
 
 		assertEquals(Long.valueOf(courtAppearanceId), courtAppearanceRoP.getId());
 		assertEquals(courtroomNumberTxt, courtAppearanceRoP.getRoom());
@@ -476,6 +482,7 @@ public class JJDisputeMapperTest extends BaseTestSuite {
 		assertEquals(judgeOrJjNameTxt, courtAppearanceRoP.getAdjudicator());
 		assertEquals(defenceCounselPresenceCd, courtAppearanceRoP.getDattCd());
 		assertEquals(commentsTxt, courtAppearanceRoP.getComments());
+		assertEquals(duration, courtAppearanceRoP.getDuration());
 		assertEquals(courtAppearanceTs, courtAppearanceRoP.getCreatedTs());
 		assertEquals(courtAppearanceCreatedBy, courtAppearanceRoP.getCreatedBy());
 		assertEquals(courtAppearanceModifedTs, courtAppearanceRoP.getModifiedTs());


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- [TCVP-2337](https://justice.gov.bc.ca/jira/browse/TCVP-2337)
- Added functionality to map hearing duration data from Justin into "JJDisputeCourtAppearanceRoP" model's 'duration' property in minutes when a JJDispute or list of JJDisputes returned from an ORDS endpoint.
- Added unit test for duration field mapping.
- NOTE: This fix also requires applying database changes in SVN revision: 162086 to the environment where this code will be deployed.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Created an appearance with estimated hearing duration in hours and minutes which is associated to an existing JJDispute in TCO. Confirmed that the duration field is returned in minutes successfully when the JJDispute is retrieved by calling the Oracle Data API endpoint. 

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
