### PR TITLE
Oracle data api opentelemetry & Empty Object

### DIFF
--- a/.gitops/charts/traffic-court-online/values.yaml
+++ b/.gitops/charts/traffic-court-online/values.yaml
@@ -64,9 +64,10 @@ oracle-data-api:
     "ORDS_API_RETRY_DELAY_SEC": "5"
     "ORDS_API_TIMEOUT_MS": "2000"
     "OTEL_EXPORTER_JAEGER_ENDPOINT": "http://jaeger-collector:14250"
+    "OTEL_SERVICE_NAME": "oracle-data-api"
+    "OTEL_TRACES_EXPORTER": "jaeger"
     "REDIS_HOST": "redis-master"
     "REDIS_PORT": "6379"
-    "SPRING_SLEUTH_ENABLED": "true"
     "UNASSIGN_DISPUTES_CRON": "0 0/5 * * * *"
     "UNASSIGN_DISPUTES_ENABLED": "true"
 

--- a/src/backend/oracle-data-api/Dockerfile
+++ b/src/backend/oracle-data-api/Dockerfile
@@ -26,7 +26,8 @@ RUN mvn -B clean package \
 ### Stage where Docker is running a java process to run a service built in previous stage ###
 #############################################################################################
 FROM $RUNTIME_IMAGE:11
-ARG PROMETHEUS_AGENT_VERSION=0.17.2
+ARG PROMETHEUS_AGENT_VERSION=0.18.0
+ARG OPENTELEMETRY_AGENT_VERSION=1.26.0
 
 # Optional Git Version arguments
 ARG GIT_COMMIT_DATE=not-set
@@ -60,11 +61,14 @@ lowercaseOutputLabelNames: false \n\
 RUN chgrp 0 /app/jmx_prometheus_javaagent.jar         && chmod a+rw,o-rw /app/jmx_prometheus_javaagent.jar
 RUN chgrp 0 /app/jmx_prometheus_javaagent_config.yaml && chmod a+rw,o-rw /app/jmx_prometheus_javaagent_config.yaml
 
+ADD https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/download/v${OPENTELEMETRY_AGENT_VERSION}/opentelemetry-javaagent.jar /app/opentelemetry-javaagent.jar
+RUN chgrp 0 /app/opentelemetry-javaagent.jar          && chmod a+rw,o-rw opentelemetry-javaagent.jar
+
 ENV TZ=America/Vancouver
 
 COPY --from=build ./target/oracle-data-api.jar .
 COPY --from=build ./entrypoint.sh .
 RUN chgrp 0 entrypoint.sh && chmod a+rwx,o-rwx entrypoint.sh
 # use CMD "shell form" so we can expand env vars
-CMD ./entrypoint.sh java -javaagent:/app/jmx_prometheus_javaagent.jar=9090:/app/jmx_prometheus_javaagent_config.yaml $JAVA_OPTS -jar /app/oracle-data-api.jar
+CMD ./entrypoint.sh java -javaagent:/app/jmx_prometheus_javaagent.jar=9090:/app/jmx_prometheus_javaagent_config.yaml -javaagent:/app/opentelemetry-javaagent.jar $JAVA_OPTS -jar /app/oracle-data-api.jar
 #############################################################################################

--- a/src/backend/oracle-data-api/pom.xml
+++ b/src/backend/oracle-data-api/pom.xml
@@ -18,7 +18,6 @@
 		<java.version>11</java.version>
 		<log4j2.version>2.17.1</log4j2.version>
 		<release.train.version>2021.0.4</release.train.version>
-		<spring-cloud-sleuth-otel.version>1.1.0</spring-cloud-sleuth-otel.version>
 		<org.mapstruct.version>1.5.5.Final</org.mapstruct.version>
 		<org.projectlombok.version>1.18.28</org.projectlombok.version>
 		<occam-package>ca.bc.gov.open.jag.tco.oracledataapi.ords.occam</occam-package>
@@ -33,13 +32,6 @@
 				<version>${release.train.version}</version>
 				<type>pom</type>
 				<scope>import</scope>
