### PR TITLE
TCVP-2559 VT1 tickets are no longer supported

### DIFF
--- a/src/frontend/citizen-portal/src/app/services/violation-ticket.service.ts
+++ b/src/frontend/citizen-portal/src/app/services/violation-ticket.service.ts
@@ -372,7 +372,12 @@ export class ViolationTicketService {
         }
         this.logger.error("ViolationTicketService:onError critical validation error has occurred", errorMessages);
         this.openErrorScenarioOneDialog();
-      } else if (this.isErrorMatch(err, "more than 30 days ago.", false)) {  // more than 30 days old
+      }
+      else if (this.isErrorMatch(err, "Form recognizer has identified this ticket as having an old format (VT1) which is no longer accepted.")) {
+        this.logger.error("ViolationTicketService:onError validation error has occurred", "VT1 no longer supported");
+        this.openErrorScenarioThreeDialog();
+      }
+      else if (this.isErrorMatch(err, "more than 30 days ago.", false)) {  // more than 30 days old
         this.logger.error("ViolationTicketService:onError validation error has occurred", "More than 30 days old");
         this.openErrorScenarioTwoDialog();
       }
@@ -411,6 +416,10 @@ export class ViolationTicketService {
 
   private openErrorScenarioTwoDialog() {
     return this.openImageTicketNotFoundDialog("Your ticket is over 30 days old", "error2");
+  }
+
+  private openErrorScenarioThreeDialog() {
+    return this.openImageTicketNotFoundDialog("The system has identified your ticket as an old format that is no longer supported.", "error3");
   }
 
   private openErrorScenarioFourDialog() {


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

TCVP-2559
When a VT1 image is uploaded as a new dispute, VT1 tickets now error out with the below error message (TBD by BA).

![image](https://github.com/bcgov/jag-traffic-courts-online/assets/55215368/9fd29197-be57-480f-b62d-666220c535fc)


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
