### PR TITLE
TCVP-2441 Added missing REJECTED status to timeline/status widget

### DIFF
--- a/src/frontend/citizen-portal/src/app/services/dispute.service.ts
+++ b/src/frontend/citizen-portal/src/app/services/dispute.service.ts
@@ -177,6 +177,7 @@ export enum StatusStepType {
   SCHEDULED = "Hearing Scheduled",
   CONFIRMED = "Decision Made",
   CANCELLED = "Cancelled",
+  REJECTED = "Rejected",
   CONCLUDED = "Concluded"
 }
 

--- a/src/frontend/citizen-portal/src/app/shared/dialogs/dispute-status-dialog/dispute-status-dialog.component.ts
+++ b/src/frontend/citizen-portal/src/app/shared/dialogs/dispute-status-dialog/dispute-status-dialog.component.ts
@@ -55,6 +55,11 @@ export class DisputeStatusDialogComponent {
           if (step.isCompleted) this.steps.push(step);
           break;
           }
+        case StatusStepType.REJECTED: {
+          step.isCompleted = this.checkRejected();
+          if (step.isCompleted) this.steps.push(step);
+          break;
+          }
         case StatusStepType.CONCLUDED: {
           step.isCompleted = this.checkConcluded();
           if (step.isCompleted) this.steps.push(step);
@@ -68,7 +73,7 @@ export class DisputeStatusDialogComponent {
   private checkProcessingCompleted(): boolean {
     if (this.checkScheduledCompleted()) return true;
     else {
-      let statuses: DisputeStatus[] = [DisputeStatus.Processing];
+      let statuses: DisputeStatus[] = [DisputeStatus.Processing, DisputeStatus.Rejected];
       if (statuses.indexOf(this.dispute?.dispute_status) > -1) {
         return true;
       } else return false;
@@ -92,7 +97,7 @@ export class DisputeStatusDialogComponent {
   }
 
   private checkConfirmedCompleted(): boolean {
-    if (this.dispute?.jjdispute_status === JJDisputeStatus.Confirmed) return true;
+    if (this.checkRejected() || this.dispute?.jjdispute_status === JJDisputeStatus.Confirmed) return true;
     else return false;
   }
 
@@ -100,6 +105,12 @@ export class DisputeStatusDialogComponent {
     if ([DisputeStatus.Cancelled].indexOf(this.dispute?.dispute_status) > -1 || [JJDisputeStatus.Cancelled].indexOf(this.dispute?.jjdispute_status) > -1) return true;
     else return false;
   }
+  
+  private checkRejected(): boolean {
+    if ([DisputeStatus.Rejected].indexOf(this.dispute?.dispute_status) > -1) return true;
+    else return false;
+  }
+
   private checkConcluded(): boolean {
     if ([JJDisputeStatus.Concluded].indexOf(this.dispute?.jjdispute_status) > -1) return true;
     else if ([DisputeStatus.Concluded].indexOf(this.dispute?.dispute_status) > -1) return true;


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

TCVP-2441 bug fix

When a staff rejects a dispute the status is set to REJECTED. This status was missing from the status/timeline widget on the Citizen Portal.

This is now what one sees on a REJECTED Dispute.
![image](https://github.com/bcgov/jag-traffic-courts-online/assets/55215368/e2c7a247-2eb5-4de4-88d2-25f5d6f00929)

ie. 
http://localhost:8080/dispute/manage?ticketNumber=AK43849384&time=19:34

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
