### PR TITLE
Add empty body on POST or DELETE calls required by ORDS

### DIFF
--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/repository/impl/ords/DisputeRepositoryImpl.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/repository/impl/ords/DisputeRepositoryImpl.java
@@ -39,6 +39,11 @@ import net.logstash.logback.argument.StructuredArguments;
 public class DisputeRepositoryImpl implements DisputeRepository {
 
 	private static Logger logger = LoggerFactory.getLogger(DisputeRepositoryImpl.class);
+	
+	/** 
+	 * ORDS POST or DELETE requests must include a body. Use an empty body for those requests. 
+	 */	
+	public static final Object EmptyBody = new Object();
 
 	// Delegate, OpenAPI generated client
 	private final ViolationTicketApi violationTicketApi;
@@ -122,7 +127,7 @@ public class DisputeRepositoryImpl implements DisputeRepository {
 		}
 
 		// Propagate any ApiException to caller
-		ResponseResult result = violationTicketApi.v1DeleteViolationTicketDelete(disputeId);
+		ResponseResult result = violationTicketApi.v1DeleteViolationTicketDelete(disputeId, EmptyBody);
 
 		if (result == null) {
 			throw new InternalServerErrorException("Invalid ResponseResult object");
@@ -210,7 +215,7 @@ public class DisputeRepositoryImpl implements DisputeRepository {
 
 	@Override
 	public void assignDisputeToUser(Long disputeId, String userName) {
-		assertNoExceptions(() -> violationTicketApi.v1AssignViolationTicketPost(disputeId, userName));
+		assertNoExceptions(() -> violationTicketApi.v1AssignViolationTicketPost(disputeId, userName, EmptyBody));
 	}
 
 	@Override
@@ -221,12 +226,12 @@ public class DisputeRepositoryImpl implements DisputeRepository {
 
 		logger.debug("Unassigning Disputes older than {}", StructuredArguments.value("date", dateStr));
 
-		assertNoExceptions(() -> violationTicketApi.v1UnassignViolationTicketPost(dateStr));
+		assertNoExceptions(() -> violationTicketApi.v1UnassignViolationTicketPost(EmptyBody, dateStr));
 	}
 
 	@Override
 	public void setStatus(Long disputeId, DisputeStatus disputeStatus, String rejectedReason) {
-		assertNoExceptions(() -> violationTicketApi.v1ViolationTicketStatusPost(disputeId, disputeStatus.toShortName(), rejectedReason));
+		assertNoExceptions(() -> violationTicketApi.v1ViolationTicketStatusPost(EmptyBody, disputeId, disputeStatus.toShortName(), rejectedReason));
 	}
 
 	@Override

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/repository/impl/ords/DisputeUpdateRequestRepositoryImpl.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/repository/impl/ords/DisputeUpdateRequestRepositoryImpl.java
@@ -28,6 +28,10 @@ import net.logstash.logback.argument.StructuredArguments;
 public class DisputeUpdateRequestRepositoryImpl implements DisputeUpdateRequestRepository{
 
 	private static Logger logger = LoggerFactory.getLogger(DisputeUpdateRequestRepositoryImpl.class);
+	/** 
+	 * ORDS POST or DELETE requests must include a body. Use an empty body for those requests. 
+	 */
+	public static final Object EmptyBody = new Object();
 
 	// Delegate, OpenAPI generated client
 	private final DisputeUpdateRequestApi disputeUpdateRequestApi;
@@ -125,7 +129,7 @@ public class DisputeUpdateRequestRepositoryImpl implements DisputeUpdateRequestR
 		}
 
 		try {
-			UpdateRequestResponseResult result = assertNoExceptions(() -> disputeUpdateRequestApi.v1DeleteDisputeUpdateRequestDelete(id, null));
+			UpdateRequestResponseResult result = assertNoExceptions(() -> disputeUpdateRequestApi.v1DeleteDisputeUpdateRequestDelete(EmptyBody, id, null));
 			logger.debug("Successfully deleted the dispute update request through ORDS with id {}", StructuredArguments.value("disputeUpdateRequestId", id));
 
 		} catch (ApiException e) {

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/repository/impl/ords/JJDisputeRepositoryImpl.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/repository/impl/ords/JJDisputeRepositoryImpl.java
@@ -40,6 +40,10 @@ import net.logstash.logback.argument.StructuredArguments;
 public class JJDisputeRepositoryImpl implements JJDisputeRepository {
 
 	private static Logger logger = LoggerFactory.getLogger(JJDisputeRepositoryImpl.class);
+	/** 
+	 * ORDS POST or DELETE requests must include a body. Use an empty body for those requests. 
+	 */
+	public static final Object EmptyBody = new Object();
 
 	// Delegate, OpenAPI generated client
 	private final JjDisputeApi jjDisputeApi;
@@ -53,17 +57,17 @@ public class JJDisputeRepositoryImpl implements JJDisputeRepository {
 
 	@Override
 	public void assignJJDisputeJj(String ticketNumber, String username) {
-		assertNoExceptionsGeneric(() -> jjDisputeApi.v1AssignDisputeJjPost(username, ticketNumber));
+		assertNoExceptionsGeneric(() -> jjDisputeApi.v1AssignDisputeJjPost(EmptyBody, username, ticketNumber));
 	}
 
 	@Override
 	public void assignJJDisputeVtc(String ticketNumber, String username) {
-		assertNoExceptionsGeneric(() -> jjDisputeApi.v1AssignDisputeVtcPost(username, ticketNumber));
+		assertNoExceptionsGeneric(() -> jjDisputeApi.v1AssignDisputeVtcPost(EmptyBody, username, ticketNumber));
 	}
 
 	@Override
 	public void unassignJJDisputeVtc(String ticketNumber, Date assignedBeforeTs) {
-		assertNoExceptionsGeneric(() -> jjDisputeApi.v1UnassignDisputeVtcPost(DateUtil.formatAsDateTimeUTC(assignedBeforeTs), ticketNumber));
+		assertNoExceptionsGeneric(() -> jjDisputeApi.v1UnassignDisputeVtcPost(EmptyBody, DateUtil.formatAsDateTimeUTC(assignedBeforeTs), ticketNumber));
 	}
 
 	@Override
@@ -141,6 +145,7 @@ public class JJDisputeRepositoryImpl implements JJDisputeRepository {
 				disputeId,
 				disputeStatus.getShortName(),
 				userId,
+				EmptyBody,
 				courtAppearanceId,
 				Objects.toString(seizedYn, null),
 				adjudicatorPartId,
@@ -151,7 +156,7 @@ public class JJDisputeRepositoryImpl implements JJDisputeRepository {
 
 	@Override
 	public void deleteByIdOrTicketNumber(Long id, String ticketNumber) {
-		assertNoExceptionsGeneric(() -> jjDisputeApi.v1DeleteDisputeDelete(id, ticketNumber));
+		assertNoExceptionsGeneric(() -> jjDisputeApi.v1DeleteDisputeDelete(EmptyBody, id, ticketNumber));
 	}
 
 	private JJDispute map(ca.bc.gov.open.jag.tco.oracledataapi.ords.tco.api.model.JJDispute jjDispute) {

--- a/src/backend/oracle-data-api/src/main/resources/occm-openapi-spec.yaml
+++ b/src/backend/oracle-data-api/src/main/resources/occm-openapi-spec.yaml
@@ -210,6 +210,13 @@ paths:
           schema:
             type: integer
             format: int64
+      requestBody:
+        description: Empty body required by ORDS for DELETE request
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EmptyObject'
       responses:
         '200':
           description: Ok
@@ -238,6 +245,13 @@ paths:
           schema:
             type: string
             maxLength: 30
+      requestBody:
+        description: Empty body required by ORDS for POST request
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EmptyObject'
       responses:
         '200':
           description: Ok
@@ -258,6 +272,13 @@ paths:
           schema:
             type: string
             maxLength: 19
+      requestBody:
+        description: Empty body required by ORDS for POST request
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EmptyObject'
       responses:
         '200':
           description: Ok
@@ -290,6 +311,13 @@ paths:
           schema:
             type: string
             maxLength: 500
+      requestBody:
+        description: Empty body required by ORDS for POST request
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EmptyObject'
       responses:
         '200':
           description: Ok
@@ -455,6 +483,13 @@ paths:
           schema:
             type: integer
             format: int64
+      requestBody:
+        description: Empty body required by ORDS for DELETE request
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EmptyObject'
       responses:
         '200':
           description: Ok
@@ -550,6 +585,9 @@ components:
       type: http
       scheme: basic
   schemas:
+    EmptyObject:
+      type: object
+      description: an empty object
     AgenciesListResult:
       type: object
       properties:

--- a/src/backend/oracle-data-api/src/main/resources/tco-openapi-spec.yaml
+++ b/src/backend/oracle-data-api/src/main/resources/tco-openapi-spec.yaml
@@ -73,6 +73,13 @@ paths:
           in: query
           schema:
             type: string
+      requestBody:
+        description: Empty body required by ORDS for POST request
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EmptyObject'
       responses:
         '200':
           description: Ok
@@ -115,6 +122,13 @@ paths:
           in: query
           schema:
             type: string
+      requestBody:
+        description: Empty body required by ORDS for POST request
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EmptyObject'
       responses:
         '200':
           description: Ok
@@ -137,6 +151,13 @@ paths:
           in: query
           schema:
             type: string
+      requestBody:
+        description: Empty body required by ORDS for POST request
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EmptyObject'
       responses:
         '200':
           description: Ok
@@ -238,6 +259,13 @@ paths:
           schema:
             type: string
             maxLength: 30
+      requestBody:
+        description: Empty body required by ORDS for POST request
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EmptyObject'
       responses:
         '200':
           description: Ok
@@ -282,6 +310,13 @@ paths:
           in: query
           schema:
             type: string
+      requestBody:
+        description: Empty body required by ORDS for DELETE request
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EmptyObject'
       responses:
         '200':
           description: Ok
@@ -299,6 +334,9 @@ components:
       type: http
       scheme: basic
   schemas:
+    EmptyObject:
+      type: object
+      description: an empty object
     AuditBase:
       type: object
       properties:

--- a/src/backend/oracle-data-api/src/test/java/ca/bc/gov/open/jag/tco/oracledataapi/service/impl/ords/DisputeServiceImplTest.java
+++ b/src/backend/oracle-data-api/src/test/java/ca/bc/gov/open/jag/tco/oracledataapi/service/impl/ords/DisputeServiceImplTest.java
@@ -52,7 +52,7 @@ class DisputeServiceImplTest extends BaseTestSuite {
 		ResponseResult response = new ResponseResult();
 		response.setStatus("1");
 
-		Mockito.when(violationTicketApi.v1AssignViolationTicketPost(disputeId, userName)).thenReturn(response);
+		Mockito.when(violationTicketApi.v1AssignViolationTicketPost(disputeId, userName, DisputeRepositoryImpl.EmptyBody)).thenReturn(response);
 
 		assertDoesNotThrow(() -> {
 			repository.assignDisputeToUser(disputeId, userName);
@@ -64,7 +64,7 @@ class DisputeServiceImplTest extends BaseTestSuite {
 		Long disputeId = Long.valueOf(1);
 		String userName = "testUser";
 
-		Mockito.when(violationTicketApi.v1AssignViolationTicketPost(disputeId, userName)).thenThrow(ApiException.class);
+		Mockito.when(violationTicketApi.v1AssignViolationTicketPost(disputeId, userName, DisputeRepositoryImpl.EmptyBody)).thenThrow(ApiException.class);
 
 		assertThrows(ApiException.class, () -> {
 			repository.assignDisputeToUser(disputeId, userName);
@@ -78,7 +78,7 @@ class DisputeServiceImplTest extends BaseTestSuite {
 		ResponseResult response = new ResponseResult();
 		response.setStatus("0"); // 0 status (meaning failure)
 
-		Mockito.when(violationTicketApi.v1AssignViolationTicketPost(disputeId, userName)).thenReturn(response);
+		Mockito.when(violationTicketApi.v1AssignViolationTicketPost(disputeId, userName, DisputeRepositoryImpl.EmptyBody)).thenReturn(response);
 
 		assertThrows(InternalServerErrorException.class, () -> {
 			repository.assignDisputeToUser(disputeId, userName);
@@ -90,7 +90,7 @@ class DisputeServiceImplTest extends BaseTestSuite {
 		Long disputeId = Long.valueOf(1);
 		String userName = "testUser";
 
-		Mockito.when(violationTicketApi.v1AssignViolationTicketPost(disputeId, userName)).thenReturn(null);
+		Mockito.when(violationTicketApi.v1AssignViolationTicketPost(disputeId, userName, DisputeRepositoryImpl.EmptyBody)).thenReturn(null);
 
 		assertThrows(InternalServerErrorException.class, () -> {
 			repository.assignDisputeToUser(disputeId, userName);
@@ -105,7 +105,7 @@ class DisputeServiceImplTest extends BaseTestSuite {
 		response.setStatus("0"); // 0 status (meaning failure)
 		response.setException("some failure cause");
 
-		Mockito.when(violationTicketApi.v1AssignViolationTicketPost(disputeId, userName)).thenReturn(response);
+		Mockito.when(violationTicketApi.v1AssignViolationTicketPost(disputeId, userName, DisputeRepositoryImpl.EmptyBody)).thenReturn(response);
 
 		assertThrows(InternalServerErrorException.class, () -> {
 			repository.assignDisputeToUser(disputeId, userName);
@@ -118,7 +118,7 @@ class DisputeServiceImplTest extends BaseTestSuite {
 		ResponseResult response = new ResponseResult();
 		response.setStatus("1");
 
-		Mockito.when(violationTicketApi.v1DeleteViolationTicketDelete(disputeId)).thenReturn(response);
+		Mockito.when(violationTicketApi.v1DeleteViolationTicketDelete(disputeId, DisputeRepositoryImpl.EmptyBody)).thenReturn(response);
 
 		assertDoesNotThrow(() -> {
 			repository.deleteById(disputeId);
@@ -141,7 +141,7 @@ class DisputeServiceImplTest extends BaseTestSuite {
 		response.setStatus("0");
 		response.setException("ORA-01403: no data found");
 
-		Mockito.when(violationTicketApi.v1DeleteViolationTicketDelete(disputeId)).thenReturn(response);
+		Mockito.when(violationTicketApi.v1DeleteViolationTicketDelete(disputeId, DisputeRepositoryImpl.EmptyBody)).thenReturn(response);
 
 		assertThrows(NoSuchElementException.class, () -> {
 			repository.deleteById(disputeId);
@@ -152,7 +152,7 @@ class DisputeServiceImplTest extends BaseTestSuite {
 	public void testDeleteExpect500_ApiException() throws Exception {
 		Long disputeId = Long.valueOf(1);
 
-		Mockito.when(violationTicketApi.v1DeleteViolationTicketDelete(disputeId)).thenThrow(ApiException.class);
+		Mockito.when(violationTicketApi.v1DeleteViolationTicketDelete(disputeId, DisputeRepositoryImpl.EmptyBody)).thenThrow(ApiException.class);
 
 		assertThrows(ApiException.class, () -> {
 			repository.deleteById(disputeId);
@@ -165,7 +165,7 @@ class DisputeServiceImplTest extends BaseTestSuite {
 		ResponseResult response = new ResponseResult();
 		response.setStatus("0"); // 0 status (meaning failure) and no message
 
-		Mockito.when(violationTicketApi.v1DeleteViolationTicketDelete(disputeId)).thenReturn(response);
+		Mockito.when(violationTicketApi.v1DeleteViolationTicketDelete(disputeId, DisputeRepositoryImpl.EmptyBody)).thenReturn(response);
 
 		assertThrows(InternalServerErrorException.class, () -> {
 			repository.deleteById(disputeId);
@@ -176,7 +176,7 @@ class DisputeServiceImplTest extends BaseTestSuite {
 	public void testDeleteExpect500_nullReponse() throws ApiException {
 		Long disputeId = Long.valueOf(1);
 
-		Mockito.when(violationTicketApi.v1DeleteViolationTicketDelete(disputeId)).thenReturn(null);
+		Mockito.when(violationTicketApi.v1DeleteViolationTicketDelete(disputeId, DisputeRepositoryImpl.EmptyBody)).thenReturn(null);
 
 		assertThrows(InternalServerErrorException.class, () -> {
 			repository.deleteById(disputeId);
@@ -190,7 +190,7 @@ class DisputeServiceImplTest extends BaseTestSuite {
 		response.setStatus("0"); // 0 status (meaning failure) and no message
 		response.setException("some failure cause");
 
-		Mockito.when(violationTicketApi.v1DeleteViolationTicketDelete(disputeId)).thenReturn(response);
+		Mockito.when(violationTicketApi.v1DeleteViolationTicketDelete(disputeId, DisputeRepositoryImpl.EmptyBody)).thenReturn(response);
 
 		assertThrows(InternalServerErrorException.class, () -> {
 			repository.deleteById(disputeId);
@@ -205,7 +205,7 @@ class DisputeServiceImplTest extends BaseTestSuite {
 		ResponseResult response = new ResponseResult();
 		response.setStatus("1");
 
-		Mockito.when(violationTicketApi.v1ViolationTicketStatusPost(disputeId, disputeStatus.toShortName(), rejectedReason)).thenReturn(response);
+		Mockito.when(violationTicketApi.v1ViolationTicketStatusPost(DisputeRepositoryImpl.EmptyBody, disputeId, disputeStatus.toShortName(), rejectedReason)).thenReturn(response);
 
 		assertDoesNotThrow(() -> {
 			repository.setStatus(disputeId, disputeStatus, rejectedReason);
@@ -218,7 +218,7 @@ class DisputeServiceImplTest extends BaseTestSuite {
 		DisputeStatus disputeStatus = DisputeStatus.NEW;
 		String rejectedReason = "just because";
 
-		Mockito.when(violationTicketApi.v1ViolationTicketStatusPost(disputeId, disputeStatus.toShortName(), rejectedReason)).thenThrow(ApiException.class);
+		Mockito.when(violationTicketApi.v1ViolationTicketStatusPost(DisputeRepositoryImpl.EmptyBody, disputeId, disputeStatus.toShortName(), rejectedReason)).thenThrow(ApiException.class);
 
 		assertThrows(ApiException.class, () -> {
 			repository.setStatus(disputeId, disputeStatus, rejectedReason);
@@ -233,7 +233,7 @@ class DisputeServiceImplTest extends BaseTestSuite {
 		ResponseResult response = new ResponseResult();
 		response.setStatus("0"); // 0 status (meaning failure) and no message
 
-		Mockito.when(violationTicketApi.v1ViolationTicketStatusPost(disputeId, disputeStatus.toShortName(), rejectedReason)).thenReturn(response);
+		Mockito.when(violationTicketApi.v1ViolationTicketStatusPost(DisputeRepositoryImpl.EmptyBody, disputeId, disputeStatus.toShortName(), rejectedReason)).thenReturn(response);
 
 		assertThrows(InternalServerErrorException.class, () -> {
 			repository.setStatus(disputeId, disputeStatus, rejectedReason);
@@ -246,7 +246,7 @@ class DisputeServiceImplTest extends BaseTestSuite {
 		DisputeStatus disputeStatus = DisputeStatus.NEW;
 		String rejectedReason = "just because";
 
-		Mockito.when(violationTicketApi.v1ViolationTicketStatusPost(disputeId, disputeStatus.toShortName(), rejectedReason)).thenReturn(null);
+		Mockito.when(violationTicketApi.v1ViolationTicketStatusPost(DisputeRepositoryImpl.EmptyBody, disputeId, disputeStatus.toShortName(), rejectedReason)).thenReturn(null);
 
 		assertThrows(InternalServerErrorException.class, () -> {
 			repository.setStatus(disputeId, disputeStatus, rejectedReason);
@@ -262,7 +262,7 @@ class DisputeServiceImplTest extends BaseTestSuite {
 		response.setStatus("0"); // 0 status (meaning failure)
 		response.setException("some failure cause");
 
-		Mockito.when(violationTicketApi.v1ViolationTicketStatusPost(disputeId, disputeStatus.toShortName(), rejectedReason)).thenReturn(response);
+		Mockito.when(violationTicketApi.v1ViolationTicketStatusPost(DisputeRepositoryImpl.EmptyBody, disputeId, disputeStatus.toShortName(), rejectedReason)).thenReturn(response);
 
 		assertThrows(InternalServerErrorException.class, () -> {
 			repository.setStatus(disputeId, disputeStatus, rejectedReason);
@@ -276,7 +276,7 @@ class DisputeServiceImplTest extends BaseTestSuite {
 		ResponseResult response = new ResponseResult();
 		response.setStatus("1");
 
-		Mockito.when(violationTicketApi.v1UnassignViolationTicketPost(assignedBeforeTs)).thenReturn(response);
+		Mockito.when(violationTicketApi.v1UnassignViolationTicketPost(DisputeRepositoryImpl.EmptyBody, assignedBeforeTs)).thenReturn(response);
 
 		assertDoesNotThrow(() -> {
 			repository.unassignDisputes(now);
@@ -288,7 +288,7 @@ class DisputeServiceImplTest extends BaseTestSuite {
 		Date now = new Date();
 		String assignedBeforeTs = dateToString(now, DateUtil.DATE_TIME_FORMAT);
 
-		Mockito.when(violationTicketApi.v1UnassignViolationTicketPost(assignedBeforeTs)).thenThrow(ApiException.class);
+		Mockito.when(violationTicketApi.v1UnassignViolationTicketPost(DisputeRepositoryImpl.EmptyBody, assignedBeforeTs)).thenThrow(ApiException.class);
 
 		assertThrows(ApiException.class, () -> {
 			repository.unassignDisputes(now);
@@ -302,7 +302,7 @@ class DisputeServiceImplTest extends BaseTestSuite {
 		ResponseResult response = new ResponseResult();
 		response.setStatus("0"); // 0 status (meaning failure) and no message
 
-		Mockito.when(violationTicketApi.v1UnassignViolationTicketPost(assignedBeforeTs)).thenReturn(response);
+		Mockito.when(violationTicketApi.v1UnassignViolationTicketPost(DisputeRepositoryImpl.EmptyBody, assignedBeforeTs)).thenReturn(response);
 
 		assertThrows(InternalServerErrorException.class, () -> {
 			repository.unassignDisputes(now);
@@ -314,7 +314,7 @@ class DisputeServiceImplTest extends BaseTestSuite {
 		Date now = new Date();
 		String assignedBeforeTs = dateToString(now, DateUtil.DATE_TIME_FORMAT);
 
-		Mockito.when(violationTicketApi.v1UnassignViolationTicketPost(assignedBeforeTs)).thenReturn(null);
+		Mockito.when(violationTicketApi.v1UnassignViolationTicketPost(DisputeRepositoryImpl.EmptyBody, assignedBeforeTs)).thenReturn(null);
 
 		assertThrows(InternalServerErrorException.class, () -> {
 			repository.unassignDisputes(now);
@@ -329,7 +329,7 @@ class DisputeServiceImplTest extends BaseTestSuite {
 		response.setStatus("0"); // 0 status (meaning failure)
 		response.setException("some failure cause");
 
-		Mockito.when(violationTicketApi.v1UnassignViolationTicketPost(assignedBeforeTs)).thenReturn(response);
+		Mockito.when(violationTicketApi.v1UnassignViolationTicketPost(DisputeRepositoryImpl.EmptyBody, assignedBeforeTs)).thenReturn(response);
 
 		assertThrows(InternalServerErrorException.class, () -> {
 			repository.unassignDisputes(now);


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- Add empty body for POST or DELETE requests

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [ ] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
