### PR TITLE
OCR tweak to improve Violation Date parsing

### DIFF
--- a/src/backend/TrafficCourts/Citizen.Service/Validators/FormRecognizerValidator.cs
+++ b/src/backend/TrafficCourts/Citizen.Service/Validators/FormRecognizerValidator.cs
@@ -162,7 +162,6 @@ public class FormRecognizerValidator : IFormRecognizerValidator
             violationDate = violationDate.Replace("l", "1");
             violationDate = violationDate.Replace("f", "1");
             violationTicket.Fields[OcrViolationTicket.ViolationDate].Value = violationDate;
-
             violationTicket.Fields[OcrViolationTicket.ViolationDate].Value = violationTicket.Fields[OcrViolationTicket.ViolationDate].GetDate()?.ToString("yyyy-MM-dd");
         }
         if (violationTicket.Fields.ContainsKey(OcrViolationTicket.DateOfService))
@@ -174,13 +173,19 @@ public class FormRecognizerValidator : IFormRecognizerValidator
             dateOfService = dateOfService.Replace("l", "1");
             dateOfService = dateOfService.Replace("f", "1");
             violationTicket.Fields[OcrViolationTicket.DateOfService].Value = dateOfService;
+            violationTicket.Fields[OcrViolationTicket.DateOfService].Value = violationTicket.Fields[OcrViolationTicket.DateOfService].GetDate()?.ToString("yyyy-MM-dd");
+        }
 
-            if (violationTicket.Fields[OcrViolationTicket.DateOfService].IsPopulated()) // if date of service is present try putting it in good format
-                violationTicket.Fields[OcrViolationTicket.DateOfService].Value = violationTicket.Fields[OcrViolationTicket.DateOfService].GetDate()?.ToString("yyyy-MM-dd");
-
-            // if formatting date of service didnt work or its null or not populated set it to violation date
-            if (violationTicket.Fields[OcrViolationTicket.DateOfService].Value is null || !violationTicket.Fields[OcrViolationTicket.DateOfService].IsPopulated())
-                violationTicket.Fields[OcrViolationTicket.DateOfService].Value = violationTicket.Fields[OcrViolationTicket.ViolationDate].GetDate()?.ToString("yyyy-MM-dd");
+        // ViolationDate and DateOfService are usually the same day. If either is misread/null, try using the other date value.
+        if (violationTicket.Fields.ContainsKey(OcrViolationTicket.ViolationDate) && violationTicket.Fields.ContainsKey(OcrViolationTicket.DateOfService)) {
+            if (violationTicket.Fields[OcrViolationTicket.ViolationDate].Value is null
+                && violationTicket.Fields[OcrViolationTicket.DateOfService].Value is not null) {
+                violationTicket.Fields[OcrViolationTicket.ViolationDate].Value = violationTicket.Fields[OcrViolationTicket.DateOfService].Value;
+            }
+            if (violationTicket.Fields[OcrViolationTicket.DateOfService].Value is null
+                && violationTicket.Fields[OcrViolationTicket.ViolationDate].Value is not null) {
+                violationTicket.Fields[OcrViolationTicket.DateOfService].Value = violationTicket.Fields[OcrViolationTicket.ViolationDate].Value;
+            }
         }
 
         if (violationTicket.Fields.ContainsKey(OcrViolationTicket.ViolationTime)) {


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

Form Recognizer appears to struggle with recognizing 1's or 11's on a VT2 image in a standalone field (ie. the Violation Date field). Maybe it thinks they are vertical lines??
![image](https://github.com/bcgov/jag-traffic-courts-online/assets/55215368/ef970d61-5778-4db3-b957-78d90c2549d3)

However, when a 1 or 11 is in a string of characters, Form Recognizer does a much better job (ie. the Date of Service).
![image](https://github.com/bcgov/jag-traffic-courts-online/assets/55215368/804b28e6-6306-40dd-bb71-b038a63baea2)

This means that for the month of November VT2 images will be difficult to read in general since the Violation Date will be almost always null. :(

In TCO, the Violation Date and Date of Service are usually (if not always) the same date. This small tweak will use DoS date if the VD is unrecognizable (ie. null) and vice versa. VT Staff can update the Dispute if the date is not correct.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
