### PR TITLE
TCVP-2542 Add Locking Functionality for JJ Disputes

### DIFF
--- a/src/backend/TrafficCourts/Common/Models/JJDispute.cs
+++ b/src/backend/TrafficCourts/Common/Models/JJDispute.cs
@@ -12,4 +12,19 @@ public partial class JJDispute
     /// List of file metadata that contain ID and Filename of all the uploaded documents related to this particular JJDispute
     /// </summary>
     public List<FileMetadata>? FileData { get; set; }
+
+    /// <summary>
+    /// ID of the read/write Lock acquired by the user
+    /// </summary>
+    public string? LockId { get; set; }
+
+    /// <summary>
+    /// Username of the user who acquired read/write lock on the dispute
+    /// </summary>
+    public string? LockedBy { get; set; }
+
+    /// <summary>
+    /// The time in UTC when the acquired dispute user lock expires.
+    /// </summary>
+    public DateTimeOffset? LockExpiresAtUtc { get; set; }
 }

--- a/src/backend/TrafficCourts/Staff.Service/Controllers/DisputeLockController.cs
+++ b/src/backend/TrafficCourts/Staff.Service/Controllers/DisputeLockController.cs
@@ -1,0 +1,134 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using System.Net;
+using TrafficCourts.Staff.Service.Models;
+using TrafficCourts.Staff.Service.Services;
+
+namespace TrafficCourts.Staff.Service.Controllers;
+
+public class DisputeLockController : StaffControllerBase<DisputeLockController>
+{
+    private readonly IDisputeLockService _disputeLockService;
+    
+    /// <summary>
+    /// Defafult constructor for DisputeLockController
+    /// </summary>
+    /// <param name="disputeLockService"></param>
+    /// <param name="logger"></param>
+    public DisputeLockController(IDisputeLockService disputeLockService, ILogger<DisputeLockController> logger) : base(logger)
+    {
+        _disputeLockService = disputeLockService;
+    }
+
+    /// <summary>
+    /// Acquires a lock for a JJ Dispute.
+    /// </summary>
+    /// <param name="ticketNumber"></param>
+    /// <param name="username"></param>
+    /// <returns></returns>
+    [HttpGet]
+    [ProducesResponseType(typeof(Lock), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status409Conflict)]
+    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+    public Task<ActionResult<Lock>> GetLock(string ticketNumber, string username)
+    {
+        try
+        {
+            var result = _disputeLockService.GetLock(ticketNumber, username);
+            return Task.FromResult<ActionResult<Lock>>(Ok(result));
+        }
+        catch (LockIsInUseException e)
+        {
+            _logger.LogInformation(e, "JJ Dispute has already been locked by another user");
+            ProblemDetails problemDetails = new();
+            problemDetails.Status = (int)HttpStatusCode.Conflict;
+            problemDetails.Title = e.Source + ": Error Locking JJ Dispute";
+            problemDetails.Instance = HttpContext?.Request?.Path;
+            string? innerExceptionMessage = e.InnerException?.Message;
+            string? lockedBy = e.Username;
+            problemDetails.Extensions.Add("lockedBy", lockedBy ?? string.Empty);
+            if (innerExceptionMessage is not null)
+            {
+                problemDetails.Extensions.Add("errors", new string[] { e.Message, innerExceptionMessage });
+            }
+            else
+            {
+                problemDetails.Extensions.Add("errors", new string[] { e.Message });
+            }
+            var result = new ObjectResult(problemDetails);
+            return Task.FromResult<ActionResult<Lock>>(result);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to get lock for ticket: {ticketNumber}", ticketNumber);
+            return Task.FromResult<ActionResult<Lock>>(StatusCode((int)HttpStatusCode.InternalServerError));
+        }
+    }
+
+    /// <summary>
+    /// Refreshes the expiry time of a lock.
+    /// </summary>
+    /// <param name="lockId"></param>
+    /// <returns></returns>
+    [HttpPut("{lockId}")]
+    [ProducesResponseType(typeof(DateTimeOffset), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status409Conflict)]
+    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+    public Task<ActionResult<Lock>> RefreshLock(string lockId)
+    {
+        try
+        {
+            var result = _disputeLockService.RefreshLock(lockId, User.Identity!.Name!);
+            if (result is null) return Task.FromResult<ActionResult<Lock>>(NotFound());
+            return Task.FromResult<ActionResult<Lock>>(Ok(result));
+        }
+        catch (LockIsInUseException e)
+        {
+            _logger.LogInformation(e, "Failed to refresh lock {lockId}", lockId);
+            ProblemDetails problemDetails = new();
+            problemDetails.Status = (int)HttpStatusCode.Conflict;
+            problemDetails.Title = e.Source + ": Error Refreshing Lock";
+            problemDetails.Instance = HttpContext?.Request?.Path;
+            string? innerExceptionMessage = e.InnerException?.Message;
+            string? lockedBy = e.Username;
+            problemDetails.Extensions.Add("lockedBy", lockedBy ?? string.Empty);
+            if (innerExceptionMessage is not null)
+            {
+                problemDetails.Extensions.Add("errors", new string[] { e.Message, innerExceptionMessage });
+            }
+            else
+            {
+                problemDetails.Extensions.Add("errors", new string[] { e.Message });
+            }
+            var result = new ObjectResult(problemDetails);
+            return Task.FromResult<ActionResult<Lock>>(result);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to refresh lock {lockId}", lockId);
+            return Task.FromResult<ActionResult<Lock>>(StatusCode((int)HttpStatusCode.InternalServerError));
+        }
+    }
+
+    /// <summary>
+    /// Releases a lock.
+    /// </summary>
+    /// <param name="lockId"></param>
+    /// <returns></returns>
+    [HttpDelete("{lockId}")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+    public Task<ActionResult> ReleaseLock(string lockId)
+    {
+        try
+        {
+            _disputeLockService.ReleaseLock(lockId);
+            return Task.FromResult<ActionResult>(Ok());
+        }
+        catch (Exception ex)
+        {
+            _logger.LogInformation(ex, "Failed to release lock {lockId}", lockId);
+            return Task.FromResult<ActionResult>(NotFound());
+        }
+    }
+}

--- a/src/backend/TrafficCourts/Staff.Service/Models/Lock.cs
+++ b/src/backend/TrafficCourts/Staff.Service/Models/Lock.cs
@@ -1,0 +1,44 @@
+﻿namespace TrafficCourts.Staff.Service.Models;
+
+public class Lock
+{
+    /// <summary>
+    /// The function that returns the current UTC date and time. Overriden for tests.
+    /// </summary>
+    private readonly Func<DateTimeOffset> _utcNow;
+
+    public Lock() : this(() => DateTimeOffset.UtcNow)
+    {
+    }
+
+    internal Lock(Func<DateTimeOffset> utcNow)
+    {
+        _utcNow = utcNow ?? throw new ArgumentNullException(nameof(utcNow));
+        CreatedAtUtc = _utcNow();
+    }
+
+    /// <summary>
+    /// Lock ID
+    /// </summary>
+    public string? LockId { get; set; }
+
+    /// <summary>
+    /// JJ Dispute ID
+    /// </summary>
+    public long DisputeId { get; set; }
+
+    /// <summary>
+    /// Username of the person who acquired the lock.
+    /// </summary>
+    public string Username { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The time in UTC when the acquired lock expires.
+    /// </summary>
+    public DateTimeOffset ExpiryTimeUtc { get; set; }
+
+    /// <summary>
+    /// The time in UTC when the lock was created.
+    /// </summary>
+    public DateTimeOffset CreatedAtUtc { get; }
+}

--- a/src/backend/TrafficCourts/Staff.Service/Models/Lock.cs
+++ b/src/backend/TrafficCourts/Staff.Service/Models/Lock.cs
@@ -23,9 +23,9 @@ public class Lock
     public string? LockId { get; set; }
 
     /// <summary>
-    /// JJ Dispute ID
+    /// The ticket number associated with the dispute.
     /// </summary>
-    public long DisputeId { get; set; }
+    public string TicketNumber { get; set; } = string.Empty;
 
     /// <summary>
     /// Username of the person who acquired the lock.

--- a/src/backend/TrafficCourts/Staff.Service/Services/DisputeLockService.cs
+++ b/src/backend/TrafficCourts/Staff.Service/Services/DisputeLockService.cs
@@ -1,4 +1,5 @@
-﻿using TrafficCourts.Staff.Service.Models;
+﻿using System.Collections;
+using TrafficCourts.Staff.Service.Models;
 using static System.Runtime.InteropServices.JavaScript.JSType;
 
 namespace TrafficCourts.Staff.Service.Services;
@@ -63,10 +64,20 @@ public class DisputeLockService : IDisputeLockService
         {
             var toRemove = _database.Where(x => x.Value.LockId == lockId).ToList();
 
+            if (toRemove.Count == 0) throw new KeyNotFoundException($"Lock with id {lockId} not found");
+
             foreach (var item in toRemove)
             {
                 _database.Remove(item.Key);
             }
+        }
+    }
+
+    internal IEnumerable GetLocks()
+    {
+        lock (_database)
+        {
+            return _database.Values;
         }
     }
 }

