### PR TITLE
TCVP-2380 remove extra saga initial state causing duplicate emails

### DIFF
--- a/src/backend/TrafficCourts/Messaging/MessageContracts/DisputantEmailVerification.cs
+++ b/src/backend/TrafficCourts/Messaging/MessageContracts/DisputantEmailVerification.cs
@@ -64,7 +64,6 @@ public class NoticeOfDisputeSubmitted
     public long DisputeId { get; set; }
     public Guid NoticeOfDisputeGuid { get; set; }
     public string EmailAddress { get; set; } = string.Empty;
-    public bool RequiresEmailVerification { get; set; } = true;
 }
 
 /// <summary>

--- a/src/backend/TrafficCourts/Workflow.Service/Sagas/VerifyEmailAddressSagaStateMachine.cs
+++ b/src/backend/TrafficCourts/Workflow.Service/Sagas/VerifyEmailAddressSagaStateMachine.cs
@@ -70,13 +70,7 @@ public class VerifyEmailAddressStateMachine : MassTransitStateMachine<VerifyEmai
                 .Then(context => _logger.LogDebug("Email verification started"))
                 .Then(CreateToken)
                 .ThenAsync(SendVerificationEmail)
-                .TransitionTo(Active),
-            When(NoticeOfDisputeSubmitted)
-                .If(context => context.Message.RequiresEmailVerification,
-                    x => x.Then(context => _logger.LogDebug("Notice of dispute submitted and requires email verification"))
-                          .ThenAsync(HandleNoticeOfDisputeSubmitted)
-                          .TransitionTo(Active))
-        );
+                .TransitionTo(Active));
 
         During(Active,
             When(ResendEmailVerificationEmail)


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- Removes the second initial state for verify email which causes state conflicts and duplicate emails

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [ ] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
