### PR TITLE
Remove passing exception to StatusCode result

### DIFF
--- a/src/backend/TrafficCourts/Citizen.Service/Controllers/DisputesController.cs
+++ b/src/backend/TrafficCourts/Citizen.Service/Controllers/DisputesController.cs
@@ -86,7 +86,7 @@ public class DisputesController : ControllerBase
         if (response.Exception is not null)
         {
             _logger.LogInformation(response.Exception, "Failed to create Notice of Dispute");
-            return StatusCode(StatusCodes.Status500InternalServerError, response.Exception);
+            return StatusCode(StatusCodes.Status500InternalServerError);
         }
 
         return Ok(response);

--- a/src/backend/TrafficCourts/Citizen.Service/Features/Disputes/Create.cs
+++ b/src/backend/TrafficCourts/Citizen.Service/Features/Disputes/Create.cs
@@ -162,9 +162,11 @@ namespace TrafficCourts.Citizen.Service.Features.Disputes
                     }
 
                     SubmitNoticeOfDispute submitNoticeOfDispute = _mapper.Map<SubmitNoticeOfDispute>(dispute);
-                    if (dispute.AppearanceLessThan14Days is true)
-                        submitNoticeOfDispute.AppearanceLessThan14DaysYn = DisputeAppearanceLessThan14DaysYn.Y;
-                    else submitNoticeOfDispute.AppearanceLessThan14DaysYn = DisputeAppearanceLessThan14DaysYn.N;
+                    
+                    submitNoticeOfDispute.AppearanceLessThan14DaysYn = dispute.AppearanceLessThan14Days is true 
+                        ? DisputeAppearanceLessThan14DaysYn.Y 
+                        : DisputeAppearanceLessThan14DaysYn.N;
+
                     submitNoticeOfDispute.NoticeOfDisputeGuid = noticeOfDisputeId;
                     submitNoticeOfDispute.SubmittedTs = _clock.GetCurrentInstant().ToDateTimeUtc();
 


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- Fixes issue where `response.Exception` was being passed to the `StatusCode` call.  Passing the exception results in the following error being logged. The `StatusCode` function is trying to serialize the entire exception which cannot be done and results in a NotSupportedException during Json serialization.

![image](https://github.com/bcgov/jag-traffic-courts-online/assets/1844480/822cc91b-a28b-481e-9913-ebcebdad98d3)


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [ ] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