--- a/src/backend/TrafficCourts/Staff.Service/Services/DisputeLockService.cs
+++ b/src/backend/TrafficCourts/Staff.Service/Services/DisputeLockService.cs
@@ -1,0 +1,50 @@
+﻿using TrafficCourts.Staff.Service.Models;
+using static System.Runtime.InteropServices.JavaScript.JSType;
+
+namespace TrafficCourts.Staff.Service.Services;
+
+public class DisputeLockService : IDisputeLockService
+{
+    private static readonly Dictionary<long, Lock> _database;
+
+    public Lock? GetLock(long disputeId, string username)
+    {
+        lock (_database)
+        {
+            if (_database.TryGetValue(disputeId, out Lock? value)) throw new LockIsInUseException(value.Username);
+
+            Lock disputeLock = new()
+            {
+                LockId = Guid.NewGuid().ToString("n"),
+                DisputeId = disputeId,
+                Username = username,
+                ExpiryTimeUtc = DateTime.UtcNow.AddSeconds(5 * 60) // 5 minutes
+            };
+
+            _database[disputeId] = disputeLock;
+
+            return disputeLock;
+        }
+    }
+
+    public DateTimeOffset? RefreshLock(Guid lockId, string username)
+    {
+        throw new NotImplementedException();
+    }
+
+    public void ReleaseLock(Guid lockId)
+    {
+        throw new NotImplementedException();
+    }
+}
+
+[Serializable]
+public class LockIsInUseException : Exception
+{
+    public LockIsInUseException(string username) : base($"Failed to acquire the lock. The following user has the lock for the given dispute: {username}")
+    {
+        Username = username;
+    }
+
+    public string Username { get; init; }
+}

