### PR TITLE
Bug fix for a single-count VT2 image

### DIFF
--- a/src/backend/TrafficCourts/Citizen.Service/Validators/FormRecognizerValidator.cs
+++ b/src/backend/TrafficCourts/Citizen.Service/Validators/FormRecognizerValidator.cs
@@ -155,10 +155,26 @@ public class FormRecognizerValidator : IFormRecognizerValidator
         // TCVP-1645 Use DateOfService if available, otherwise fallback to ViolationDate
         if (violationTicket.Fields.ContainsKey(OcrViolationTicket.ViolationDate))
         {
+            // Replace letters with likely digits
+            string violationDate = violationTicket.Fields[OcrViolationTicket.ViolationDate].Value ?? "";
+            violationDate = violationDate.Replace("O", "0");
+            violationDate = violationDate.Replace("o", "0");
+            violationDate = violationDate.Replace("l", "1");
+            violationDate = violationDate.Replace("f", "1");
+            violationTicket.Fields[OcrViolationTicket.ViolationDate].Value = violationDate;
+
             violationTicket.Fields[OcrViolationTicket.ViolationDate].Value = violationTicket.Fields[OcrViolationTicket.ViolationDate].GetDate()?.ToString("yyyy-MM-dd");
         }
         if (violationTicket.Fields.ContainsKey(OcrViolationTicket.DateOfService))
         {
+            // Replace letters with likely digits
+            string dateOfService = violationTicket.Fields[OcrViolationTicket.DateOfService].Value ?? "";
+            dateOfService = dateOfService.Replace("O", "0");
+            dateOfService = dateOfService.Replace("o", "0");
+            dateOfService = dateOfService.Replace("l", "1");
+            dateOfService = dateOfService.Replace("f", "1");
+            violationTicket.Fields[OcrViolationTicket.DateOfService].Value = dateOfService;
+
             if (violationTicket.Fields[OcrViolationTicket.DateOfService].IsPopulated()) // if date of service is present try putting it in good format
                 violationTicket.Fields[OcrViolationTicket.DateOfService].Value = violationTicket.Fields[OcrViolationTicket.DateOfService].GetDate()?.ToString("yyyy-MM-dd");
 
@@ -174,6 +190,10 @@ public class FormRecognizerValidator : IFormRecognizerValidator
 
             string violationTime = violationTicket.Fields[OcrViolationTicket.ViolationTime].Value ?? "";
             violationTime = violationTime.TrimEnd(new char[] { ':' });
+            violationTime = violationTime.Replace("O", "0");
+            violationTime = violationTime.Replace("o", "0");
+            violationTime = violationTime.Replace("l", "1");
+            violationTime = violationTime.Replace("f", "1");
             violationTicket.Fields[OcrViolationTicket.ViolationTime].Value = violationTime;
         }
 

--- a/src/backend/TrafficCourts/Common/Models/OcrViolationTicket.cs
+++ b/src/backend/TrafficCourts/Common/Models/OcrViolationTicket.cs
@@ -115,7 +115,7 @@ public class OcrViolationTicket
     public bool IsCount1Populated()
     {
         return Fields[Count1Description].IsPopulated()
-            || Fields[Count1ActRegs].IsPopulated()
+            || (ViolationTicketVersion.VT1 == TicketVersion && Fields[Count1ActRegs].IsPopulated())
             || Fields[Count1Section].IsPopulated()
             || Fields[Count1TicketAmount].IsPopulated();
     }
@@ -126,7 +126,7 @@ public class OcrViolationTicket
     public bool IsCount2Populated()
     {
         return Fields[Count2Description].IsPopulated()
-            || Fields[Count2ActRegs].IsPopulated()
+            || (ViolationTicketVersion.VT1 == TicketVersion && Fields[Count2ActRegs].IsPopulated())
             || Fields[Count2Section].IsPopulated()
             || Fields[Count2TicketAmount].IsPopulated();
     }
@@ -137,7 +137,7 @@ public class OcrViolationTicket
     public bool IsCount3Populated()
     {
         return Fields[Count3Description].IsPopulated()
-            || Fields[Count3ActRegs].IsPopulated()
+            || (ViolationTicketVersion.VT1 == TicketVersion && Fields[Count3ActRegs].IsPopulated())
             || Fields[Count3Section].IsPopulated()
             || Fields[Count3TicketAmount].IsPopulated();
     }

--- a/src/backend/TrafficCourts/Common/Models/OcrViolationTicket.cs
+++ b/src/backend/TrafficCourts/Common/Models/OcrViolationTicket.cs
@@ -145,8 +145,8 @@ public class OcrViolationTicket
 
 public class Field
 {
-    private static readonly string _dateRegex = @"^(\d{2}|\d{4})\D+(\d{1,2})\D+(\d{1,2})$";
-    private static readonly string _timeRegex = @"^(\d{1,2})\D*(\d{1,2})$";
+    private static readonly string _dateRegex = @"^\s*(\d{2}|\d{4})\D*(\d{1,2})\D*(\d{1,2})\s*$";
+    private static readonly string _timeRegex = @"^\s*(\d{1,2})\s*:?\s*(\d{1,2})\s*$";
     private static readonly string _currencyRegex = @"^\$?(\d{1,3}(\,\d{3})*|(\d+))(\.\d{2})?$";
 
     public Field() { }
@@ -244,6 +244,8 @@ public class Field
         {
             try
             {
+                Value = Regex.Replace(Value, @"\D", " "); // remove all non-digits
+
                 Regex rg = new(_timeRegex);
                 Match match = rg.Match(Value);
                 if (match.Groups.Count == 3 && Value.Length > 2) // 2 + index 0 (the Value itself)

--- a/src/backend/TrafficCourts/Test/Citizen.Service/Validators/Rules/TimeRuleTest.cs
+++ b/src/backend/TrafficCourts/Test/Citizen.Service/Validators/Rules/TimeRuleTest.cs
@@ -14,6 +14,8 @@ public class TimeRuleTest
     [InlineData("1:59", true, 1, 59)]
     [InlineData("11:05", true, 11, 5)]
     [InlineData("13:05", true, 13, 5)]
+    [InlineData("o3:59", true, 3, 59)]
+    [InlineData("10:f3", true, 10, 3)]
     [InlineData(null, false, 0, 0)]
     [InlineData("", false, 0, 0)]
     [InlineData("text", false, 0, 0)]


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

Small bug fix. VT2 images don't have count Act/Reg sections and so these fields are not available and should be exclude from application logic when dealing with VT2 images.

Currently, VT2 images throw an error if they only have 1 or 2 counts. This fixes that.

Also improved the Time santisation and parsing.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
