### PR TITLE
TCVP-2560 Block VT1 Tickets from RSI Lookup Search

### DIFF
--- a/src/backend/TrafficCourts/Citizen.Service/Controllers/TicketsController.cs
+++ b/src/backend/TrafficCourts/Citizen.Service/Controllers/TicketsController.cs
@@ -34,6 +34,7 @@ namespace TrafficCourts.Citizen.Service.Controllers
         /// <response code="500">There was a server error that prevented the search from completing successfully.</response>
         [HttpGet]
         [ProducesResponseType(typeof(Models.Tickets.ViolationTicket), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
         public async Task<IActionResult> SearchAsync(
@@ -55,7 +56,8 @@ namespace TrafficCourts.Citizen.Service.Controllers
 
             var result = response.Result.Match<IActionResult>(
                 ticket => Ok(ticket),
-                exception => StatusCode(StatusCodes.Status500InternalServerError));
+                exception => StatusCode(StatusCodes.Status500InternalServerError),
+                invalidTicketException => StatusCode(StatusCodes.Status400BadRequest));
 
             return result;
         }

--- a/src/backend/TrafficCourts/Test/Citizen.Service/Features/Tickets/SearchHandlerTest.cs
+++ b/src/backend/TrafficCourts/Test/Citizen.Service/Features/Tickets/SearchHandlerTest.cs
@@ -91,5 +91,25 @@ namespace TrafficCourts.Test.Citizen.Service.Features.Tickets
             Assert.NotNull(actual);
             Assert.Same(exception, actual.Result.Value);
         }
+
+        [Fact]
+        public async Task search_throws_InvalidTicketVersionException()
+        {
+            DateTime violationDate = new(2023, 4, 9);
+            InvalidTicketVersionException exception = new(violationDate);
+
+            _serviceMock
+                .Setup(_ => _.SearchAsync(It.IsAny<string>(), It.IsAny<TimeOnly>(), It.IsAny<CancellationToken>()))
+                .ThrowsAsync(exception);
+
+            var request = new Search.Request("AA00000000", "00:00");
+
+            var sut = new Search.Handler(_serviceMock.Object, _loggerMock.Object, _redisCacheServiceMock.Object);
+
+            var actual = await sut.Handle(request, CancellationToken.None);
+
+            Assert.NotNull(actual);
+            Assert.Same(exception, actual.Result.Value);
+        }
     }
 }


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- TCVP-2560
- Added functionality to prevent RSI look-up from searching and returning older version tickets (VT1) which have violation date before April 9, 2024.
- Returns 400 bad request if the searched ticket is invalid.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