--- a/src/backend/TrafficCourts/Staff.Service/Services/IDisputeLockService.cs
+++ b/src/backend/TrafficCourts/Staff.Service/Services/IDisputeLockService.cs
@@ -8,10 +8,10 @@ public interface IDisputeLockService
     /// <summary>
     /// Inserts a lock record for a JJDispute based on the given disputeId and username.
     /// </summary>
-    /// <param name="disputeId"></param>
+    /// <param name="ticketNumber"></param>
     /// <param name="username"></param>
     /// <returns>The saved lock.</returns>
-    Lock? GetLock(long disputeId, string username);
+    Lock? GetLock(string ticketNumber, string username);
 
     /// <summary>
     /// Refreshes an existing lock's expiry time by extending it.
@@ -19,12 +19,12 @@ public interface IDisputeLockService
     /// <param name="lockId"></param>
     /// <param name="username"></param>
     /// <returns>Refreshed lock expiry time</returns>
-    DateTimeOffset? RefreshLock(Guid lockId, string username);
+    DateTimeOffset? RefreshLock(string lockId, string username);
 
     /// <summary>
     /// Removes an existing lock from the database.
     /// </summary>
     /// <param name="lockId"></param>
-    void ReleaseLock(Guid lockId);
+    void ReleaseLock(string lockId);
 
 }

--- a/src/backend/TrafficCourts/Staff.Service/Services/IDisputeLockService.cs
+++ b/src/backend/TrafficCourts/Staff.Service/Services/IDisputeLockService.cs
@@ -1,0 +1,30 @@
+﻿using TrafficCourts.Common.OpenAPIs.KeycloakAdminApi.v18_0;
+using TrafficCourts.Staff.Service.Models;
+
+namespace TrafficCourts.Staff.Service.Services;
+
+public interface IDisputeLockService
+{
+    /// <summary>
+    /// Inserts a lock record for a JJDispute based on the given disputeId and username.
+    /// </summary>
+    /// <param name="disputeId"></param>
+    /// <param name="username"></param>
+    /// <returns>The saved lock.</returns>
+    Lock? GetLock(long disputeId, string username);
+
+    /// <summary>
+    /// Refreshes an existing lock's expiry time by extending it.
+    /// </summary>
+    /// <param name="lockId"></param>
+    /// <param name="username"></param>
+    /// <returns>Refreshed lock expiry time</returns>
+    DateTimeOffset? RefreshLock(Guid lockId, string username);
+
+    /// <summary>
+    /// Removes an existing lock from the database.
+    /// </summary>
+    /// <param name="lockId"></param>
+    void ReleaseLock(Guid lockId);
+
+}

--- a/src/backend/TrafficCourts/Staff.Service/Startup.cs
+++ b/src/backend/TrafficCourts/Staff.Service/Startup.cs
@@ -62,6 +62,7 @@ public static class Startup
         builder.Services.AddTransient<IEmailHistoryService, EmailHistoryService>();
         builder.Services.AddTransient<IJJDisputeService, JJDisputeService>();
         builder.Services.AddTransient<IStaffDocumentService, StaffDocumentService>();
+        builder.Services.AddTransient<IDisputeLockService, DisputeLockService>();
 
         // staff service should not be creating emails, should send messages for workflow
         builder.Services.AddEmailTemplates();

