### PR TITLE
Fixed ports with docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -447,7 +447,7 @@ services:
     container_name: smtp-server
     image: gessnerfl/fake-smtp-server
     environment:
-      - "SERVER-PORT=8080"
+      - "SERVER_PORT=8080"
       - "SMTP_PORT=5025"
     ports:
       - "5125:8080"

--- a/src/frontend/staff-portal/package.json
+++ b/src/frontend/staff-portal/package.json
@@ -8,7 +8,7 @@
     "build-dev": "ng build --source-map=false",
     "build-prod": "ng build --configuration production --source-map=false",
     "api:clean": "npx del-cli \"src/app/api/**\" \"!src/app/api/templates\"",
-    "api:download": "npx download -o src/app/api http://localhost:5005/swagger/v1/swagger.json",
+    "api:download": "npx download -o src/app/api http://localhost:5090/swagger/v1/swagger.json",
     "api:generate": "npx openapi-generator-cli generate -i src/app/api/swagger.json -g typescript-angular -t src/app/api/templates --additional-properties=modelFileSuffix=.model -o src/app/api",
     "api:regenerate": "yarn run api:clean && yarn run api:download && yarn run api:generate",
     "api:r": "yarn run api:regenerate",


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

Due to the recent changing of ports in docker-compose, this PR addresses a couple of stragglers. 
- fake smtp-server wasn't actually working locally
- fixed the port to staff-api from staff-portal

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Fake email server is now accessible with `docker-compose up`.
`ng api:download` works again from the staff-portal application

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