-			</dependency>
-			<dependency>
-				<groupId>org.springframework.cloud</groupId>
-				<artifactId>spring-cloud-sleuth-otel-dependencies</artifactId>
-				<version>${spring-cloud-sleuth-otel.version}</version>
-				<scope>import</scope>
-				<type>pom</type>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>
@@ -136,14 +128,6 @@
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-actuator</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-sleuth-otel-autoconfigure</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>io.opentelemetry</groupId>
-			<artifactId>opentelemetry-exporter-jaeger</artifactId>
 		</dependency>
 
 		<!-- Mapstruct dependencies -->

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/model/EmptyObject.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/model/EmptyObject.java
@@ -1,0 +1,18 @@
+package ca.bc.gov.open.jag.tco.oracledataapi.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * Empty object used send empty body
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class EmptyObject {
+    private String field;
+    public static final EmptyObject instance = new EmptyObject();
+}

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/repository/impl/ords/DisputeUpdateRequestRepositoryImpl.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/repository/impl/ords/DisputeUpdateRequestRepositoryImpl.java
@@ -16,6 +16,7 @@ import org.springframework.stereotype.Repository;
 import ca.bc.gov.open.jag.tco.oracledataapi.mapper.DisputeUpdateRequestMapper;
 import ca.bc.gov.open.jag.tco.oracledataapi.model.DisputeUpdateRequest;
 import ca.bc.gov.open.jag.tco.oracledataapi.model.DisputeUpdateRequestStatus;
+import ca.bc.gov.open.jag.tco.oracledataapi.model.EmptyObject;
 import ca.bc.gov.open.jag.tco.oracledataapi.ords.occam.api.DisputeUpdateRequestApi;
 import ca.bc.gov.open.jag.tco.oracledataapi.ords.occam.api.handler.ApiException;
 import ca.bc.gov.open.jag.tco.oracledataapi.ords.occam.api.model.UpdateRequestListResponse;