--- a/src/backend/TrafficCourts/TrafficCourts.Staff.Service.Test/Controllers/DisputeLockControllerTest.cs
+++ b/src/backend/TrafficCourts/TrafficCourts.Staff.Service.Test/Controllers/DisputeLockControllerTest.cs
@@ -1,0 +1,143 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Moq;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Text;
+using System.Threading.Tasks;
+using TrafficCourts.Staff.Service.Controllers;
+using TrafficCourts.Staff.Service.Models;
+using TrafficCourts.Staff.Service.Services;
+using Xunit;
+
+namespace TrafficCourts.Staff.Service.Test.Controllers;
+
+public class DisputeLockControllerTest
+{
+    [Fact]
+    public async void GetLockReturns200OkWhenLockAcquiredSuccessfully()
+    {
+        // Arrange
+        var mockService = new Mock<IDisputeLockService>();
+        var mockLogger = new Mock<ILogger<DisputeLockController>>();
+        mockService.Setup(x => x.GetLock(It.IsAny<string>(), It.IsAny<string>())).Returns(new Lock());
+        var controller = new DisputeLockController(mockService.Object, mockLogger.Object);
+
+        // Act
+        var result = await controller.GetLock("ticketNumber", "username");
+
+        // Assert
+        Assert.IsType<ActionResult<Lock>>(result);
+        var objectResult = Assert.IsType<OkObjectResult>(result.Result);
+        Assert.Equal((int)HttpStatusCode.OK, objectResult.StatusCode);
+    }
+
+    [Fact]
+    public async void GetLockReturns409ConflictWhenLockIsInUse()
+    {
+        // Arrange
+        var mockService = new Mock<IDisputeLockService>();
+        var mockLogger = new Mock<ILogger<DisputeLockController>>();
+        mockService.Setup(x => x.GetLock(It.IsAny<string>(), It.IsAny<string>())).Throws(new LockIsInUseException("username", new Lock()));
+        var controller = new DisputeLockController(mockService.Object, mockLogger.Object);
+
+        // Act
+        var result = await controller.GetLock("ticketNumber", "username");
+
+        // Assert
+        var objectResult = Assert.IsType<ObjectResult>(result.Result);
+        var problemDetails = Assert.IsType<ProblemDetails>(objectResult.Value);
+        Assert.Equal((int)HttpStatusCode.Conflict, problemDetails.Status);
+        string lockedBy = Assert.IsType<string>(problemDetails.Extensions["lockedBy"]);
+        Assert.True(lockedBy == "username");
+    }
+
+    [Fact]
+    public async void GetLockReturns500InternalServerErrorWhenExceptionThrown()
+    {
+        // Arrange
+        var mockService = new Mock<IDisputeLockService>();
+        var mockLogger = new Mock<ILogger<DisputeLockController>>();
+        mockService.Setup(x => x.GetLock(It.IsAny<string>(), It.IsAny<string>())).Throws(new Exception());
+        var controller = new DisputeLockController(mockService.Object, mockLogger.Object);
+
+        // Act
+        var result = await controller.GetLock("ticketNumber", "username");
+
+        // Assert
+        var errorResult = Assert.IsType<Common.Errors.HttpError>(result.Result);
+        Assert.Equal((int)HttpStatusCode.InternalServerError, errorResult.StatusCode);
+    }
+
+    [Fact]
+    public async void RefreshLockReturns200OkWhenLockRefreshedSuccessfully()
+    {
+        // Arrange
+        var mockService = new Mock<IDisputeLockService>();
+        var mockLogger = new Mock<ILogger<DisputeLockController>>();
+        mockService.Setup(x => x.RefreshLock(It.IsAny<string>(), It.IsAny<string>())).Returns(DateTimeOffset.UtcNow);
+        var controller = new DisputeLockController(mockService.Object, mockLogger.Object);
+
+        // Act
+        var result = await controller.RefreshLock("lockId");
+
+        // Assert
+        Assert.IsType<ActionResult<DateTimeOffset>>(result);
+        var objectResult = Assert.IsType<OkObjectResult>(result.Result);
+        Assert.Equal((int)HttpStatusCode.OK, objectResult.StatusCode);
+    }
+
+    [Fact]
+    public async void RefreshLockReturns500InternalServerErrorWhenExceptionThrown()
+    {
+        // Arrange
+        var mockService = new Mock<IDisputeLockService>();
+        var mockLogger = new Mock<ILogger<DisputeLockController>>();
+        mockService.Setup(x => x.RefreshLock(It.IsAny<string>(), It.IsAny<string>())).Throws(new Exception());
+        var controller = new DisputeLockController(mockService.Object, mockLogger.Object);
+
+        // Act
+        var result = await controller.RefreshLock("lockId");
+
+        // Assert
+        var errorResult = Assert.IsType<Common.Errors.HttpError>(result.Result);
+        Assert.Equal((int)HttpStatusCode.InternalServerError, errorResult.StatusCode);
+    }
+
+    [Fact]
+    public async void ReleaseLockReturns200OkWhenLockReleasedSuccessfully()
+    {
+        // Arrange
+        var mockService = new Mock<IDisputeLockService>();
+        var mockLogger = new Mock<ILogger<DisputeLockController>>();
+        var controller = new DisputeLockController(mockService.Object, mockLogger.Object);
+
+        // Act
+        var result = await controller.ReleaseLock("lockId");
+
+        // Assert
+        Assert.IsAssignableFrom<ActionResult>(result);
+        var okResult = Assert.IsType<OkResult>(result);
+        Assert.Equal((int)HttpStatusCode.OK, okResult.StatusCode);
+    }
+
+    [Fact]
+    public async void ReleaseLockReturns500InternalServerErrorWhenExceptionThrown()
+    {
+        // Arrange
+        var mockService = new Mock<IDisputeLockService>();
+        var mockLogger = new Mock<ILogger<DisputeLockController>>();
+        mockService.Setup(x => x.ReleaseLock(It.IsAny<string>())).Throws(new Exception());
+        var controller = new DisputeLockController(mockService.Object, mockLogger.Object);
+
+        // Act
+        var result = await controller.ReleaseLock("lockId");
+
+        // Assert
+        var errorResult = Assert.IsType<Common.Errors.HttpError>(result);
+        Assert.Equal((int)HttpStatusCode.InternalServerError, errorResult.StatusCode);
+    }
+
+}

