### PR TITLE
TCVP-2492 Saved recent search filters in session

### DIFF
--- a/src/frontend/staff-portal/src/app/components/jj-workbench/jj-dispute-digital-case-file/jj-dispute-digital-case-file.component.html
+++ b/src/frontend/staff-portal/src/app/components/jj-workbench/jj-dispute-digital-case-file/jj-dispute-digital-case-file.component.html
@@ -121,5 +121,10 @@
 
     <tr mat-header-row *matHeaderRowDef="displayedColumns; sticky: true"></tr>
     <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
+    <tr class="mat-row" *matNoDataRow>
+      <td class="mat-cell" [attr.colspan]="displayedColumns.length">
+        No results
+      </td>
+    </tr>
   </table>
 </div>

--- a/src/frontend/staff-portal/src/app/components/jj-workbench/jj-dispute-digital-case-file/jj-dispute-digital-case-file.component.scss
+++ b/src/frontend/staff-portal/src/app/components/jj-workbench/jj-dispute-digital-case-file/jj-dispute-digital-case-file.component.scss
@@ -14,6 +14,7 @@ th {
 
 .table-responsive {
   width: 100%;
+  min-height: 110px;
 }
 
 .reset-filters {

--- a/src/frontend/staff-portal/src/app/components/jj-workbench/jj-dispute-digital-case-file/jj-dispute-digital-case-file.component.ts
+++ b/src/frontend/staff-portal/src/app/components/jj-workbench/jj-dispute-digital-case-file/jj-dispute-digital-case-file.component.ts
@@ -54,6 +54,14 @@ export class JJDisputeDigitalCaseFileComponent implements OnInit, AfterViewInit 
       this.subscription = this.data$.subscribe(data => {
         this.dataSource.data = data;
         // this.dataSource.data = this.sampleData();
+ 
+        // load dataFilters (DCF tab) in session for page reload
+        let __dataFilter = sessionStorage.getItem("dataFilters-DCF");
+        if (__dataFilter) {
+          this.dataFilters = JSON.parse(__dataFilter);
+        }
+
+        this.onApplyFilter();
       });
     }
   }
@@ -62,12 +70,16 @@ export class JJDisputeDigitalCaseFileComponent implements OnInit, AfterViewInit 
     this.dataSource.sort = this.sort;
   }
 
-  backWorkbench(element) {
+  backWorkbench(element: JJDispute) {
     this.jjDisputeInfo.emit(element);
   }
 
   onApplyFilter() {
     this.dataSource.filter = JSON.stringify(this.dataFilters);
+    
+    // cache dataFilters (for DCF tab) in session for page reload
+    sessionStorage.setItem("dataFilters-DCF", this.dataSource.filter);
+
     this.tableHeight = this.calcTableHeight(350);
   }
 

--- a/src/frontend/staff-portal/src/app/components/staff-workbench/dispute-decision-inbox/dispute-decision-inbox.component.ts
+++ b/src/frontend/staff-portal/src/app/components/staff-workbench/dispute-decision-inbox/dispute-decision-inbox.component.ts
@@ -80,16 +80,33 @@ export class DisputeDecisionInboxComponent implements OnInit, AfterViewInit {
                     })
               };
             });
+          
+          // load dataFilters (Decision Validation tab) in session for page reload
+          let __dataFilter = sessionStorage.getItem("dataFilters-DV");
+          if (__dataFilter) {
+            this.dataFilters = JSON.parse(__dataFilter);
+          }
+          
           this.getAll();
         })
       }
     });
   }
 
-  onApplyFilter(filterName: string, value: string) {
-    const filterValue = value;
-    this.dataFilters[filterName] = filterValue;
+  ngAfterViewInit() {
+    this.dataSource.sort = this.sort;
+  }
+
+  onApplyFilter(filterName: string, value: string) {    
+    if (filterName) {
+      const filterValue = value;
+      this.dataFilters[filterName] = filterValue;
+    }
     this.dataSource.filter = JSON.stringify(this.dataFilters);
+    
+    // cache dataFilters (for Decision Validation tab) in session for page reload
+    sessionStorage.setItem("dataFilters-DV", this.dataSource.filter);
+
     this.tableHeight = this.calcTableHeight(352);
   }
 
@@ -136,10 +153,6 @@ export class DisputeDecisionInboxComponent implements OnInit, AfterViewInit {
     });
   }.bind(this);
 
-  ngAfterViewInit() {
-    this.dataSource.sort = this.sort;
-  }
-
   calcTableHeight(heightOther: number) {
     return Math.min(window.innerHeight - heightOther, (this.dataSource.filteredData.length + 1) * 60)
   }
@@ -161,6 +174,6 @@ export class DisputeDecisionInboxComponent implements OnInit, AfterViewInit {
       if (a.jjDecisionDate > b.jjDecisionDate) { return 1; } else { return -1; }
     });
 
-    this.tableHeight = this.calcTableHeight(325);
+    this.onApplyFilter(null, null);
   }
 }

