### PR TITLE
TCVP-2423 Skipped counts shouldn't show dispute reasons

### DIFF
--- a/src/frontend/citizen-portal/src/app/components/dispute-ticket-summary/count-item-dispute-summary/count-item-dispute-summary.component.html
+++ b/src/frontend/citizen-portal/src/app/components/dispute-ticket-summary/count-item-dispute-summary/count-item-dispute-summary.component.html
@@ -13,16 +13,16 @@
       <div *ngIf="disputeCount?.__skip || (disputeCount?.plea_cd === Plea.G && disputeCount?.request_reduction === RequestReduction.N && disputeCount?.request_time_to_pay === RequestTimeToPay.N && noticeOfDispute.request_court_appearance === RequestCourtAppearance.N)">
         No action at this time
       </div>
-      <div *ngIf="disputeCount?.request_reduction === RequestReduction.Y && disputeCount?.plea_cd === Plea.G && noticeOfDispute.request_court_appearance === RequestCourtAppearance.N">
+      <div *ngIf="!disputeCount?.__skip && disputeCount?.request_reduction === RequestReduction.Y && disputeCount?.plea_cd === Plea.G && noticeOfDispute.request_court_appearance === RequestCourtAppearance.N">
         Plead guilty and request a fine reduction with written reasons
       </div>
-      <div *ngIf="disputeCount?.request_time_to_pay === RequestTimeToPay.Y && disputeCount?.plea_cd === Plea.G && noticeOfDispute.request_court_appearance === RequestCourtAppearance.N">
+      <div *ngIf="!disputeCount?.__skip && disputeCount?.request_time_to_pay === RequestTimeToPay.Y && disputeCount?.plea_cd === Plea.G && noticeOfDispute.request_court_appearance === RequestCourtAppearance.N">
         Plead guilty and request time to pay with written reasons
       </div>
-      <div *ngIf="disputeCount?.plea_cd === Plea.N">
+      <div *ngIf="!disputeCount?.__skip && disputeCount?.plea_cd === Plea.N">
         Dispute the charge
       </div>
-      <div *ngIf="disputeCount?.plea_cd === Plea.G && noticeOfDispute.request_court_appearance === RequestCourtAppearance.Y">
+      <div *ngIf="!disputeCount?.__skip && disputeCount?.plea_cd === Plea.G && noticeOfDispute.request_court_appearance === RequestCourtAppearance.Y">
         Plead guilty and request a fine reduction and/or time to pay on this count in court
       </div>
     </strong>


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

TCVP-2423

For a multi-count ticket, if one chooses to skip a count, the dispute reason shouldn't appear.

Before this PR, the "Plead guilty and request..." phrase was showing on all 3 counts, even though counts 1 and 3 were skipped in this example. 
![image](https://github.com/bcgov/jag-traffic-courts-online/assets/55215368/0684c538-171f-4392-a2a3-a87a958d6ed0)


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