--- a/src/backend/TrafficCourts/TrafficCourts.Staff.Service.Test/Controllers/JJControllerTest.cs
+++ b/src/backend/TrafficCourts/TrafficCourts.Staff.Service.Test/Controllers/JJControllerTest.cs
@@ -2,9 +2,7 @@
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using Moq;
-using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Net;
 using System.Security.Claims;
 using System.Threading;
@@ -35,7 +33,8 @@ public class JJControllerTest
             .Setup(_ => _.AcceptJJDisputeAsync(ticketNumber, It.IsAny<bool>(), It.IsAny<ClaimsPrincipal>(), It.IsAny<CancellationToken>()));
         var mockLogger = new Mock<ILogger<JJController>>();
         var printService = Mock.Of<IPrintDigitalCaseFileService>();
-        JJController jjDisputeController = new(jjDisputeService.Object, printService, mockLogger.Object);
+        var lockService = Mock.Of<IDisputeLockService>();
+        JJController jjDisputeController = new(jjDisputeService.Object, printService, lockService, mockLogger.Object);
 
         
         // Act
@@ -60,7 +59,8 @@ public class JJControllerTest
             .Setup(_ => _.AssignJJDisputesToJJ(ticketnumbers, "Bruce Wayne", It.IsAny<ClaimsPrincipal>(), It.IsAny<CancellationToken>()));
         var mockLogger = new Mock<ILogger<JJController>>();
         var printService = Mock.Of<IPrintDigitalCaseFileService>();
-        JJController jjDisputeController = new(jjDisputeService.Object, printService, mockLogger.Object);
+        var lockService = Mock.Of<IDisputeLockService>();
+        JJController jjDisputeController = new(jjDisputeService.Object, printService, lockService, mockLogger.Object);
 
         // Act
         IActionResult? result = await jjDisputeController.AssignJJDisputesToJJ(ticketnumbers, "Bruce Wayne", CancellationToken.None);
@@ -84,7 +84,8 @@ public class JJControllerTest
             .Throws(new ApiException("msg", StatusCodes.Status400BadRequest, "rsp", null, null));
         var mockLogger = new Mock<ILogger<JJController>>();
         var printService = Mock.Of<IPrintDigitalCaseFileService>();
-        JJController jjDisputeController = new(jjDisputeService.Object, printService, mockLogger.Object);
+        var lockService = Mock.Of<IDisputeLockService>();
+        JJController jjDisputeController = new(jjDisputeService.Object, printService, lockService, mockLogger.Object);
 
         // Act
         IActionResult? result = await jjDisputeController.AssignJJDisputesToJJ(null!, "Bruce Wayne", CancellationToken.None);
@@ -110,7 +111,8 @@ public class JJControllerTest
             .Throws(new ApiException("msg", StatusCodes.Status404NotFound, "rsp", null, null));
         var mockLogger = new Mock<ILogger<JJController>>();
         var printService = Mock.Of<IPrintDigitalCaseFileService>();
-        JJController jjDisputeController = new(jjDisputeService.Object, printService, mockLogger.Object);
+        var lockService = Mock.Of<IDisputeLockService>();
+        JJController jjDisputeController = new(jjDisputeService.Object, printService, lockService, mockLogger.Object);
 
         // Act
         IActionResult? result = await jjDisputeController.AssignJJDisputesToJJ(ticketnumbers, "Bruce Wayne", CancellationToken.None);
@@ -134,7 +136,8 @@ public class JJControllerTest
             .Setup(_ => _.RequireCourtHearingJJDisputeAsync(ticketnumber, null!, It.IsAny<ClaimsPrincipal>(), It.IsAny<CancellationToken>()));
         var mockLogger = new Mock<ILogger<JJController>>();
         var printService = Mock.Of<IPrintDigitalCaseFileService>();
-        JJController jjDisputeController = new(jjDisputeService.Object, printService, mockLogger.Object);
+        var lockService = Mock.Of<IDisputeLockService>();
+        JJController jjDisputeController = new(jjDisputeService.Object, printService, lockService, mockLogger.Object);
 
         // Act
         IActionResult? result = await jjDisputeController.UpdateCourtAppearanceAndRequireCourtHearingJJDisputeAsync(ticketnumber, CancellationToken.None);