--- a/src/frontend/staff-portal/src/app/components/staff-workbench/ticket-inbox/ticket-inbox.component.ts
+++ b/src/frontend/staff-portal/src/app/components/staff-workbench/ticket-inbox/ticket-inbox.component.ts
@@ -66,11 +66,21 @@ export class TicketInboxComponent implements OnInit, AfterViewInit {
     this.getAllDisputes();
   }
 
+  ngAfterViewInit() {
+    // load dataFilters (Ticket Validation tab) in session for page reload
+    let __dataFilter = sessionStorage.getItem("dataFilters-TV");
+    if (__dataFilter) {
+      this.dataFilters = JSON.parse(__dataFilter);
+    }
+    
+    this.dataSource.sort = this.tickTbSort;
+  }
+
   isNew(d: Dispute): boolean {
     return d.status == DisputeStatus.New && (d.emailAddressVerified === true || !d.emailAddress);
   }
 
-  calcTableHeight(heightOther) {
+  calcTableHeight(heightOther: number) {
     return Math.min(window.innerHeight - heightOther, (this.dataSource.filteredData.length + 1) * 80)
   }
 
@@ -95,9 +105,7 @@ export class TicketInboxComponent implements OnInit, AfterViewInit {
 
       // this section allows filtering by ticket number or partial ticket number by setting the filter predicate
       this.dataSource.filterPredicate = this.searchFilter;
-      this.onApplyFilter("status", null);
-
-      this.tableHeight = this.calcTableHeight(351);
+      this.onApplyFilter(null, null);
     });
   }
 
@@ -138,19 +146,21 @@ export class TicketInboxComponent implements OnInit, AfterViewInit {
     else return 0;
   }
 
-  ngAfterViewInit() {
-    this.dataSource.sort = this.tickTbSort;
-  }
-
   // called on keyup in filter field
   onApplyFilter(filterName: string, value: string) {
-    const filterValue = value;
-    this.dataFilters[filterName] = filterValue;
+    if (filterName) {
+      const filterValue = value;
+      this.dataFilters[filterName] = filterValue;
+    }
     this.dataSource.filter = JSON.stringify(this.dataFilters);
+    
+    // cache dataFilters (for Ticket Validation tab) in session for page reload
+    sessionStorage.setItem("dataFilters-TV", this.dataSource.filter);
+
     this.tableHeight = this.calcTableHeight(351);
   }
 
-  backWorkbench(element) {
+  backWorkbench(element: Dispute) {
     this.disputeInfo.emit(element);
   }
 }

--- a/src/frontend/staff-portal/src/app/components/staff-workbench/update-request-inbox/update-request-inbox.component.ts
+++ b/src/frontend/staff-portal/src/app/components/staff-workbench/update-request-inbox/update-request-inbox.component.ts
@@ -65,6 +65,16 @@ export class UpdateRequestInboxComponent implements OnInit, AfterViewInit {
     this.getAllDisputesWithPendingUpdates();
   }
 
+  ngAfterViewInit() {
+    // load dataFilters (Update Request tab) in session for page reload
+    let __dataFilter = sessionStorage.getItem("dataFilters-UR");
+    if (__dataFilter) {
+      this.dataFilters = JSON.parse(__dataFilter);
+    }
+
+    this.dataSource.sort = this.tickTbSort;
+  }
+
   getAllDisputesWithPendingUpdates(): void {
     this.logger.log('UpdateRequestInboxComponent::getAllDisputesWithPendingUpdates');
 
@@ -83,13 +93,8 @@ export class UpdateRequestInboxComponent implements OnInit, AfterViewInit {
 
       // this section allows filtering by ticket number or partial ticket number by setting the filter predicate
       this.dataSource.filterPredicate = this.searchFilter;
-
-      this.tableHeight = this.calcTableHeight(352);
+      this.onApplyFilter(null, null);
     });
-  }
-
-  ngAfterViewInit() {
-    this.dataSource.sort = this.tickTbSort;
   }
 
   searchFilter = function (record: DisputeWithUpdates, filter: string) {
@@ -108,9 +113,15 @@ export class UpdateRequestInboxComponent implements OnInit, AfterViewInit {
   };
 
   onApplyFilter(filterName: string, value: string) {
-    const filterValue = value;
-    this.dataFilters[filterName] = filterValue;
+    if (filterName) {
+      const filterValue = value;
+      this.dataFilters[filterName] = filterValue;
+    }
     this.dataSource.filter = JSON.stringify(this.dataFilters);
+    
+    // cache dataFilters (for Update Request tab) in session for page reload
+    sessionStorage.setItem("dataFilters-UR", this.dataSource.filter);
+
     this.tableHeight = this.calcTableHeight(352);
   }
 


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

TCVP-2492 Saved recent Staff Workbench search filters (of all 4 tabs) in session so as the user browsers into records and back to the search screens, the filters persist.

![image](https://github.com/bcgov/jag-traffic-courts-online/assets/55215368/84042843-b49b-430b-81fa-d8cc6c6e3e43)

Per requirements, displayed "No results" on DCF tab when no results.

![image](https://github.com/bcgov/jag-traffic-courts-online/assets/55215368/c06008d5-aeec-4858-af1f-5d873205d66c)


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
