### PR TITLE
Fixed parsing of Checkboxes with the new Composite model

### DIFF
--- a/src/backend/TrafficCourts/Citizen.Service/Validators/ValidationMessages.cs
+++ b/src/backend/TrafficCourts/Citizen.Service/Validators/ValidationMessages.cs
@@ -8,7 +8,7 @@ public static class ValidationMessages
     public static readonly string DriversLicenceProvinceError = "Drivers Licence Province is not 'BC'. Could not validate Drivers Licence Number.";
     public static readonly string TicketTitleInvalid = @"Ticket title must be 'VIOLATION TICKET'.";
     public static readonly string TicketNumberInvalid = @"Violation ticket number must start with an A and be of the form 'AX00000000'.";
-    public static readonly string CheckboxInvalid = @"Checkbox '{0}' has an unknown value '{1}'. Expecting ':selected:' or ':unselected:'.";
+    public static readonly string CheckboxInvalid = @"Checkbox '{0}' has an unknown value '{1}'. Expecting 'selected' or 'unselected'.";
     public static readonly string CurrencyInvalid = @"Amount '{0}' is not a valid currency value.";
     public static readonly string MVAMustBeSelectedError = @"MVA must be selected under the 'Did commit the offence(s) indicated' section.";
     public static readonly string MVAMustBeCountValue = @"TCO only supports counts with MVA or MVR as the ACT/REG at this time. Read '{0}' for count {1}.";

--- a/src/backend/TrafficCourts/Common/Models/OcrViolationTicket.cs
+++ b/src/backend/TrafficCourts/Common/Models/OcrViolationTicket.cs
@@ -178,11 +178,11 @@ public class Field
     /// <summary>Returns true if the given field's value is "selected", false if "unselected", otherwise null (unknown) value.</summary> 
     public bool? IsCheckboxSelected()
     {
-        if (Value?.Equals(":selected:", StringComparison.OrdinalIgnoreCase) ?? false)
+        if (Value?.Equals("selected", StringComparison.OrdinalIgnoreCase) ?? false)
         {
             return true;
         }
-        if (Value?.Equals(":unselected:", StringComparison.OrdinalIgnoreCase) ?? false)
+        if (Value?.Equals("unselected", StringComparison.OrdinalIgnoreCase) ?? false)
         {
             return false;
         }

--- a/src/backend/TrafficCourts/Test/Citizen.Service/Validators/Rules/CheckboxIsValidRuleTest.cs
+++ b/src/backend/TrafficCourts/Test/Citizen.Service/Validators/Rules/CheckboxIsValidRuleTest.cs
@@ -41,8 +41,8 @@ public class CheckboxIsValidRuleTest
     {
         public TestData()
         {
-            Add(OcrViolationTicket.OffenceIsMVA, ":selected:", false);
-            Add(OcrViolationTicket.OffenceIsMVA, ":unselected:", false);
+            Add(OcrViolationTicket.OffenceIsMVA, "selected", false);
+            Add(OcrViolationTicket.OffenceIsMVA, "unselected", false);
             Add(OcrViolationTicket.OffenceIsMVA, "randomText", true);
             Add(OcrViolationTicket.OffenceIsMVA, null, true);
         }


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

The FormRecognizer outputs the strings "selected" and "unselected" for checkboxes.
Updated the parser and validator in Citizen API to properly recognize these hard-coded strings.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Updated tests
Deployed citizen-api to DEV to confirm parsing against FormRecognizer also running in DEV.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