@@ -158,7 +161,8 @@ public class JJControllerTest
             .Throws(new ApiException("msg", StatusCodes.Status400BadRequest, "rsp", null, null));
         var mockLogger = new Mock<ILogger<JJController>>();
         var printService = Mock.Of<IPrintDigitalCaseFileService>();
-        JJController jjDisputeController = new(jjDisputeService.Object, printService, mockLogger.Object);
+        var lockService = Mock.Of<IDisputeLockService>();
+        JJController jjDisputeController = new(jjDisputeService.Object, printService, lockService, mockLogger.Object);
 
         // Act
         IActionResult? result = await jjDisputeController.UpdateCourtAppearanceAndRequireCourtHearingJJDisputeAsync(ticketnumber, CancellationToken.None);
@@ -183,7 +187,8 @@ public class JJControllerTest
             .Throws(new ApiException("msg", StatusCodes.Status404NotFound, "rsp", null, null));
         var mockLogger = new Mock<ILogger<JJController>>();
         var printService = Mock.Of<IPrintDigitalCaseFileService>();
-        JJController jjDisputeController = new(jjDisputeService.Object, printService, mockLogger.Object);
+        var lockService = Mock.Of<IDisputeLockService>();
+        JJController jjDisputeController = new(jjDisputeService.Object, printService, lockService, mockLogger.Object);
 
         // Act
         IActionResult? result = await jjDisputeController.UpdateCourtAppearanceAndRequireCourtHearingJJDisputeAsync(ticketnumber, CancellationToken.None);
@@ -208,7 +213,8 @@ public class JJControllerTest
             .Throws(new ApiException("msg", StatusCodes.Status405MethodNotAllowed, "rsp", null, null));
         var mockLogger = new Mock<ILogger<JJController>>();
         var printService = Mock.Of<IPrintDigitalCaseFileService>();
-        JJController jjDisputeController = new(jjDisputeService.Object, printService, mockLogger.Object);
+        var lockService = Mock.Of<IDisputeLockService>();
+        JJController jjDisputeController = new(jjDisputeService.Object, printService, lockService, mockLogger.Object);
 
         // Act
         IActionResult? result = await jjDisputeController.UpdateCourtAppearanceAndRequireCourtHearingJJDisputeAsync(ticketnumber, CancellationToken.None);
@@ -232,7 +238,8 @@ public class JJControllerTest
             .Setup(_ => _.ConfirmJJDisputeAsync(ticketnumber, It.IsAny<ClaimsPrincipal>(), It.IsAny<CancellationToken>()));
         var mockLogger = new Mock<ILogger<JJController>>();
         var printService = Mock.Of<IPrintDigitalCaseFileService>();
-        JJController jjDisputeController = new(jjDisputeService.Object, printService, mockLogger.Object);
+        var lockService = Mock.Of<IDisputeLockService>();
+        JJController jjDisputeController = new(jjDisputeService.Object, printService, lockService, mockLogger.Object);
 
         // Act
         IActionResult? result = await jjDisputeController.UpdateCourtAppearanceAndConfirmJJDisputeAsync(ticketnumber, CancellationToken.None);
@@ -256,7 +263,8 @@ public class JJControllerTest
             .Throws(new ApiException("msg", StatusCodes.Status400BadRequest, "rsp", null, null));
         var mockLogger = new Mock<ILogger<JJController>>();
         var printService = Mock.Of<IPrintDigitalCaseFileService>();
-        JJController jjDisputeController = new(jjDisputeService.Object, printService, mockLogger.Object);
+        var lockService = Mock.Of<IDisputeLockService>();
+        JJController jjDisputeController = new(jjDisputeService.Object, printService, lockService, mockLogger.Object);
 
         // Act
         IActionResult? result = await jjDisputeController.UpdateCourtAppearanceAndConfirmJJDisputeAsync(ticketnumber, CancellationToken.None);
@@ -281,7 +289,8 @@ public class JJControllerTest
             .Throws(new ApiException("msg", StatusCodes.Status404NotFound, "rsp", null, null));
         var mockLogger = new Mock<ILogger<JJController>>();
         var printService = Mock.Of<IPrintDigitalCaseFileService>();
-        JJController jjDisputeController = new(jjDisputeService.Object, printService, mockLogger.Object);
+        var lockService = Mock.Of<IDisputeLockService>();
+        JJController jjDisputeController = new(jjDisputeService.Object, printService, lockService, mockLogger.Object);
 
         // Act
         IActionResult? result = await jjDisputeController.UpdateCourtAppearanceAndConfirmJJDisputeAsync(ticketnumber, CancellationToken.None);
