### PR TITLE
Disable cookies on all OpenShift routes

### DIFF
--- a/.gitops/charts/traffic-court-online/charts/citizen-web/templates/route.yaml
+++ b/.gitops/charts/traffic-court-online/charts/citizen-web/templates/route.yaml
@@ -7,6 +7,7 @@ metadata:
     {{- include "citizen-web.labels" . | nindent 4 }}
   annotations:
     haproxy.router.openshift.io/ip_whitelist: {{ .Values.route.allowedIPs }}
+    haproxy.router.openshift.io/disable_cookies: "true"
 spec:
   host: citizen-web-for-justice-proxy-{{ .Values.global.namespace }}.apps.silver.devops.gov.bc.ca
   to:

--- a/.gitops/charts/traffic-court-online/charts/staff-web/templates/route.yaml
+++ b/.gitops/charts/traffic-court-online/charts/staff-web/templates/route.yaml
@@ -7,6 +7,7 @@ metadata:
     {{- include "staff-web.labels" . | nindent 4 }}
   annotations:
     haproxy.router.openshift.io/ip_whitelist: {{ .Values.route.allowedIPs }}
+    haproxy.router.openshift.io/disable_cookies: "true"
 spec:
   host: staff-web-for-jag-proxy-{{ .Values.global.namespace }}.apps.silver.devops.gov.bc.ca
   to:

--- a/infrastructure/openshift/dev/oidc-route.yaml
+++ b/infrastructure/openshift/dev/oidc-route.yaml
@@ -13,6 +13,7 @@ metadata:
     openshift.io/host.generated: 'true'
     # restrict connections to the load balancer
     #haproxy.router.openshift.io/ip_whitelist: 142.34.45.132 142.36.41.0/24
+    haproxy.router.openshift.io/disable_cookies: "true"
 spec:
   to:
     kind: Service

--- a/infrastructure/openshift/dev/ords-proxy.yaml
+++ b/infrastructure/openshift/dev/ords-proxy.yaml
@@ -98,6 +98,7 @@ metadata:
     openshift.io/host.generated: 'true'
     # replace with developer's ip address list, see TCVP-1682
     # haproxy.router.openshift.io/ip_whitelist: 127.0.0.1 
+    haproxy.router.openshift.io/disable_cookies: "true"
 spec:
   to:
     kind: Service

--- a/infrastructure/openshift/prod/citizen-web-for-jag-proxy-route.yaml
+++ b/infrastructure/openshift/prod/citizen-web-for-jag-proxy-route.yaml
@@ -9,6 +9,7 @@ metadata:
     app.kubernetes.io/version: 1.16.0
   annotations:
     haproxy.router.openshift.io/ip_whitelist: 142.34.133.71 99.79.165.63
+    haproxy.router.openshift.io/disable_cookies: "true"
 spec:
   host: citizen-web-0198bb-prod.apps.silver.devops.gov.bc.ca
   to:

--- a/infrastructure/openshift/test/oidc-route.yaml
+++ b/infrastructure/openshift/test/oidc-route.yaml
@@ -13,6 +13,7 @@ metadata:
     openshift.io/host.generated: 'true'
     # restrict connections to the load balancer
     #haproxy.router.openshift.io/ip_whitelist: 142.34.45.132 142.36.41.0/24
+    haproxy.router.openshift.io/disable_cookies: "true"
 spec:
   to:
     kind: Service


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- disables cookies generated by OpenShift route (ingress) which are flagged in the App Scan.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [ ] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
