### PR TITLE
Fix COMS updatedAt field issue

### DIFF
--- a/src/backend/TrafficCourts/TrafficCourts.Coms.Client/FileSearchResult.cs
+++ b/src/backend/TrafficCourts/TrafficCourts.Coms.Client/FileSearchResult.cs
@@ -16,7 +16,7 @@ public class FileSearchResult : TimestampUserData
         Guid createdBy, 
         DateTimeOffset createdAt, 
         Guid updatedBy, 
-        DateTimeOffset updatedAt,
+        DateTimeOffset? updatedAt,
         IReadOnlyDictionary<string, string>? metadata,
         IReadOnlyDictionary<string, string>? tags)
     {

--- a/src/backend/TrafficCourts/TrafficCourts.Coms.Client/Models.cs
+++ b/src/backend/TrafficCourts/TrafficCourts.Coms.Client/Models.cs
@@ -27,7 +27,7 @@ public class ObjectMetadata
 
     public Guid? UpdatedBy { get; set; }
 
-    public DateTime UpdatedAt { get; set; }
+    public DateTime? UpdatedAt { get; set; }
 
     [JsonPropertyName("metadata")]
     public IList<MetadataItem> Metadata { get; set; }

--- a/src/backend/TrafficCourts/TrafficCourts.Coms.Client/Models.g.cs
+++ b/src/backend/TrafficCourts/TrafficCourts.Coms.Client/Models.g.cs
@@ -395,7 +395,7 @@ namespace TrafficCourts.Coms.Client
 
         [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.Never)]   
         [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
-        public System.DateTimeOffset UpdatedAt { get; set; } = default!;
+        public System.DateTimeOffset? UpdatedAt { get; set; } = default!;
 
         private System.Collections.Generic.IDictionary<string, object>? _additionalProperties;
 

--- a/src/backend/TrafficCourts/TrafficCourts.Coms.Client/TimestampUserData.cs
+++ b/src/backend/TrafficCourts/TrafficCourts.Coms.Client/TimestampUserData.cs
@@ -20,5 +20,5 @@ public abstract class TimestampUserData
     /// <summary>
     /// Time when this record was last updated
     /// </summary>
-    public DateTimeOffset UpdatedAt { get; set; } = default!;
+    public DateTimeOffset? UpdatedAt { get; set; } = default!;
 }


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- This is a fix for the issue that prevents submission of a dispute if COMS service is running locally.
- The main cause of the issue was communicated to the COMS developer team through this issue ticket opened on COMS GitHub repo by @pbolduc: https://github.com/bcgov/common-object-management-service/issues/165. Although this issue seem to be resolved on COMS' later version, we still need a workaround for this because we're using version 0.4.0.
- This fix is a workaround for COMS date serialization issue caused by `updatedAt` property which we don't ever need in TCO so this fix allows that property to be nullable.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