@@ -306,7 +315,8 @@ public class JJControllerTest
             .Throws(new ApiException("msg", StatusCodes.Status405MethodNotAllowed, "rsp", null, null));
         var mockLogger = new Mock<ILogger<JJController>>();
         var printService = Mock.Of<IPrintDigitalCaseFileService>();
-        JJController jjDisputeController = new(jjDisputeService.Object, printService, mockLogger.Object);
+        var lockService = Mock.Of<IDisputeLockService>();
+        JJController jjDisputeController = new(jjDisputeService.Object, printService, lockService, mockLogger.Object);
 
         // Act
         IActionResult? result = await jjDisputeController.UpdateCourtAppearanceAndConfirmJJDisputeAsync(ticketnumber, CancellationToken.None);
@@ -330,7 +340,8 @@ public class JJControllerTest
             .ReturnsAsync(dispute);
         var mockLogger = new Mock<ILogger<JJController>>();
         var printService = Mock.Of<IPrintDigitalCaseFileService>();
-        JJController jjDisputeController = new(jjDisputeService.Object, printService, mockLogger.Object);
+        var lockService = Mock.Of<IDisputeLockService>();
+        JJController jjDisputeController = new(jjDisputeService.Object, printService, lockService, mockLogger.Object);
 
         // Act
         IActionResult? result = await jjDisputeController.GetJJDisputeAsync(1, ticketnumber, false, CancellationToken.None);
@@ -354,7 +365,8 @@ public class JJControllerTest
             .Throws(new ApiException("msg", StatusCodes.Status400BadRequest, "rsp", null, null));
         var mockLogger = new Mock<ILogger<JJController>>();
         var printService = Mock.Of<IPrintDigitalCaseFileService>();
-        JJController jjDisputeController = new(jjDisputeService.Object, printService, mockLogger.Object);
+        var lockService = Mock.Of<IDisputeLockService>();
+        JJController jjDisputeController = new(jjDisputeService.Object, printService, lockService, mockLogger.Object);
 
         // Act
         IActionResult? result = await jjDisputeController.GetJJDisputeAsync(1, ticketnumber, false, CancellationToken.None);
@@ -378,7 +390,8 @@ public class JJControllerTest
             .Throws(new ApiException("msg", StatusCodes.Status404NotFound, "rsp", null, null));
         var mockLogger = new Mock<ILogger<JJController>>();
         var printService = Mock.Of<IPrintDigitalCaseFileService>();
-        JJController jjDisputeController = new(jjDisputeService.Object, printService, mockLogger.Object);
+        var lockService = Mock.Of<IDisputeLockService>();
+        JJController jjDisputeController = new(jjDisputeService.Object, printService, lockService, mockLogger.Object);
 
         // Act
         IActionResult? result = await jjDisputeController.GetJJDisputeAsync(1, ticketnumber, false, CancellationToken.None);
@@ -408,7 +421,8 @@ public class JJControllerTest
             .ReturnsAsync(justinDocument);
         var mockLogger = new Mock<ILogger<JJController>>();
         var printService = Mock.Of<IPrintDigitalCaseFileService>();
-        JJController jjDisputeController = new(jjDisputeService.Object, printService, mockLogger.Object);
+        var lockService = Mock.Of<IDisputeLockService>();
+        JJController jjDisputeController = new(jjDisputeService.Object, printService, lockService, mockLogger.Object);
 
         // Act
         IActionResult? result = await jjDisputeController.GetJustinDocument(ticketnumber, documentType, CancellationToken.None);
@@ -434,7 +448,8 @@ public class JJControllerTest
             .Throws(new ApiException("msg", StatusCodes.Status404NotFound, "rsp", null, null));
         var mockLogger = new Mock<ILogger<JJController>>();
         var printService = Mock.Of<IPrintDigitalCaseFileService>();
-        JJController jjDisputeController = new(jjDisputeService.Object, printService, mockLogger.Object);
+        var lockService = Mock.Of<IDisputeLockService>();
+        JJController jjDisputeController = new(jjDisputeService.Object, printService, lockService, mockLogger.Object);
 
         // Act
         IActionResult? result = await jjDisputeController.GetJustinDocument(ticketnumber, documentType, CancellationToken.None);
@@ -458,7 +473,8 @@ public class JJControllerTest
             .Throws(new ApiException("msg", StatusCodes.Status409Conflict, "rsp", null, null));
         var mockLogger = new Mock<ILogger<JJController>>();
         var printService = Mock.Of<IPrintDigitalCaseFileService>();
-        JJController jjDisputeController = new(jjDisputeService.Object, printService, mockLogger.Object);
+        var lockService = Mock.Of<IDisputeLockService>();
+        JJController jjDisputeController = new(jjDisputeService.Object, printService, lockService, mockLogger.Object);
 
         // Act
         IActionResult? result = await jjDisputeController.GetJJDisputeAsync(1, ticketnumber, true, CancellationToken.None);
@@ -486,7 +502,8 @@ public class JJControllerTest
             .Throws(new ObjectManagementServiceException(It.IsAny<string>()));
         var mockLogger = new Mock<ILogger<JJController>>();
         var printService = Mock.Of<IPrintDigitalCaseFileService>();
