### PR TITLE
TCVP-2461 Enable NoApp conditionally on AppCd value.

### DIFF
--- a/src/frontend/staff-portal/src/app/components/jj-dispute-info/jj-dispute/jj-dispute.component.html
+++ b/src/frontend/staff-portal/src/app/components/jj-dispute-info/jj-dispute/jj-dispute.component.html
@@ -184,7 +184,7 @@
           <span class="section-grid-cell">
             <p class="section-grid-header">APP (P/N/A)</p>
             <p class="section-grid-text">
-              <mat-select *ngIf="!isViewOnly" formControlName="appCd" style="background:#fffee6">
+              <mat-select *ngIf="!isViewOnly" formControlName="appCd" style="background:#fffee6" (selectionChange)="onUpdateAPPCd()">
                 <mat-option [value]="RoPApp.P">{{ RoPApp.P }}</mat-option>
                 <mat-option [value]="RoPApp.N">{{ RoPApp.N }}</mat-option>
                 <mat-option [value]="RoPApp.A">{{ RoPApp.A }}</mat-option>
@@ -195,7 +195,7 @@
           <span class="section-grid-cell">
             <p class="section-grid-header">No APP</p>
             <p class="section-grid-text">{{ noAppTsFormattedDate
-              }}&nbsp;<button *ngIf="!isViewOnly" type="button" style="background:#fffee6"
+              }}&nbsp;<button *ngIf="!isViewOnly && isNoAppEnabled" type="button" style="background:#fffee6"
                 (click)="updateNoAPPTs()">Now</button></p>
           </span>
           <span class="section-grid-cell">

--- a/src/frontend/staff-portal/src/app/components/jj-dispute-info/jj-dispute/jj-dispute.component.ts
+++ b/src/frontend/staff-portal/src/app/components/jj-dispute-info/jj-dispute/jj-dispute.component.ts
@@ -70,6 +70,7 @@ export class JJDisputeComponent implements OnInit {
   jjDecisionDateFormattedDate: string;
   concludeStatusOnly: boolean = false;
   cancelStatusOnly: boolean = false;
+  isNoAppEnabled: boolean = true;
 
   constructor(
     private formBuilder: FormBuilder,
@@ -228,6 +229,19 @@ export class JJDisputeComponent implements OnInit {
       });
   }
 
+  onUpdateAPPCd() {
+    // TCVP-2461 If AppCd is P or A, disable No App field and set to blank.
+    if (JJDisputeCourtAppearanceRoPAppCd.P === this.courtAppearanceForm.value.appCd
+        || JJDisputeCourtAppearanceRoPAppCd.A === this.courtAppearanceForm.value.appCd) {
+      this.courtAppearanceForm.controls.noAppTs.setValue(null);
+      this.noAppTsFormattedDate = null;
+      this.isNoAppEnabled = false;
+    }
+    else {
+      this.isNoAppEnabled = true;
+    }
+  }
+
   updateNoAPPTs() {
     this.courtAppearanceForm.controls.noAppTs.setValue( this.datePipe.transform(new Date(), "yyyy-MM-dd") + "T" + this.datePipe.transform(new Date(), "HH:mm:ss") + "Z");
     this.noAppTsFormattedDate = this.datePipe.transform(new Date(), "MM/dd/yyyy HH:mm");
@@ -380,6 +394,9 @@ export class JJDisputeComponent implements OnInit {
         }
         this.determineIfConcludeOrCancel();
       }
+
+      // init No App field
+      this.onUpdateAPPCd();
     });
   }
 


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

TCVP-2461 bug fix.

The No App field should be conditionally disabled (and blank) if the AppCd is A or P, enabled otherwise.

![image](https://github.com/bcgov/jag-traffic-courts-online/assets/55215368/94ddaeb0-d5ab-441a-9a91-98787fe5a825)
![image](https://github.com/bcgov/jag-traffic-courts-online/assets/55215368/687dce2f-b5bf-4c88-a386-5f8aad680499)


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
