### PR TITLE
TCVP-2421 assign part ids from csv file

### DIFF
--- a/tools/docker-compose.yml
+++ b/tools/docker-compose.yml
@@ -40,6 +40,7 @@ services:
   keycloak-user-init:
     container_name: keycloak-init
     environment:
+      IDIR_API_CLIENT_ENV: ${IDIR_API_CLIENT_ENV:-DEV}
       IDIR_API_CLIENT_ID: ${IDIR_API_CLIENT_ID:-id}
       IDIR_API_CLIENT_SECRET: ${IDIR_API_CLIENT_SECRET:-secret}
       IDIR_API_DEBUG: ${IDIR_API_DEBUG:-false}

--- a/tools/keycloak-user-initializer/README.md
+++ b/tools/keycloak-user-initializer/README.md
@@ -3,8 +3,9 @@ This spring-boot Java project is a tool for initializing users in a Keycloak env
 and lookup their IDIR data by their email from CSS SSO API (https://api.loginproxy.gov.bc.ca/openapi/swagger) and link it as an external IDP account in Keycloak.
 
 ## Columns must be specified in the CSV file (tco-user-list.csv)
-Email,Realm Administrator,admin-judicial-justice,admin-vtc-staff,judicial-justice,vtc-staff
-example@email.com,TRUE,TRUE,TRUE,TRUE,TRUE
+Email,Realm Administrator,admin-judicial-justice,admin-vtc-staff,judicial-justice,vtc-staff,part-id
+
+example@email.com,TRUE,TRUE,TRUE,TRUE,TRUE,190225.0866
 
 ## How to build
 From the /tools folder,

--- a/tools/keycloak-user-initializer/src/main/java/ca/bc/gov/open/jag/tco/keycloakuserinitializer/config/IdirApiClientConfigProperties.java
+++ b/tools/keycloak-user-initializer/src/main/java/ca/bc/gov/open/jag/tco/keycloakuserinitializer/config/IdirApiClientConfigProperties.java
@@ -2,8 +2,10 @@ package ca.bc.gov.open.jag.tco.keycloakuserinitializer.config;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Component;
 
+import ca.bc.gov.open.jag.tco.keycloakuserinitializer.idir.api.model.Environment;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -15,9 +17,13 @@ import lombok.Setter;
  */
 @Component
 @ConfigurationProperties
+@Primary
 @Getter
 @Setter
 public class IdirApiClientConfigProperties {
+	
+	@Value("${idir.api.client.env}")
+	private Environment idirApiClientEnv;
 
 	@Value("${idir.api.client.id}")
 	private String idirApiClientId;

--- a/tools/keycloak-user-initializer/src/main/java/ca/bc/gov/open/jag/tco/keycloakuserinitializer/model/TcoUser.java
+++ b/tools/keycloak-user-initializer/src/main/java/ca/bc/gov/open/jag/tco/keycloakuserinitializer/model/TcoUser.java
@@ -34,5 +34,8 @@ public class TcoUser {
 	
 	@CsvBindByPosition(position = 5)
 	private Boolean vtcStaff;
+	
+	@CsvBindByPosition(position = 6)
+	private String partId;
 
 }

--- a/tools/keycloak-user-initializer/src/main/resources/application.yml
+++ b/tools/keycloak-user-initializer/src/main/resources/application.yml
@@ -10,6 +10,8 @@ logging:
 idir:
   api:
     client:
+      # IDIR environment to be connected. One of the following environment should be set: DEV, TEST, PROD
+      environmnet: ${IDIR_API_CLIENT_ENV:DEV}
       # OAuth client id for calling IDIR API
       id: ${IDIR_API_CLIENT_ID:id}
       # OAuth client secret for calling IDIR API


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- [TCVP-2421](https://justice.gov.bc.ca/jira/browse/TCVP-2421)
- Added functionality to read partId of the users from the CSV file and add it to the attributes of the user who is initialized in Keycloak.
- Externalized the env variable to specify to call an IDIR API Client environment. Default is set to DEV.
- Updated the docker-compose file to add the new env variable.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [x] Yes
- [ ] No

If Yes: Has Docker been updated accordingly?

- [x] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
