### PR TITLE
Feature/TCVP-2400 set default partId

### DIFF
--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/filters/PreAuthenticatedTokenFilter.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/filters/PreAuthenticatedTokenFilter.java
@@ -36,14 +36,14 @@ public class PreAuthenticatedTokenFilter implements Filter {
 		String username = httpRequest.getHeader("x-username");
 		String fullName = httpRequest.getHeader("x-fullName");
 		String partId = httpRequest.getHeader("x-partId");
-		
+
 		// Add the required authority role
 		List<GrantedAuthority> authority = new ArrayList<>();
-        authority.add(new SimpleGrantedAuthority("User"));
+		authority.add(new SimpleGrantedAuthority("User"));
 
 		// If the username is null, default to "System"
 		// If the fullName is null, default to "System"
-		CustomUserDetails user = new CustomUserDetails(username == null ? "System" : username, username == null ? "Password" : username, fullName == null ? "System" : fullName, partId == null ? "System" : partId, authority);
+		CustomUserDetails user = new CustomUserDetails(username == null ? "System" : username, username == null ? "Password" : username, fullName == null ? "System" : fullName, partId, authority);
 		Authentication authentication = new PreAuthenticatedToken(user);
 		SecurityContextHolder.getContext().setAuthentication(authentication);
 

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/service/JJDisputeService.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/service/JJDisputeService.java
@@ -292,6 +292,11 @@ public class JJDisputeService {
 		CustomUserDetails user = (CustomUserDetails) ((PreAuthenticatedToken) principal).getPrincipal();
 		String staffPartId = user.getPartId(); // staffPartId comes from the person currently logged in, the Principal (aka. CustomUserDetails).
 
+		if (courtAppearance != null && StringUtils.isBlank(staffPartId)) {
+			logger.error("Updating a court appearance requires a staff part id. staffPartId is null.");
+			throw new NotAllowedException("Updating a court appearance requires a staff part id.");
+		}
+
 		jjDisputeRepository.setStatus(jjDisputeToUpdate.getId(), jjDisputeStatus, principal.getName(), courtAppearanceId, seizedYn , adjudicatorPartId, aattCd, dattCd, staffPartId);
 
 		// Set remarks with user's full name if a remark note is provided along with the status update

--- a/src/backend/oracle-data-api/src/test/java/ca/bc/gov/open/jag/tco/oracledataapi/BaseTestSuite.java
+++ b/src/backend/oracle-data-api/src/test/java/ca/bc/gov/open/jag/tco/oracledataapi/BaseTestSuite.java
@@ -72,7 +72,7 @@ public class BaseTestSuite {
 		disputeRepository.deleteAll();
 		jjDisputeRepository.deleteAll();
 
-		setPrincipal("System");
+		setPrincipal("System", true);
 	}
 
 	/** Prepends the base restTemplate url to the path. */
@@ -80,19 +80,19 @@ public class BaseTestSuite {
 		return UriComponentsBuilder.fromUriString("/api/v1.0" + url);
 	}
 
-    /**
-     * Performs a GET request against the given uriBuilder
-     * @param uriBuilder a the builder used to build a URI
-     */
-    protected ResultActions get(UriComponentsBuilder uriBuilder) throws Exception {
-        assertNotNull(uriBuilder);
-        return get(uriBuilder.build().encode().toUri());
-    }
+	/**
+	 * Performs a GET request against the given uriBuilder
+	 * @param uriBuilder a the builder used to build a URI
+	 */
+	protected ResultActions get(UriComponentsBuilder uriBuilder) throws Exception {
+		assertNotNull(uriBuilder);
+		return get(uriBuilder.build().encode().toUri());
+	}
 
-    /**
-     * Performs a GET request against the given uri
-     * @param uri
-     */
+	/**
+	 * Performs a GET request against the given uri
+	 * @param uri
+	 */
 	protected ResultActions get(URI uri) throws Exception {
 		MockHttpServletRequestBuilder requestBuilder = MockMvcRequestBuilders.get(uri);
 		return mvc.perform(requestBuilder);
@@ -124,22 +124,22 @@ public class BaseTestSuite {
 	}
 
 	/** Sets the currently logged in user */
-	protected void setPrincipal(String username) {
+	protected void setPrincipal(String username, boolean setPartId) {
 		List<GrantedAuthority> authority = new ArrayList<>();
-        authority.add(new SimpleGrantedAuthority("User"));
+		authority.add(new SimpleGrantedAuthority("User"));
 
-		CustomUserDetails user = new CustomUserDetails(username == null ? "System" : username, username == null ? "Password" : username, "System", "System", authority);
+		CustomUserDetails user = new CustomUserDetails(username == null ? "System" : username, username == null ? "Password" : username, "System", setPartId ? "System" : null, authority);
 		Authentication authentication = new PreAuthenticatedToken(user);
 		SecurityContextHolder.getContext().setAuthentication(authentication);
 	}
 
 	/** Serializes the given object to a json string. */
 	protected String asJsonString(final Object obj) {
-	    try {
-	        return new ObjectMapper().writeValueAsString(obj);
-	    } catch (Exception e) {
-	        throw new RuntimeException(e);
-	    }
+		try {
+			return new ObjectMapper().writeValueAsString(obj);
+		} catch (Exception e) {
+			throw new RuntimeException(e);
+		}
 	}
 
 	protected <T> List<Diff<?>> getDifferences(T lhs, T rhs, String... ignoredFields) {

--- a/src/backend/oracle-data-api/src/test/java/ca/bc/gov/open/jag/tco/oracledataapi/controller/v1_0/DisputeControllerTest.java
+++ b/src/backend/oracle-data-api/src/test/java/ca/bc/gov/open/jag/tco/oracledataapi/controller/v1_0/DisputeControllerTest.java
@@ -124,7 +124,7 @@ class DisputeControllerTest extends BaseTestSuite {
 		Long disputeId = saveDispute(dispute);
 
 		// Login
-		setPrincipal("TestUser1");
+		setPrincipal("TestUser1", true);
 
 		// Retrieve it from the controller's endpoint
 		dispute = getDispute(disputeId, true);
@@ -133,7 +133,7 @@ class DisputeControllerTest extends BaseTestSuite {
 		assertEquals(dispute.getUserAssignedTo(), "TestUser1");
 
 		// Login with a different user
-		setPrincipal("TestUser2");
+		setPrincipal("TestUser2", true);
 
 		// Attempt to set the status to REJECTED - should fail with a 409
 		rejectDispute(disputeId, "Just because")
@@ -593,18 +593,18 @@ class DisputeControllerTest extends BaseTestSuite {
 		assertEquals(disputeUpdateRequest2.getDisputeUpdateRequestId(), results.get(0).getDisputeUpdateRequestId());
 		assertEquals(disputeUpdateRequest2.getStatus(), results.get(0).getStatus());
 		assertEquals(controllerResponse.getStatusCode().value(), HttpStatus.OK.value());
-		
+
 		// Get all update requests with null params
 		results.add(disputeUpdateRequest1);
 		results.add(disputeUpdateRequest3);
 		results.add(disputeUpdateRequest4);
 		Mockito.when(service.findDisputeUpdateRequestByDisputeIdAndStatus(null, null)).thenReturn(results);
 		controllerResponse = disputeController.getDisputeUpdateRequests(null, null);
-	    resultList = controllerResponse.getBody();
+		resultList = controllerResponse.getBody();
 		assertNotNull(resultList);
 		assertEquals(resultList.size(),4);
-				
-    	// Get all update requests with pending status
+
+		// Get all update requests with pending status
 		results.clear();
 		results.add(disputeUpdateRequest1);
 		results.add(disputeUpdateRequest3);
@@ -614,17 +614,17 @@ class DisputeControllerTest extends BaseTestSuite {
 		assertNotNull(resultList);
 		assertEquals(resultList.size(),2);
 		assertEquals(resultList.get(0).getStatus(), DisputeUpdateRequestStatus.PENDING);
-				
-    	// Get all update requests for given dispute id
+
+		// Get all update requests for given dispute id
 		results.clear();
 		results.add(disputeUpdateRequest1);
 		results.add(disputeUpdateRequest2);
 		Mockito.when(service.findDisputeUpdateRequestByDisputeIdAndStatus(dispute1.getDisputeId(), null)).thenReturn(results);
 		controllerResponse = disputeController.getDisputeUpdateRequests(dispute1.getDisputeId(), null);
-	    resultList = controllerResponse.getBody();
-	    assertNotNull(resultList);
+		resultList = controllerResponse.getBody();
+		assertNotNull(resultList);
 		assertEquals(resultList.size(),2);
-		assertEquals(resultList.get(0).getDisputeId(), dispute1.getDisputeId());	
+		assertEquals(resultList.get(0).getDisputeId(), dispute1.getDisputeId());
 	}
 
 	@Test
@@ -646,7 +646,7 @@ class DisputeControllerTest extends BaseTestSuite {
 		assertEquals(DisputeUpdateRequestStatus.ACCEPTED, result.getStatus());
 		assertEquals(controllerResponse.getStatusCode().value(), HttpStatus.OK.value());
 	}
-	
+
 	/** Issue a POST request to /api/v1.0/dispute. The appropriate controller is automatically called by the DispatchServlet */
 	private Long saveDispute(Dispute dispute) {
 		return postForObject(fromUriString("/dispute"), dispute, Long.class);

--- a/src/backend/oracle-data-api/src/test/java/ca/bc/gov/open/jag/tco/oracledataapi/controller/v1_0/JJDisputeControllerTest.java
+++ b/src/backend/oracle-data-api/src/test/java/ca/bc/gov/open/jag/tco/oracledataapi/controller/v1_0/JJDisputeControllerTest.java
@@ -131,7 +131,7 @@ class JJDisputeControllerTest extends BaseTestSuite {
 		// Create a single JJ Dispute with a specified remark
 		JJDispute jjDispute = RandomUtil.createJJDispute();
 		String ticketNumber = jjDispute.getTicketNumber();
-		setPrincipal("testUser");
+		setPrincipal("testUser", true);
 		jjDispute.setCourthouseLocation("Vancouver");
 		jjDisputeRepository.saveAndFlush(jjDispute);
 
@@ -290,7 +290,7 @@ class JJDisputeControllerTest extends BaseTestSuite {
 		jjDispute = jjDisputeController.getJJDispute(ticketNumber, false, principal).getBody();
 		assertEquals(JJDisputeStatus.CONCLUDED, jjDispute.getStatus());
 	}
-	
+
 
 	@Test
 	public void testSetJJDisputeStatusToCancelled() {


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- The bug mentioned in [TCVP-2400](https://justice.gov.bc.ca/jira/browse/TCVP-2400) ticket can be reproduced if Oracle Data API receives empty partId from the request header so it was defaulting partId to a string value "System". However, it is actually a numeric value in Oracle database and the default "System" partId value (if no actual value is received from the request header) could not be converted into  a number value which results in character to number conversion error in the database.
- Removed assigning a default partId as 'System' and set it to null if no partId is provided.
- Added checks, logs and error handling for not updating the status of a JJ Dispute if the staff part ID is null despite there is a court appearance associated.
- Added JUnit test for checking null staff part id.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Ran JUnit test.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
