### PR TITLE
TCVP-1847 Fix DCF File History showing wrong time

### DIFF
--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/model/AuditLogEntryType.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/model/AuditLogEntryType.java
@@ -44,6 +44,7 @@ public enum AuditLogEntryType {
 	JCNF,
 	JDIV,
 	JPRG,
+	OCNT,
 	RECN,
 	SCAN,
 	SPRC,

--- a/src/backend/oracle-data-api/src/main/resources/occm-openapi-spec.yaml
+++ b/src/backend/oracle-data-api/src/main/resources/occm-openapi-spec.yaml
@@ -792,13 +792,13 @@ components:
         entDtm:
           type: string
           format: date-time
-          x-field-extra-annotation: "@com.fasterxml.jackson.annotation.JsonFormat(pattern=\"yyyy-MM-dd'T'HH:mm:ss'Z'\")"
+          x-field-extra-annotation: "@com.fasterxml.jackson.annotation.JsonFormat(pattern=\"yyyy-MM-dd HH:mm:ss\", timezone = \"PST\")"
         entUserId:
           type: string
         updDtm:
           type: string
           format: date-time
-          x-field-extra-annotation: "@com.fasterxml.jackson.annotation.JsonFormat(pattern=\"yyyy-MM-dd'T'HH:mm:ss'Z'\")"
+          x-field-extra-annotation: "@com.fasterxml.jackson.annotation.JsonFormat(pattern=\"yyyy-MM-dd HH:mm:ss\", timezone = \"PST\")"
         updUserId:
           type: string
           format: nullable

--- a/src/backend/oracle-data-api/src/main/resources/tco-openapi-spec.yaml
+++ b/src/backend/oracle-data-api/src/main/resources/tco-openapi-spec.yaml
@@ -561,13 +561,13 @@ components:
         accEntDtm:
           type: string
           format: date-time
-          x-field-extra-annotation: "@com.fasterxml.jackson.annotation.JsonFormat(pattern=\"yyyy-MM-dd'T'HH:mm:ss'Z'\")"
+          x-field-extra-annotation: "@com.fasterxml.jackson.annotation.JsonFormat(pattern=\"yyyy-MM-dd HH:mm:ss\", timezone = \"PST\")"
         accEntUserId:
           type: string
         accUpdDtm:
           type: string
           format: date-time
-          x-field-extra-annotation: "@com.fasterxml.jackson.annotation.JsonFormat(pattern=\"yyyy-MM-dd'T'HH:mm:ss'Z'\")"
+          x-field-extra-annotation: "@com.fasterxml.jackson.annotation.JsonFormat(pattern=\"yyyy-MM-dd HH:mm:ss\", timezone = \"PST\")"
         accUpdUserId:
           type: string
         adjustedAmt:

--- a/src/backend/oracle-data-api/src/main/resources/tco-openapi-spec.yaml
+++ b/src/backend/oracle-data-api/src/main/resources/tco-openapi-spec.yaml
@@ -353,13 +353,13 @@ components:
         entDtm:
           type: string
           format: date-time
-          x-field-extra-annotation: "@com.fasterxml.jackson.annotation.JsonFormat(pattern=\"yyyy-MM-dd'T'HH:mm:ss'Z'\")"
+          x-field-extra-annotation: "@com.fasterxml.jackson.annotation.JsonFormat(pattern=\"yyyy-MM-dd HH:mm:ss\", timezone = \"PST\")"
         entUserId:
           type: string
         updDtm:
           type: string
           format: date-time
-          x-field-extra-annotation: "@com.fasterxml.jackson.annotation.JsonFormat(pattern=\"yyyy-MM-dd'T'HH:mm:ss'Z'\")"
+          x-field-extra-annotation: "@com.fasterxml.jackson.annotation.JsonFormat(pattern=\"yyyy-MM-dd HH:mm:ss\", timezone = \"PST\")"
         updUserId:
           type: string
           format: nullable


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- TCVP-1847
- Updated audit fields (createdTs and modifiedTs) returned date/time format to set it as PST since all audit fields are retuned from ORDS in database's system date/time zone which is in PST.
- When the createdTs and modifiedTs fields returned by the Oracle Data API, they are converted to proper UTC format automatically.
- Added missing audit log entry type enum.
- Note: this update should be coordinated with the Oracle database package updates in order not cause any data fetching issues.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Updated database packages in DEV and tested running oracle data api locally to make sure createdTS and modifiedTS fields from the pulled data returned in correct UTC time.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
