### PR TITLE
TCVP-2559 VT1 are no longer supported by OCR

### DIFF
--- a/src/backend/TrafficCourts/Citizen.Service/Validators/FormRecognizerValidator.cs
+++ b/src/backend/TrafficCourts/Citizen.Service/Validators/FormRecognizerValidator.cs
@@ -213,11 +213,13 @@ public class FormRecognizerValidator : IFormRecognizerValidator
     private static async void ApplyGlobalRules(OcrViolationTicket violationTicket)
     {
         // TCVP-933 A ticket is considered valid iff
+        // - TCVP-2559 Ticket Version must not be VT1 (superceded by VT2 and is no longer supported)
         // - Ticket title reads 'VIOLATION TICKET' at top
         // - Ticket number must start with 'A', another alphabetic character, and then 8 digits
         // - Count ACT/REGs must be MVA or MVR as text - all 3 counts must be MVA/R at this time.
         // - If the Date of Service is less than 30 days for handwritten tickets
         List<ValidationRule> rules = new();
+        rules.Add(new VersionVT1DisallowedRule(new Field(), violationTicket));
         rules.Add(new FieldMatchesRegexRule(violationTicket.Fields[OcrViolationTicket.ViolationTicketTitle], _ticketTitleRegex, ValidationMessages.TicketTitleInvalid));
         rules.Add(new FieldMatchesRegexRule(violationTicket.Fields[OcrViolationTicket.ViolationTicketNumber], _violationTicketNumberRegex, ValidationMessages.TicketNumberInvalid));
         if (ViolationTicketVersion.VT1.Equals(violationTicket.TicketVersion)) {

--- a/src/backend/TrafficCourts/Citizen.Service/Validators/Rules/VersionVT1DisallowedRule.cs
+++ b/src/backend/TrafficCourts/Citizen.Service/Validators/Rules/VersionVT1DisallowedRule.cs
@@ -1,0 +1,26 @@
+using TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0;
+
+namespace TrafficCourts.Citizen.Service.Validators.Rules;
+
+/// <summary>
+/// Violation Tickets that were originally used 2022-04 (aka VT1) are no longer supported.
+/// @see TCVP-2559
+/// </summary>
+public class VersionVT1DisallowedRule : ValidationRule {
+
+    private readonly OcrViolationTicket _violationTicket;
+
+    public VersionVT1DisallowedRule(Field field, OcrViolationTicket violationTicket) : base(field)
+    {
+        this._violationTicket = violationTicket;
+    }
+
+    public override Task RunAsync()
+    {
+        if (ViolationTicketVersion.VT1 == _violationTicket.TicketVersion) {
+            _violationTicket.GlobalValidationErrors.Add(ValidationMessages.TicketVersionInvalid);
+        }
+
+        return Task.CompletedTask;
+    }
+}

--- a/src/backend/TrafficCourts/Citizen.Service/Validators/ValidationMessages.cs
+++ b/src/backend/TrafficCourts/Citizen.Service/Validators/ValidationMessages.cs
@@ -7,6 +7,7 @@ public static class ValidationMessages
     public static readonly string DriversLicenceNumberError = "Drivers Licence Number is not 7 digits.";
     public static readonly string DriversLicenceProvinceError = "Drivers Licence Province is not 'BC'. Could not validate Drivers Licence Number.";
     public static readonly string TicketTitleInvalid = @"Ticket title must be 'VIOLATION TICKET'.";
+    public static readonly string TicketVersionInvalid = @"Form recognizer has identified this ticket as having an old format (VT1) which is no longer accepted.";
     public static readonly string TicketNumberInvalid = @"Violation ticket number must start with an A and be of the form 'AX00000000'.";
     public static readonly string CheckboxInvalid = @"Checkbox '{0}' has an unknown value '{1}'. Expecting 'selected' or 'unselected'.";
     public static readonly string CurrencyInvalid = @"Amount '{0}' is not a valid currency value.";

--- a/src/backend/TrafficCourts/Common/Models/OcrViolationTicket.cs
+++ b/src/backend/TrafficCourts/Common/Models/OcrViolationTicket.cs
@@ -36,6 +36,7 @@ public class OcrViolationTicket
 
     public static readonly string ViolationTicketTitle = "violationTicketTitle";
     public static readonly string ViolationTicketNumber = "ticket_number";
+    public static readonly string Version = "ticket_version";
     public static readonly string Surname = "disputant_surname";
     public static readonly string GivenName = "disputant_given_names";
     public static readonly string DriverLicenceProvince = "drivers_licence_province";

--- a/src/backend/TrafficCourts/Test/Citizen.Service/Validators/Rules/VersionVT1DisallowedRuleTest.cs
+++ b/src/backend/TrafficCourts/Test/Citizen.Service/Validators/Rules/VersionVT1DisallowedRuleTest.cs
@@ -1,0 +1,32 @@
+using MassTransit.SagaStateMachine;
+using System.Threading.Tasks;
+using TrafficCourts.Citizen.Service.Validators;
+using TrafficCourts.Citizen.Service.Validators.Rules;
+using TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0;
+using Xunit;
+
+namespace TrafficCourts.Test.Citizen.Service.Validators.Rules;
+
+public class VersionVT1DisallowedRuleTest
+{
+
+    [Theory]
+    [InlineData(ViolationTicketVersion.VT1, true)]
+    [InlineData(ViolationTicketVersion.VT2, false)]
+    public async Task TestViolationTicketVersion(ViolationTicketVersion version, bool expectError)
+    {
+        // Given
+        OcrViolationTicket violationTicket = new()
+        {
+            TicketVersion = version
+        };
+        VersionVT1DisallowedRule rule = new(new Field(), violationTicket);
+
+        // When
+        await rule.RunAsync();
+
+        // Then
+        Assert.True(violationTicket.GlobalValidationErrors.Count == (expectError ? 1 : 0));
+    }
+
+}


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

TCVP-2559 Violation Ticket images that were originally used 2022-04 (aka VT1) are no longer supported.
- Added new global validation rule
- Added XUnit tests

In the Citizen API when attempting to analyze a VT1 ticket, the API now returns:
![image](https://github.com/bcgov/jag-traffic-courts-online/assets/55215368/0662de4e-12f6-416e-80ae-0544f746e1fb)


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
