### PR TITLE
TCVP-2506 Enabled Citizen-API to be able to analyze VT2 ticket images

### DIFF
--- a/.docker/docker-compose-ocr.yml
+++ b/.docker/docker-compose-ocr.yml
@@ -9,7 +9,7 @@ services:
     environment:
       FORMRECOGNIZER__APIVERSION: ${FORMRECOGNIZER__APIVERSION:-2.1}
       FORMRECOGNIZER__ENDPOINT: ${FORMRECOGNIZER__ENDPOINT:-http://azure-cognitive-service-proxy:5200}
-      FORMRECOGNIZER__MODELID: ${FORMRECOGNIZER__MODELID:-75f5614c-eded-4413-a3d9-c67281e8402e}
+      FORMRECOGNIZER__MODELID: ${FORMRECOGNIZER__MODELID:-25ebebe0-af8c-470a-ab79-7ec155eec4a8}
       
   form-rec-nginx:
     build:

--- a/src/backend/TrafficCourts/Citizen.Service/Controllers/TicketsController.cs
+++ b/src/backend/TrafficCourts/Citizen.Service/Controllers/TicketsController.cs
@@ -65,7 +65,8 @@ namespace TrafficCourts.Citizen.Service.Controllers
         /// </summary>
         /// <param name="file">A PNG, JPEG, or PDF of a scanned Traffic Violation Ticket</param>
         /// <param name="cancellationToken">The cancellation token.</param>
-        /// <param name="validate">Optional. If true, will perform business validation on ocr results. Defaults to true.</param>
+        /// <param name="sanitize">If true, will perform basic cleanup on ocr results before validation. Defaults to true.</param>
+        /// <param name="validate">If true, will perform business validation on ocr results. Defaults to true.</param>
         /// <returns></returns>
         /// <response code="200">The file appears to be a valid Violation Ticket. JSON data is extracted.</response>
         /// <response code="400">The uploaded file is too large or the Violation Ticket does not appear to be valid. Either 
@@ -77,13 +78,15 @@ namespace TrafficCourts.Citizen.Service.Controllers
         [RequestSizeLimit(10485760)]
         public async Task<IActionResult> AnalyseAsync(
             [Required]
-            [PermittedFileContentType(new string[] { "image/png", "image/jpeg", "application/pdf" })] 
+            [PermittedFileContentType(new string[] { "image/png", "image/jpeg", "application/pdf", "application/octet-stream" })] 
             IFormFile file,
-            bool? validate,
-            CancellationToken cancellationToken)
+            CancellationToken cancellationToken,
+            bool sanitize = true,
+            bool validate = true)
         {
             AnalyseHandler.AnalyseRequest request = new(file);
-            request.Validate = validate ?? true; // default to true
+            request.Sanitize = sanitize;
+            request.Validate = validate;
             AnalyseHandler.AnalyseResponse response;
             try
             {

--- a/src/backend/TrafficCourts/Citizen.Service/Features/Tickets/AnalyseHandler.cs
+++ b/src/backend/TrafficCourts/Citizen.Service/Features/Tickets/AnalyseHandler.cs
@@ -16,6 +16,7 @@ public static class AnalyseHandler
         }
 
         public IFormFile Image { get; set; }
+        public bool Sanitize { get; set; }
         public bool Validate { get; set; }
     }
 
@@ -80,6 +81,11 @@ public static class AnalyseHandler
 
                 _logger.LogError(exception, "Exception thrown during analysis");
                 throw;
