### PR TITLE
TCVP-1981 Added update-admin to jj-dispute resource in Keycloak.

### DIFF
--- a/infrastructure/keycloak/realm-export.json
+++ b/infrastructure/keycloak/realm-export.json
@@ -534,6 +534,9 @@
                 "name": "read"
               },
               {
+                "name": "update-admin"
+              },
+              {
                 "name": "require_court_hearing"
               },
               {
@@ -543,9 +546,13 @@
                 "name": "review"
               },
               {
+                "name": "update_court_appearance"
+              },
+              {
                 "name": "assign"
               }
-            ]
+            ],
+            "icon_uri": ""
           },
           {
             "name": "dispute",
@@ -622,6 +629,17 @@
             "decisionStrategy": "UNANIMOUS",
             "config": {
               "roles": "[{\"id\":\"staff-api/judicial-justice\",\"required\":true}]"
+            }
+          },
+          {
+            "id": "741f65d1-8316-438f-88df-542316389ade",
+            "name": "has role support-staff",
+            "description": "Has ability to allow CSB support team users to edit a variety of fields in DCF to ensure they match JUSTIN.",
+            "type": "role",
+            "logic": "POSITIVE",
+            "decisionStrategy": "UNANIMOUS",
+            "config": {
+              "roles": "[{\"id\":\"staff-api/support-staff\",\"required\":true}]"
             }
           },
           {
@@ -767,6 +785,31 @@
               "scopes": "[\"review\"]",
               "applyPolicies": "[\"has role vtc-staff\",\"has role admin-vtc-staff\"]"
             }
+          },
+          {
+            "id": "88c9008c-af82-4ea6-b537-cf75f92a086e",
+            "name": "can update_court_appearance jj-dispute",
+            "type": "scope",
+            "logic": "POSITIVE",
+            "decisionStrategy": "AFFIRMATIVE",
+            "config": {
+              "resources": "[\"jj-dispute\"]",
+              "scopes": "[\"update_court_appearance\"]",
+              "applyPolicies": "[\"has role vtc-staff\",\"has role admin-vtc-staff\"]"
+            }
+          },
+          {
+            "id": "256c918b-9d46-4336-ba5e-6a479b035806",
+            "name": "can update-admin jj-dispute",
+            "description": "This permission is to update a jj-dispute, all fields, any field. Not to be confused with \"can update jj-dispute\" where updates are not really updates but rather only adding or removing associated documents.",
+            "type": "scope",
+            "logic": "POSITIVE",
+            "decisionStrategy": "AFFIRMATIVE",
+            "config": {
+              "resources": "[\"jj-dispute\"]",
+              "scopes": "[\"update-admin\"]",
+              "applyPolicies": "[\"has role support-staff\"]"
+            }
           }
         ],
         "scopes": [
@@ -820,6 +863,17 @@
             "id": "899689eb-f7d3-4494-9c06-37d9a841a336",
             "name": "require_court_hearing",
             "displayName": "require_court_hearing"
+          },
+          {
+            "id": "0b2af363-f7ab-4337-b02a-c56f08624f47",
+            "name": "update_court_appearance",
+            "displayName": "update_court_appearance"
+          },
+          {
+            "id": "550b8e63-3bbb-4c9b-bada-c40d51eb7682",
+            "name": "update-admin",
+            "iconUri": "",
+            "displayName": "update-admin"
           }
         ],
         "decisionStrategy": "UNANIMOUS"

--- a/infrastructure/keycloak/staff-api-authz-config.json
+++ b/infrastructure/keycloak/staff-api-authz-config.json
@@ -18,6 +18,9 @@
           "name": "read"
         },
         {
+          "name": "update-admin"
+        },
+        {
           "name": "require_court_hearing"
         },
         {
@@ -27,9 +30,13 @@
           "name": "review"
         },
         {
+          "name": "update_court_appearance"
+        },
+        {
           "name": "assign"
         }
-      ]
+      ],
+      "icon_uri": ""
     },
     {
       "name": "dispute",
@@ -106,6 +113,17 @@
       "decisionStrategy": "UNANIMOUS",
       "config": {
         "roles": "[{\"id\":\"staff-api/judicial-justice\",\"required\":true}]"
+      }
+    },
+    {
+      "id": "741f65d1-8316-438f-88df-542316389ade",
+      "name": "has role support-staff",
+      "description": "Has ability to allow CSB support team users to edit a variety of fields in DCF to ensure they match JUSTIN.",
+      "type": "role",
+      "logic": "POSITIVE",
+      "decisionStrategy": "UNANIMOUS",
+      "config": {
+        "roles": "[{\"id\":\"staff-api/support-staff\",\"required\":true}]"
       }
     },
     {
@@ -251,6 +269,31 @@
         "scopes": "[\"review\"]",
         "applyPolicies": "[\"has role vtc-staff\",\"has role admin-vtc-staff\"]"
       }
+    },
+    {
+      "id": "88c9008c-af82-4ea6-b537-cf75f92a086e",
+      "name": "can update_court_appearance jj-dispute",
+      "type": "scope",
+      "logic": "POSITIVE",
+      "decisionStrategy": "AFFIRMATIVE",
+      "config": {
+        "resources": "[\"jj-dispute\"]",
+        "scopes": "[\"update_court_appearance\"]",
+        "applyPolicies": "[\"has role vtc-staff\",\"has role admin-vtc-staff\"]"
+      }
+    },
+    {
+      "id": "256c918b-9d46-4336-ba5e-6a479b035806",
+      "name": "can update-admin jj-dispute",
+      "description": "This permission is to update a jj-dispute, all fields, any field. Not to be confused with \"can update jj-dispute\" where updates are not really updates but rather only adding or removing associated documents.",
+      "type": "scope",
+      "logic": "POSITIVE",
+      "decisionStrategy": "AFFIRMATIVE",
+      "config": {
+        "resources": "[\"jj-dispute\"]",
+        "scopes": "[\"update-admin\"]",
+        "applyPolicies": "[\"has role support-staff\"]"
+      }
     }
   ],
   "scopes": [
@@ -304,6 +347,17 @@
       "id": "899689eb-f7d3-4494-9c06-37d9a841a336",
       "name": "require_court_hearing",
       "displayName": "require_court_hearing"
+    },
+    {
+      "id": "0b2af363-f7ab-4337-b02a-c56f08624f47",
+      "name": "update_court_appearance",
+      "displayName": "update_court_appearance"
+    },
+    {
+      "id": "550b8e63-3bbb-4c9b-bada-c40d51eb7682",
+      "name": "update-admin",
+      "iconUri": "",
+      "displayName": "update-admin"
     }
   ],
   "decisionStrategy": "UNANIMOUS"


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

TCVP-1981 Created new update-admin permisison in Keycloak DEV and exported Authorization details.

1. Created Role **support-staff**
_Clients > staff-api > Roles_

2. Created Policy **has role support-staff**
_Clients > staff-api > Authorization > Policies_

3. Created Scope **update-admin**
_Clients > staff-api > Authorization > Scopes_

4. Updated Resource details to include update-admin scope
_Clients > staff-api > Authorization > Resources > jj-dispute_

5. Created Permission **can update-admin jj-dispute**
_Clients > staff-api > Authorization > Permissions_

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