-        JJController jjDisputeController = new(jjDisputeService.Object, printService, mockLogger.Object);
+        var lockService = Mock.Of<IDisputeLockService>();
+        JJController jjDisputeController = new(jjDisputeService.Object, printService, lockService, mockLogger.Object);
 
         // Act
         IActionResult? result = await jjDisputeController.GetJJDisputeAsync(1, ticketnumber, true, CancellationToken.None);

--- a/src/backend/TrafficCourts/TrafficCourts.Staff.Service.Test/Services/DisputeLockServiceTest.cs
+++ b/src/backend/TrafficCourts/TrafficCourts.Staff.Service.Test/Services/DisputeLockServiceTest.cs
@@ -1,0 +1,113 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using TrafficCourts.Staff.Service.Services;
+using Xunit;
+
+namespace TrafficCourts.Staff.Service.Test.Services;
+
+public class DisputeLockServiceTest
+{
+    [Fact]
+    public void GetLockTest()
+    {
+        // Arrange
+        var disputeLockService = new DisputeLockService();
+
+        // Act
+        var result = disputeLockService.GetLock("ticketNumber", "username");
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal("ticketNumber", result.TicketNumber);
+        Assert.Equal("username", result.Username);
+        Assert.True(DateTime.UtcNow < result.ExpiryTimeUtc);
+    }
+
+    [Fact]
+    public void GetLockTest_LockIsInUseException()
+    {
+        // Arrange
+        var disputeLockService = new DisputeLockService();
+        var result = disputeLockService.GetLock("ticketNumber", "username");
+
+        // Act
+        var exception = Assert.Throws<LockIsInUseException>(() => disputeLockService.GetLock("ticketNumber", "anotherUsername"));
+
+        // Assert
+        Assert.Equal("username", exception.Username);
+        Assert.Equal(result, exception.Lock);
+    }
+
+    [Fact]
+    public void RefreshLockTest()
+    {
+        // Arrange
+        var disputeLockService = new DisputeLockService();
+        var result = disputeLockService.GetLock("ticketNumber", "username");
+
+        // Act
+        var refreshResult = disputeLockService.RefreshLock(result!.LockId!, "username");
+
+        // Assert
+        Assert.NotNull(refreshResult);
+        Assert.True(DateTime.UtcNow < refreshResult);
+    }
+
+    [Fact]
+    public void RefreshLockTest_LockIsInUseException()
+    {
+        // Arrange
+        var disputeLockService = new DisputeLockService();
+        var result = disputeLockService.GetLock("ticketNumber", "username");
+
+        // Act
+        var exception = Assert.Throws<LockIsInUseException>(() => disputeLockService.RefreshLock(result!.LockId!, "anotherUsername"));
+
+        // Assert
+        Assert.Equal("username", exception.Username);
+        Assert.Equal(result, exception.Lock);
+    }
+
+    [Fact]
+    public void RefreshLockTest_LockNotFound()
+    {
+        // Arrange
+        var disputeLockService = new DisputeLockService();
+
+        // Act
+        var result = disputeLockService.RefreshLock("lockId", "username");
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void ReleaseLockTest()
+    {
+        // Arrange
+        var disputeLockService = new DisputeLockService();
+        var result = disputeLockService.GetLock("ticketNumber", "username");
+
+        // Act
+        disputeLockService.ReleaseLock(result!.LockId!);
+
+        // Assert
+        Assert.Empty(disputeLockService.GetLocks());
+    }
+
+    [Fact]
+    public void ReleaseLockTest_LockNotFound()
+    {
+        // Arrange
+        var disputeLockService = new DisputeLockService();
+
+        // Act
+        var exception = Assert.Throws<KeyNotFoundException>(() => disputeLockService.ReleaseLock("lockId"));
+
+        // Assert
+        Assert.Equal("Lock with id lockId not found", exception.Message);
+    }
+}


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- TCVP-2542
- Add a in memory Dictionary based locking functionality in Staff API for the JJ Dispute records to prevent more than one JJs from editing the same DCF at the same time.
- Allows the logged in user to acquire write lock for a JJ dispute on a get request by adding a Lock model that can be added to a dictionary through the new DisputeLockService.
- Added functionality to refresh the expire time of a lock and release a lock. 
- Added DisputeLockController for triggering lock operations. 
- Updated JJController PUT endpoints to apply lock in order to prevent more than one users to call the endpoints at the same to edit a particular JJ Dispute.
- Added XUnit tests for Dispute Lock Service and Dispute Lock Controller as well as fixed the existing JJController tests.

![disputeLock](https://github.com/bcgov/jag-traffic-courts-online/assets/98848668/6631ab8f-99ba-47fd-95f8-bf1d4c0b3aed)


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Ran the Staff API locally and tested the lock operations through the new Lock and JJDispute endpoints on Swagger UI.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