@@ -28,10 +29,6 @@ import net.logstash.logback.argument.StructuredArguments;
 public class DisputeUpdateRequestRepositoryImpl implements DisputeUpdateRequestRepository{
 
 	private static Logger logger = LoggerFactory.getLogger(DisputeUpdateRequestRepositoryImpl.class);
-	/** 
-	 * ORDS POST or DELETE requests must include a body. Use an empty body for those requests. 
-	 */
-	public static final Object EmptyBody = new Object();
 
 	// Delegate, OpenAPI generated client
 	private final DisputeUpdateRequestApi disputeUpdateRequestApi;
@@ -129,7 +126,7 @@ public class DisputeUpdateRequestRepositoryImpl implements DisputeUpdateRequestR
 		}
 
 		try {
-			UpdateRequestResponseResult result = assertNoExceptions(() -> disputeUpdateRequestApi.v1DeleteDisputeUpdateRequestDelete(EmptyBody, id, null));
+			UpdateRequestResponseResult result = assertNoExceptions(() -> disputeUpdateRequestApi.v1DeleteDisputeUpdateRequestDelete(EmptyObject.instance, id, null));
 			logger.debug("Successfully deleted the dispute update request through ORDS with id {}", StructuredArguments.value("disputeUpdateRequestId", id));
 
 		} catch (ApiException e) {

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/repository/impl/ords/JJDisputeRemarkRepositoryImpl.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/repository/impl/ords/JJDisputeRemarkRepositoryImpl.java
@@ -32,7 +32,7 @@ public class JJDisputeRemarkRepositoryImpl implements JJDisputeRemarkRepository 
 
 	@Override
 	public JJDisputeRemark saveAndFlush(JJDisputeRemark jjDisputeRemark) {
-		assertNoExceptions(() -> jjDisputeApi.v1ProcessDisputeRemarkPost(jjDisputeMapper.convert(jjDisputeRemark)));
+		assertNoExceptions(() -> jjDisputeApi.processDisputeRemarkPost(jjDisputeMapper.convert(jjDisputeRemark)));
 		return null; // There is no TCO ORDS endpoint that will fetch a JJDisputeRemark by id so we can't return the newly saved record.
 	}
 

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/repository/impl/ords/JJDisputeRepositoryImpl.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/repository/impl/ords/JJDisputeRepositoryImpl.java
@@ -20,6 +20,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Repository;
 
 import ca.bc.gov.open.jag.tco.oracledataapi.mapper.JJDisputeMapper;
+import ca.bc.gov.open.jag.tco.oracledataapi.model.EmptyObject;
 import ca.bc.gov.open.jag.tco.oracledataapi.model.JJDispute;
 import ca.bc.gov.open.jag.tco.oracledataapi.model.JJDisputeCourtAppearanceAPP;
 import ca.bc.gov.open.jag.tco.oracledataapi.model.JJDisputeCourtAppearanceDATT;
@@ -40,10 +41,6 @@ import net.logstash.logback.argument.StructuredArguments;
 public class JJDisputeRepositoryImpl implements JJDisputeRepository {
 
 	private static Logger logger = LoggerFactory.getLogger(JJDisputeRepositoryImpl.class);
-	/** 
-	 * ORDS POST or DELETE requests must include a body. Use an empty body for those requests. 
-	 */
-	public static final Object EmptyBody = new Object();
 
 	// Delegate, OpenAPI generated client
 	private final JjDisputeApi jjDisputeApi;
@@ -57,22 +54,22 @@ public class JJDisputeRepositoryImpl implements JJDisputeRepository {
 
 	@Override
 	public void assignJJDisputeJj(String ticketNumber, String username) {
-		assertNoExceptionsGeneric(() -> jjDisputeApi.v1AssignDisputeJjPost(EmptyBody, username, ticketNumber));
+		assertNoExceptionsGeneric(() -> jjDisputeApi.assignDisputeJjPost(EmptyObject.instance, username, ticketNumber));
 	}
 
 	@Override
 	public void assignJJDisputeVtc(String ticketNumber, String username) {
-		assertNoExceptionsGeneric(() -> jjDisputeApi.v1AssignDisputeVtcPost(EmptyBody, username, ticketNumber));
+		assertNoExceptionsGeneric(() -> jjDisputeApi.assignDisputeVtcPost(EmptyObject.instance, username, ticketNumber));
 	}
 
 	@Override
 	public void unassignJJDisputeVtc(String ticketNumber, Date assignedBeforeTs) {
-		assertNoExceptionsGeneric(() -> jjDisputeApi.v1UnassignDisputeVtcPost(EmptyBody, DateUtil.formatAsDateTimeUTC(assignedBeforeTs), ticketNumber));
+		assertNoExceptionsGeneric(() -> jjDisputeApi.unassignDisputeVtcPost(EmptyObject.instance, DateUtil.formatAsDateTimeUTC(assignedBeforeTs), ticketNumber));
 	}
 
 	@Override
 	public List<JJDispute> findByJjAssignedToIgnoreCase(String jjAssignedTo) {
-		JJDisputeListResponse response = jjDisputeApi.v1JjDisputeListGet(null, null, null, jjAssignedTo);
+		JJDisputeListResponse response = jjDisputeApi.jjDisputeListGet(null, null, null, jjAssignedTo);
 		if (response == null)
 			return new ArrayList<JJDispute>();
 
@@ -89,7 +86,7 @@ public class JJDisputeRepositoryImpl implements JJDisputeRepository {
 
 	@Override
 	public List<JJDispute> findAll() {
-		JJDisputeListResponse response = jjDisputeApi.v1JjDisputeListGet(null, null, null, null);
+		JJDisputeListResponse response = jjDisputeApi.jjDisputeListGet(null, null, null, null);
 		if (response == null)
 			return new ArrayList<JJDispute>();
 
@@ -101,7 +98,7 @@ public class JJDisputeRepositoryImpl implements JJDisputeRepository {
 
 	@Override
 	public List<JJDispute> findByTicketNumber(String ticketNumber) {
-		JJDispute jjDispute = map(jjDisputeApi.v1JjDisputeGet(ticketNumber));
+		JJDispute jjDispute = map(jjDisputeApi.jjDisputeGet(ticketNumber));
 		// For some reason ORDS returns a valid object but with null fields if no object is found.
 		if (jjDispute != null && !StringUtils.isBlank(jjDispute.getTicketNumber())) {
 			return Arrays.asList(jjDispute);
@@ -114,7 +111,7 @@ public class JJDisputeRepositoryImpl implements JJDisputeRepository {
 		try {
 			DisputeResponseResult responseResult = assertNoExceptions(() -> {
 				ca.bc.gov.open.jag.tco.oracledataapi.ords.tco.api.model.JJDispute convert = jjDisputeMapper.convert(jjDispute);
-				return jjDisputeApi.v1UpdateDisputePut(convert);
+				return jjDisputeApi.updateDisputePut(convert);
 			});
 			if (responseResult.getDisputeId() != null) {
 				logger.debug("Successfully updated the jjDispute through ORDS with dispute id {}", StructuredArguments.value("disputeId", responseResult.getDisputeId()));
@@ -141,11 +138,11 @@ public class JJDisputeRepositoryImpl implements JJDisputeRepository {
 
 	@Override
 	public void setStatus(Long disputeId, JJDisputeStatus disputeStatus, String userId, Long courtAppearanceId, YesNo seizedYn, String adjudicatorPartId, JJDisputeCourtAppearanceAPP aattCd, JJDisputeCourtAppearanceDATT dattCd, String staffPartId) {
-		assertNoExceptions(() -> jjDisputeApi.v1DisputeStatusPost(
+		assertNoExceptions(() -> jjDisputeApi.disputeStatusPost(
 				disputeId,
 				disputeStatus.getShortName(),
 				userId,
-				EmptyBody,
+				EmptyObject.instance,
 				courtAppearanceId,
 				Objects.toString(seizedYn, null),
 				adjudicatorPartId,
@@ -156,7 +153,7 @@ public class JJDisputeRepositoryImpl implements JJDisputeRepository {
 
 	@Override
 	public void deleteByIdOrTicketNumber(Long id, String ticketNumber) {
-		assertNoExceptionsGeneric(() -> jjDisputeApi.v1DeleteDisputeDelete(EmptyBody, id, ticketNumber));
+		assertNoExceptionsGeneric(() -> jjDisputeApi.disputeDelete(EmptyObject.instance, id, ticketNumber));
 	}
 
 	private JJDispute map(ca.bc.gov.open.jag.tco.oracledataapi.ords.tco.api.model.JJDispute jjDispute) {

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/repository/impl/ords/TicketImageDataRepositoryImpl.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/repository/impl/ords/TicketImageDataRepositoryImpl.java
@@ -37,7 +37,7 @@ public class TicketImageDataRepositoryImpl implements TicketImageDataRepository 
 		docKey.setReportTypes(reportType);
 		parms.addDocumentKeysItem(docKey); // expects an array of document keys
 
-		TicketImageDataGetResponseResult response = jjDisputeApi.v1TicketImageDataGetPost(parms);
+		TicketImageDataGetResponseResult response = jjDisputeApi.ticketImageDataGetPost(parms);
 		if (response == null || response.getDocuments().isEmpty())
 			return new TicketImageDataJustinDocument();
 		

--- a/src/backend/oracle-data-api/src/main/resources/application.yml
+++ b/src/backend/oracle-data-api/src/main/resources/application.yml
@@ -8,15 +8,6 @@ spring:
   jmx:
     enabled: true
 
-  sleuth:
-    enabled: ${SPRING_SLEUTH_ENABLED:false}
-    otel:   
-      config:
-        trace-id-ratio-based: 1.0
-      exporter:
-        jaeger:
-          endpoint: ${OTEL_EXPORTER_JAEGER_ENDPOINT:http://localhost:14250}
-
   redis:
     host: ${REDIS_HOST:localhost}
     port: ${REDIS_PORT:6379}

--- a/src/backend/oracle-data-api/src/main/resources/occm-openapi-spec.yaml
+++ b/src/backend/oracle-data-api/src/main/resources/occm-openapi-spec.yaml
@@ -131,6 +131,7 @@ paths:
         - Lookup Values
   /v1/violationTicket:
     get:
+      operationId: violationTicketGet
       parameters:
         - name: violationTicketId
           in: query
@@ -157,6 +158,7 @@ paths:
         - Violation Ticket
   /v1/violationTicketList:
     get:
+      operationId: violationTicketListGet
       parameters:
         - name: fromDate
           in: query
@@ -202,6 +204,7 @@ paths:
         - Violation Ticket
   /v1/deleteViolationTicket:
     delete:
+      operationId: violationTicketDelete
       parameters:
         - name: disputeId
           in: query
@@ -230,6 +233,7 @@ paths:
         - Violation Ticket
   /v1/assignViolationTicket:
     post:
+      operationId: assignViolationTicketPost
       parameters:
         - name: disputeId
           in: query
@@ -265,6 +269,7 @@ paths:
         - Violation Ticket
   /v1/unassignViolationTicket:
     post:
+      operationId: unassignViolationTicketPost
       parameters:
         - name: assignedBeforeTs
           in: query
@@ -292,6 +297,7 @@ paths:
         - Violation Ticket
   /v1/violationTicketStatus:
     post:
+      operationId: violationTicketStatusPost
       parameters:
         - name: disputeId
           in: query
@@ -331,6 +337,7 @@ paths:
         - Violation Ticket
   /v1/processViolationTicket:
     post:
+      operationId: processViolationTicketPost
       requestBody:
         description: body
         content:

--- a/src/backend/oracle-data-api/src/main/resources/tco-openapi-spec.yaml
+++ b/src/backend/oracle-data-api/src/main/resources/tco-openapi-spec.yaml
@@ -26,6 +26,7 @@ paths:
         - Health
   /v1/jjDispute:
     get:
+      operationId: jjDisputeGet
       parameters:
         - name: ticketNumber
           in: query
@@ -44,6 +45,7 @@ paths:
         - JJDispute
   /v1/updateDispute:
     put:
+      operationId: updateDisputePut
       requestBody:
         description: body
         content:
@@ -64,6 +66,7 @@ paths:
         - JJDispute
   /v1/assignDisputeJj:
     post:
+      operationId: assignDisputeJjPost
       parameters:
         - name: userId
           in: query
@@ -93,6 +96,7 @@ paths:
         - JJDispute
   /v1/ticketImageDataGet:
     post:
+      operationId: ticketImageDataGetPost
       requestBody:
         description: body
         content:
@@ -113,6 +117,7 @@ paths:
         - JJDispute
   /v1/assignDisputeVtc:
     post:
+      operationId: assignDisputeVtcPost
       parameters:
         - name: userId
           in: query
@@ -142,6 +147,7 @@ paths:
         - JJDispute
   /v1/unassignDisputeVtc:
     post:
+      operationId: unassignDisputeVtcPost
       parameters:
         - name: assignedBeforeTs
           in: query
@@ -171,6 +177,7 @@ paths:
         - JJDispute
   /v1/jjDisputeList:
     get:
+      operationId: jjDisputeListGet
       parameters:
         - name: justinRccId
           in: query
@@ -201,6 +208,7 @@ paths:
         - JJDispute
   /v1/disputeStatus:
     post:
+      operationId: disputeStatusPost
       parameters:
         - name: disputeId
           in: query
@@ -279,6 +287,7 @@ paths:
         - JJDispute
   /v1/processDisputeRemark:
     post:
+      operationId: processDisputeRemarkPost
       requestBody:
         description: body
         content:
@@ -299,6 +308,7 @@ paths:
         - JJDispute
   /v1/deleteDispute:
     delete:
+      operationId: disputeDelete
       parameters:
         - name: disputeId
           in: query

--- a/src/backend/oracle-data-api/src/test/java/ca/bc/gov/open/jag/tco/oracledataapi/service/impl/ords/DisputeServiceImplTest.java
+++ b/src/backend/oracle-data-api/src/test/java/ca/bc/gov/open/jag/tco/oracledataapi/service/impl/ords/DisputeServiceImplTest.java
@@ -24,6 +24,7 @@ import ca.bc.gov.open.jag.tco.oracledataapi.model.ContactType;
 import ca.bc.gov.open.jag.tco.oracledataapi.model.Dispute;
 import ca.bc.gov.open.jag.tco.oracledataapi.model.DisputeResult;
 import ca.bc.gov.open.jag.tco.oracledataapi.model.DisputeStatus;
+import ca.bc.gov.open.jag.tco.oracledataapi.model.EmptyObject;
 import ca.bc.gov.open.jag.tco.oracledataapi.ords.occam.api.ViolationTicketApi;
 import ca.bc.gov.open.jag.tco.oracledataapi.ords.occam.api.handler.ApiException;
 import ca.bc.gov.open.jag.tco.oracledataapi.ords.occam.api.model.ResponseResult;
@@ -52,7 +53,7 @@ class DisputeServiceImplTest extends BaseTestSuite {
 		ResponseResult response = new ResponseResult();
 		response.setStatus("1");
 
-		Mockito.when(violationTicketApi.v1AssignViolationTicketPost(disputeId, userName, DisputeRepositoryImpl.EmptyBody)).thenReturn(response);
+		Mockito.when(violationTicketApi.assignViolationTicketPost(disputeId, userName, EmptyObject.instance)).thenReturn(response);
 
 		assertDoesNotThrow(() -> {
 			repository.assignDisputeToUser(disputeId, userName);
@@ -64,7 +65,7 @@ class DisputeServiceImplTest extends BaseTestSuite {
 		Long disputeId = Long.valueOf(1);
 		String userName = "testUser";
 
-		Mockito.when(violationTicketApi.v1AssignViolationTicketPost(disputeId, userName, DisputeRepositoryImpl.EmptyBody)).thenThrow(ApiException.class);
+		Mockito.when(violationTicketApi.assignViolationTicketPost(disputeId, userName, EmptyObject.instance)).thenThrow(ApiException.class);
 
 		assertThrows(ApiException.class, () -> {
 			repository.assignDisputeToUser(disputeId, userName);
@@ -78,7 +79,7 @@ class DisputeServiceImplTest extends BaseTestSuite {
 		ResponseResult response = new ResponseResult();
 		response.setStatus("0"); // 0 status (meaning failure)
 
-		Mockito.when(violationTicketApi.v1AssignViolationTicketPost(disputeId, userName, DisputeRepositoryImpl.EmptyBody)).thenReturn(response);
+		Mockito.when(violationTicketApi.assignViolationTicketPost(disputeId, userName, EmptyObject.instance)).thenReturn(response);
 
 		assertThrows(InternalServerErrorException.class, () -> {
 			repository.assignDisputeToUser(disputeId, userName);
@@ -90,7 +91,7 @@ class DisputeServiceImplTest extends BaseTestSuite {
 		Long disputeId = Long.valueOf(1);
 		String userName = "testUser";
 
-		Mockito.when(violationTicketApi.v1AssignViolationTicketPost(disputeId, userName, DisputeRepositoryImpl.EmptyBody)).thenReturn(null);
+		Mockito.when(violationTicketApi.assignViolationTicketPost(disputeId, userName, EmptyObject.instance)).thenReturn(null);
 
 		assertThrows(InternalServerErrorException.class, () -> {
 			repository.assignDisputeToUser(disputeId, userName);
@@ -105,7 +106,7 @@ class DisputeServiceImplTest extends BaseTestSuite {
 		response.setStatus("0"); // 0 status (meaning failure)
 		response.setException("some failure cause");
 
-		Mockito.when(violationTicketApi.v1AssignViolationTicketPost(disputeId, userName, DisputeRepositoryImpl.EmptyBody)).thenReturn(response);
+		Mockito.when(violationTicketApi.assignViolationTicketPost(disputeId, userName, EmptyObject.instance)).thenReturn(response);
 
 		assertThrows(InternalServerErrorException.class, () -> {
 			repository.assignDisputeToUser(disputeId, userName);
@@ -118,7 +119,7 @@ class DisputeServiceImplTest extends BaseTestSuite {
 		ResponseResult response = new ResponseResult();
 		response.setStatus("1");
 
-		Mockito.when(violationTicketApi.v1DeleteViolationTicketDelete(disputeId, DisputeRepositoryImpl.EmptyBody)).thenReturn(response);
+		Mockito.when(violationTicketApi.violationTicketDelete(disputeId, EmptyObject.instance)).thenReturn(response);
 
 		assertDoesNotThrow(() -> {
 			repository.deleteById(disputeId);
@@ -141,7 +142,7 @@ class DisputeServiceImplTest extends BaseTestSuite {
 		response.setStatus("0");
 		response.setException("ORA-01403: no data found");
 
-		Mockito.when(violationTicketApi.v1DeleteViolationTicketDelete(disputeId, DisputeRepositoryImpl.EmptyBody)).thenReturn(response);
+		Mockito.when(violationTicketApi.violationTicketDelete(disputeId, EmptyObject.instance)).thenReturn(response);
 
 		assertThrows(NoSuchElementException.class, () -> {
 			repository.deleteById(disputeId);
@@ -152,7 +153,7 @@ class DisputeServiceImplTest extends BaseTestSuite {
 	public void testDeleteExpect500_ApiException() throws Exception {
 		Long disputeId = Long.valueOf(1);
 
-		Mockito.when(violationTicketApi.v1DeleteViolationTicketDelete(disputeId, DisputeRepositoryImpl.EmptyBody)).thenThrow(ApiException.class);
+		Mockito.when(violationTicketApi.violationTicketDelete(disputeId, EmptyObject.instance)).thenThrow(ApiException.class);
 
 		assertThrows(ApiException.class, () -> {
 			repository.deleteById(disputeId);
@@ -165,7 +166,7 @@ class DisputeServiceImplTest extends BaseTestSuite {
 		ResponseResult response = new ResponseResult();
 		response.setStatus("0"); // 0 status (meaning failure) and no message
 
-		Mockito.when(violationTicketApi.v1DeleteViolationTicketDelete(disputeId, DisputeRepositoryImpl.EmptyBody)).thenReturn(response);
+		Mockito.when(violationTicketApi.violationTicketDelete(disputeId, EmptyObject.instance)).thenReturn(response);
 
 		assertThrows(InternalServerErrorException.class, () -> {
 			repository.deleteById(disputeId);
@@ -176,7 +177,7 @@ class DisputeServiceImplTest extends BaseTestSuite {
 	public void testDeleteExpect500_nullReponse() throws ApiException {
 		Long disputeId = Long.valueOf(1);
 
-		Mockito.when(violationTicketApi.v1DeleteViolationTicketDelete(disputeId, DisputeRepositoryImpl.EmptyBody)).thenReturn(null);
+		Mockito.when(violationTicketApi.violationTicketDelete(disputeId, EmptyObject.instance)).thenReturn(null);
 
 		assertThrows(InternalServerErrorException.class, () -> {
 			repository.deleteById(disputeId);
@@ -190,7 +191,7 @@ class DisputeServiceImplTest extends BaseTestSuite {
 		response.setStatus("0"); // 0 status (meaning failure) and no message
 		response.setException("some failure cause");
 
-		Mockito.when(violationTicketApi.v1DeleteViolationTicketDelete(disputeId, DisputeRepositoryImpl.EmptyBody)).thenReturn(response);
+		Mockito.when(violationTicketApi.violationTicketDelete(disputeId, EmptyObject.instance)).thenReturn(response);
 
 		assertThrows(InternalServerErrorException.class, () -> {
 			repository.deleteById(disputeId);
@@ -205,7 +206,7 @@ class DisputeServiceImplTest extends BaseTestSuite {
 		ResponseResult response = new ResponseResult();
 		response.setStatus("1");
 
-		Mockito.when(violationTicketApi.v1ViolationTicketStatusPost(DisputeRepositoryImpl.EmptyBody, disputeId, disputeStatus.toShortName(), rejectedReason)).thenReturn(response);
+		Mockito.when(violationTicketApi.violationTicketStatusPost(EmptyObject.instance, disputeId, disputeStatus.toShortName(), rejectedReason)).thenReturn(response);
 
 		assertDoesNotThrow(() -> {
 			repository.setStatus(disputeId, disputeStatus, rejectedReason);
@@ -218,7 +219,7 @@ class DisputeServiceImplTest extends BaseTestSuite {
 		DisputeStatus disputeStatus = DisputeStatus.NEW;
 		String rejectedReason = "just because";
 
-		Mockito.when(violationTicketApi.v1ViolationTicketStatusPost(DisputeRepositoryImpl.EmptyBody, disputeId, disputeStatus.toShortName(), rejectedReason)).thenThrow(ApiException.class);
+		Mockito.when(violationTicketApi.violationTicketStatusPost(EmptyObject.instance, disputeId, disputeStatus.toShortName(), rejectedReason)).thenThrow(ApiException.class);
 
 		assertThrows(ApiException.class, () -> {
 			repository.setStatus(disputeId, disputeStatus, rejectedReason);
@@ -233,7 +234,7 @@ class DisputeServiceImplTest extends BaseTestSuite {
 		ResponseResult response = new ResponseResult();
 		response.setStatus("0"); // 0 status (meaning failure) and no message
 
-		Mockito.when(violationTicketApi.v1ViolationTicketStatusPost(DisputeRepositoryImpl.EmptyBody, disputeId, disputeStatus.toShortName(), rejectedReason)).thenReturn(response);
+		Mockito.when(violationTicketApi.violationTicketStatusPost(EmptyObject.instance, disputeId, disputeStatus.toShortName(), rejectedReason)).thenReturn(response);
 
 		assertThrows(InternalServerErrorException.class, () -> {
 			repository.setStatus(disputeId, disputeStatus, rejectedReason);
@@ -246,7 +247,7 @@ class DisputeServiceImplTest extends BaseTestSuite {
 		DisputeStatus disputeStatus = DisputeStatus.NEW;
 		String rejectedReason = "just because";
 
-		Mockito.when(violationTicketApi.v1ViolationTicketStatusPost(DisputeRepositoryImpl.EmptyBody, disputeId, disputeStatus.toShortName(), rejectedReason)).thenReturn(null);
+		Mockito.when(violationTicketApi.violationTicketStatusPost(EmptyObject.instance, disputeId, disputeStatus.toShortName(), rejectedReason)).thenReturn(null);
 
 		assertThrows(InternalServerErrorException.class, () -> {
 			repository.setStatus(disputeId, disputeStatus, rejectedReason);
@@ -262,7 +263,7 @@ class DisputeServiceImplTest extends BaseTestSuite {
 		response.setStatus("0"); // 0 status (meaning failure)
 		response.setException("some failure cause");
 
-		Mockito.when(violationTicketApi.v1ViolationTicketStatusPost(DisputeRepositoryImpl.EmptyBody, disputeId, disputeStatus.toShortName(), rejectedReason)).thenReturn(response);
+		Mockito.when(violationTicketApi.violationTicketStatusPost(EmptyObject.instance, disputeId, disputeStatus.toShortName(), rejectedReason)).thenReturn(response);
 
 		assertThrows(InternalServerErrorException.class, () -> {
 			repository.setStatus(disputeId, disputeStatus, rejectedReason);
@@ -276,7 +277,7 @@ class DisputeServiceImplTest extends BaseTestSuite {
 		ResponseResult response = new ResponseResult();
 		response.setStatus("1");
 
-		Mockito.when(violationTicketApi.v1UnassignViolationTicketPost(DisputeRepositoryImpl.EmptyBody, assignedBeforeTs)).thenReturn(response);
+		Mockito.when(violationTicketApi.unassignViolationTicketPost(EmptyObject.instance, assignedBeforeTs)).thenReturn(response);
 
 		assertDoesNotThrow(() -> {
 			repository.unassignDisputes(now);
@@ -288,7 +289,7 @@ class DisputeServiceImplTest extends BaseTestSuite {
 		Date now = new Date();
 		String assignedBeforeTs = dateToString(now, DateUtil.DATE_TIME_FORMAT);
 
-		Mockito.when(violationTicketApi.v1UnassignViolationTicketPost(DisputeRepositoryImpl.EmptyBody, assignedBeforeTs)).thenThrow(ApiException.class);
+		Mockito.when(violationTicketApi.unassignViolationTicketPost(EmptyObject.instance, assignedBeforeTs)).thenThrow(ApiException.class);
 
 		assertThrows(ApiException.class, () -> {
 			repository.unassignDisputes(now);
@@ -302,7 +303,7 @@ class DisputeServiceImplTest extends BaseTestSuite {
 		ResponseResult response = new ResponseResult();
 		response.setStatus("0"); // 0 status (meaning failure) and no message
 
-		Mockito.when(violationTicketApi.v1UnassignViolationTicketPost(DisputeRepositoryImpl.EmptyBody, assignedBeforeTs)).thenReturn(response);
+		Mockito.when(violationTicketApi.unassignViolationTicketPost(EmptyObject.instance, assignedBeforeTs)).thenReturn(response);
 
 		assertThrows(InternalServerErrorException.class, () -> {
 			repository.unassignDisputes(now);
@@ -314,7 +315,7 @@ class DisputeServiceImplTest extends BaseTestSuite {
 		Date now = new Date();
 		String assignedBeforeTs = dateToString(now, DateUtil.DATE_TIME_FORMAT);
 
-		Mockito.when(violationTicketApi.v1UnassignViolationTicketPost(DisputeRepositoryImpl.EmptyBody, assignedBeforeTs)).thenReturn(null);
+		Mockito.when(violationTicketApi.unassignViolationTicketPost(EmptyObject.instance, assignedBeforeTs)).thenReturn(null);
 
 		assertThrows(InternalServerErrorException.class, () -> {
 			repository.unassignDisputes(now);
@@ -329,7 +330,7 @@ class DisputeServiceImplTest extends BaseTestSuite {
 		response.setStatus("0"); // 0 status (meaning failure)
 		response.setException("some failure cause");
 
-		Mockito.when(violationTicketApi.v1UnassignViolationTicketPost(DisputeRepositoryImpl.EmptyBody, assignedBeforeTs)).thenReturn(response);
+		Mockito.when(violationTicketApi.unassignViolationTicketPost(EmptyObject.instance, assignedBeforeTs)).thenReturn(response);
 
 		assertThrows(InternalServerErrorException.class, () -> {
 			repository.unassignDisputes(now);
@@ -360,7 +361,7 @@ class DisputeServiceImplTest extends BaseTestSuite {
 		ViolationTicketListResponse emptyResponse = new ViolationTicketListResponse();
 		emptyResponse.setViolationTickets(new ArrayList<ViolationTicket>());
 
-		Mockito.when(violationTicketApi.v1ViolationTicketListGet(null, null, ticketNumber, null, issuedDateStr)).thenReturn(validResponse);
+		Mockito.when(violationTicketApi.violationTicketListGet(null, null, ticketNumber, null, issuedDateStr)).thenReturn(validResponse);
 
 		List<DisputeResult> disputeResults = repository.findByTicketNumberAndTime(ticketNumber, issuedDate);
 		assertEquals(1, disputeResults.size());
@@ -376,7 +377,7 @@ class DisputeServiceImplTest extends BaseTestSuite {
 
 	@Test
 	public void testFindByTicketNumberAndTime500() throws Exception {
-		Mockito.when(violationTicketApi.v1ViolationTicketListGet(any(), any(), any(), any(), any())).thenThrow(ApiException.class);
+		Mockito.when(violationTicketApi.violationTicketListGet(any(), any(), any(), any(), any())).thenThrow(ApiException.class);
 
 		assertThrows(ApiException.class, () -> {
 			repository.findByTicketNumberAndTime("AX00000000", new Date());
@@ -393,7 +394,7 @@ class DisputeServiceImplTest extends BaseTestSuite {
 		List<ViolationTicket> violationTickets = new ArrayList<ViolationTicket>();
 		response.setViolationTickets(violationTickets);
 
-		Mockito.when(violationTicketApi.v1ViolationTicketListGet(olderThanDate, excludedStatus.toShortName(), null, noticeOfDisputeGuid, null)).thenReturn(response);
+		Mockito.when(violationTicketApi.violationTicketListGet(olderThanDate, excludedStatus.toShortName(), null, noticeOfDisputeGuid, null)).thenReturn(response);
 
 		assertDoesNotThrow(() -> {
 			repository.findByStatusNotAndCreatedTsBeforeAndNoticeOfDisputeGuid(excludedStatus, now, noticeOfDisputeGuid);
@@ -410,7 +411,7 @@ class DisputeServiceImplTest extends BaseTestSuite {
 		List<ViolationTicket> violationTickets = new ArrayList<ViolationTicket>();
 		response.setViolationTickets(violationTickets);
 
-		Mockito.when(violationTicketApi.v1ViolationTicketListGet(olderThanDate, excludedStatus.toShortName(), null, noticeOfDisputeGuid, null)).thenThrow(ApiException.class);
+		Mockito.when(violationTicketApi.violationTicketListGet(olderThanDate, excludedStatus.toShortName(), null, noticeOfDisputeGuid, null)).thenThrow(ApiException.class);
 
 		assertThrows(InternalServerErrorException.class, () -> {
 			repository.findByStatusNotAndCreatedTsBeforeAndNoticeOfDisputeGuid(excludedStatus, now, noticeOfDisputeGuid);


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- changes how we send empty object
- changes the operation names instead of using generated name (may have missed 1 or 2)
- changes to use OpenTelemetry agent instead of spring slueth

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [ ] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