+            }
+
+            if (request.Sanitize) {
+                // Perform basic cleanup from a bad OCR scan.
+                _formRecognizerValidator.SanitizeViolationTicket(violationTicket);
             }
 
             if (request.Validate) {

--- a/src/backend/TrafficCourts/Citizen.Service/Services/IFormRecognizerService.cs
+++ b/src/backend/TrafficCourts/Citizen.Service/Services/IFormRecognizerService.cs
@@ -8,8 +8,8 @@ public interface IFormRecognizerService
     /// <summary>Analyses the specified image, extracting all text via OCR and mapping results to an OcrViolationTicket.</summary>
     public Task<OcrViolationTicket> AnalyzeImageAsync(MemoryStream stream, CancellationToken cancellationToken);
 
-    // A mapping list of fields extracted from Azure Form Recognizer and their equivalent JSON name
-    protected readonly static Dictionary<string, string> FieldLabels = new ()
+    // A mapping list of fields extracted from Azure Form Recognizer and their equivalent JSON name from the 2022-04 version of the Violation Ticket image
+    protected readonly static Dictionary<string, string> FieldLabels_2022_04 = new ()
     {
         { "Violation Ticket Label", OcrViolationTicket.ViolationTicketTitle },
         { "Violation Ticket Number", OcrViolationTicket.ViolationTicketNumber },
@@ -41,6 +41,46 @@ public interface IFormRecognizerService
         { "Count 2 Ticket Amount", OcrViolationTicket.Count2TicketAmount },
         { "Count 3 Description", OcrViolationTicket.Count3Description },
         { "Count 3 Act/Regs", OcrViolationTicket.Count3ActRegs },
+        { "Count 3 is ACT", OcrViolationTicket.Count3IsACT },
+        { "Count 3 is REGS", OcrViolationTicket.Count3IsREGS },
+        { "Count 3 Section", OcrViolationTicket.Count3Section },
+        { "Count 3 Ticket Amount", OcrViolationTicket.Count3TicketAmount },
+        { "Hearing Location", OcrViolationTicket.HearingLocation },
+        { "Detachment Location", OcrViolationTicket.DetachmentLocation },
+        { "Date of Service", OcrViolationTicket.DateOfService }
+    };
+    
+    // A mapping list of fields extracted from Azure Form Recognizer and their equivalent JSON name from the 2023-09 version of the Violation Ticket image
+    protected readonly static Dictionary<string, string> FieldLabels_2023_09 = new ()
+    {
+        { "Label Violation Ticket", OcrViolationTicket.ViolationTicketTitle },
+        { "Violation Ticket Number", OcrViolationTicket.ViolationTicketNumber },
+        { "Surname", OcrViolationTicket.Surname },
+        { "Given Name", OcrViolationTicket.GivenName },
+        { "Drivers Licence Province", OcrViolationTicket.DriverLicenceProvince },
+        { "Drivers Licence Number", OcrViolationTicket.DriverLicenceNumber },
+        { "Violation Date", OcrViolationTicket.ViolationDate },
+        { "Violation Time", OcrViolationTicket.ViolationTime },
+        { "Offence is MVA", OcrViolationTicket.OffenceIsMVA },
+        { "Offence is MVAR", OcrViolationTicket.OffenceIsMVAR },
+        { "Offence is CCLA", OcrViolationTicket.OffenceIsCCLA },
+        { "Offence is CTA", OcrViolationTicket.OffenceIsCTA },
+        { "Offence is LCLA", OcrViolationTicket.OffenceIsLCLA },
+        { "Offence is TCSR", OcrViolationTicket.OffenceIsTCSR },
+        { "Offence is WLA", OcrViolationTicket.OffenceIsWLA },
+        { "Offence is FVPA", OcrViolationTicket.OffenceIsFVPA },
+        { "Offence is Other", OcrViolationTicket.OffenceIsOther },
+        { "Count 1 Description", OcrViolationTicket.Count1Description },
+        { "Count 1 is ACT", OcrViolationTicket.Count1IsACT },
+        { "Count 1 is REGS", OcrViolationTicket.Count1IsREGS },
+        { "Count 1 Section", OcrViolationTicket.Count1Section },
+        { "Count 1 Ticket Amount", OcrViolationTicket.Count1TicketAmount },
+        { "Count 2 Description", OcrViolationTicket.Count2Description },
+        { "Count 2 is ACT", OcrViolationTicket.Count2IsACT },
+        { "Count 2 is REGS", OcrViolationTicket.Count2IsREGS },
+        { "Count 2 Section", OcrViolationTicket.Count2Section },
+        { "Count 2 Ticket Amount", OcrViolationTicket.Count2TicketAmount },
+        { "Count 3 Description", OcrViolationTicket.Count3Description },
         { "Count 3 is ACT", OcrViolationTicket.Count3IsACT },
         { "Count 3 is REGS", OcrViolationTicket.Count3IsREGS },
         { "Count 3 Section", OcrViolationTicket.Count3Section },

--- a/src/backend/TrafficCourts/Citizen.Service/Services/Impl/FormRecognizerService_2022_06_30_preview.cs
+++ b/src/backend/TrafficCourts/Citizen.Service/Services/Impl/FormRecognizerService_2022_06_30_preview.cs
@@ -83,7 +83,7 @@ public class FormRecognizerService_2022_06_30_preview : IFormRecognizerService
             violationTicket.GlobalConfidence = result.Documents[0]?.Confidence ?? 0f;
         }
 
-        foreach (var fieldLabel in IFormRecognizerService.FieldLabels)
+        foreach (var fieldLabel in IFormRecognizerService.FieldLabels_2022_04)
         {
             Field field = new();
             field.TagName = fieldLabel.Key;

--- a/src/backend/TrafficCourts/Citizen.Service/Validators/IFormRecognizerValidator.cs
+++ b/src/backend/TrafficCourts/Citizen.Service/Validators/IFormRecognizerValidator.cs
@@ -5,6 +5,14 @@ namespace TrafficCourts.Citizen.Service.Validators;
 public interface IFormRecognizerValidator
 {
     /// <summary>
+    /// Performs basic preprocessing to cleanup a bad OCR scan.
+    /// ie. knowing the Violation Ticket number starts with 2 characters, replaces A0 with AO, A1 with AI, etc.
+    /// </summary>
+    /// <param name="violationTicket"></param>
+    /// <returns></returns>
+    public void SanitizeViolationTicket(OcrViolationTicket violationTicket);
+
+    /// <summary>
     ///    Validates the Violation Ticket, updating the global and field-specific confidence scores and validation results.
     ///    ie. A valid handwritten Violation Ticket must have the title "Violation Ticket"
     ///    ie. A valid ticket number must have 2 characters (starting with A) followed by 8 digits

--- a/src/backend/TrafficCourts/Citizen.Service/Validators/Rules/LowConfidenceGlobalRule.cs
+++ b/src/backend/TrafficCourts/Citizen.Service/Validators/Rules/LowConfidenceGlobalRule.cs
@@ -18,13 +18,21 @@ public class LowConfidenceGlobalRule
         numOfLowConfFields += (violationTicket.Fields[DriverLicenceNumber].FieldConfidence < _minViableConfidence) ? 1 : 0;
         numOfLowConfFields += (violationTicket.Fields[DriverLicenceProvince].FieldConfidence < _minViableConfidence) ? 1 : 0;
         numOfLowConfFields += (violationTicket.Fields[Count1Description].FieldConfidence < _minViableConfidence) ? 1 : 0;
-        numOfLowConfFields += (violationTicket.Fields[Count1ActRegs].FieldConfidence < _minViableConfidence) ? 1 : 0;
+        if (ViolationTicketVersion.VT1.Equals(violationTicket.TicketVersion))
+        {
+            // The Act/Regs is only applicable for the old VT1 images
+            numOfLowConfFields += (violationTicket.Fields[Count1ActRegs].FieldConfidence < _minViableConfidence) ? 1 : 0;
+        }
         numOfLowConfFields += (violationTicket.Fields[Count1Section].FieldConfidence < _minViableConfidence) ? 1 : 0;
         numOfLowConfFields += (violationTicket.Fields[Count1TicketAmount].FieldConfidence < _minViableConfidence) ? 1 : 0;
         if (violationTicket.IsCount2Populated())
         {
             numOfLowConfFields += (violationTicket.Fields[Count2Description].FieldConfidence < _minViableConfidence) ? 1 : 0;
-            numOfLowConfFields += (violationTicket.Fields[Count2ActRegs].FieldConfidence < _minViableConfidence) ? 1 : 0;
+            if (ViolationTicketVersion.VT1.Equals(violationTicket.TicketVersion))
+            {
+                // The Act/Regs is only applicable for the old VT1 images
+                numOfLowConfFields += (violationTicket.Fields[Count2ActRegs].FieldConfidence < _minViableConfidence) ? 1 : 0;
+            }
             numOfLowConfFields += (violationTicket.Fields[Count2Section].FieldConfidence < _minViableConfidence) ? 1 : 0;
             numOfLowConfFields += (violationTicket.Fields[Count2TicketAmount].FieldConfidence < _minViableConfidence) ? 1 : 0;
             minViableThreshold += 2;
@@ -32,7 +40,11 @@ public class LowConfidenceGlobalRule
         if (violationTicket.IsCount3Populated())
         {
             numOfLowConfFields += (violationTicket.Fields[Count3Description].FieldConfidence < _minViableConfidence) ? 1 : 0;
-            numOfLowConfFields += (violationTicket.Fields[Count3ActRegs].FieldConfidence < _minViableConfidence) ? 1 : 0;
+            if (ViolationTicketVersion.VT1.Equals(violationTicket.TicketVersion))
+            {
+                // The Act/Regs is only applicable for the old VT1 images
+                numOfLowConfFields += (violationTicket.Fields[Count3ActRegs].FieldConfidence < _minViableConfidence) ? 1 : 0;
+            }
             numOfLowConfFields += (violationTicket.Fields[Count3Section].FieldConfidence < _minViableConfidence) ? 1 : 0;
             numOfLowConfFields += (violationTicket.Fields[Count3TicketAmount].FieldConfidence < _minViableConfidence) ? 1 : 0;
             minViableThreshold += 2;

--- a/src/backend/TrafficCourts/Common/Models/OcrViolationTicket.cs
+++ b/src/backend/TrafficCourts/Common/Models/OcrViolationTicket.cs
@@ -3,12 +3,36 @@ using System.Text.Json.Serialization;
 using System.Text.RegularExpressions;
 
 namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0;
+
+public enum ViolationTicketVersion {
+    /// <summary>
+    /// Violation Ticket that was originally used 2022-04
+    /// </summary>
+    VT1,
+
+    /// <summary>
+    /// Violation Ticket was was introduced in 2023-09. This new Violation Ticket form contains most of the same
+    /// fields as the VT1, though there are a few new fields and some have been removed.
+    /// </summary>
+    VT2
+}
+
 /// <summary>
 /// A model representation of the extracted OCR results.
 /// </summary>
 [ExcludeFromCodeCoverage]
 public class OcrViolationTicket
 {
+
+    /// <summary>
+    /// A Violation Ticket form that was in circulation around 2022.04
+    /// </summary>
+    public static readonly string ViolationTicketVersion1 = "Violation Ticket:Violation Ticket 2022.04";
+    
+    /// <summary>
+    /// A new Violation Ticket form that was in introduced in 2023.09
+    /// </summary>
+    public static readonly string ViolationTicketVersion2 = "Violation Ticket:Violation Ticket 2023.09";
 
     public static readonly string ViolationTicketTitle = "violationTicketTitle";
     public static readonly string ViolationTicketNumber = "ticket_number";
@@ -25,6 +49,11 @@ public class OcrViolationTicket
     public static readonly string OffenceIsFAA = "is_faa_offence";
     public static readonly string OffenceIsLCA = "is_lca_offence";
     public static readonly string OffenceIsTCR = "is_tcr_offence";
+    public static readonly string OffenceIsMVAR = "is_mvar_offence";
+    public static readonly string OffenceIsCCLA = "is_ccla_offence";
+    public static readonly string OffenceIsLCLA = "is_lcla_offence";
+    public static readonly string OffenceIsTCSR = "is_tcsr_offence";
+    public static readonly string OffenceIsFVPA = "is_fvpa_offence";
     public static readonly string OffenceIsOther = "is_other_offence";
     public static readonly string Count1Description = "counts.count_no_1.description";
     public static readonly string Count1ActRegs = "counts.count_no_1.act_or_regulation_name_code";
@@ -47,6 +76,11 @@ public class OcrViolationTicket
     public static readonly string HearingLocation = "court_location";
     public static readonly string DetachmentLocation = "detachment_location";
     public static readonly string DateOfService = "service_date";
+
+    /// <summary>
+    /// Gets of sets the version of this ViolationTicket
+    /// </summary>
+    public ViolationTicketVersion TicketVersion { get; set; }
 
     /// <summary>
     /// Gets or sets the saved image filename.

--- a/src/backend/TrafficCourts/Test/Citizen.Service/Controllers/TicketsControllerTests.cs
+++ b/src/backend/TrafficCourts/Test/Citizen.Service/Controllers/TicketsControllerTests.cs
@@ -29,7 +29,7 @@ public class TicketsControllerTests
             .ReturnsAsync(analyseResponse);
 
         // Act
-        var result = await ticketController.AnalyseAsync(mockImage.Object, false, CancellationToken.None);
+        var result = await ticketController.AnalyseAsync(mockImage.Object, CancellationToken.None, false, false);
 
         // Assert
         var okResult = Assert.IsType<OkObjectResult>(result);
@@ -53,7 +53,7 @@ public class TicketsControllerTests
             .ReturnsAsync(analyseResponse); // This response has a null (invalid) OcrViolationTicket
 
         // Act
-        var result = await ticketController.AnalyseAsync(mockImage.Object, false, CancellationToken.None);
+        var result = await ticketController.AnalyseAsync(mockImage.Object, CancellationToken.None, false, false);
 
         // Assert
         var objectResult = Assert.IsType<ObjectResult>(result);


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

TCVP-2506 - enabled Citizen-API to be able to analyze VT2 ticket images

- updated the default form recognizer modelID to be the new composite model.
- separated the logic of sanitizing analyzed results from validation for easier testability.
- split FieldLabels into their respective versions (2022_04 and 2023_09)
- some field validations are no longer applicable for the new VT2 model.
- improved sanitization of certain fields for better results

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Performed a docker-compose up and confirmed both VT1 and VT2 images can be scanned by citizen-portal:
New VT2 sample image:
![image](https://github.com/bcgov/jag-traffic-courts-online/assets/55215368/51dc73d9-f9e4-45f7-9b34-ee71ab1ae63d)

Results in Citizen Portal:
![image](https://github.com/bcgov/jag-traffic-courts-online/assets/55215368/4c264462-cc0a-4456-9522-175e0ad8eb33)



## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
