### PR TITLE
TCVP-2525 Added endpoint to cascade update JJDispute

### DIFF
--- a/src/backend/TrafficCourts/Common/OpenAPIs/OracleDataAPI/v1_0/OracleDataApi.v1_0.json
+++ b/src/backend/TrafficCourts/Common/OpenAPIs/OracleDataAPI/v1_0/OracleDataApi.v1_0.json
@@ -1,3046 +1,1537 @@
 {
-  "openapi": "3.0.1",
-  "info": {
-    "title": "Oracle Data Api",
-    "version": "1.0.0"
-  },
-  "servers": [
-    {
-      "url": "http://localhost:8080",
-      "description": "Generated server url"
+    "openapi": "3.0.1",
+    "info": { "title": "Oracle Data Api", "version": "1.0.0" },
+    "servers": [{ "url": "http://localhost:5010", "description": "Generated server url" }],
+    "security": [{ "x-username": [] }],
+    "paths": {
+        "/api/v1.0/jj/dispute/{ticketNumber}": {
+            "put": {
+                "tags": ["jj-dispute-controller"],
+                "summary": "Updates the properties of a particular JJ Dispute record based on the given values.",
+                "operationId": "updateJJDispute",
+                "parameters": [
+                    { "name": "ticketNumber", "in": "path", "required": true, "schema": { "type": "string" } },
+                    { "name": "checkVTCAssigned", "in": "query", "required": true, "schema": { "type": "boolean" } }
+                ],
+                "requestBody": {
+                    "content": { "application/json": { "schema": { "$ref": "#/components/schemas/JJDispute" } } },
+                    "required": true
+                },
+                "responses": {
+                    "400": { "description": "Bad Request.", "content": { "*/*": { "schema": { "type": "object" } } } },
+                    "404": {
+                        "description": "JJDispute record not found. Update failed.",
+                        "content": { "*/*": { "schema": { "type": "object" } } }
+                    },
+                    "405": {
+                        "description": "An invalid JJ Dispute status is provided. Update failed.",
+                        "content": { "*/*": { "schema": { "type": "object" } } }
+                    },
+                    "500": { "description": "Internal Server Error", "content": { "*/*": { "schema": { "type": "object" } } } },
+                    "200": { "description": "Ok", "content": { "*/*": { "schema": { "$ref": "#/components/schemas/JJDispute" } } } }
+                }
+            }
+        },
+        "/api/v1.0/jj/dispute/{ticketNumber}/review": {
+            "put": {
+                "tags": ["jj-dispute-controller"],
+                "summary": "Updates the status of a particular JJDispute record to REVIEW.",
+                "operationId": "reviewJJDispute",
+                "parameters": [
+                    { "name": "ticketNumber", "in": "path", "required": true, "schema": { "type": "string" } },
+                    { "name": "checkVTCAssigned", "in": "query", "required": true, "schema": { "type": "boolean" } }
+                ],
+                "requestBody": {
+                    "content": { "application/json": { "schema": { "maxLength": 256, "minLength": 0, "type": "string" } } },
+                    "required": true
+                },
+                "responses": {
+                    "400": { "description": "Bad Request.", "content": { "*/*": { "schema": { "type": "object" } } } },
+                    "404": {
+                        "description": "JJDispute record not found. Update failed.",
+                        "content": { "*/*": { "schema": { "type": "object" } } }
+                    },
+                    "405": {
+                        "description": "A JJDispute status can only be set to REVIEW iff status is NEW or VALIDATED and the remark must be <= 256 characters. Update failed.",
+                        "content": { "*/*": { "schema": { "type": "object" } } }
+                    },
+                    "500": { "description": "Internal server error occured.", "content": { "*/*": { "schema": { "type": "object" } } } },
+                    "200": {
+                        "description": "Ok. Updated JJDispute record returned.",
+                        "content": { "*/*": { "schema": { "$ref": "#/components/schemas/JJDispute" } } }
+                    }
+                }
+            }
+        },
+        "/api/v1.0/jj/dispute/{ticketNumber}/requirecourthearing": {
+            "put": {
+                "tags": ["jj-dispute-controller"],
+                "summary": "Updates the status of a particular JJDispute record to REQUIRE_COURT_HEARING, type to COURT_APPEARANCE.",
+                "operationId": "requireCourtHearingJJDispute",
+                "parameters": [
+                    { "name": "ticketNumber", "in": "path", "required": true, "schema": { "type": "string" } },
+                    { "name": "remark", "in": "query", "required": false, "schema": { "maxLength": 256, "minLength": 0, "type": "string" } }
+                ],
+                "responses": {
+                    "400": { "description": "Bad Request.", "content": { "*/*": { "schema": { "type": "object" } } } },
+                    "404": {
+                        "description": "JJDispute record not found. Update failed.",
+                        "content": { "*/*": { "schema": { "type": "object" } } }
+                    },
+                    "405": {
+                        "description": "A JJDispute status can only be set to REQUIRE_COURT_HEARING iff status is one of the following: NEW, IN_PROGRESS, REVIEW, REQUIRE_COURT_HEARING and the remark must be <= 256 characters. Update failed.",
+                        "content": { "*/*": { "schema": { "type": "object" } } }
+                    },
+                    "500": { "description": "Internal server error occured.", "content": { "*/*": { "schema": { "type": "object" } } } },
+                    "200": {
+                        "description": "Ok. Updated JJDispute record returned.",
+                        "content": { "*/*": { "schema": { "$ref": "#/components/schemas/JJDispute" } } }
+                    }
+                }
+            }
+        },
+        "/api/v1.0/jj/dispute/{ticketNumber}/confirm": {
+            "put": {
+                "tags": ["jj-dispute-controller"],
+                "summary": "Updates the status of a particular JJDispute record to CONFIRMED.",
+                "operationId": "confirmJJDispute",
+                "parameters": [{ "name": "ticketNumber", "in": "path", "required": true, "schema": { "type": "string" } }],
+                "responses": {
+                    "400": { "description": "Bad Request.", "content": { "*/*": { "schema": { "type": "object" } } } },
+                    "404": {
+                        "description": "JJDispute record not found. Update failed.",
+                        "content": { "*/*": { "schema": { "type": "object" } } }
+                    },
+                    "405": {
+                        "description": "A JJDispute status can only be set to CONFIRMED iff status is one of the following: REVIEW, NEW, HEARING_SCHEDULED, IN_PROGRESS, CONFIRMED. Update failed.",
+                        "content": { "*/*": { "schema": { "type": "object" } } }
+                    },
+                    "500": { "description": "Internal server error occured.", "content": { "*/*": { "schema": { "type": "object" } } } },
+                    "200": {
+                        "description": "Ok. Updated JJDispute record returned.",
+                        "content": { "*/*": { "schema": { "$ref": "#/components/schemas/JJDispute" } } }
+                    }
+                }
+            }
+        },
+        "/api/v1.0/jj/dispute/{ticketNumber}/conclude": {
+            "put": {
+                "tags": ["jj-dispute-controller"],
+                "summary": "Updates the status of a particular JJDispute record to CONCLUDED.",
+                "operationId": "concludeJJDispute",
+                "parameters": [
+                    { "name": "ticketNumber", "in": "path", "required": true, "schema": { "type": "string" } },
+                    { "name": "checkVTCAssigned", "in": "query", "required": true, "schema": { "type": "boolean" } }
+                ],
+                "responses": {
+                    "400": { "description": "Bad Request.", "content": { "*/*": { "schema": { "type": "object" } } } },
+                    "404": {
+                        "description": "JJDispute record not found. Update failed.",
+                        "content": { "*/*": { "schema": { "type": "object" } } }
+                    },
+                    "405": { "description": "Method Not Allowed", "content": { "*/*": { "schema": { "type": "object" } } } },
+                    "500": { "description": "Internal server error occured.", "content": { "*/*": { "schema": { "type": "object" } } } },
+                    "200": {
+                        "description": "Ok. Updated JJDispute record returned.",
+                        "content": { "*/*": { "schema": { "$ref": "#/components/schemas/JJDispute" } } }
+                    }
+                }
+            }
+        },
+        "/api/v1.0/jj/dispute/{ticketNumber}/cascade": {
+            "put": {
+                "tags": ["jj-dispute-controller"],
+                "summary": "Updates the properties of a particular JJ Dispute record as well as cascading to underlying related Dispute data.",
+                "operationId": "updateJJDisputeCascade",
+                "parameters": [
+                    { "name": "ticketNumber", "in": "path", "required": true, "schema": { "type": "string" } },
+                    { "name": "checkVTCAssigned", "in": "query", "required": true, "schema": { "type": "boolean" } }
+                ],
+                "requestBody": {
+                    "content": { "application/json": { "schema": { "$ref": "#/components/schemas/JJDispute" } } },
+                    "required": true
+                },
+                "responses": {
+                    "400": { "description": "Bad Request.", "content": { "*/*": { "schema": { "type": "object" } } } },
+                    "404": {
+                        "description": "JJDispute record not found. Update failed.",
+                        "content": { "*/*": { "schema": { "type": "object" } } }
+                    },
+                    "405": {
+                        "description": "An invalid JJ Dispute status is provided. Update failed.",
+                        "content": { "*/*": { "schema": { "type": "object" } } }
+                    },
+                    "500": { "description": "Internal Server Error", "content": { "*/*": { "schema": { "type": "object" } } } },
+                    "200": { "description": "Ok", "content": { "*/*": { "schema": { "$ref": "#/components/schemas/JJDispute" } } } }
+                }
+            }
+        },
+        "/api/v1.0/jj/dispute/{ticketNumber}/cancel": {
+            "put": {
+                "tags": ["jj-dispute-controller"],
+                "summary": "Updates the status of a particular JJDispute record to CANCELLED.",
+                "operationId": "cancelJJDispute",
+                "parameters": [
+                    { "name": "ticketNumber", "in": "path", "required": true, "schema": { "type": "string" } },
+                    { "name": "checkVTCAssigned", "in": "query", "required": true, "schema": { "type": "boolean" } }
+                ],
+                "responses": {
+                    "400": { "description": "Bad Request.", "content": { "*/*": { "schema": { "type": "object" } } } },
+                    "404": {
+                        "description": "JJDispute record not found. Update failed.",
+                        "content": { "*/*": { "schema": { "type": "object" } } }
+                    },
+                    "405": { "description": "Method Not Allowed", "content": { "*/*": { "schema": { "type": "object" } } } },
+                    "500": { "description": "Internal server error occured.", "content": { "*/*": { "schema": { "type": "object" } } } },
+                    "200": {
+                        "description": "Ok. Updated JJDispute record returned.",
+                        "content": { "*/*": { "schema": { "$ref": "#/components/schemas/JJDispute" } } }
+                    }
+                }
+            }
+        },
+        "/api/v1.0/jj/dispute/{ticketNumber}/accept": {
+            "put": {
+                "tags": ["jj-dispute-controller"],
+                "summary": "Updates the status of a particular JJDispute record to ACCEPTED.",
+                "operationId": "acceptJJDispute",
+                "parameters": [
+                    { "name": "ticketNumber", "in": "path", "required": true, "schema": { "type": "string" } },
+                    { "name": "checkVTCAssigned", "in": "query", "required": true, "schema": { "type": "boolean" } },
+                    {
+                        "name": "partId",
+                        "in": "query",
+                        "description": "Adjudicator's participant ID",
+                        "required": false,
+                        "schema": { "type": "string" }
+                    }
+                ],
+                "responses": {
+                    "400": { "description": "Bad Request.", "content": { "*/*": { "schema": { "type": "object" } } } },
+                    "404": {
+                        "description": "JJDispute record not found. Update failed.",
+                        "content": { "*/*": { "schema": { "type": "object" } } }
+                    },
+                    "405": {
+                        "description": "A JJDispute status can only be set to ACCEPTED iff status is CONFIRMED. Update failed.",
+                        "content": { "*/*": { "schema": { "type": "object" } } }
+                    },
+                    "500": { "description": "Internal server error occured.", "content": { "*/*": { "schema": { "type": "object" } } } },
+                    "200": {
+                        "description": "Ok. Updated JJDispute record returned.",
+                        "content": { "*/*": { "schema": { "$ref": "#/components/schemas/JJDispute" } } }
+                    }
+                }
+            }
+        },
+        "/api/v1.0/jj/dispute/assign": {
+            "put": {
+                "tags": ["jj-dispute-controller"],
+                "summary": "Updates each JJ Dispute based on the passed in ticket numbers to assign them to a specific JJ or unassign them if JJ not specified.",
+                "operationId": "assignJJDisputesToJJ",
+                "parameters": [
+                    {
+                        "name": "ticketNumbers",
+                        "in": "query",
+                        "required": true,
+                        "schema": { "type": "array", "items": { "type": "string" } }
+                    },
+                    { "name": "jjUsername", "in": "query", "required": false, "schema": { "type": "string" } }
+                ],
+                "responses": {
+                    "400": { "description": "Bad Request.", "content": { "*/*": { "schema": { "type": "object" } } } },
+                    "404": {
+                        "description": "JJDispute record(s) not found. Update failed.",
+                        "content": { "*/*": { "schema": { "type": "object" } } }
+                    },
+                    "405": { "description": "Method Not Allowed", "content": { "*/*": { "schema": { "type": "object" } } } },
+                    "500": { "description": "Internal server error occured.", "content": { "*/*": { "schema": { "type": "object" } } } },
+                    "200": { "description": "Ok" }
+                }
+            }
+        },
+        "/api/v1.0/dispute/{id}": {
+            "put": {
+                "tags": ["dispute-controller"],
+                "summary": "Updates the properties of a particular Dispute record based on the given values.",
+                "operationId": "updateDispute",
+                "parameters": [{ "name": "id", "in": "path", "required": true, "schema": { "type": "integer", "format": "int64" } }],
+                "requestBody": {
+                    "content": { "application/json": { "schema": { "$ref": "#/components/schemas/Dispute" } } },
+                    "required": true
+                },
+                "responses": {
+                    "400": { "description": "Bad Request.", "content": { "*/*": { "schema": { "type": "object" } } } },
+                    "404": {
+                        "description": "Dispute record not found. Update failed.",
+                        "content": { "*/*": { "schema": { "type": "object" } } }
+                    },
+                    "405": { "description": "Method Not Allowed", "content": { "*/*": { "schema": { "type": "object" } } } },
+                    "500": { "description": "Internal Server Error", "content": { "*/*": { "schema": { "type": "object" } } } },
+                    "409": {
+                        "description": "The Dispute has already been assigned to a different user. Dispute cannot be modified until assigned time expires.",
+                        "content": { "*/*": { "schema": { "$ref": "#/components/schemas/Dispute" } } }
+                    },
+                    "200": { "description": "Ok", "content": { "*/*": { "schema": { "$ref": "#/components/schemas/Dispute" } } } }
+                }
+            },
+            "delete": {
+                "tags": ["dispute-controller"],
+                "summary": "Deletes a particular Dispute record.",
+                "operationId": "deleteDispute",
+                "parameters": [{ "name": "id", "in": "path", "required": true, "schema": { "type": "integer", "format": "int64" } }],
+                "responses": {
+                    "400": { "description": "Bad Request.", "content": { "*/*": { "schema": { "type": "object" } } } },
+                    "404": {
+                        "description": "Dispute record not found. Delete failed.",
+                        "content": { "*/*": { "schema": { "type": "object" } } }
+                    },
+                    "405": { "description": "Method Not Allowed", "content": { "*/*": { "schema": { "type": "object" } } } },
+                    "500": {
+                        "description": "Internal Server Error. Delete failed.",
+                        "content": { "*/*": { "schema": { "type": "object" } } }
+                    },
+                    "200": { "description": "Ok. Dispute record deleted." }
+                }
+            }
+        },
+        "/api/v1.0/dispute/{id}/validate": {
+            "put": {
+                "tags": ["dispute-controller"],
+                "summary": "Updates the status of a particular Dispute record to VALIDATED.",
+                "operationId": "validateDispute",
+                "parameters": [{ "name": "id", "in": "path", "required": true, "schema": { "type": "integer", "format": "int64" } }],
+                "responses": {
+                    "400": { "description": "Bad Request.", "content": { "*/*": { "schema": { "type": "object" } } } },
+                    "404": {
+                        "description": "Dispute record not found. Update failed.",
+                        "content": { "*/*": { "schema": { "type": "object" } } }
+                    },
+                    "405": {
+                        "description": "A Dispute status can only be set to VALIDATED iff status is NEW. Update failed.",
+                        "content": { "*/*": { "schema": { "type": "object" } } }
+                    },
+                    "500": { "description": "Internal Server Error", "content": { "*/*": { "schema": { "type": "object" } } } },
+                    "200": {
+                        "description": "Ok. Updated Dispute record returned.",
+                        "content": { "*/*": { "schema": { "$ref": "#/components/schemas/Dispute" } } }
+                    },
+                    "409": {
+                        "description": "The Dispute has already been assigned to a different user. Dispute cannot be modified until assigned time expires.",
+                        "content": { "*/*": { "schema": { "$ref": "#/components/schemas/Dispute" } } }
+                    }
+                }
+            }
+        },
+        "/api/v1.0/dispute/{id}/submit": {
+            "put": {
+                "tags": ["dispute-controller"],
+                "summary": "Updates the status of a particular Dispute record to PROCESSING.",
+                "operationId": "submitDispute",
+                "parameters": [{ "name": "id", "in": "path", "required": true, "schema": { "type": "integer", "format": "int64" } }],
+                "responses": {
+                    "400": { "description": "Bad Request.", "content": { "*/*": { "schema": { "type": "object" } } } },
+                    "404": {
+                        "description": "Dispute record not found. Update failed.",
+                        "content": { "*/*": { "schema": { "type": "object" } } }
+                    },
+                    "405": {
+                        "description": "A Dispute status can only be set to PROCESSING iff status is NEW or REJECTED. Update failed.",
+                        "content": { "*/*": { "schema": { "type": "object" } } }
+                    },
+                    "500": { "description": "Internal Server Error", "content": { "*/*": { "schema": { "type": "object" } } } },
+                    "200": {
+                        "description": "Ok. Updated Dispute record returned.",
+                        "content": { "*/*": { "schema": { "$ref": "#/components/schemas/Dispute" } } }
+                    },
+                    "409": {
+                        "description": "The Dispute has already been assigned to a different user. Dispute cannot be modified until assigned time expires.",
+                        "content": { "*/*": { "schema": { "$ref": "#/components/schemas/Dispute" } } }
+                    }
+                }
+            }
+        },
+        "/api/v1.0/dispute/{id}/reject": {
+            "put": {
+                "tags": ["dispute-controller"],
+                "summary": "Updates the status of a particular Dispute record to REJECTED.",
+                "operationId": "rejectDispute",
+                "parameters": [{ "name": "id", "in": "path", "required": true, "schema": { "type": "integer", "format": "int64" } }],
+                "requestBody": {
+                    "content": { "application/json": { "schema": { "maxLength": 256, "minLength": 1, "type": "string" } } },
+                    "required": true
+                },
+                "responses": {
+                    "400": { "description": "Bad Request.", "content": { "*/*": { "schema": { "type": "object" } } } },
+                    "404": {
+                        "description": "Dispute record not found. Update failed.",
+                        "content": { "*/*": { "schema": { "type": "object" } } }
+                    },
+                    "405": {
+                        "description": "A Dispute status can only be set to REJECTED iff status is NEW or VALIDATED and the rejected reason must be <= 256 characters. Update failed.",
+                        "content": { "*/*": { "schema": { "type": "object" } } }
+                    },
+                    "500": { "description": "Internal Server Error", "content": { "*/*": { "schema": { "type": "object" } } } },
+                    "200": {
+                        "description": "Ok. Updated Dispute record returned.",
+                        "content": { "*/*": { "schema": { "$ref": "#/components/schemas/Dispute" } } }
+                    },
+                    "409": {
+                        "description": "The Dispute has already been assigned to a different user. Dispute cannot be modified until assigned time expires.",
+                        "content": { "*/*": { "schema": { "$ref": "#/components/schemas/Dispute" } } }
+                    }
+                }
+            }
+        },
+        "/api/v1.0/dispute/{id}/email/verify": {
+            "put": {
+                "tags": ["dispute-controller"],
+                "summary": "Updates the emailVerification flag of a particular Dispute to true.",
+                "operationId": "verifyDisputeEmail",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "The id of the Dispute to update.",
+                        "required": true,
+                        "schema": { "type": "integer", "format": "int64" }
+                    }
+                ],
+                "responses": {
+                    "400": { "description": "Bad Request", "content": { "*/*": { "schema": { "type": "object" } } } },
+                    "404": {
+                        "description": "Dispute with specified id not found",
+                        "content": { "*/*": { "schema": { "type": "object" } } }
+                    },
+                    "405": { "description": "Method Not Allowed", "content": { "*/*": { "schema": { "type": "object" } } } },
+                    "500": { "description": "Internal server error occured.", "content": { "*/*": { "schema": { "type": "object" } } } },
+                    "200": { "description": "Ok. Email verified." }
+                }
+            }
+        },
+        "/api/v1.0/dispute/{id}/email/reset": {
+            "put": {
+                "tags": ["dispute-controller"],
+                "summary": "Updates the email address of a particular Dispute.",
+                "operationId": "resetDisputeEmail",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "The id of the Dispute to update.",
+                        "required": true,
+                        "schema": { "type": "integer", "format": "int64" }
+                    },
+                    {
+                        "name": "email",
+                        "in": "query",
+                        "description": "The new email address of the Disputant.",
+                        "required": false,
+                        "schema": { "maxLength": 100, "minLength": 1, "type": "string" }
+                    }
+                ],
+                "responses": {
+                    "400": {
+                        "description": "If the email address is > 100 characters",
+                        "content": { "*/*": { "schema": { "type": "object" } } }
+                    },
+                    "404": {
+                        "description": "Dispute with specified id not found",
+                        "content": { "*/*": { "schema": { "type": "object" } } }
+                    },
+                    "405": { "description": "Method Not Allowed", "content": { "*/*": { "schema": { "type": "object" } } } },
+                    "500": { "description": "Internal server error occured.", "content": { "*/*": { "schema": { "type": "object" } } } },
+                    "200": {
+                        "description": "Ok. Email reset.",
+                        "content": { "*/*": { "schema": { "$ref": "#/components/schemas/Dispute" } } }
+                    }
+                }
+            }
+        },
+        "/api/v1.0/dispute/{id}/cancel": {
+            "put": {
+                "tags": ["dispute-controller"],
+                "summary": "Updates the status of a particular Dispute record to CANCELLED.",
+                "operationId": "cancelDispute",
+                "parameters": [{ "name": "id", "in": "path", "required": true, "schema": { "type": "integer", "format": "int64" } }],
+                "requestBody": {
+                    "content": { "application/json": { "schema": { "maxLength": 256, "minLength": 1, "type": "string" } } },
+                    "required": true
+                },
+                "responses": {
+                    "400": { "description": "Bad Request.", "content": { "*/*": { "schema": { "type": "object" } } } },
+                    "404": {
+                        "description": "Dispute record not found. Update failed.",
+                        "content": { "*/*": { "schema": { "type": "object" } } }
+                    },
+                    "405": {
+                        "description": "A Dispute status can only be set to CANCELLED iff status is NEW, REJECTED or PROCESSING. Update failed.",
+                        "content": { "*/*": { "schema": { "type": "object" } } }
+                    },
+                    "500": { "description": "Internal Server Error", "content": { "*/*": { "schema": { "type": "object" } } } },
+                    "200": {
+                        "description": "Ok. Updated Dispute record returned.",
+                        "content": { "*/*": { "schema": { "$ref": "#/components/schemas/Dispute" } } }
+                    },
+                    "409": {
+                        "description": "The Dispute has already been assigned to a different user. Dispute cannot be modified until assigned time expires.",
+                        "content": { "*/*": { "schema": { "$ref": "#/components/schemas/Dispute" } } }
+                    }
+                }
+            }
+        },
+        "/api/v1.0/dispute/updateRequest/{id}": {
+            "put": {
+                "tags": ["dispute-controller"],
+                "summary": "An endpoint that updates the status of a DisputeUpdateRequest record.",
+                "operationId": "updateDisputeUpdateRequestStatus",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "The id of the DisputeUpdateRequest record to update.",
+                        "required": true,
+                        "schema": { "type": "integer", "format": "int64" }
+                    },
+                    {
+                        "name": "disputeUpdateRequestStatus",
+                        "in": "query",
+                        "description": "The status of the request record should be updated to.",
+                        "required": true,
+                        "schema": { "type": "string", "enum": ["UNKNOWN", "ACCEPTED", "PENDING", "REJECTED"] },
+                        "example": "ACCEPTED"
+                    }
+                ],
+                "responses": {
+                    "400": { "description": "Bad Request", "content": { "*/*": { "schema": { "type": "object" } } } },
+                    "404": {
+                        "description": "DisputeUpdateRequest could not be found.",
+                        "content": { "*/*": { "schema": { "type": "object" } } }
+                    },
+                    "405": { "description": "Method Not Allowed", "content": { "*/*": { "schema": { "type": "object" } } } },
+                    "500": {
+                        "description": "Internal Server Error. Save failed.",
+                        "content": { "*/*": { "schema": { "type": "object" } } }
+                    },
+                    "200": {
+                        "description": "Ok. DisputeUpdateRequest updated.",
+                        "content": { "*/*": { "schema": { "$ref": "#/components/schemas/DisputeUpdateRequest" } } }
+                    }
+                }
+            }
+        },
+        "/api/v1.0/fileHistory": {
+            "post": {
+                "tags": ["file-history-controller"],
+                "summary": "Inserts a file history record for the given ticket number.",
+                "operationId": "insertFileHistory",
+                "requestBody": {
+                    "content": { "application/json": { "schema": { "$ref": "#/components/schemas/FileHistory" } } },
+                    "required": true
+                },
+                "responses": {
+                    "400": { "description": "Bad Request.", "content": { "*/*": { "schema": { "type": "object" } } } },
+                    "404": {
+                        "description": "An invalid file history record provided. Insert failed.",
+                        "content": { "*/*": { "schema": { "type": "object" } } }
+                    },
+                    "405": { "description": "Method Not Allowed", "content": { "*/*": { "schema": { "type": "object" } } } },
+                    "500": { "description": "Internal Server Error", "content": { "*/*": { "schema": { "type": "object" } } } },
+                    "200": { "description": "Ok", "content": { "*/*": { "schema": { "type": "integer", "format": "int64" } } } }
+                }
+            }
+        },
+        "/api/v1.0/emailHistory": {
+            "post": {
+                "tags": ["email-history-controller"],
+                "summary": "Inserts an email history record for the given ticket number.",
+                "operationId": "insertEmailHistory",
+                "requestBody": {
+                    "content": { "application/json": { "schema": { "$ref": "#/components/schemas/EmailHistory" } } },
+                    "required": true
+                },
+                "responses": {
+                    "400": { "description": "Bad Request.", "content": { "*/*": { "schema": { "type": "object" } } } },
+                    "404": {
+                        "description": "An invalid email history record provided. Insert failed.",
+                        "content": { "*/*": { "schema": { "type": "object" } } }
+                    },
+                    "405": { "description": "Method Not Allowed", "content": { "*/*": { "schema": { "type": "object" } } } },
+                    "500": { "description": "Internal Server Error", "content": { "*/*": { "schema": { "type": "object" } } } },
+                    "200": { "description": "Ok", "content": { "*/*": { "schema": { "type": "integer", "format": "int64" } } } }
+                }
+            }
+        },
+        "/api/v1.0/dispute": {
+            "post": {
+                "tags": ["dispute-controller"],
+                "operationId": "saveDispute",
+                "requestBody": {
+                    "content": { "application/json": { "schema": { "$ref": "#/components/schemas/Dispute" } } },
+                    "required": true
+                },
+                "responses": {
+                    "400": { "description": "Bad Request", "content": { "*/*": { "schema": { "type": "object" } } } },
+                    "404": { "description": "Not Found", "content": { "*/*": { "schema": { "type": "object" } } } },
+                    "405": { "description": "Method Not Allowed", "content": { "*/*": { "schema": { "type": "object" } } } },
+                    "500": { "description": "Internal Server Error", "content": { "*/*": { "schema": { "type": "object" } } } },
+                    "200": { "description": "OK", "content": { "*/*": { "schema": { "type": "integer", "format": "int64" } } } }
+                }
+            }
+        },
+        "/api/v1.0/dispute/{guid}/updateRequest": {
+            "post": {
+                "tags": ["dispute-controller"],
+                "summary": "An endpoint that inserts a DisputeUpdateRequest into persistent storage.",
+                "operationId": "saveDisputeUpdateRequest",
+                "parameters": [
+                    {
+                        "name": "guid",
+                        "in": "path",
+                        "description": "The noticeOfDisputeGuid of the Dispute to associate with.",
+                        "required": true,
+                        "schema": { "type": "string" }
+                    }
+                ],
+                "requestBody": {
+                    "content": { "application/json": { "schema": { "$ref": "#/components/schemas/DisputeUpdateRequest" } } },
+                    "required": true
+                },
+                "responses": {
+                    "400": { "description": "Bad Request", "content": { "*/*": { "schema": { "type": "object" } } } },
+                    "404": { "description": "Dispute could not be found.", "content": { "*/*": { "schema": { "type": "object" } } } },
+                    "405": { "description": "Method Not Allowed", "content": { "*/*": { "schema": { "type": "object" } } } },
+                    "500": {
+                        "description": "Internal Server Error. Save failed.",
+                        "content": { "*/*": { "schema": { "type": "object" } } }
+                    },
+                    "200": {
+                        "description": "Ok. DisputeUpdateRequest record saved.",
+                        "content": { "*/*": { "schema": { "type": "integer", "format": "int64" } } }
+                    }
+                }
+            }
+        },
+        "/api/v1.0/jj/disputes": {
+            "get": {
+                "tags": ["jj-dispute-controller"],
+                "operationId": "getJJDisputes",
+                "parameters": [
+                    {
+                        "name": "jjAssignedTo",
+                        "in": "query",
+                        "description": "If specified, will retrieve the records which are assigned to the specified jj staff",
+                        "required": false,
+                        "schema": { "type": "string" }
+                    },
+                    {
+                        "name": "ticketNumber",
+                        "in": "query",
+                        "description": "If specified will filter by TicketNumber. (Format is XX00000000)",
+                        "required": false,
+                        "schema": { "pattern": "[A-Z]{2}\\d{8}", "type": "string" },
+                        "example": "AX12345678"
+                    }
+                ],
+                "responses": {
+                    "400": { "description": "Bad Request", "content": { "*/*": { "schema": { "type": "object" } } } },
+                    "404": { "description": "Not Found", "content": { "*/*": { "schema": { "type": "object" } } } },
+                    "405": { "description": "Method Not Allowed", "content": { "*/*": { "schema": { "type": "object" } } } },
+                    "500": { "description": "Internal Server Error", "content": { "*/*": { "schema": { "type": "object" } } } },
+                    "200": {
+                        "description": "OK",
+                        "content": { "*/*": { "schema": { "type": "array", "items": { "$ref": "#/components/schemas/JJDispute" } } } }
+                    }
+                }
+            }
+        },
+        "/api/v1.0/jj/dispute/{ticketNumber}/{assignVTC}": {
+            "get": {
+                "tags": ["jj-dispute-controller"],
+                "operationId": "getJJDispute",
+                "parameters": [
+                    {
+                        "name": "ticketNumber",
+                        "in": "path",
+                        "description": "The primary key of the jj dispute to retrieve",
+                        "required": true,
+                        "schema": { "type": "string" }
+                    },
+                    { "name": "assignVTC", "in": "path", "required": true, "schema": { "type": "boolean" } }
+                ],
+                "responses": {
+                    "400": { "description": "Bad Request", "content": { "*/*": { "schema": { "type": "object" } } } },
+                    "404": { "description": "Not Found", "content": { "*/*": { "schema": { "type": "object" } } } },
+                    "405": { "description": "Method Not Allowed", "content": { "*/*": { "schema": { "type": "object" } } } },
+                    "500": { "description": "Internal Server Error", "content": { "*/*": { "schema": { "type": "object" } } } },
+                    "200": { "description": "OK", "content": { "*/*": { "schema": { "$ref": "#/components/schemas/JJDispute" } } } }
+                }
+            }
+        },
+        "/api/v1.0/jj/dispute/ticketImage/{ticketNumber}/{documentType}": {
+            "get": {
+                "tags": ["jj-dispute-controller"],
+                "operationId": "getTicketImageData",
+                "parameters": [
+                    { "name": "ticketNumber", "in": "path", "required": true, "schema": { "type": "string" } },
+                    {
+                        "name": "documentType",
+                        "in": "path",
+                        "required": true,
+                        "schema": { "type": "string", "enum": ["UNKNOWN", "NOTICE_OF_DISPUTE", "TICKET_IMAGE"] }
+                    }
+                ],
+                "responses": {
+                    "400": { "description": "Bad Request", "content": { "*/*": { "schema": { "type": "object" } } } },
+                    "404": { "description": "Not Found", "content": { "*/*": { "schema": { "type": "object" } } } },
+                    "405": { "description": "Method Not Allowed", "content": { "*/*": { "schema": { "type": "object" } } } },
+                    "500": { "description": "Internal Server Error", "content": { "*/*": { "schema": { "type": "object" } } } },
+                    "200": {
+                        "description": "OK",
+                        "content": { "*/*": { "schema": { "$ref": "#/components/schemas/TicketImageDataJustinDocument" } } }
+                    }
+                }
+            }
+        },
+        "/api/v1.0/fileHistory/{ticketNumber}": {
+            "get": {
+                "tags": ["file-history-controller"],
+                "operationId": "getFileHistoryByTicketNumber",
+                "parameters": [
+                    {
+                        "name": "ticketNumber",
+                        "in": "path",
+                        "description": "Ticket number to retrieve related file history.",
+                        "required": true,
+                        "schema": { "type": "string" }
+                    }
+                ],
+                "responses": {
+                    "400": { "description": "Bad Request", "content": { "*/*": { "schema": { "type": "object" } } } },
+                    "404": { "description": "Not Found", "content": { "*/*": { "schema": { "type": "object" } } } },
+                    "405": { "description": "Method Not Allowed", "content": { "*/*": { "schema": { "type": "object" } } } },
+                    "500": { "description": "Internal Server Error", "content": { "*/*": { "schema": { "type": "object" } } } },
+                    "200": {
+                        "description": "OK",
+                        "content": { "*/*": { "schema": { "type": "array", "items": { "$ref": "#/components/schemas/FileHistory" } } } }
+                    }
+                }
+            }
+        },
+        "/api/v1.0/emailHistory/{ticketNumber}": {
+            "get": {
+                "tags": ["email-history-controller"],
+                "operationId": "getEmailHistoryByTicketNumber",
+                "parameters": [
+                    {
+                        "name": "ticketNumber",
+                        "in": "path",
+                        "description": "Ticket number to retrieve related emails.",
+                        "required": true,
+                        "schema": { "type": "string" }
+                    }
+                ],
+                "responses": {
+                    "400": { "description": "Bad Request", "content": { "*/*": { "schema": { "type": "object" } } } },
+                    "404": { "description": "Not Found", "content": { "*/*": { "schema": { "type": "object" } } } },
+                    "405": { "description": "Method Not Allowed", "content": { "*/*": { "schema": { "type": "object" } } } },
+                    "500": { "description": "Internal Server Error", "content": { "*/*": { "schema": { "type": "object" } } } },
+                    "200": {
+                        "description": "OK",
+                        "content": { "*/*": { "schema": { "type": "array", "items": { "$ref": "#/components/schemas/EmailHistory" } } } }
+                    }
+                }
+            }
+        },
+        "/api/v1.0/disputes": {
+            "get": {
+                "tags": ["dispute-controller"],
+                "summary": "Returns all Dispute records based on the specified optional parameters.",
+                "operationId": "getAllDisputes",
+                "parameters": [
+                    {
+                        "name": "olderThan",
+                        "in": "query",
+                        "description": "If specified, will retrieve records older than this date (specified by yyyy-MM-dd)",
+                        "required": false,
+                        "schema": { "type": "string", "format": "date-time" },
+                        "example": "2022-03-15"
+                    },
+                    {
+                        "name": "excludeStatus",
+                        "in": "query",
+                        "description": "If specified, will retrieve records which do not have the specified status",
+                        "required": false,
+                        "schema": {
+                            "type": "string",
+                            "enum": ["UNKNOWN", "NEW", "VALIDATED", "PROCESSING", "REJECTED", "CANCELLED", "CONCLUDED"]
+                        },
+                        "example": "CANCELLED"
+                    }
+                ],
+                "responses": {
+                    "400": { "description": "Bad Request.", "content": { "*/*": { "schema": { "type": "object" } } } },
+                    "404": { "description": "Not Found", "content": { "*/*": { "schema": { "type": "object" } } } },
+                    "405": { "description": "Method Not Allowed", "content": { "*/*": { "schema": { "type": "object" } } } },
+                    "500": {
+                        "description": "Internal Server Error. Getting disputes failed.",
+                        "content": { "*/*": { "schema": { "type": "object" } } }
+                    },
+                    "200": {
+                        "description": "Ok. Disputes are returned.",
+                        "content": { "*/*": { "schema": { "type": "array", "items": { "$ref": "#/components/schemas/DisputeListItem" } } } }
+                    }
+                }
+            }
+        },
+        "/api/v1.0/disputes/unassign": {
+            "get": {
+                "tags": ["dispute-controller"],
+                "summary": "An endpoint hook to trigger the Unassign Dispute job.",
+                "description": "A Dispute can be assigned to a specific user that \"locks\" the record for others. This endpoing manually triggers the Unassign Dispute job that clears the assignment of all Disputes that were assigned for more than 1 hour.",
+                "operationId": "unassignDisputes",
+                "responses": {
+                    "400": { "description": "Bad Request", "content": { "*/*": { "schema": { "type": "object" } } } },
+                    "404": { "description": "Not Found", "content": { "*/*": { "schema": { "type": "object" } } } },
+                    "405": { "description": "Method Not Allowed", "content": { "*/*": { "schema": { "type": "object" } } } },
+                    "500": {
+                        "description": "Internal Server Error. Unassigned failed.",
+                        "content": { "*/*": { "schema": { "type": "object" } } }
+                    },
+                    "200": { "description": "Ok. Dispute record unassigned." }
+                }
+            }
+        },
+        "/api/v1.0/dispute/{id}/{isAssign}": {
+            "get": {
+                "tags": ["dispute-controller"],
+                "operationId": "getDispute",
+                "parameters": [
+                    { "name": "id", "in": "path", "required": true, "schema": { "type": "integer", "format": "int64" } },
+                    { "name": "isAssign", "in": "path", "required": true, "schema": { "type": "boolean" } }
+                ],
+                "responses": {
+                    "400": { "description": "Bad Request", "content": { "*/*": { "schema": { "type": "object" } } } },
+                    "404": { "description": "Not Found", "content": { "*/*": { "schema": { "type": "object" } } } },
+                    "405": { "description": "Method Not Allowed", "content": { "*/*": { "schema": { "type": "object" } } } },
+                    "500": { "description": "Internal Server Error", "content": { "*/*": { "schema": { "type": "object" } } } },
+                    "200": { "description": "OK", "content": { "*/*": { "schema": { "$ref": "#/components/schemas/Dispute" } } } }
+                }
+            }
+        },
+        "/api/v1.0/dispute/updateRequests": {
+            "get": {
+                "tags": ["dispute-controller"],
+                "summary": "An endpoint that retrieves all DisputeUpdateRequest optionally for a given Dispute, optionally filtered by DisputeUpdateRequestStatus.",
+                "operationId": "getDisputeUpdateRequests",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "query",
+                        "description": "If specified, filter request by the disputeId of the Dispute.",
+                        "required": false,
+                        "schema": { "type": "integer", "format": "int64" }
+                    },
+                    {
+                        "name": "status",
+                        "in": "query",
+                        "description": "If specified, filter request by DisputeUpdateRequestStatus",
+                        "required": false,
+                        "schema": { "type": "string", "enum": ["UNKNOWN", "ACCEPTED", "PENDING", "REJECTED"] },
+                        "example": "PENDING"
+                    }
+                ],
+                "responses": {
+                    "400": { "description": "Bad Request", "content": { "*/*": { "schema": { "type": "object" } } } },
+                    "404": { "description": "Not Found", "content": { "*/*": { "schema": { "type": "object" } } } },
+                    "405": { "description": "Method Not Allowed", "content": { "*/*": { "schema": { "type": "object" } } } },
+                    "500": {
+                        "description": "Internal Server Error. retrieve update requests failed.",
+                        "content": { "*/*": { "schema": { "type": "object" } } }
+                    },
+                    "200": {
+                        "description": "Ok. DisputeUpdateRequest record saved.",
+                        "content": {
+                            "*/*": { "schema": { "type": "array", "items": { "$ref": "#/components/schemas/DisputeUpdateRequest" } } }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1.0/dispute/status": {
+            "get": {
+                "tags": ["dispute-controller"],
+                "summary": "Finds Dispute statuses by TicketNumber and IssuedTime or noticeOfDisputeGuid if specified.",
+                "operationId": "findDisputeStatuses",
+                "parameters": [
+                    {
+                        "name": "ticketNumber",
+                        "in": "query",
+                        "description": "The Dispute.ticketNumber to search for (of the format XX00000000)",
+                        "required": false,
+                        "schema": { "pattern": "^$|([A-Z]{2}\\d{8})", "type": "string" },
+                        "example": "AX12345678"
+                    },
+                    {
+                        "name": "issuedTime",
+                        "in": "query",
+                        "description": "The time portion of the Dispute.issuedTs field to search for (of the format HH:mm). Time is in UTC.",
+                        "required": false,
+                        "schema": { "type": "string" },
+                        "example": "14:53"
+                    },
+                    {
+                        "name": "noticeOfDisputeGuid",
+                        "in": "query",
+                        "description": "The noticeOfDisputeGuid of the Dispute to retreive.",
+                        "required": false,
+                        "schema": { "type": "string" }
+                    }
+                ],
+                "responses": {
+                    "400": { "description": "Bad Request, check parameters.", "content": { "*/*": { "schema": { "type": "object" } } } },
+                    "404": { "description": "Not Found", "content": { "*/*": { "schema": { "type": "object" } } } },
+                    "405": { "description": "Method Not Allowed", "content": { "*/*": { "schema": { "type": "object" } } } },
+                    "500": {
+                        "description": "Internal Server Error. Search failed.",
+                        "content": { "*/*": { "schema": { "type": "object" } } }
+                    },
+                    "200": {
+                        "description": "Ok.",
+                        "content": { "*/*": { "schema": { "type": "array", "items": { "$ref": "#/components/schemas/DisputeResult" } } } }
+                    }
+                }
+            }
+        },
+        "/api/v1.0/dispute/noticeOfDispute/{id}": {
+            "get": {
+                "tags": ["dispute-controller"],
+                "summary": "Retrieves Dispute by the noticeOfDisputeGuid (UUID).",
+                "operationId": "getDisputeByNoticeOfDisputeGuid",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "The noticeOfDisputeGuid of the Dispute to retreive.",
+                        "required": true,
+                        "schema": { "type": "string" }
+                    }
+                ],
+                "responses": {
+                    "400": { "description": "Bad Request", "content": { "*/*": { "schema": { "type": "object" } } } },
+                    "404": { "description": "Dispute could not be found.", "content": { "*/*": { "schema": { "type": "object" } } } },
+                    "405": { "description": "Method Not Allowed", "content": { "*/*": { "schema": { "type": "object" } } } },
+                    "500": { "description": "Internal server error occured.", "content": { "*/*": { "schema": { "type": "object" } } } },
+                    "200": {
+                        "description": "Ok. Dispute retrieved.",
+                        "content": { "*/*": { "schema": { "$ref": "#/components/schemas/Dispute" } } }
+                    }
+                }
+            }
+        },
+        "/api/v1.0/codetable/refresh": {
+            "get": {
+                "tags": ["dispute-controller"],
+                "summary": "An endpoint hook to trigger a redis rebuild of cached codetable data.",
+                "description": "The codetables in redis are cached copies of data pulled from Oracle to ensure TCO remains stable. This data is periodically refreshed, but can be forced by hitting this endpoint.",
+                "operationId": "codeTableRefresh",
+                "responses": {
+                    "400": { "description": "Bad Request", "content": { "*/*": { "schema": { "type": "object" } } } },
+                    "404": { "description": "Not Found", "content": { "*/*": { "schema": { "type": "object" } } } },
+                    "405": { "description": "Method Not Allowed", "content": { "*/*": { "schema": { "type": "object" } } } },
+                    "500": { "description": "Internal Server Error", "content": { "*/*": { "schema": { "type": "object" } } } },
+                    "200": { "description": "OK" }
+                }
+            }
+        },
+        "/api/v1.0/jj/dispute": {
+            "delete": {
+                "tags": ["jj-dispute-controller"],
+                "summary": "Deletes a particular JJDispute record.",
+                "operationId": "DeleteJJDispute",
+                "parameters": [
+                    {
+                        "name": "jjDisputeId",
+                        "in": "query",
+                        "description": "If specified, will delete the record of the specified jj dispute by this ID. JJ Dispute ID will take precedence if both ID and ticket number supplied",
+                        "required": false,
+                        "schema": { "type": "integer", "format": "int64" }
+                    },
+                    {
+                        "name": "ticketNumber",
+                        "in": "query",
+                        "description": "If specified, will delete the record of the specified jj dispute by this TicketNumber. (Format is XX00000000)",
+                        "required": false,
+                        "schema": { "pattern": "[A-Z]{2}\\d{8}", "type": "string" },
+                        "example": "AX12345678"
+                    }
+                ],
+                "responses": {
+                    "400": { "description": "Bad Request.", "content": { "*/*": { "schema": { "type": "object" } } } },
+                    "404": { "description": "Not Found", "content": { "*/*": { "schema": { "type": "object" } } } },
+                    "405": { "description": "Method Not Allowed", "content": { "*/*": { "schema": { "type": "object" } } } },
+                    "500": {
+                        "description": "Internal Server Error. Delete failed.",
+                        "content": { "*/*": { "schema": { "type": "object" } } }
+                    },
+                    "200": { "description": "Ok. JJ Dispute record deleted." }
+                }
+            }
+        }
+    },
+    "components": {
+        "schemas": {
+            "JJDispute": {
+                "type": "object",
+                "properties": {
+                    "createdBy": { "type": "string" },
+                    "createdTs": { "type": "string", "format": "date-time" },
+                    "modifiedBy": { "type": "string", "nullable": true },
+                    "modifiedTs": { "type": "string", "format": "date-time", "nullable": true },
+                    "id": { "type": "integer", "description": "ID", "format": "int64", "readOnly": true },
+                    "ticketNumber": { "type": "string" },
+                    "addressLine1": { "type": "string" },
+                    "addressLine2": { "type": "string", "nullable": true },
+                    "addressLine3": { "type": "string", "nullable": true },
+                    "addressCity": { "type": "string", "nullable": true },
+                    "addressProvince": { "type": "string", "nullable": true },
+                    "addressCountry": { "type": "string", "nullable": true },
+                    "addressPostalCode": { "type": "string", "nullable": true },
+                    "disputantBirthdate": { "type": "string", "format": "date-time", "nullable": true },
+                    "driversLicenceNumber": { "type": "string", "nullable": true },
+                    "drvLicIssuedProvSeqNo": { "type": "string", "nullable": true },
+                    "drvLicIssuedCtryId": { "type": "string", "nullable": true },
+                    "emailAddress": { "type": "string", "nullable": true },
+                    "status": {
+                        "type": "string",
+                        "enum": [
+                            "UNKNOWN",
+                            "NEW",
+                            "IN_PROGRESS",
+                            "DATA_UPDATE",
+                            "CONFIRMED",
+                            "REQUIRE_COURT_HEARING",
+                            "REQUIRE_MORE_INFO",
+                            "ACCEPTED",
+                            "REVIEW",
+                            "CONCLUDED",
+                            "CANCELLED",
+                            "HEARING_SCHEDULED"
+                        ]
+                    },
+                    "hearingType": { "type": "string", "nullable": true, "enum": ["UNKNOWN", "COURT_APPEARANCE", "WRITTEN_REASONS"] },
+                    "noticeOfDisputeGuid": { "type": "string", "nullable": true },
+                    "noticeOfHearingYn": { "type": "string", "nullable": true, "enum": ["UNKNOWN", "Y", "N"] },
+                    "occamDisputantGiven1Nm": { "type": "string", "nullable": true },
+                    "occamDisputantGiven2Nm": { "type": "string", "nullable": true },
+                    "occamDisputantGiven3Nm": { "type": "string", "nullable": true },
+                    "occamDisputantSurnameNm": { "type": "string", "nullable": true },
+                    "occamDisputeId": { "type": "integer", "format": "int64" },
+                    "occamViolationTicketUpldId": { "type": "string", "nullable": true },
+                    "submittedTs": { "type": "string", "format": "date-time", "nullable": true },
+                    "issuedTs": { "type": "string", "format": "date-time", "nullable": true },
+                    "violationDate": { "type": "string", "format": "date-time", "nullable": true },
+                    "icbcReceivedDate": { "type": "string", "format": "date-time", "nullable": true },
+                    "enforcementOfficer": { "type": "string", "nullable": true },
+                    "electronicTicketYn": { "type": "string", "nullable": true, "enum": ["UNKNOWN", "Y", "N"] },
+                    "policeDetachment": { "type": "string", "nullable": true },
+                    "courthouseLocation": { "type": "string", "nullable": true },
+                    "offenceLocation": { "type": "string", "nullable": true },
+                    "jjAssignedTo": { "type": "string", "nullable": true },
+                    "jjDecisionDate": { "type": "string", "format": "date-time", "nullable": true },
+                    "vtcAssignedTo": { "type": "string", "nullable": true },
+                    "vtcAssignedTs": { "type": "string", "format": "date-time", "nullable": true },
+                    "fineReductionReason": { "type": "string", "nullable": true },
+                    "timeToPayReason": { "type": "string", "nullable": true },
+                    "contactLawFirmName": { "type": "string", "nullable": true },
+                    "contactGivenName1": { "type": "string", "nullable": true },
+                    "contactGivenName2": { "type": "string", "nullable": true },
+                    "contactGivenName3": { "type": "string", "nullable": true },
+                    "contactSurname": { "type": "string", "nullable": true },
+                    "contactType": { "type": "string", "nullable": true, "enum": ["UNKNOWN", "INDIVIDUAL", "LAWYER", "OTHER"] },
+                    "appearInCourt": { "type": "string", "enum": ["UNKNOWN", "Y", "N"] },
+                    "courtAgenId": { "type": "string", "nullable": true },
+                    "lawFirmName": { "type": "string", "nullable": true },
+                    "lawyerSurname": { "type": "string", "nullable": true },
+                    "lawyerGivenName1": { "type": "string", "nullable": true },
+                    "lawyerGivenName2": { "type": "string", "nullable": true },
+                    "lawyerGivenName3": { "type": "string", "nullable": true },
+                    "justinRccId": { "type": "string", "nullable": true },
+                    "interpreterLanguageCd": { "type": "string", "nullable": true },
+                    "witnessNo": { "type": "integer", "format": "int32", "nullable": true },
+                    "disputantAttendanceType": {
+                        "type": "string",
+                        "nullable": true,
+                        "enum": [
+                            "UNKNOWN",
+                            "WRITTEN_REASONS",
+                            "VIDEO_CONFERENCE",
+                            "TELEPHONE_CONFERENCE",
+                            "MSTEAMS_AUDIO",
+                            "MSTEAMS_VIDEO",
+                            "IN_PERSON"
+                        ]
+                    },
+                    "remarks": { "type": "array", "items": { "$ref": "#/components/schemas/JJDisputeRemark" } },
+                    "jjDisputedCounts": { "type": "array", "items": { "$ref": "#/components/schemas/JJDisputedCount" } },
+                    "jjDisputeCourtAppearanceRoPs": {
+                        "type": "array",
+                        "items": { "$ref": "#/components/schemas/JJDisputeCourtAppearanceRoP" }
+                    }
+                }
+            },
+            "JJDisputeCourtAppearanceRoP": {
+                "type": "object",
+                "properties": {
+                    "justinAppearanceId": { "type": "string", "description": "Justin Appearance ID", "readOnly": true },
+                    "id": {
+                        "type": "integer",
+                        "description": "TCO Court Appearance ID",
+                        "format": "int64",
+                        "nullable": true,
+                        "readOnly": true
+                    },
+                    "appearanceTs": { "type": "string", "format": "date-time", "nullable": true },
+                    "room": { "type": "string", "nullable": true },
+                    "duration": { "type": "integer", "format": "int32", "nullable": true },
+                    "reason": { "type": "string", "nullable": true },
+                    "appCd": { "type": "string", "nullable": true, "enum": ["UNKNOWN", "A", "P", "N"] },
+                    "noAppTs": { "type": "string", "format": "date-time", "nullable": true },
+                    "clerkRecord": { "type": "string", "nullable": true },
+                    "defenceCounsel": { "type": "string", "nullable": true },
+                    "dattCd": { "type": "string", "nullable": true, "enum": ["UNKNOWN", "A", "C", "N"] },
+                    "crown": { "type": "string", "nullable": true, "enum": ["UNKNOWN", "P", "N"] },
+                    "jjSeized": { "type": "string", "nullable": true, "enum": ["UNKNOWN", "Y", "N"] },
+                    "adjudicator": { "type": "string", "nullable": true },
+                    "comments": { "maxLength": 4000, "minLength": 0, "type": "string", "nullable": true }
+                }
+            },
+            "JJDisputeRemark": {
+                "type": "object",
+                "properties": {
+                    "createdBy": { "type": "string" },
+                    "createdTs": { "type": "string", "format": "date-time" },
+                    "modifiedBy": { "type": "string", "nullable": true },
+                    "modifiedTs": { "type": "string", "format": "date-time", "nullable": true },
+                    "id": { "type": "integer", "description": "ID", "format": "int64", "readOnly": true },
+                    "userFullName": { "type": "string" },
+                    "note": { "maxLength": 4000, "minLength": 0, "type": "string" },
+                    "remarksMadeTs": { "type": "string", "format": "date-time" }
+                }
+            },
+            "JJDisputedCount": {
+                "type": "object",
+                "properties": {
+                    "createdBy": { "type": "string" },
+                    "createdTs": { "type": "string", "format": "date-time" },
+                    "modifiedBy": { "type": "string", "nullable": true },
+                    "modifiedTs": { "type": "string", "format": "date-time", "nullable": true },
+                    "id": { "type": "integer", "description": "ID", "format": "int64", "readOnly": true },
+                    "plea": {
+                        "type": "string",
+                        "description": "Represents the disputant's initial plea on count.",
+                        "enum": ["UNKNOWN", "G", "N"]
+                    },
+                    "count": { "maximum": 3, "minimum": 1, "type": "integer", "format": "int32" },
+                    "requestTimeToPay": { "type": "string", "enum": ["UNKNOWN", "Y", "N"] },
+                    "requestReduction": { "type": "string", "enum": ["UNKNOWN", "Y", "N"] },
+                    "appearInCourt": { "type": "string", "enum": ["UNKNOWN", "Y", "N"] },
+                    "description": { "type": "string", "nullable": true },
+                    "dueDate": { "type": "string", "format": "date-time", "nullable": true },
+                    "ticketedFineAmount": { "type": "number", "format": "float", "nullable": true },
+                    "lesserOrGreaterAmount": { "type": "number", "format": "float", "nullable": true },
+                    "includesSurcharge": { "type": "string", "nullable": true, "enum": ["UNKNOWN", "Y", "N"] },
+                    "revisedDueDate": { "type": "string", "format": "date-time", "nullable": true },
+                    "totalFineAmount": { "type": "number", "format": "float", "nullable": true },
+                    "violationDate": { "type": "string", "format": "date-time", "nullable": true },
+                    "comments": { "maxLength": 4000, "minLength": 0, "type": "string", "nullable": true },
+                    "latestPlea": {
+                        "type": "string",
+                        "description": "Represents the disputant's latest plea on count.",
+                        "nullable": true,
+                        "enum": ["UNKNOWN", "G", "N"]
+                    },
+                    "latestPleaUpdateTs": {
+                        "type": "string",
+                        "description": "The timestamp for when the last time disputant changed their plea.",
+                        "format": "date-time",
+                        "nullable": true
+                    },
+                    "jjDisputedCountRoP": { "$ref": "#/components/schemas/JJDisputedCountRoP" }
+                }
+            },
+            "JJDisputedCountRoP": {
+                "type": "object",
+                "properties": {
+                    "createdBy": { "type": "string" },
+                    "createdTs": { "type": "string", "format": "date-time" },
+                    "modifiedBy": { "type": "string", "nullable": true },
+                    "modifiedTs": { "type": "string", "format": "date-time", "nullable": true },
+                    "id": { "type": "integer", "description": "ID", "format": "int64", "readOnly": true },
+                    "finding": {
+                        "type": "string",
+                        "nullable": true,
+                        "enum": ["UNKNOWN", "GUILTY", "NOT_GUILTY", "CANCELLED", "PAID_PRIOR_TO_APPEARANCE", "GUILTY_LESSER"]
+                    },
+                    "lesserDescription": { "type": "string", "nullable": true },
+                    "ssProbationDuration": { "type": "string", "nullable": true },
+                    "ssProbationConditions": { "type": "string", "nullable": true },
+                    "jailDuration": { "type": "string", "nullable": true },
+                    "jailIntermittent": { "type": "string", "enum": ["UNKNOWN", "Y", "N"] },
+                    "probationDuration": { "type": "string", "nullable": true },
+                    "probationConditions": { "type": "string", "nullable": true },
+                    "drivingProhibition": { "type": "string", "nullable": true },
+                    "drivingProhibitionMVASection": { "type": "string", "nullable": true },
+                    "dismissed": { "type": "string", "enum": ["UNKNOWN", "Y", "N"] },
+                    "forWantOfProsecution": { "type": "string", "enum": ["UNKNOWN", "Y", "N"] },
+                    "withdrawn": { "type": "string", "enum": ["UNKNOWN", "Y", "N"] },
+                    "abatement": { "type": "string", "enum": ["UNKNOWN", "Y", "N"] },
+                    "stayOfProceedingsBy": { "type": "string", "nullable": true },
+                    "other": { "type": "string", "nullable": true }
+                },
+                "nullable": true
+            },
+            "Dispute": {
+                "type": "object",
+                "properties": {
+                    "createdBy": { "type": "string" },
+                    "createdTs": { "type": "string", "format": "date-time" },
+                    "modifiedBy": { "type": "string", "nullable": true },
+                    "modifiedTs": { "type": "string", "format": "date-time", "nullable": true },
+                    "disputeId": { "type": "integer", "description": "ID", "format": "int64", "readOnly": true },
+                    "noticeOfDisputeGuid": { "type": "string", "nullable": true },
+                    "ticketNumber": { "type": "string" },
+                    "issuedTs": { "type": "string", "format": "date-time", "nullable": true },
+                    "submittedTs": { "type": "string", "format": "date-time", "nullable": true },
+                    "disputantSurname": { "type": "string", "nullable": true },
+                    "disputantGivenName1": { "type": "string", "nullable": true },
+                    "disputantGivenName2": { "type": "string", "nullable": true },
+                    "disputantGivenName3": { "type": "string", "nullable": true },
+                    "disputantBirthdate": { "type": "string", "format": "date-time", "nullable": true },
+                    "driversLicenceNumber": { "maxLength": 30, "minLength": 0, "type": "string", "nullable": true },
+                    "disputantOrganization": { "type": "string", "nullable": true },
+                    "disputantClientId": { "type": "string", "nullable": true, "readOnly": true },
+                    "driversLicenceIssuedCountryId": { "type": "integer", "format": "int32", "nullable": true },
+                    "driversLicenceIssuedProvinceSeqNo": { "type": "integer", "format": "int32", "nullable": true },
+                    "driversLicenceProvince": { "maxLength": 30, "minLength": 0, "type": "string", "nullable": true },
+                    "status": {
+                        "type": "string",
+                        "enum": ["UNKNOWN", "NEW", "VALIDATED", "PROCESSING", "REJECTED", "CANCELLED", "CONCLUDED"]
+                    },
+                    "addressLine1": { "type": "string", "nullable": true },
+                    "addressLine2": { "type": "string", "nullable": true },
+                    "addressLine3": { "type": "string", "nullable": true },
+                    "addressCity": { "maxLength": 30, "minLength": 0, "type": "string", "nullable": true },
+                    "addressProvince": { "maxLength": 30, "minLength": 0, "type": "string", "nullable": true },
+                    "addressProvinceCountryId": { "type": "integer", "format": "int32", "nullable": true },
+                    "addressProvinceSeqNo": { "type": "integer", "format": "int32", "nullable": true },
+                    "addressCountryId": { "type": "integer", "format": "int32", "nullable": true },
+                    "postalCode": { "maxLength": 10, "minLength": 0, "type": "string", "nullable": true },
+                    "homePhoneNumber": { "type": "string", "nullable": true },
+                    "workPhoneNumber": { "type": "string", "nullable": true },
+                    "emailAddress": { "type": "string", "nullable": true },
+                    "emailAddressVerified": { "type": "boolean" },
+                    "filingDate": { "type": "string", "format": "date-time", "nullable": true },
+                    "representedByLawyer": { "type": "string", "nullable": true, "enum": ["UNKNOWN", "Y", "N"] },
+                    "lawFirmName": { "type": "string", "nullable": true },
+                    "lawyerSurname": { "type": "string", "nullable": true },
+                    "lawyerGivenName1": { "type": "string", "nullable": true },
+                    "lawyerGivenName2": { "type": "string", "nullable": true },
+                    "lawyerGivenName3": { "type": "string", "nullable": true },
+                    "lawyerAddress": { "maxLength": 300, "minLength": 0, "type": "string", "nullable": true },
+                    "lawyerPhoneNumber": { "type": "string", "nullable": true },
+                    "lawyerEmail": { "maxLength": 100, "minLength": 0, "type": "string", "nullable": true },
+                    "officerPin": { "type": "string", "nullable": true },
+                    "contactTypeCd": { "type": "string", "enum": ["UNKNOWN", "INDIVIDUAL", "LAWYER", "OTHER"] },
+                    "requestCourtAppearanceYn": { "type": "string", "nullable": true, "enum": ["UNKNOWN", "Y", "N"] },
+                    "contactLawFirmNm": { "type": "string", "nullable": true },
+                    "contactGiven1Nm": { "type": "string", "nullable": true },
+                    "contactGiven2Nm": { "type": "string", "nullable": true },
+                    "contactGiven3Nm": { "type": "string", "nullable": true },
+                    "contactSurnameNm": { "type": "string", "nullable": true },
+                    "appearanceDtm": { "type": "string", "format": "date-time", "nullable": true },
+                    "appearanceLessThan14DaysYn": { "type": "string", "nullable": true, "enum": ["UNKNOWN", "Y", "N"] },
+                    "detachmentLocation": { "type": "string", "nullable": true },
+                    "courtAgenId": { "type": "string", "nullable": true },
+                    "interpreterLanguageCd": { "maxLength": 3, "minLength": 0, "type": "string", "nullable": true },
+                    "interpreterRequired": { "type": "string", "nullable": true, "enum": ["UNKNOWN", "Y", "N"] },
+                    "witnessNo": { "type": "integer", "format": "int32", "nullable": true },
+                    "fineReductionReason": { "type": "string", "nullable": true },
+                    "timeToPayReason": { "type": "string", "nullable": true },
+                    "disputantComment": { "type": "string", "nullable": true },
+                    "rejectedReason": { "type": "string", "nullable": true },
+                    "userAssignedTo": { "type": "string", "nullable": true },
+                    "userAssignedTs": { "type": "string", "format": "date-time", "nullable": true },
+                    "disputantDetectedOcrIssues": { "type": "string", "nullable": true, "enum": ["UNKNOWN", "Y", "N"] },
+                    "disputantOcrIssues": { "type": "string", "nullable": true },
+                    "systemDetectedOcrIssues": { "type": "string", "enum": ["UNKNOWN", "Y", "N"] },
+                    "ocrTicketFilename": { "maxLength": 100, "minLength": 0, "type": "string", "nullable": true },
+                    "violationTicket": { "$ref": "#/components/schemas/ViolationTicket" },
+                    "disputeCounts": { "type": "array", "items": { "$ref": "#/components/schemas/DisputeCount" } }
+                }
+            },
+            "DisputeCount": {
+                "type": "object",
+                "properties": {
+                    "createdBy": { "type": "string" },
+                    "createdTs": { "type": "string", "format": "date-time" },
+                    "modifiedBy": { "type": "string", "nullable": true },
+                    "modifiedTs": { "type": "string", "format": "date-time", "nullable": true },
+                    "countNo": { "maximum": 3, "minimum": 1, "type": "integer", "format": "int32" },
+                    "pleaCode": { "type": "string", "enum": ["UNKNOWN", "G", "N"] },
+                    "requestTimeToPay": { "type": "string", "enum": ["UNKNOWN", "Y", "N"] },
+                    "requestReduction": { "type": "string", "enum": ["UNKNOWN", "Y", "N"] },
+                    "requestCourtAppearance": { "type": "string", "enum": ["UNKNOWN", "Y", "N"] }
+                }
+            },
+            "ViolationTicket": {
+                "type": "object",
+                "properties": {
+                    "createdBy": { "type": "string" },
+                    "createdTs": { "type": "string", "format": "date-time" },
+                    "modifiedBy": { "type": "string", "nullable": true },
+                    "modifiedTs": { "type": "string", "format": "date-time", "nullable": true },
+                    "violationTicketId": { "type": "integer", "description": "ID", "format": "int64", "readOnly": true },
+                    "ticketNumber": { "type": "string", "nullable": true },
+                    "disputantOrganizationName": { "type": "string", "nullable": true },
+                    "disputantSurname": { "type": "string", "nullable": true },
+                    "disputantGivenNames": { "type": "string", "nullable": true },
+                    "isYoungPerson": { "type": "string", "nullable": true, "enum": ["UNKNOWN", "Y", "N"] },
+                    "disputantDriversLicenceNumber": { "maxLength": 30, "minLength": 7, "type": "string", "nullable": true },
+                    "disputantClientNumber": { "type": "string", "nullable": true },
+                    "driversLicenceProvince": { "maxLength": 100, "minLength": 0, "type": "string", "nullable": true },
+                    "driversLicenceCountry": { "maxLength": 100, "minLength": 0, "type": "string" },
+                    "driversLicenceIssuedYear": { "type": "integer", "format": "int32", "nullable": true },
+                    "driversLicenceExpiryYear": { "type": "integer", "format": "int32", "nullable": true },
+                    "disputantBirthdate": { "type": "string", "format": "date-time", "nullable": true },
+                    "address": { "maxLength": 100, "minLength": 0, "type": "string", "nullable": true },
+                    "addressCity": { "type": "string", "nullable": true },
+                    "addressProvince": { "type": "string", "nullable": true },
+                    "addressPostalCode": { "type": "string", "nullable": true },
+                    "addressCountry": { "type": "string", "nullable": true },
+                    "officerPin": { "type": "string", "nullable": true },
+                    "detachmentLocation": { "type": "string", "nullable": true },
+                    "issuedTs": { "type": "string", "format": "date-time", "nullable": true },
+                    "issuedOnRoadOrHighway": { "type": "string", "nullable": true },
+                    "issuedAtOrNearCity": { "type": "string", "nullable": true },
+                    "isChangeOfAddress": { "type": "string", "nullable": true, "enum": ["UNKNOWN", "Y", "N"] },
+                    "isDriver": { "type": "string", "nullable": true, "enum": ["UNKNOWN", "Y", "N"] },
+                    "isOwner": { "type": "string", "nullable": true, "enum": ["UNKNOWN", "Y", "N"] },
+                    "courtLocation": { "type": "string", "nullable": true },
+                    "violationTicketCounts": { "type": "array", "items": { "$ref": "#/components/schemas/ViolationTicketCount" } }
+                },
+                "nullable": true
+            },
+            "ViolationTicketCount": {
+                "type": "object",
+                "properties": {
+                    "createdBy": { "type": "string" },
+                    "createdTs": { "type": "string", "format": "date-time" },
+                    "modifiedBy": { "type": "string", "nullable": true },
+                    "modifiedTs": { "type": "string", "format": "date-time", "nullable": true },
+                    "violationTicketCountId": { "type": "integer", "description": "ID", "format": "int64", "readOnly": true },
+                    "countNo": { "maximum": 3, "minimum": 1, "type": "integer", "format": "int32" },
+                    "description": { "type": "string", "nullable": true },
+                    "actOrRegulationNameCode": { "type": "string", "nullable": true },
+                    "isAct": { "type": "string", "nullable": true, "enum": ["UNKNOWN", "Y", "N"] },
+                    "isRegulation": { "type": "string", "nullable": true, "enum": ["UNKNOWN", "Y", "N"] },
+                    "section": { "maxLength": 10, "minLength": 0, "type": "string", "nullable": true, "readOnly": true },
+                    "subsection": { "maxLength": 4, "minLength": 0, "type": "string", "nullable": true, "readOnly": true },
+                    "paragraph": { "maxLength": 3, "minLength": 0, "type": "string", "nullable": true, "readOnly": true },
+                    "subparagraph": { "maxLength": 5, "minLength": 0, "type": "string", "nullable": true, "readOnly": true },
+                    "ticketedAmount": { "type": "number", "format": "float", "nullable": true }
+                }
+            },
+            "DisputeUpdateRequest": {
+                "required": ["status", "updateJson", "updateType"],
+                "type": "object",
+                "properties": {
+                    "createdBy": { "type": "string" },
+                    "createdTs": { "type": "string", "format": "date-time" },
+                    "modifiedBy": { "type": "string", "nullable": true },
+                    "modifiedTs": { "type": "string", "format": "date-time", "nullable": true },
+                    "disputeUpdateRequestId": { "type": "integer", "description": "ID", "format": "int64", "readOnly": true },
+                    "disputeId": { "type": "integer", "format": "int64" },
+                    "status": { "type": "string", "enum": ["UNKNOWN", "ACCEPTED", "PENDING", "REJECTED"] },
+                    "updateType": {
+                        "type": "string",
+                        "enum": [
+                            "UNKNOWN",
+                            "DISPUTANT_ADDRESS",
+                            "DISPUTANT_PHONE",
+                            "DISPUTANT_NAME",
+                            "COUNT",
+                            "DISPUTANT_EMAIL",
+                            "DISPUTANT_DOCUMENT",
+                            "COURT_OPTIONS"
+                        ]
+                    },
+                    "updateJson": { "maxLength": 1000, "minLength": 3, "type": "string" }
+                }
+            },
+            "FileHistory": {
+                "required": ["auditLogEntryType", "disputeId"],
+                "type": "object",
+                "properties": {
+                    "createdBy": { "type": "string" },
+                    "createdTs": { "type": "string", "format": "date-time" },
+                    "modifiedBy": { "type": "string", "nullable": true },
+                    "modifiedTs": { "type": "string", "format": "date-time", "nullable": true },
+                    "fileHistoryId": { "type": "integer", "description": "ID", "format": "int64", "readOnly": true },
+                    "disputeId": { "type": "integer", "format": "int64" },
+                    "auditLogEntryType": {
+                        "type": "string",
+                        "enum": [
+                            "UNKNOWN",
+                            "ARFL",
+                            "CAIN",
+                            "CAWT",
+                            "CCAN",
+                            "CCON",
+                            "CCWR",
+                            "CLEG",
+                            "CUEM",
+                            "CUEV",
+                            "CUIN",
+                            "CULG",
+                            "CUPD",
+                            "CUWR",
+                            "CUWT",
+                            "DURA",
+                            "DURR",
+                            "EMCA",
+                            "EMCF",
+                            "EMCR",
+                            "EMDC",
+                            "EMFD",
+                            "EMPR",
+                            "EMRJ",
+                            "EMRV",
+                            "EMST",
+                            "EMUP",
+                            "EMVF",
+                            "ESUR",
+                            "FDLD",
+                            "FDLS",
+                            "FUPD",
+                            "FUPS",
+                            "INIT",
+                            "JASG",
+                            "JCNF",
+                            "JDIV",
+                            "JPRG",
+                            "OCNT",
+                            "RECN",
+                            "SADM",
+                            "SCAN",
+                            "SPRC",
+                            "SREJ",
+                            "SUB",
+                            "SUPL",
+                            "SVAL",
+                            "URSR",
+                            "VREV",
+                            "VSUB"
+                        ]
+                    },
+                    "description": { "type": "string", "nullable": true },
+                    "actionByApplicationUser": { "type": "string", "nullable": true }
+                }
+            },
+            "EmailHistory": {
+                "type": "object",
+                "properties": {
+                    "createdBy": { "type": "string" },
+                    "createdTs": { "type": "string", "format": "date-time" },
+                    "modifiedBy": { "type": "string", "nullable": true },
+                    "modifiedTs": { "type": "string", "format": "date-time", "nullable": true },
+                    "emailHistoryId": { "type": "integer", "description": "ID", "format": "int64", "readOnly": true },
+                    "emailSentTs": { "type": "string", "format": "date-time" },
+                    "fromEmailAddress": { "maxLength": 100, "minLength": 0, "type": "string" },
+                    "toEmailAddress": { "maxLength": 4000, "minLength": 0, "type": "string" },
+                    "ccEmailAddress": { "maxLength": 4000, "minLength": 0, "type": "string", "nullable": true },
+                    "bccEmailAddress": { "maxLength": 4000, "minLength": 0, "type": "string", "nullable": true },
+                    "subject": { "maxLength": 1000, "minLength": 0, "type": "string" },
+                    "htmlContent": { "maxLength": 4000, "minLength": 0, "type": "string", "nullable": true },
+                    "plainTextContent": { "maxLength": 4000, "minLength": 0, "type": "string", "nullable": true },
+                    "successfullySent": { "type": "string", "enum": ["UNKNOWN", "Y", "N"] },
+                    "occamDisputeId": { "type": "integer", "format": "int64" }
+                }
+            },
+            "TicketImageDataJustinDocument": {
+                "type": "object",
+                "properties": {
+                    "reportType": { "type": "string", "nullable": true, "enum": ["UNKNOWN", "NOTICE_OF_DISPUTE", "TICKET_IMAGE"] },
+                    "reportFormat": { "type": "string", "nullable": true },
+                    "partId": { "type": "string", "nullable": true },
+                    "participantName": { "type": "string", "nullable": true },
+                    "index": { "type": "string", "nullable": true },
+                    "fileData": { "type": "string", "nullable": true }
+                }
+            },
+            "DisputeListItem": {
+                "type": "object",
+                "properties": {
+                    "createdBy": { "type": "string" },
+                    "createdTs": { "type": "string", "format": "date-time" },
+                    "modifiedBy": { "type": "string", "nullable": true },
+                    "modifiedTs": { "type": "string", "format": "date-time", "nullable": true },
+                    "disputeId": { "type": "integer", "description": "ID", "format": "int64", "readOnly": true },
+                    "ticketNumber": { "type": "string" },
+                    "submittedTs": { "type": "string", "format": "date-time", "nullable": true },
+                    "disputantSurname": { "type": "string", "nullable": true },
+                    "disputantGivenName1": { "type": "string", "nullable": true },
+                    "disputantGivenName2": { "type": "string", "nullable": true },
+                    "disputantGivenName3": { "type": "string", "nullable": true },
+                    "status": {
+                        "type": "string",
+                        "enum": ["UNKNOWN", "NEW", "VALIDATED", "PROCESSING", "REJECTED", "CANCELLED", "CONCLUDED"]
+                    },
+                    "emailAddress": { "type": "string", "nullable": true },
+                    "emailAddressVerified": { "type": "boolean" },
+                    "filingDate": { "type": "string", "format": "date-time", "nullable": true },
+                    "requestCourtAppearanceYn": { "type": "string", "nullable": true, "enum": ["UNKNOWN", "Y", "N"] },
+                    "userAssignedTo": { "type": "string", "nullable": true },
+                    "userAssignedTs": { "type": "string", "format": "date-time", "nullable": true },
+                    "disputantDetectedOcrIssues": { "type": "string", "nullable": true, "enum": ["UNKNOWN", "Y", "N"] },
+                    "systemDetectedOcrIssues": { "type": "string", "enum": ["UNKNOWN", "Y", "N"] }
+                }
+            },
+            "DisputeResult": {
+                "type": "object",
+                "properties": {
+                    "disputeId": { "type": "integer", "format": "int64" },
+                    "noticeOfDisputeGuid": { "type": "string" },
+                    "disputeStatus": {
+                        "type": "string",
+                        "enum": ["UNKNOWN", "NEW", "VALIDATED", "PROCESSING", "REJECTED", "CANCELLED", "CONCLUDED"]
+                    },
+                    "jjDisputeStatus": {
+                        "type": "string",
+                        "nullable": true,
+                        "enum": [
+                            "UNKNOWN",
+                            "NEW",
+                            "IN_PROGRESS",
+                            "DATA_UPDATE",
+                            "CONFIRMED",
+                            "REQUIRE_COURT_HEARING",
+                            "REQUIRE_MORE_INFO",
+                            "ACCEPTED",
+                            "REVIEW",
+                            "CONCLUDED",
+                            "CANCELLED",
+                            "HEARING_SCHEDULED"
+                        ]
+                    },
+                    "jjDisputeHearingType": {
+                        "type": "string",
+                        "nullable": true,
+                        "enum": ["UNKNOWN", "COURT_APPEARANCE", "WRITTEN_REASONS"]
+                    }
+                }
+            }
+        },
+        "securitySchemes": { "x-username": { "type": "apiKey", "name": "x-username", "in": "header" } }
     }
-  ],
-  "security": [ { "x-username": [] } ],
-  "paths": {
-    "/api/v1.0/jj/dispute/{ticketNumber}": {
-      "put": {
-        "tags": [ "jj-dispute-controller" ],
-        "summary": "Updates the properties of a particular JJ Dispute record based on the given values.",
-        "operationId": "updateJJDispute",
-        "parameters": [
-          {
-            "name": "ticketNumber",
-            "in": "path",
-            "required": true,
-            "schema": { "type": "string" }
-          },
-          {
-            "name": "checkVTCAssigned",
-            "in": "query",
-            "required": true,
-            "schema": { "type": "boolean" }
-          }
-        ],
-        "requestBody": {
-          "content": { "application/json": { "schema": { "$ref": "#/components/schemas/JJDispute" } } },
-          "required": true
-        },
-        "responses": {
-          "404": {
-            "description": "JJDispute record not found. Update failed.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "400": {
-            "description": "Bad Request.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "500": {
-            "description": "Internal Server Error",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "405": {
-            "description": "An invalid JJ Dispute status is provided. Update failed.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "200": {
-            "description": "Ok",
-            "content": { "*/*": { "schema": { "$ref": "#/components/schemas/JJDispute" } } }
-          }
-        }
-      }
-    },
-    "/api/v1.0/jj/dispute/{ticketNumber}/review": {
-      "put": {
-        "tags": [ "jj-dispute-controller" ],
-        "summary": "Updates the status of a particular JJDispute record to REVIEW.",
-        "operationId": "reviewJJDispute",
-        "parameters": [
-          {
-            "name": "ticketNumber",
-            "in": "path",
-            "required": true,
-            "schema": { "type": "string" }
-          },
-          {
-            "name": "checkVTCAssigned",
-            "in": "query",
-            "required": true,
-            "schema": { "type": "boolean" }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "maxLength": 256,
-                "minLength": 0,
-                "type": "string"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "404": {
-            "description": "JJDispute record not found. Update failed.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "400": {
-            "description": "Bad Request.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "500": {
-            "description": "Internal server error occured.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "405": {
-            "description": "A JJDispute status can only be set to REVIEW iff status is NEW or VALIDATED and the remark must be <= 256 characters. Update failed.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "200": {
-            "description": "Ok. Updated JJDispute record returned.",
-            "content": { "*/*": { "schema": { "$ref": "#/components/schemas/JJDispute" } } }
-          }
-        }
-      }
-    },
-    "/api/v1.0/jj/dispute/{ticketNumber}/requirecourthearing": {
-      "put": {
-        "tags": [ "jj-dispute-controller" ],
-        "summary": "Updates the status of a particular JJDispute record to REQUIRE_COURT_HEARING, type to COURT_APPEARANCE.",
-        "operationId": "requireCourtHearingJJDispute",
-        "parameters": [
-          {
-            "name": "ticketNumber",
-            "in": "path",
-            "required": true,
-            "schema": { "type": "string" }
-          },
-          {
-            "name": "remark",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "maxLength": 256,
-              "minLength": 0,
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "404": {
-            "description": "JJDispute record not found. Update failed.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "400": {
-            "description": "Bad Request.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "500": {
-            "description": "Internal server error occured.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "405": {
-            "description": "A JJDispute status can only be set to REQUIRE_COURT_HEARING iff status is one of the following: NEW, IN_PROGRESS, REVIEW, REQUIRE_COURT_HEARING and the remark must be <= 256 characters. Update failed.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "200": {
-            "description": "Ok. Updated JJDispute record returned.",
-            "content": { "*/*": { "schema": { "$ref": "#/components/schemas/JJDispute" } } }
-          }
-        }
-      }
-    },
-    "/api/v1.0/jj/dispute/{ticketNumber}/confirm": {
-      "put": {
-        "tags": [ "jj-dispute-controller" ],
-        "summary": "Updates the status of a particular JJDispute record to CONFIRMED.",
-        "operationId": "confirmJJDispute",
-        "parameters": [
-          {
-            "name": "ticketNumber",
-            "in": "path",
-            "required": true,
-            "schema": { "type": "string" }
-          }
-        ],
-        "responses": {
-          "404": {
-            "description": "JJDispute record not found. Update failed.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "400": {
-            "description": "Bad Request.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "500": {
-            "description": "Internal server error occured.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "405": {
-            "description": "A JJDispute status can only be set to CONFIRMED iff status is one of the following: REVIEW, NEW, HEARING_SCHEDULED, IN_PROGRESS, CONFIRMED. Update failed.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "200": {
-            "description": "Ok. Updated JJDispute record returned.",
-            "content": { "*/*": { "schema": { "$ref": "#/components/schemas/JJDispute" } } }
-          }
-        }
-      }
-    },
-    "/api/v1.0/jj/dispute/{ticketNumber}/conclude": {
-      "put": {
-        "tags": [ "jj-dispute-controller" ],
-        "summary": "Updates the status of a particular JJDispute record to CONCLUDED.",
-        "operationId": "concludeJJDispute",
-        "parameters": [
-          {
-            "name": "ticketNumber",
-            "in": "path",
-            "required": true,
-            "schema": { "type": "string" }
-          },
-          {
-            "name": "checkVTCAssigned",
-            "in": "query",
-            "required": true,
-            "schema": { "type": "boolean" }
-          }
-        ],
-        "responses": {
-          "404": {
-            "description": "JJDispute record not found. Update failed.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "400": {
-            "description": "Bad Request.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "500": {
-            "description": "Internal server error occured.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "405": {
-            "description": "Method Not Allowed",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "200": {
-            "description": "Ok. Updated JJDispute record returned.",
-            "content": { "*/*": { "schema": { "$ref": "#/components/schemas/JJDispute" } } }
-          }
-        }
-      }
-    },
-    "/api/v1.0/jj/dispute/{ticketNumber}/cancel": {
-      "put": {
-        "tags": [ "jj-dispute-controller" ],
-        "summary": "Updates the status of a particular JJDispute record to CANCELLED.",
-        "operationId": "cancelJJDispute",
-        "parameters": [
-          {
-            "name": "ticketNumber",
-            "in": "path",
-            "required": true,
-            "schema": { "type": "string" }
-          },
-          {
-            "name": "checkVTCAssigned",
-            "in": "query",
-            "required": true,
-            "schema": { "type": "boolean" }
-          }
-        ],
-        "responses": {
-          "404": {
-            "description": "JJDispute record not found. Update failed.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "400": {
-            "description": "Bad Request.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "500": {
-            "description": "Internal server error occured.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "405": {
-            "description": "Method Not Allowed",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "200": {
-            "description": "Ok. Updated JJDispute record returned.",
-            "content": { "*/*": { "schema": { "$ref": "#/components/schemas/JJDispute" } } }
-          }
-        }
-      }
-    },
-    "/api/v1.0/jj/dispute/{ticketNumber}/accept": {
-      "put": {
-        "tags": [ "jj-dispute-controller" ],
-        "summary": "Updates the status of a particular JJDispute record to ACCEPTED.",
-        "operationId": "acceptJJDispute",
-        "parameters": [
-          {
-            "name": "ticketNumber",
-            "in": "path",
-            "required": true,
-            "schema": { "type": "string" }
-          },
-          {
-            "name": "checkVTCAssigned",
-            "in": "query",
-            "required": true,
-            "schema": { "type": "boolean" }
-          },
-          {
-            "name": "partId",
-            "in": "query",
-            "description": "Adjudicator's participant ID",
-            "required": false,
-            "schema": { "type": "string" }
-          }
-        ],
-        "responses": {
-          "404": {
-            "description": "JJDispute record not found. Update failed.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "400": {
-            "description": "Bad Request.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "500": {
-            "description": "Internal server error occured.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "405": {
-            "description": "A JJDispute status can only be set to ACCEPTED iff status is CONFIRMED. Update failed.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "200": {
-            "description": "Ok. Updated JJDispute record returned.",
-            "content": { "*/*": { "schema": { "$ref": "#/components/schemas/JJDispute" } } }
-          }
-        }
-      }
-    },
-    "/api/v1.0/jj/dispute/assign": {
-      "put": {
-        "tags": [ "jj-dispute-controller" ],
-        "summary": "Updates each JJ Dispute based on the passed in ticket numbers to assign them to a specific JJ or unassign them if JJ not specified.",
-        "operationId": "assignJJDisputesToJJ",
-        "parameters": [
-          {
-            "name": "ticketNumbers",
-            "in": "query",
-            "required": true,
-            "schema": {
-              "type": "array",
-              "items": { "type": "string" }
-            }
-          },
-          {
-            "name": "jjUsername",
-            "in": "query",
-            "required": false,
-            "schema": { "type": "string" }
-          }
-        ],
-        "responses": {
-          "404": {
-            "description": "JJDispute record(s) not found. Update failed.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "400": {
-            "description": "Bad Request.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "500": {
-            "description": "Internal server error occured.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "405": {
-            "description": "Method Not Allowed",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "200": { "description": "Ok" }
-        }
-      }
-    },
-    "/api/v1.0/dispute/{id}": {
-      "put": {
-        "tags": [ "dispute-controller" ],
-        "summary": "Updates the properties of a particular Dispute record based on the given values.",
-        "operationId": "updateDispute",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "format": "int64"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": { "application/json": { "schema": { "$ref": "#/components/schemas/Dispute" } } },
-          "required": true
-        },
-        "responses": {
-          "404": {
-            "description": "Dispute record not found. Update failed.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "400": {
-            "description": "Bad Request.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "500": {
-            "description": "Internal Server Error",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "405": {
-            "description": "Method Not Allowed",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "409": {
-            "description": "The Dispute has already been assigned to a different user. Dispute cannot be modified until assigned time expires.",
-            "content": { "*/*": { "schema": { "$ref": "#/components/schemas/Dispute" } } }
-          },
-          "200": {
-            "description": "Ok",
-            "content": { "*/*": { "schema": { "$ref": "#/components/schemas/Dispute" } } }
-          }
-        }
-      },
-      "delete": {
-        "tags": [ "dispute-controller" ],
-        "summary": "Deletes a particular Dispute record.",
-        "operationId": "deleteDispute",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "format": "int64"
-            }
-          }
-        ],
-        "responses": {
-          "404": {
-            "description": "Dispute record not found. Delete failed.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "400": {
-            "description": "Bad Request.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "500": {
-            "description": "Internal Server Error. Delete failed.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "405": {
-            "description": "Method Not Allowed",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "200": { "description": "Ok. Dispute record deleted." }
-        }
-      }
-    },
-    "/api/v1.0/dispute/{id}/validate": {
-      "put": {
-        "tags": [ "dispute-controller" ],
-        "summary": "Updates the status of a particular Dispute record to VALIDATED.",
-        "operationId": "validateDispute",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "format": "int64"
-            }
-          }
-        ],
-        "responses": {
-          "404": {
-            "description": "Dispute record not found. Update failed.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "400": {
-            "description": "Bad Request.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "500": {
-            "description": "Internal Server Error",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "405": {
-            "description": "A Dispute status can only be set to VALIDATED iff status is NEW. Update failed.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "200": {
-            "description": "Ok. Updated Dispute record returned.",
-            "content": { "*/*": { "schema": { "$ref": "#/components/schemas/Dispute" } } }
-          },
-          "409": {
-            "description": "The Dispute has already been assigned to a different user. Dispute cannot be modified until assigned time expires.",
-            "content": { "*/*": { "schema": { "$ref": "#/components/schemas/Dispute" } } }
-          }
-        }
-      }
-    },
-    "/api/v1.0/dispute/{id}/submit": {
-      "put": {
-        "tags": [ "dispute-controller" ],
-        "summary": "Updates the status of a particular Dispute record to PROCESSING.",
-        "operationId": "submitDispute",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "format": "int64"
-            }
-          }
-        ],
-        "responses": {
-          "404": {
-            "description": "Dispute record not found. Update failed.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "400": {
-            "description": "Bad Request.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "500": {
-            "description": "Internal Server Error",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "405": {
-            "description": "A Dispute status can only be set to PROCESSING iff status is NEW or REJECTED. Update failed.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "200": {
-            "description": "Ok. Updated Dispute record returned.",
-            "content": { "*/*": { "schema": { "$ref": "#/components/schemas/Dispute" } } }
-          },
-          "409": {
-            "description": "The Dispute has already been assigned to a different user. Dispute cannot be modified until assigned time expires.",
-            "content": { "*/*": { "schema": { "$ref": "#/components/schemas/Dispute" } } }
-          }
-        }
-      }
-    },
-    "/api/v1.0/dispute/{id}/reject": {
-      "put": {
-        "tags": [ "dispute-controller" ],
-        "summary": "Updates the status of a particular Dispute record to REJECTED.",
-        "operationId": "rejectDispute",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "format": "int64"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "maxLength": 256,
-                "minLength": 1,
-                "type": "string"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "404": {
-            "description": "Dispute record not found. Update failed.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "400": {
-            "description": "Bad Request.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "500": {
-            "description": "Internal Server Error",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "405": {
-            "description": "A Dispute status can only be set to REJECTED iff status is NEW or VALIDATED and the rejected reason must be <= 256 characters. Update failed.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "200": {
-            "description": "Ok. Updated Dispute record returned.",
-            "content": { "*/*": { "schema": { "$ref": "#/components/schemas/Dispute" } } }
-          },
-          "409": {
-            "description": "The Dispute has already been assigned to a different user. Dispute cannot be modified until assigned time expires.",
-            "content": { "*/*": { "schema": { "$ref": "#/components/schemas/Dispute" } } }
-          }
-        }
-      }
-    },
-    "/api/v1.0/dispute/{id}/email/verify": {
-      "put": {
-        "tags": [ "dispute-controller" ],
-        "summary": "Updates the emailVerification flag of a particular Dispute to true.",
-        "operationId": "verifyDisputeEmail",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "description": "The id of the Dispute to update.",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "format": "int64"
-            }
-          }
-        ],
-        "responses": {
-          "404": {
-            "description": "Dispute with specified id not found",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "400": {
-            "description": "Bad Request",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "500": {
-            "description": "Internal server error occured.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "405": {
-            "description": "Method Not Allowed",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "200": { "description": "Ok. Email verified." }
-        }
-      }
-    },
-    "/api/v1.0/dispute/{id}/email/reset": {
-      "put": {
-        "tags": [ "dispute-controller" ],
-        "summary": "Updates the email address of a particular Dispute.",
-        "operationId": "resetDisputeEmail",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "description": "The id of the Dispute to update.",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "format": "int64"
-            }
-          },
-          {
-            "name": "email",
-            "in": "query",
-            "description": "The new email address of the Disputant.",
-            "required": false,
-            "schema": {
-              "maxLength": 100,
-              "minLength": 1,
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "404": {
-            "description": "Dispute with specified id not found",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "400": {
-            "description": "If the email address is > 100 characters",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "500": {
-            "description": "Internal server error occured.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "405": {
-            "description": "Method Not Allowed",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "200": {
-            "description": "Ok. Email reset.",
-            "content": { "*/*": { "schema": { "$ref": "#/components/schemas/Dispute" } } }
-          }
-        }
-      }
-    },
-    "/api/v1.0/dispute/{id}/cancel": {
-      "put": {
-        "tags": [ "dispute-controller" ],
-        "summary": "Updates the status of a particular Dispute record to CANCELLED.",
-        "operationId": "cancelDispute",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "format": "int64"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "maxLength": 256,
-                "minLength": 1,
-                "type": "string"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "404": {
-            "description": "Dispute record not found. Update failed.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "400": {
-            "description": "Bad Request.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "500": {
-            "description": "Internal Server Error",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "405": {
-            "description": "A Dispute status can only be set to CANCELLED iff status is NEW, REJECTED or PROCESSING. Update failed.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "200": {
-            "description": "Ok. Updated Dispute record returned.",
-            "content": { "*/*": { "schema": { "$ref": "#/components/schemas/Dispute" } } }
-          },
-          "409": {
-            "description": "The Dispute has already been assigned to a different user. Dispute cannot be modified until assigned time expires.",
-            "content": { "*/*": { "schema": { "$ref": "#/components/schemas/Dispute" } } }
-          }
-        }
-      }
-    },
-    "/api/v1.0/dispute/updateRequest/{id}": {
-      "put": {
-        "tags": [ "dispute-controller" ],
-        "summary": "An endpoint that updates the status of a DisputeUpdateRequest record.",
-        "operationId": "updateDisputeUpdateRequestStatus",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "description": "The id of the DisputeUpdateRequest record to update.",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "format": "int64"
-            }
-          },
-          {
-            "name": "disputeUpdateRequestStatus",
-            "in": "query",
-            "description": "The status of the request record should be updated to.",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "enum": [ "UNKNOWN", "ACCEPTED", "PENDING", "REJECTED" ]
-            },
-            "example": "ACCEPTED"
-          }
-        ],
-        "responses": {
-          "404": {
-            "description": "DisputeUpdateRequest could not be found.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "400": {
-            "description": "Bad Request",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "500": {
-            "description": "Internal Server Error. Save failed.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "405": {
-            "description": "Method Not Allowed",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "200": {
-            "description": "Ok. DisputeUpdateRequest updated.",
-            "content": { "*/*": { "schema": { "$ref": "#/components/schemas/DisputeUpdateRequest" } } }
-          }
-        }
-      }
-    },
-    "/api/v1.0/fileHistory": {
-      "post": {
-        "tags": [ "file-history-controller" ],
-        "summary": "Inserts a file history record for the given ticket number.",
-        "operationId": "insertFileHistory",
-        "requestBody": {
-          "content": { "application/json": { "schema": { "$ref": "#/components/schemas/FileHistory" } } },
-          "required": true
-        },
-        "responses": {
-          "404": {
-            "description": "An invalid file history record provided. Insert failed.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "400": {
-            "description": "Bad Request.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "500": {
-            "description": "Internal Server Error",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "405": {
-            "description": "Method Not Allowed",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "200": {
-            "description": "Ok",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "type": "integer",
-                  "format": "int64"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/v1.0/emailHistory": {
-      "post": {
-        "tags": [ "email-history-controller" ],
-        "summary": "Inserts an email history record for the given ticket number.",
-        "operationId": "insertEmailHistory",
-        "requestBody": {
-          "content": { "application/json": { "schema": { "$ref": "#/components/schemas/EmailHistory" } } },
-          "required": true
-        },
-        "responses": {
-          "404": {
-            "description": "An invalid email history record provided. Insert failed.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "400": {
-            "description": "Bad Request.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "500": {
-            "description": "Internal Server Error",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "405": {
-            "description": "Method Not Allowed",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "200": {
-            "description": "Ok",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "type": "integer",
-                  "format": "int64"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/v1.0/dispute": {
-      "post": {
-        "tags": [ "dispute-controller" ],
-        "operationId": "saveDispute",
-        "requestBody": {
-          "content": { "application/json": { "schema": { "$ref": "#/components/schemas/Dispute" } } },
-          "required": true
-        },
-        "responses": {
-          "404": {
-            "description": "Not Found",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "400": {
-            "description": "Bad Request",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "500": {
-            "description": "Internal Server Error",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "405": {
-            "description": "Method Not Allowed",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "200": {
-            "description": "OK",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "type": "integer",
-                  "format": "int64"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/v1.0/dispute/{guid}/updateRequest": {
-      "post": {
-        "tags": [ "dispute-controller" ],
-        "summary": "An endpoint that inserts a DisputeUpdateRequest into persistent storage.",
-        "operationId": "saveDisputeUpdateRequest",
-        "parameters": [
-          {
-            "name": "guid",
-            "in": "path",
-            "description": "The noticeOfDisputeGuid of the Dispute to associate with.",
-            "required": true,
-            "schema": { "type": "string" }
-          }
-        ],
-        "requestBody": {
-          "content": { "application/json": { "schema": { "$ref": "#/components/schemas/DisputeUpdateRequest" } } },
-          "required": true
-        },
-        "responses": {
-          "404": {
-            "description": "Dispute could not be found.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "400": {
-            "description": "Bad Request",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "500": {
-            "description": "Internal Server Error. Save failed.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "405": {
-            "description": "Method Not Allowed",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "200": {
-            "description": "Ok. DisputeUpdateRequest record saved.",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "type": "integer",
-                  "format": "int64"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/v1.0/jj/disputes": {
-      "get": {
-        "tags": [ "jj-dispute-controller" ],
-        "operationId": "getJJDisputes",
-        "parameters": [
-          {
-            "name": "jjAssignedTo",
-            "in": "query",
-            "description": "If specified, will retrieve the records which are assigned to the specified jj staff",
-            "required": false,
-            "schema": { "type": "string" }
-          },
-          {
-            "name": "ticketNumber",
-            "in": "query",
-            "description": "If specified will filter by TicketNumber. (Format is XX00000000)",
-            "required": false,
-            "schema": {
-              "pattern": "[A-Z]{2}\\d{8}",
-              "type": "string"
-            },
-            "example": "AX12345678"
-          }
-        ],
-        "responses": {
-          "404": {
-            "description": "Not Found",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "400": {
-            "description": "Bad Request",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "500": {
-            "description": "Internal Server Error",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "405": {
-            "description": "Method Not Allowed",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "200": {
-            "description": "OK",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "type": "array",
-                  "items": { "$ref": "#/components/schemas/JJDispute" }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/v1.0/jj/dispute/{ticketNumber}/{assignVTC}": {
-      "get": {
-        "tags": [ "jj-dispute-controller" ],
-        "operationId": "getJJDispute",
-        "parameters": [
-          {
-            "name": "ticketNumber",
-            "in": "path",
-            "description": "The primary key of the jj dispute to retrieve",
-            "required": true,
-            "schema": { "type": "string" }
-          },
-          {
-            "name": "assignVTC",
-            "in": "path",
-            "required": true,
-            "schema": { "type": "boolean" }
-          }
-        ],
-        "responses": {
-          "404": {
-            "description": "Not Found",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "400": {
-            "description": "Bad Request",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "500": {
-            "description": "Internal Server Error",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "405": {
-            "description": "Method Not Allowed",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "200": {
-            "description": "OK",
-            "content": { "*/*": { "schema": { "$ref": "#/components/schemas/JJDispute" } } }
-          }
-        }
-      }
-    },
-    "/api/v1.0/jj/dispute/ticketImage/{ticketNumber}/{documentType}": {
-      "get": {
-        "tags": [ "jj-dispute-controller" ],
-        "operationId": "getTicketImageData",
-        "parameters": [
-          {
-            "name": "ticketNumber",
-            "in": "path",
-            "required": true,
-            "schema": { "type": "string" }
-          },
-          {
-            "name": "documentType",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "enum": [ "UNKNOWN", "NOTICE_OF_DISPUTE", "TICKET_IMAGE" ]
-            }
-          }
-        ],
-        "responses": {
-          "404": {
-            "description": "Not Found",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "400": {
-            "description": "Bad Request",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "500": {
-            "description": "Internal Server Error",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "405": {
-            "description": "Method Not Allowed",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "200": {
-            "description": "OK",
-            "content": { "*/*": { "schema": { "$ref": "#/components/schemas/TicketImageDataJustinDocument" } } }
-          }
-        }
-      }
-    },
-    "/api/v1.0/fileHistory/{ticketNumber}": {
-      "get": {
-        "tags": [ "file-history-controller" ],
-        "operationId": "getFileHistoryByTicketNumber",
-        "parameters": [
-          {
-            "name": "ticketNumber",
-            "in": "path",
-            "description": "Ticket number to retrieve related file history.",
-            "required": true,
-            "schema": { "type": "string" }
-          }
-        ],
-        "responses": {
-          "404": {
-            "description": "Not Found",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "400": {
-            "description": "Bad Request",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "500": {
-            "description": "Internal Server Error",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "405": {
-            "description": "Method Not Allowed",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "200": {
-            "description": "OK",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "type": "array",
-                  "items": { "$ref": "#/components/schemas/FileHistory" }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/v1.0/emailHistory/{ticketNumber}": {
-      "get": {
-        "tags": [ "email-history-controller" ],
-        "operationId": "getEmailHistoryByTicketNumber",
-        "parameters": [
-          {
-            "name": "ticketNumber",
-            "in": "path",
-            "description": "Ticket number to retrieve related emails.",
-            "required": true,
-            "schema": { "type": "string" }
-          }
-        ],
-        "responses": {
-          "404": {
-            "description": "Not Found",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "400": {
-            "description": "Bad Request",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "500": {
-            "description": "Internal Server Error",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "405": {
-            "description": "Method Not Allowed",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "200": {
-            "description": "OK",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "type": "array",
-                  "items": { "$ref": "#/components/schemas/EmailHistory" }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/v1.0/disputes": {
-      "get": {
-        "tags": [ "dispute-controller" ],
-        "summary": "Returns all Dispute records based on the specified optional parameters.",
-        "operationId": "getAllDisputes",
-        "parameters": [
-          {
-            "name": "olderThan",
-            "in": "query",
-            "description": "If specified, will retrieve records older than this date (specified by yyyy-MM-dd)",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "format": "date-time"
-            },
-            "example": "2022-03-15"
-          },
-          {
-            "name": "excludeStatus",
-            "in": "query",
-            "description": "If specified, will retrieve records which do not have the specified status",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "enum": [ "UNKNOWN", "NEW", "VALIDATED", "PROCESSING", "REJECTED", "CANCELLED", "CONCLUDED" ]
-            },
-            "example": "CANCELLED"
-          }
-        ],
-        "responses": {
-          "404": {
-            "description": "Not Found",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "400": {
-            "description": "Bad Request.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "500": {
-            "description": "Internal Server Error. Getting disputes failed.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "405": {
-            "description": "Method Not Allowed",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "200": {
-            "description": "Ok. Disputes are returned.",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "type": "array",
-                  "items": { "$ref": "#/components/schemas/DisputeListItem" }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/v1.0/disputes/unassign": {
-      "get": {
-        "tags": [ "dispute-controller" ],
-        "summary": "An endpoint hook to trigger the Unassign Dispute job.",
-        "description": "A Dispute can be assigned to a specific user that \"locks\" the record for others. This endpoing manually triggers the Unassign Dispute job that clears the assignment of all Disputes that were assigned for more than 1 hour.",
-        "operationId": "unassignDisputes",
-        "responses": {
-          "404": {
-            "description": "Not Found",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "400": {
-            "description": "Bad Request",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "500": {
-            "description": "Internal Server Error. Unassigned failed.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "405": {
-            "description": "Method Not Allowed",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "200": { "description": "Ok. Dispute record unassigned." }
-        }
-      }
-    },
-    "/api/v1.0/dispute/{id}/{isAssign}": {
-      "get": {
-        "tags": [ "dispute-controller" ],
-        "operationId": "getDispute",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "format": "int64"
-            }
-          },
-          {
-            "name": "isAssign",
-            "in": "path",
-            "required": true,
-            "schema": { "type": "boolean" }
-          }
-        ],
-        "responses": {
-          "404": {
-            "description": "Not Found",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "400": {
-            "description": "Bad Request",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "500": {
-            "description": "Internal Server Error",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "405": {
-            "description": "Method Not Allowed",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "200": {
-            "description": "OK",
-            "content": { "*/*": { "schema": { "$ref": "#/components/schemas/Dispute" } } }
-          }
-        }
-      }
-    },
-    "/api/v1.0/dispute/updateRequests": {
-      "get": {
-        "tags": [ "dispute-controller" ],
-        "summary": "An endpoint that retrieves all DisputeUpdateRequest optionally for a given Dispute, optionally filtered by DisputeUpdateRequestStatus.",
-        "operationId": "getDisputeUpdateRequests",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "query",
-            "description": "If specified, filter request by the disputeId of the Dispute.",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "format": "int64"
-            }
-          },
-          {
-            "name": "status",
-            "in": "query",
-            "description": "If specified, filter request by DisputeUpdateRequestStatus",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "enum": [ "UNKNOWN", "ACCEPTED", "PENDING", "REJECTED" ]
-            },
-            "example": "PENDING"
-          }
-        ],
-        "responses": {
-          "404": {
-            "description": "Not Found",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "400": {
-            "description": "Bad Request",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "500": {
-            "description": "Internal Server Error. retrieve update requests failed.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "405": {
-            "description": "Method Not Allowed",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "200": {
-            "description": "Ok. DisputeUpdateRequest record saved.",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "type": "array",
-                  "items": { "$ref": "#/components/schemas/DisputeUpdateRequest" }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/v1.0/dispute/status": {
-      "get": {
-        "tags": [ "dispute-controller" ],
-        "summary": "Finds Dispute statuses by TicketNumber and IssuedTime or noticeOfDisputeGuid if specified.",
-        "operationId": "findDisputeStatuses",
-        "parameters": [
-          {
-            "name": "ticketNumber",
-            "in": "query",
-            "description": "The Dispute.ticketNumber to search for (of the format XX00000000)",
-            "required": false,
-            "schema": {
-              "pattern": "^$|([A-Z]{2}\\d{8})",
-              "type": "string"
-            },
-            "example": "AX12345678"
-          },
-          {
-            "name": "issuedTime",
-            "in": "query",
-            "description": "The time portion of the Dispute.issuedTs field to search for (of the format HH:mm). Time is in UTC.",
-            "required": false,
-            "schema": { "type": "string" },
-            "example": "14:53"
-          },
-          {
-            "name": "noticeOfDisputeGuid",
-            "in": "query",
-            "description": "The noticeOfDisputeGuid of the Dispute to retreive.",
-            "required": false,
-            "schema": { "type": "string" }
-          }
-        ],
-        "responses": {
-          "404": {
-            "description": "Not Found",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "400": {
-            "description": "Bad Request, check parameters.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "500": {
-            "description": "Internal Server Error. Search failed.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "405": {
-            "description": "Method Not Allowed",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "200": {
-            "description": "Ok.",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "type": "array",
-                  "items": { "$ref": "#/components/schemas/DisputeResult" }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/v1.0/dispute/noticeOfDispute/{id}": {
-      "get": {
-        "tags": [ "dispute-controller" ],
-        "summary": "Retrieves Dispute by the noticeOfDisputeGuid (UUID).",
-        "operationId": "getDisputeByNoticeOfDisputeGuid",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "description": "The noticeOfDisputeGuid of the Dispute to retreive.",
-            "required": true,
-            "schema": { "type": "string" }
-          }
-        ],
-        "responses": {
-          "404": {
-            "description": "Dispute could not be found.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "400": {
-            "description": "Bad Request",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "500": {
-            "description": "Internal server error occured.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "405": {
-            "description": "Method Not Allowed",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "200": {
-            "description": "Ok. Dispute retrieved.",
-            "content": { "*/*": { "schema": { "$ref": "#/components/schemas/Dispute" } } }
-          }
-        }
-      }
-    },
-    "/api/v1.0/codetable/refresh": {
-      "get": {
-        "tags": [ "dispute-controller" ],
-        "summary": "An endpoint hook to trigger a redis rebuild of cached codetable data.",
-        "description": "The codetables in redis are cached copies of data pulled from Oracle to ensure TCO remains stable. This data is periodically refreshed, but can be forced by hitting this endpoint.",
-        "operationId": "codeTableRefresh",
-        "responses": {
-          "404": {
-            "description": "Not Found",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "400": {
-            "description": "Bad Request",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "500": {
-            "description": "Internal Server Error",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "405": {
-            "description": "Method Not Allowed",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "200": { "description": "OK" }
-        }
-      }
-    },
-    "/api/v1.0/jj/dispute": {
-      "delete": {
-        "tags": [ "jj-dispute-controller" ],
-        "summary": "Deletes a particular JJDispute record.",
-        "operationId": "DeleteJJDispute",
-        "parameters": [
-          {
-            "name": "jjDisputeId",
-            "in": "query",
-            "description": "If specified, will delete the record of the specified jj dispute by this ID. JJ Dispute ID will take precedence if both ID and ticket number supplied",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "format": "int64"
-            }
-          },
-          {
-            "name": "ticketNumber",
-            "in": "query",
-            "description": "If specified, will delete the record of the specified jj dispute by this TicketNumber. (Format is XX00000000)",
-            "required": false,
-            "schema": {
-              "pattern": "[A-Z]{2}\\d{8}",
-              "type": "string"
-            },
-            "example": "AX12345678"
-          }
-        ],
-        "responses": {
-          "404": {
-            "description": "Not Found",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "400": {
-            "description": "Bad Request.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "500": {
-            "description": "Internal Server Error. Delete failed.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "405": {
-            "description": "Method Not Allowed",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "200": { "description": "Ok. JJ Dispute record deleted." }
-        }
-      }
-    }
-  },
-  "components": {
-    "schemas": {
-      "JJDispute": {
-        "type": "object",
-        "properties": {
-          "createdBy": { "type": "string" },
-          "createdTs": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "modifiedBy": {
-            "type": "string",
-            "nullable": true
-          },
-          "modifiedTs": {
-            "type": "string",
-            "format": "date-time",
-            "nullable": true
-          },
-          "id": {
-            "type": "integer",
-            "description": "ID",
-            "format": "int64",
-            "readOnly": true
-          },
-          "ticketNumber": { "type": "string" },
-          "addressLine1": { "type": "string" },
-          "addressLine2": {
-            "type": "string",
-            "nullable": true
-          },
-          "addressLine3": {
-            "type": "string",
-            "nullable": true
-          },
-          "addressCity": {
-            "type": "string",
-            "nullable": true
-          },
-          "addressProvince": {
-            "type": "string",
-            "nullable": true
-          },
-          "addressCountry": {
-            "type": "string",
-            "nullable": true
-          },
-          "addressPostalCode": {
-            "type": "string",
-            "nullable": true
-          },
-          "disputantBirthdate": {
-            "type": "string",
-            "format": "date-time",
-            "nullable": true
-          },
-          "driversLicenceNumber": {
-            "type": "string",
-            "nullable": true
-          },
-          "drvLicIssuedProvSeqNo": {
-            "type": "string",
-            "nullable": true
-          },
-          "drvLicIssuedCtryId": {
-            "type": "string",
-            "nullable": true
-          },
-          "emailAddress": {
-            "type": "string",
-            "nullable": true
-          },
-          "status": {
-            "type": "string",
-            "enum": [ "UNKNOWN", "NEW", "IN_PROGRESS", "DATA_UPDATE", "CONFIRMED", "REQUIRE_COURT_HEARING", "REQUIRE_MORE_INFO", "ACCEPTED", "REVIEW", "CONCLUDED", "CANCELLED", "HEARING_SCHEDULED" ]
-          },
-          "hearingType": {
-            "type": "string",
-            "nullable": true,
-            "enum": [ "UNKNOWN", "COURT_APPEARANCE", "WRITTEN_REASONS" ]
-          },
-          "noticeOfDisputeGuid": {
-            "type": "string",
-            "nullable": true
-          },
-          "noticeOfHearingYn": {
-            "type": "string",
-            "nullable": true,
-            "enum": [ "UNKNOWN", "Y", "N" ]
-          },
-          "occamDisputantGiven1Nm": {
-            "type": "string",
-            "nullable": true
-          },
-          "occamDisputantGiven2Nm": {
-            "type": "string",
-            "nullable": true
-          },
-          "occamDisputantGiven3Nm": {
-            "type": "string",
-            "nullable": true
-          },
-          "occamDisputantSurnameNm": {
-            "type": "string",
-            "nullable": true
-          },
-          "occamDisputeId": {
-            "type": "integer",
-            "format": "int64"
-          },
-          "occamViolationTicketUpldId": {
-            "type": "string",
-            "nullable": true
-          },
-          "submittedTs": {
-            "type": "string",
-            "format": "date-time",
-            "nullable": true
-          },
-          "issuedTs": {
-            "type": "string",
-            "format": "date-time",
-            "nullable": true
-          },
-          "violationDate": {
-            "type": "string",
-            "format": "date-time",
-            "nullable": true
-          },
-          "icbcReceivedDate": {
-            "type": "string",
-            "format": "date-time",
-            "nullable": true
-          },
-          "enforcementOfficer": {
-            "type": "string",
-            "nullable": true
-          },
-          "electronicTicketYn": {
-            "type": "string",
-            "nullable": true,
-            "enum": [ "UNKNOWN", "Y", "N" ]
-          },
-          "policeDetachment": {
-            "type": "string",
-            "nullable": true
-          },
-          "courthouseLocation": {
-            "type": "string",
-            "nullable": true
-          },
-          "offenceLocation": {
-            "type": "string",
-            "nullable": true
-          },
-          "jjAssignedTo": {
-            "type": "string",
-            "nullable": true
-          },
-          "jjDecisionDate": {
-            "type": "string",
-            "format": "date-time",
-            "nullable": true
-          },
-          "vtcAssignedTo": {
-            "type": "string",
-            "nullable": true
-          },
-          "vtcAssignedTs": {
-            "type": "string",
-            "format": "date-time",
-            "nullable": true
-          },
-          "fineReductionReason": {
-            "type": "string",
-            "nullable": true
-          },
-          "timeToPayReason": {
-            "type": "string",
-            "nullable": true
-          },
-          "contactLawFirmName": {
-            "type": "string",
-            "nullable": true
-          },
-          "contactGivenName1": {
-            "type": "string",
-            "nullable": true
-          },
-          "contactGivenName2": {
-            "type": "string",
-            "nullable": true
-          },
-          "contactGivenName3": {
-            "type": "string",
-            "nullable": true
-          },
-          "contactSurname": {
-            "type": "string",
-            "nullable": true
-          },
-          "contactType": {
-            "type": "string",
-            "nullable": true,
-            "enum": [ "UNKNOWN", "INDIVIDUAL", "LAWYER", "OTHER" ]
-          },
-          "appearInCourt": {
-            "type": "string",
-            "enum": [ "UNKNOWN", "Y", "N" ]
-          },
-          "courtAgenId": {
-            "type": "string",
-            "nullable": true
-          },
-          "lawFirmName": {
-            "type": "string",
-            "nullable": true
-          },
-          "lawyerSurname": {
-            "type": "string",
-            "nullable": true
-          },
-          "lawyerGivenName1": {
-            "type": "string",
-            "nullable": true
-          },
-          "lawyerGivenName2": {
-            "type": "string",
-            "nullable": true
-          },
-          "lawyerGivenName3": {
-            "type": "string",
-            "nullable": true
-          },
-          "justinRccId": {
-            "type": "string",
-            "nullable": true
-          },
-          "interpreterLanguageCd": {
-            "type": "string",
-            "nullable": true
-          },
-          "witnessNo": {
-            "type": "integer",
-            "format": "int32",
-            "nullable": true
-          },
-          "disputantAttendanceType": {
-            "type": "string",
-            "nullable": true,
-            "enum": [ "UNKNOWN", "WRITTEN_REASONS", "VIDEO_CONFERENCE", "TELEPHONE_CONFERENCE", "MSTEAMS_AUDIO", "MSTEAMS_VIDEO", "IN_PERSON" ]
-          },
-          "remarks": {
-            "type": "array",
-            "items": { "$ref": "#/components/schemas/JJDisputeRemark" }
-          },
-          "jjDisputedCounts": {
-            "type": "array",
-            "items": { "$ref": "#/components/schemas/JJDisputedCount" }
-          },
-          "jjDisputeCourtAppearanceRoPs": {
-            "type": "array",
-            "items": { "$ref": "#/components/schemas/JJDisputeCourtAppearanceRoP" }
-          }
-        }
-      },
-      "JJDisputeCourtAppearanceRoP": {
-        "type": "object",
-        "properties": {
-          "justinAppearanceId": {
-            "type": "string",
-            "description": "Justin Appearance ID",
-            "readOnly": true
-          },
-          "id": {
-            "type": "integer",
-            "description": "TCO Court Appearance ID",
-            "format": "int64",
-            "nullable": true,
-            "readOnly": true
-          },
-          "appearanceTs": {
-            "type": "string",
-            "format": "date-time",
-            "nullable": true
-          },
-          "room": {
-            "type": "string",
-            "nullable": true
-          },
-          "duration": {
-            "type": "integer",
-            "format": "int32",
-            "nullable": true
-          },
-          "reason": {
-            "type": "string",
-            "nullable": true
-          },
-          "appCd": {
-            "type": "string",
-            "nullable": true,
-            "enum": [ "UNKNOWN", "A", "P", "N" ]
-          },
-          "noAppTs": {
-            "type": "string",
-            "format": "date-time",
-            "nullable": true
-          },
-          "clerkRecord": {
-            "type": "string",
-            "nullable": true
-          },
-          "defenceCounsel": {
-            "type": "string",
-            "nullable": true
-          },
-          "dattCd": {
-            "type": "string",
-            "nullable": true,
-            "enum": [ "UNKNOWN", "A", "C", "N" ]
-          },
-          "crown": {
-            "type": "string",
-            "nullable": true,
-            "enum": [ "UNKNOWN", "P", "N" ]
-          },
-          "jjSeized": {
-            "type": "string",
-            "nullable": true,
-            "enum": [ "UNKNOWN", "Y", "N" ]
-          },
-          "adjudicator": {
-            "type": "string",
-            "nullable": true
-          },
-          "comments": {
-            "maxLength": 4000,
-            "minLength": 0,
-            "type": "string",
-            "nullable": true
-          }
-        }
-      },
-      "JJDisputeRemark": {
-        "type": "object",
-        "properties": {
-          "createdBy": { "type": "string" },
-          "createdTs": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "modifiedBy": {
-            "type": "string",
-            "nullable": true
-          },
-          "modifiedTs": {
-            "type": "string",
-            "format": "date-time",
-            "nullable": true
-          },
-          "id": {
-            "type": "integer",
-            "description": "ID",
-            "format": "int64",
-            "readOnly": true
-          },
-          "userFullName": { "type": "string" },
-          "note": {
-            "maxLength": 4000,
-            "minLength": 0,
-            "type": "string"
-          },
-          "remarksMadeTs": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      },
-      "JJDisputedCount": {
-        "type": "object",
-        "properties": {
-          "createdBy": { "type": "string" },
-          "createdTs": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "modifiedBy": {
-            "type": "string",
-            "nullable": true
-          },
-          "modifiedTs": {
-            "type": "string",
-            "format": "date-time",
-            "nullable": true
-          },
-          "id": {
-            "type": "integer",
-            "description": "ID",
-            "format": "int64",
-            "readOnly": true
-          },
-          "plea": {
-            "type": "string",
-            "description": "Represents the disputant's initial plea on count.",
-            "enum": [ "UNKNOWN", "G", "N" ]
-          },
-          "count": {
-            "maximum": 3,
-            "minimum": 1,
-            "type": "integer",
-            "format": "int32"
-          },
-          "requestTimeToPay": {
-            "type": "string",
-            "enum": [ "UNKNOWN", "Y", "N" ]
-          },
-          "requestReduction": {
-            "type": "string",
-            "enum": [ "UNKNOWN", "Y", "N" ]
-          },
-          "appearInCourt": {
-            "type": "string",
-            "enum": [ "UNKNOWN", "Y", "N" ]
-          },
-          "description": {
-            "type": "string",
-            "nullable": true
-          },
-          "dueDate": {
-            "type": "string",
-            "format": "date-time",
-            "nullable": true
-          },
-          "ticketedFineAmount": {
-            "type": "number",
-            "format": "float",
-            "nullable": true
-          },
-          "lesserOrGreaterAmount": {
-            "type": "number",
-            "format": "float",
-            "nullable": true
-          },
-          "includesSurcharge": {
-            "type": "string",
-            "nullable": true,
-            "enum": [ "UNKNOWN", "Y", "N" ]
-          },
-          "revisedDueDate": {
-            "type": "string",
-            "format": "date-time",
-            "nullable": true
-          },
-          "totalFineAmount": {
-            "type": "number",
-            "format": "float",
-            "nullable": true
-          },
-          "violationDate": {
-            "type": "string",
-            "format": "date-time",
-            "nullable": true
-          },
-          "comments": {
-            "maxLength": 4000,
-            "minLength": 0,
-            "type": "string",
-            "nullable": true
-          },
-          "latestPlea": {
-            "type": "string",
-            "description": "Represents the disputant's latest plea on count.",
-            "nullable": true,
-            "enum": [ "UNKNOWN", "G", "N" ]
-          },
-          "latestPleaUpdateTs": {
-            "type": "string",
-            "description": "The timestamp for when the last time disputant changed their plea.",
-            "format": "date-time",
-            "nullable": true
-          },
-          "jjDisputedCountRoP": { "$ref": "#/components/schemas/JJDisputedCountRoP" }
-        }
-      },
-      "JJDisputedCountRoP": {
-        "type": "object",
-        "properties": {
-          "createdBy": { "type": "string" },
-          "createdTs": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "modifiedBy": {
-            "type": "string",
-            "nullable": true
-          },
-          "modifiedTs": {
-            "type": "string",
-            "format": "date-time",
-            "nullable": true
-          },
-          "id": {
-            "type": "integer",
-            "description": "ID",
-            "format": "int64",
-            "readOnly": true
-          },
-          "finding": {
-            "type": "string",
-            "nullable": true,
-            "enum": [ "UNKNOWN", "GUILTY", "NOT_GUILTY", "CANCELLED", "PAID_PRIOR_TO_APPEARANCE", "GUILTY_LESSER" ]
-          },
-          "lesserDescription": {
-            "type": "string",
-            "nullable": true
-          },
-          "ssProbationDuration": {
-            "type": "string",
-            "nullable": true
-          },
-          "ssProbationConditions": {
-            "type": "string",
-            "nullable": true
-          },
-          "jailDuration": {
-            "type": "string",
-            "nullable": true
-          },
-          "jailIntermittent": {
-            "type": "string",
-            "enum": [ "UNKNOWN", "Y", "N" ]
-          },
-          "probationDuration": {
-            "type": "string",
-            "nullable": true
-          },
-          "probationConditions": {
-            "type": "string",
-            "nullable": true
-          },
-          "drivingProhibition": {
-            "type": "string",
-            "nullable": true
-          },
-          "drivingProhibitionMVASection": {
-            "type": "string",
-            "nullable": true
-          },
-          "dismissed": {
-            "type": "string",
-            "enum": [ "UNKNOWN", "Y", "N" ]
-          },
-          "forWantOfProsecution": {
-            "type": "string",
-            "enum": [ "UNKNOWN", "Y", "N" ]
-          },
-          "withdrawn": {
-            "type": "string",
-            "enum": [ "UNKNOWN", "Y", "N" ]
-          },
-          "abatement": {
-            "type": "string",
-            "enum": [ "UNKNOWN", "Y", "N" ]
-          },
-          "stayOfProceedingsBy": {
-            "type": "string",
-            "nullable": true
-          },
-          "other": {
-            "type": "string",
-            "nullable": true
-          }
-        },
-        "nullable": true
-      },
-      "Dispute": {
-        "type": "object",
-        "properties": {
-          "createdBy": { "type": "string" },
-          "createdTs": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "modifiedBy": {
-            "type": "string",
-            "nullable": true
-          },
-          "modifiedTs": {
-            "type": "string",
-            "format": "date-time",
-            "nullable": true
-          },
-          "disputeId": {
-            "type": "integer",
-            "description": "ID",
-            "format": "int64",
-            "readOnly": true
-          },
-          "noticeOfDisputeGuid": {
-            "type": "string",
-            "nullable": true
-          },
-          "ticketNumber": { "type": "string" },
-          "issuedTs": {
-            "type": "string",
-            "format": "date-time",
-            "nullable": true
-          },
-          "submittedTs": {
-            "type": "string",
-            "format": "date-time",
-            "nullable": true
-          },
-          "disputantSurname": {
-            "type": "string",
-            "nullable": true
-          },
-          "disputantGivenName1": {
-            "type": "string",
-            "nullable": true
-          },
-          "disputantGivenName2": {
-            "type": "string",
-            "nullable": true
-          },
-          "disputantGivenName3": {
-            "type": "string",
-            "nullable": true
-          },
-          "disputantBirthdate": {
-            "type": "string",
-            "format": "date-time",
-            "nullable": true
-          },
-          "driversLicenceNumber": {
-            "maxLength": 30,
-            "minLength": 0,
-            "type": "string",
-            "nullable": true
-          },
-          "disputantOrganization": {
-            "type": "string",
-            "nullable": true
-          },
-          "disputantClientId": {
-            "type": "string",
-            "nullable": true,
-            "readOnly": true
-          },
-          "driversLicenceIssuedCountryId": {
-            "type": "integer",
-            "format": "int32",
-            "nullable": true
-          },
-          "driversLicenceIssuedProvinceSeqNo": {
-            "type": "integer",
-            "format": "int32",
-            "nullable": true
-          },
-          "driversLicenceProvince": {
-            "maxLength": 30,
-            "minLength": 0,
-            "type": "string",
-            "nullable": true
-          },
-          "status": {
-            "type": "string",
-            "enum": [ "UNKNOWN", "NEW", "VALIDATED", "PROCESSING", "REJECTED", "CANCELLED", "CONCLUDED" ]
-          },
-          "addressLine1": {
-            "type": "string",
-            "nullable": true
-          },
-          "addressLine2": {
-            "type": "string",
-            "nullable": true
-          },
-          "addressLine3": {
-            "type": "string",
-            "nullable": true
-          },
-          "addressCity": {
-            "maxLength": 30,
-            "minLength": 0,
-            "type": "string",
-            "nullable": true
-          },
-          "addressProvince": {
-            "maxLength": 30,
-            "minLength": 0,
-            "type": "string",
-            "nullable": true
-          },
-          "addressProvinceCountryId": {
-            "type": "integer",
-            "format": "int32",
-            "nullable": true
-          },
-          "addressProvinceSeqNo": {
-            "type": "integer",
-            "format": "int32",
-            "nullable": true
-          },
-          "addressCountryId": {
-            "type": "integer",
-            "format": "int32",
-            "nullable": true
-          },
-          "postalCode": {
-            "maxLength": 10,
-            "minLength": 0,
-            "type": "string",
-            "nullable": true
-          },
-          "homePhoneNumber": {
-            "type": "string",
-            "nullable": true
-          },
-          "workPhoneNumber": {
-            "type": "string",
-            "nullable": true
-          },
-          "emailAddress": {
-            "type": "string",
-            "nullable": true
-          },
-          "emailAddressVerified": { "type": "boolean" },
-          "filingDate": {
-            "type": "string",
-            "format": "date-time",
-            "nullable": true
-          },
-          "representedByLawyer": {
-            "type": "string",
-            "nullable": true,
-            "enum": [ "UNKNOWN", "Y", "N" ]
-          },
-          "lawFirmName": {
-            "type": "string",
-            "nullable": true
-          },
-          "lawyerSurname": {
-            "type": "string",
-            "nullable": true
-          },
-          "lawyerGivenName1": {
-            "type": "string",
-            "nullable": true
-          },
-          "lawyerGivenName2": {
-            "type": "string",
-            "nullable": true
-          },
-          "lawyerGivenName3": {
-            "type": "string",
-            "nullable": true
-          },
-          "lawyerAddress": {
-            "maxLength": 300,
-            "minLength": 0,
-            "type": "string",
-            "nullable": true
-          },
-          "lawyerPhoneNumber": {
-            "type": "string",
-            "nullable": true
-          },
-          "lawyerEmail": {
-            "maxLength": 100,
-            "minLength": 0,
-            "type": "string",
-            "nullable": true
-          },
-          "officerPin": {
-            "type": "string",
-            "nullable": true
-          },
-          "contactTypeCd": {
-            "type": "string",
-            "enum": [ "UNKNOWN", "INDIVIDUAL", "LAWYER", "OTHER" ]
-          },
-          "requestCourtAppearanceYn": {
-            "type": "string",
-            "nullable": true,
-            "enum": [ "UNKNOWN", "Y", "N" ]
-          },
-          "contactLawFirmNm": {
-            "type": "string",
-            "nullable": true
-          },
-          "contactGiven1Nm": {
-            "type": "string",
-            "nullable": true
-          },
-          "contactGiven2Nm": {
-            "type": "string",
-            "nullable": true
-          },
-          "contactGiven3Nm": {
-            "type": "string",
-            "nullable": true
-          },
-          "contactSurnameNm": {
-            "type": "string",
-            "nullable": true
-          },
-          "appearanceDtm": {
-            "type": "string",
-            "format": "date-time",
-            "nullable": true
-          },
-          "appearanceLessThan14DaysYn": {
-            "type": "string",
-            "nullable": true,
-            "enum": [ "UNKNOWN", "Y", "N" ]
-          },
-          "detachmentLocation": {
-            "type": "string",
-            "nullable": true
-          },
-          "courtAgenId": {
-            "type": "string",
-            "nullable": true
-          },
-          "interpreterLanguageCd": {
-            "maxLength": 3,
-            "minLength": 0,
-            "type": "string",
-            "nullable": true
-          },
-          "interpreterRequired": {
-            "type": "string",
-            "nullable": true,
-            "enum": [ "UNKNOWN", "Y", "N" ]
-          },
-          "witnessNo": {
-            "type": "integer",
-            "format": "int32",
-            "nullable": true
-          },
-          "fineReductionReason": {
-            "type": "string",
-            "nullable": true
-          },
-          "timeToPayReason": {
-            "type": "string",
-            "nullable": true
-          },
-          "disputantComment": {
-            "type": "string",
-            "nullable": true
-          },
-          "rejectedReason": {
-            "type": "string",
-            "nullable": true
-          },
-          "userAssignedTo": {
-            "type": "string",
-            "nullable": true
-          },
-          "userAssignedTs": {
-            "type": "string",
-            "format": "date-time",
-            "nullable": true
-          },
-          "disputantDetectedOcrIssues": {
-            "type": "string",
-            "nullable": true,
-            "enum": [ "UNKNOWN", "Y", "N" ]
-          },
-          "disputantOcrIssues": {
-            "type": "string",
-            "nullable": true
-          },
-          "systemDetectedOcrIssues": {
-            "type": "string",
-            "enum": [ "UNKNOWN", "Y", "N" ]
-          },
-          "ocrTicketFilename": {
-            "maxLength": 100,
-            "minLength": 0,
-            "type": "string",
-            "nullable": true
-          },
-          "violationTicket": { "$ref": "#/components/schemas/ViolationTicket" },
-          "disputeCounts": {
-            "type": "array",
-            "items": { "$ref": "#/components/schemas/DisputeCount" }
-          }
-        }
-      },
-      "DisputeCount": {
-        "type": "object",
-        "properties": {
-          "createdBy": { "type": "string" },
-          "createdTs": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "modifiedBy": {
-            "type": "string",
-            "nullable": true
-          },
-          "modifiedTs": {
-            "type": "string",
-            "format": "date-time",
-            "nullable": true
-          },
-          "countNo": {
-            "maximum": 3,
-            "minimum": 1,
-            "type": "integer",
-            "format": "int32"
-          },
-          "pleaCode": {
-            "type": "string",
-            "enum": [ "UNKNOWN", "G", "N" ]
-          },
-          "requestTimeToPay": {
-            "type": "string",
-            "enum": [ "UNKNOWN", "Y", "N" ]
-          },
-          "requestReduction": {
-            "type": "string",
-            "enum": [ "UNKNOWN", "Y", "N" ]
-          },
-          "requestCourtAppearance": {
-            "type": "string",
-            "enum": [ "UNKNOWN", "Y", "N" ]
-          }
-        }
-      },
-      "ViolationTicket": {
-        "type": "object",
-        "properties": {
-          "createdBy": { "type": "string" },
-          "createdTs": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "modifiedBy": {
-            "type": "string",
-            "nullable": true
-          },
-          "modifiedTs": {
-            "type": "string",
-            "format": "date-time",
-            "nullable": true
-          },
-          "violationTicketId": {
-            "type": "integer",
-            "description": "ID",
-            "format": "int64",
-            "readOnly": true
-          },
-          "ticketNumber": {
-            "type": "string",
-            "nullable": true
-          },
-          "disputantOrganizationName": {
-            "type": "string",
-            "nullable": true
-          },
-          "disputantSurname": {
-            "type": "string",
-            "nullable": true
-          },
-          "disputantGivenNames": {
-            "type": "string",
-            "nullable": true
-          },
-          "isYoungPerson": {
-            "type": "string",
-            "nullable": true,
-            "enum": [ "UNKNOWN", "Y", "N" ]
-          },
-          "disputantDriversLicenceNumber": {
-            "maxLength": 30,
-            "minLength": 7,
-            "type": "string",
-            "nullable": true
-          },
-          "disputantClientNumber": {
-            "type": "string",
-            "nullable": true
-          },
-          "driversLicenceProvince": {
-            "maxLength": 100,
-            "minLength": 0,
-            "type": "string",
-            "nullable": true
-          },
-          "driversLicenceCountry": {
-            "maxLength": 100,
-            "minLength": 0,
-            "type": "string"
-          },
-          "driversLicenceIssuedYear": {
-            "type": "integer",
-            "format": "int32",
-            "nullable": true
-          },
-          "driversLicenceExpiryYear": {
-            "type": "integer",
-            "format": "int32",
-            "nullable": true
-          },
-          "disputantBirthdate": {
-            "type": "string",
-            "format": "date-time",
-            "nullable": true
-          },
-          "address": {
-            "maxLength": 100,
-            "minLength": 0,
-            "type": "string",
-            "nullable": true
-          },
-          "addressCity": {
-            "type": "string",
-            "nullable": true
-          },
-          "addressProvince": {
-            "type": "string",
-            "nullable": true
-          },
-          "addressPostalCode": {
-            "type": "string",
-            "nullable": true
-          },
-          "addressCountry": {
-            "type": "string",
-            "nullable": true
-          },
-          "officerPin": {
-            "type": "string",
-            "nullable": true
-          },
-          "detachmentLocation": {
-            "type": "string",
-            "nullable": true
-          },
-          "issuedTs": {
-            "type": "string",
-            "format": "date-time",
-            "nullable": true
-          },
-          "issuedOnRoadOrHighway": {
-            "type": "string",
-            "nullable": true
-          },
-          "issuedAtOrNearCity": {
-            "type": "string",
-            "nullable": true
-          },
-          "isChangeOfAddress": {
-            "type": "string",
-            "nullable": true,
-            "enum": [ "UNKNOWN", "Y", "N" ]
-          },
-          "isDriver": {
-            "type": "string",
-            "nullable": true,
-            "enum": [ "UNKNOWN", "Y", "N" ]
-          },
-          "isOwner": {
-            "type": "string",
-            "nullable": true,
-            "enum": [ "UNKNOWN", "Y", "N" ]
-          },
-          "courtLocation": {
-            "type": "string",
-            "nullable": true
-          },
-          "violationTicketCounts": {
-            "type": "array",
-            "items": { "$ref": "#/components/schemas/ViolationTicketCount" }
-          }
-        },
-        "nullable": true
-      },
-      "ViolationTicketCount": {
-        "type": "object",
-        "properties": {
-          "createdBy": { "type": "string" },
-          "createdTs": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "modifiedBy": {
-            "type": "string",
-            "nullable": true
-          },
-          "modifiedTs": {
-            "type": "string",
-            "format": "date-time",
-            "nullable": true
-          },
-          "violationTicketCountId": {
-            "type": "integer",
-            "description": "ID",
-            "format": "int64",
-            "readOnly": true
-          },
-          "countNo": {
-            "maximum": 3,
-            "minimum": 1,
-            "type": "integer",
-            "format": "int32"
-          },
-          "description": {
-            "type": "string",
-            "nullable": true
-          },
-          "actOrRegulationNameCode": {
-            "type": "string",
-            "nullable": true
-          },
-          "isAct": {
-            "type": "string",
-            "nullable": true,
-            "enum": [ "UNKNOWN", "Y", "N" ]
-          },
-          "isRegulation": {
-            "type": "string",
-            "nullable": true,
-            "enum": [ "UNKNOWN", "Y", "N" ]
-          },
-          "section": {
-            "maxLength": 10,
-            "minLength": 0,
-            "type": "string",
-            "nullable": true,
-            "readOnly": true
-          },
-          "subsection": {
-            "maxLength": 4,
-            "minLength": 0,
-            "type": "string",
-            "nullable": true,
-            "readOnly": true
-          },
-          "paragraph": {
-            "maxLength": 3,
-            "minLength": 0,
-            "type": "string",
-            "nullable": true,
-            "readOnly": true
-          },
-          "subparagraph": {
-            "maxLength": 5,
-            "minLength": 0,
-            "type": "string",
-            "nullable": true,
-            "readOnly": true
-          },
-          "ticketedAmount": {
-            "type": "number",
-            "format": "float",
-            "nullable": true
-          }
-        }
-      },
-      "DisputeUpdateRequest": {
-        "required": [ "status", "updateJson", "updateType" ],
-        "type": "object",
-        "properties": {
-          "createdBy": { "type": "string" },
-          "createdTs": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "modifiedBy": {
-            "type": "string",
-            "nullable": true
-          },
-          "modifiedTs": {
-            "type": "string",
-            "format": "date-time",
-            "nullable": true
-          },
-          "disputeUpdateRequestId": {
-            "type": "integer",
-            "description": "ID",
-            "format": "int64",
-            "readOnly": true
-          },
-          "disputeId": {
-            "type": "integer",
-            "format": "int64"
-          },
-          "status": {
-            "type": "string",
-            "enum": [ "UNKNOWN", "ACCEPTED", "PENDING", "REJECTED" ]
-          },
-          "updateType": {
-            "type": "string",
-            "enum": [ "UNKNOWN", "DISPUTANT_ADDRESS", "DISPUTANT_PHONE", "DISPUTANT_NAME", "COUNT", "DISPUTANT_EMAIL", "DISPUTANT_DOCUMENT", "COURT_OPTIONS" ]
-          },
-          "updateJson": {
-            "maxLength": 1000,
-            "minLength": 3,
-            "type": "string"
-          }
-        }
-      },
-      "FileHistory": {
-        "required": [ "auditLogEntryType", "disputeId" ],
-        "type": "object",
-        "properties": {
-          "createdBy": { "type": "string" },
-          "createdTs": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "modifiedBy": {
-            "type": "string",
-            "nullable": true
-          },
-          "modifiedTs": {
-            "type": "string",
-            "format": "date-time",
-            "nullable": true
-          },
-          "fileHistoryId": {
-            "type": "integer",
-            "description": "ID",
-            "format": "int64",
-            "readOnly": true
-          },
-          "disputeId": {
-            "type": "integer",
-            "format": "int64"
-          },
-          "auditLogEntryType": {
-            "type": "string",
-            "enum": [ "UNKNOWN", "ARFL", "CAIN", "CAWT", "CCAN", "CCON", "CCWR", "CLEG", "CUEM", "CUEV", "CUIN", "CULG", "CUPD", "CUWR", "CUWT", "DURA", "DURR", "EMCA", "EMCF", "EMCR", "EMDC", "EMFD", "EMPR", "EMRJ", "EMRV", "EMST", "EMUP", "EMVF", "ESUR", "FDLD", "FDLS", "FUPD", "FUPS", "INIT", "JASG", "JCNF", "JDIV", "JPRG", "RECN", "SCAN", "SPRC", "SREJ", "SUB", "SUPL", "SVAL", "URSR", "VREV", "VSUB" ]
-          },
-          "description": {
-            "type": "string",
-            "nullable": true
-          },
-          "actionByApplicationUser": {
-            "type": "string",
-            "nullable": true
-          }
-        }
-      },
-      "EmailHistory": {
-        "type": "object",
-        "properties": {
-          "createdBy": { "type": "string" },
-          "createdTs": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "modifiedBy": {
-            "type": "string",
-            "nullable": true
-          },
-          "modifiedTs": {
-            "type": "string",
-            "format": "date-time",
-            "nullable": true
-          },
-          "emailHistoryId": {
-            "type": "integer",
-            "description": "ID",
-            "format": "int64",
-            "readOnly": true
-          },
-          "emailSentTs": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "fromEmailAddress": {
-            "maxLength": 100,
-            "minLength": 0,
-            "type": "string"
-          },
-          "toEmailAddress": {
-            "maxLength": 4000,
-            "minLength": 0,
-            "type": "string"
-          },
-          "ccEmailAddress": {
-            "maxLength": 4000,
-            "minLength": 0,
-            "type": "string",
-            "nullable": true
-          },
-          "bccEmailAddress": {
-            "maxLength": 4000,
-            "minLength": 0,
-            "type": "string",
-            "nullable": true
-          },
-          "subject": {
-            "maxLength": 1000,
-            "minLength": 0,
-            "type": "string"
-          },
-          "htmlContent": {
-            "maxLength": 4000,
-            "minLength": 0,
-            "type": "string",
-            "nullable": true
-          },
-          "plainTextContent": {
-            "maxLength": 4000,
-            "minLength": 0,
-            "type": "string",
-            "nullable": true
-          },
-          "successfullySent": {
-            "type": "string",
-            "enum": [ "UNKNOWN", "Y", "N" ]
-          },
-          "occamDisputeId": {
-            "type": "integer",
-            "format": "int64"
-          }
-        }
-      },
-      "TicketImageDataJustinDocument": {
-        "type": "object",
-        "properties": {
-          "reportType": {
-            "type": "string",
-            "nullable": true,
-            "enum": [ "UNKNOWN", "NOTICE_OF_DISPUTE", "TICKET_IMAGE" ]
-          },
-          "reportFormat": {
-            "type": "string",
-            "nullable": true
-          },
-          "partId": {
-            "type": "string",
-            "nullable": true
-          },
-          "participantName": {
-            "type": "string",
-            "nullable": true
-          },
-          "index": {
-            "type": "string",
-            "nullable": true
-          },
-          "fileData": {
-            "type": "string",
-            "nullable": true
-          }
-        }
-      },
-      "DisputeListItem": {
-        "type": "object",
-        "properties": {
-          "createdBy": { "type": "string" },
-          "createdTs": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "modifiedBy": {
-            "type": "string",
-            "nullable": true
-          },
-          "modifiedTs": {
-            "type": "string",
-            "format": "date-time",
-            "nullable": true
-          },
-          "disputeId": {
-            "type": "integer",
-            "description": "ID",
-            "format": "int64",
-            "readOnly": true
-          },
-          "ticketNumber": { "type": "string" },
-          "submittedTs": {
-            "type": "string",
-            "format": "date-time",
-            "nullable": true
-          },
-          "disputantSurname": {
-            "type": "string",
-            "nullable": true
-          },
-          "disputantGivenName1": {
-            "type": "string",
-            "nullable": true
-          },
-          "disputantGivenName2": {
-            "type": "string",
-            "nullable": true
-          },
-          "disputantGivenName3": {
-            "type": "string",
-            "nullable": true
-          },
-          "status": {
-            "type": "string",
-            "enum": [ "UNKNOWN", "NEW", "VALIDATED", "PROCESSING", "REJECTED", "CANCELLED", "CONCLUDED" ]
-          },
-          "emailAddress": {
-            "type": "string",
-            "nullable": true
-          },
-          "emailAddressVerified": { "type": "boolean" },
-          "filingDate": {
-            "type": "string",
-            "format": "date-time",
-            "nullable": true
-          },
-          "requestCourtAppearanceYn": {
-            "type": "string",
-            "nullable": true,
-            "enum": [ "UNKNOWN", "Y", "N" ]
-          },
-          "userAssignedTo": {
-            "type": "string",
-            "nullable": true
-          },
-          "userAssignedTs": {
-            "type": "string",
-            "format": "date-time",
-            "nullable": true
-          },
-          "disputantDetectedOcrIssues": {
-            "type": "string",
-            "nullable": true,
-            "enum": [ "UNKNOWN", "Y", "N" ]
-          },
-          "systemDetectedOcrIssues": {
-            "type": "string",
-            "enum": [ "UNKNOWN", "Y", "N" ]
-          }
-        }
-      },
-      "DisputeResult": {
-        "type": "object",
-        "properties": {
-          "disputeId": {
-            "type": "integer",
-            "format": "int64"
-          },
-          "noticeOfDisputeGuid": { "type": "string" },
-          "disputeStatus": {
-            "type": "string",
-            "enum": [ "UNKNOWN", "NEW", "VALIDATED", "PROCESSING", "REJECTED", "CANCELLED", "CONCLUDED" ]
-          },
-          "jjDisputeStatus": {
-            "type": "string",
-            "nullable": true,
-            "enum": [ "UNKNOWN", "NEW", "IN_PROGRESS", "DATA_UPDATE", "CONFIRMED", "REQUIRE_COURT_HEARING", "REQUIRE_MORE_INFO", "ACCEPTED", "REVIEW", "CONCLUDED", "CANCELLED", "HEARING_SCHEDULED" ]
-          },
-          "jjDisputeHearingType": {
-            "type": "string",
-            "nullable": true,
-            "enum": [ "UNKNOWN", "COURT_APPEARANCE", "WRITTEN_REASONS" ]
-          }
-        }
-      }
-    },
-    "securitySchemes": {
-      "x-username": {
-        "type": "apiKey",
-        "name": "x-username",
-        "in": "header"
-      }
-    }
-  }
 }

--- a/src/backend/TrafficCourts/Common/OpenAPIs/OracleDataAPI/v1_0/OracleDataApiClient.g.cs
+++ b/src/backend/TrafficCourts/Common/OpenAPIs/OracleDataAPI/v1_0/OracleDataApiClient.g.cs
@@ -100,6 +100,21 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
         System.Threading.Tasks.Task<JJDispute> ConcludeJJDisputeAsync(string ticketNumber, bool checkVTCAssigned, System.Threading.CancellationToken cancellationToken);
 
         /// <summary>
+        /// Updates the properties of a particular JJ Dispute record as well as cascading to underlying related Dispute data.
+        /// </summary>
+        /// <returns>Ok</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        System.Threading.Tasks.Task<JJDispute> UpdateJJDisputeCascadeAsync(string ticketNumber, bool checkVTCAssigned, JJDispute body);
+
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <summary>
+        /// Updates the properties of a particular JJ Dispute record as well as cascading to underlying related Dispute data.
+        /// </summary>
+        /// <returns>Ok</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        System.Threading.Tasks.Task<JJDispute> UpdateJJDisputeCascadeAsync(string ticketNumber, bool checkVTCAssigned, JJDispute body, System.Threading.CancellationToken cancellationToken);
+
+        /// <summary>
         /// Updates the status of a particular JJDispute record to CANCELLED.
         /// </summary>
         /// <returns>Ok. Updated JJDispute record returned.</returns>
@@ -644,16 +659,6 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                         ProcessResponse(client_, response_);
 
                         var status_ = (int)response_.StatusCode;
-                        if (status_ == 404)
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            throw new ApiException<FileResponse>("JJDispute record not found. Update failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
-                        }
-                        else
                         if (status_ == 400)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
@@ -664,14 +669,14 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                             throw new ApiException<FileResponse>("Bad Request.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
-                        if (status_ == 500)
+                        if (status_ == 404)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
                             if (objectResponse_.Object == null)
                             {
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
-                            throw new ApiException<FileResponse>("Internal Server Error", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                            throw new ApiException<FileResponse>("JJDispute record not found. Update failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 405)
@@ -682,6 +687,16 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             throw new ApiException<FileResponse>("An invalid JJ Dispute status is provided. Update failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 500)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<FileResponse>("Internal Server Error", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 200)
@@ -780,16 +795,6 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                         ProcessResponse(client_, response_);
 
                         var status_ = (int)response_.StatusCode;
-                        if (status_ == 404)
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            throw new ApiException<FileResponse>("JJDispute record not found. Update failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
-                        }
-                        else
                         if (status_ == 400)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
@@ -800,14 +805,14 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                             throw new ApiException<FileResponse>("Bad Request.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
-                        if (status_ == 500)
+                        if (status_ == 404)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
                             if (objectResponse_.Object == null)
                             {
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
-                            throw new ApiException<FileResponse>("Internal server error occured.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                            throw new ApiException<FileResponse>("JJDispute record not found. Update failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 405)
@@ -818,6 +823,16 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             throw new ApiException<FileResponse>("A JJDispute status can only be set to REVIEW iff status is NEW or VALIDATED and the remark must be <= 256 characters. Update failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 500)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<FileResponse>("Internal server error occured.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 200)
@@ -910,16 +925,6 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                         ProcessResponse(client_, response_);
 
                         var status_ = (int)response_.StatusCode;
-                        if (status_ == 404)
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            throw new ApiException<FileResponse>("JJDispute record not found. Update failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
-                        }
-                        else
                         if (status_ == 400)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
@@ -930,14 +935,14 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                             throw new ApiException<FileResponse>("Bad Request.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
-                        if (status_ == 500)
+                        if (status_ == 404)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
                             if (objectResponse_.Object == null)
                             {
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
-                            throw new ApiException<FileResponse>("Internal server error occured.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                            throw new ApiException<FileResponse>("JJDispute record not found. Update failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 405)
@@ -948,6 +953,16 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             throw new ApiException<FileResponse>("A JJDispute status can only be set to REQUIRE_COURT_HEARING iff status is one of the following: NEW, IN_PROGRESS, REVIEW, REQUIRE_COURT_HEARING and the remark must be <= 256 characters. Update failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 500)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<FileResponse>("Internal server error occured.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 200)
@@ -1035,16 +1050,6 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                         ProcessResponse(client_, response_);
 
                         var status_ = (int)response_.StatusCode;
-                        if (status_ == 404)
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            throw new ApiException<FileResponse>("JJDispute record not found. Update failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
-                        }
-                        else
                         if (status_ == 400)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
@@ -1055,14 +1060,14 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                             throw new ApiException<FileResponse>("Bad Request.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
-                        if (status_ == 500)
+                        if (status_ == 404)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
                             if (objectResponse_.Object == null)
                             {
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
-                            throw new ApiException<FileResponse>("Internal server error occured.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                            throw new ApiException<FileResponse>("JJDispute record not found. Update failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 405)
@@ -1073,6 +1078,16 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             throw new ApiException<FileResponse>("A JJDispute status can only be set to CONFIRMED iff status is one of the following: REVIEW, NEW, HEARING_SCHEDULED, IN_PROGRESS, CONFIRMED. Update failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 500)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<FileResponse>("Internal server error occured.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 200)
@@ -1165,6 +1180,16 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                         ProcessResponse(client_, response_);
 
                         var status_ = (int)response_.StatusCode;
+                        if (status_ == 400)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<FileResponse>("Bad Request.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
                         if (status_ == 404)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
@@ -1175,14 +1200,14 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                             throw new ApiException<FileResponse>("JJDispute record not found. Update failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
-                        if (status_ == 400)
+                        if (status_ == 405)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
                             if (objectResponse_.Object == null)
                             {
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
-                            throw new ApiException<FileResponse>("Bad Request.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                            throw new ApiException<FileResponse>("Method Not Allowed", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 500)
@@ -1195,6 +1220,122 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                             throw new ApiException<FileResponse>("Internal server error occured.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
+                        if (status_ == 200)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<JJDispute>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            return objectResponse_.Object;
+                        }
+                        else
+                        {
+                            var responseData_ = response_.Content == null ? null : await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
+                            throw new ApiException("The HTTP status code of the response was not expected (" + status_ + ").", status_, responseData_, headers_, null);
+                        }
+                    }
+                    finally
+                    {
+                        if (disposeResponse_)
+                            response_.Dispose();
+                    }
+                }
+            }
+            finally
+            {
+                if (disposeClient_)
+                    client_.Dispose();
+            }
+        }
+
+        /// <summary>
+        /// Updates the properties of a particular JJ Dispute record as well as cascading to underlying related Dispute data.
+        /// </summary>
+        /// <returns>Ok</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        public virtual System.Threading.Tasks.Task<JJDispute> UpdateJJDisputeCascadeAsync(string ticketNumber, bool checkVTCAssigned, JJDispute body)
+        {
+            return UpdateJJDisputeCascadeAsync(ticketNumber, checkVTCAssigned, body, System.Threading.CancellationToken.None);
+        }
+
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <summary>
+        /// Updates the properties of a particular JJ Dispute record as well as cascading to underlying related Dispute data.
+        /// </summary>
+        /// <returns>Ok</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        public virtual async System.Threading.Tasks.Task<JJDispute> UpdateJJDisputeCascadeAsync(string ticketNumber, bool checkVTCAssigned, JJDispute body, System.Threading.CancellationToken cancellationToken)
+        {
+            if (ticketNumber == null)
+                throw new System.ArgumentNullException("ticketNumber");
+
+            if (checkVTCAssigned == null)
+                throw new System.ArgumentNullException("checkVTCAssigned");
+
+            if (body == null)
+                throw new System.ArgumentNullException("body");
+
+            var urlBuilder_ = new System.Text.StringBuilder();
+            urlBuilder_.Append("api/v1.0/jj/dispute/{ticketNumber}/cascade?");
+            urlBuilder_.Replace("{ticketNumber}", System.Uri.EscapeDataString(ConvertToString(ticketNumber, System.Globalization.CultureInfo.InvariantCulture)));
+            urlBuilder_.Append(System.Uri.EscapeDataString("checkVTCAssigned") + "=").Append(System.Uri.EscapeDataString(ConvertToString(checkVTCAssigned, System.Globalization.CultureInfo.InvariantCulture))).Append("&");
+            urlBuilder_.Length--;
+
+            var client_ = _httpClient;
+            var disposeClient_ = false;
+            try
+            {
+                using (var request_ = new System.Net.Http.HttpRequestMessage())
+                {
+                    var json_ = Newtonsoft.Json.JsonConvert.SerializeObject(body, _settings.Value);
+                    var content_ = new System.Net.Http.StringContent(json_);
+                    content_.Headers.ContentType = System.Net.Http.Headers.MediaTypeHeaderValue.Parse("application/json");
+                    request_.Content = content_;
+                    request_.Method = new System.Net.Http.HttpMethod("PUT");
+                    request_.Headers.Accept.Add(System.Net.Http.Headers.MediaTypeWithQualityHeaderValue.Parse("*/*"));
+
+                    PrepareRequest(client_, request_, urlBuilder_);
+
+                    var url_ = urlBuilder_.ToString();
+                    request_.RequestUri = new System.Uri(url_, System.UriKind.RelativeOrAbsolute);
+
+                    PrepareRequest(client_, request_, url_);
+
+                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+                    var disposeResponse_ = true;
+                    try
+                    {
+                        var headers_ = System.Linq.Enumerable.ToDictionary(response_.Headers, h_ => h_.Key, h_ => h_.Value);
+                        if (response_.Content != null && response_.Content.Headers != null)
+                        {
+                            foreach (var item_ in response_.Content.Headers)
+                                headers_[item_.Key] = item_.Value;
+                        }
+
+                        ProcessResponse(client_, response_);
+
+                        var status_ = (int)response_.StatusCode;
+                        if (status_ == 400)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<FileResponse>("Bad Request.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 404)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<FileResponse>("JJDispute record not found. Update failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
                         if (status_ == 405)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
@@ -1202,7 +1343,17 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                             {
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
-                            throw new ApiException<FileResponse>("Method Not Allowed", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                            throw new ApiException<FileResponse>("An invalid JJ Dispute status is provided. Update failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 500)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<FileResponse>("Internal Server Error", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 200)
@@ -1295,16 +1446,6 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                         ProcessResponse(client_, response_);
 
                         var status_ = (int)response_.StatusCode;
-                        if (status_ == 404)
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            throw new ApiException<FileResponse>("JJDispute record not found. Update failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
-                        }
-                        else
                         if (status_ == 400)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
@@ -1315,14 +1456,14 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                             throw new ApiException<FileResponse>("Bad Request.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
-                        if (status_ == 500)
+                        if (status_ == 404)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
                             if (objectResponse_.Object == null)
                             {
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
-                            throw new ApiException<FileResponse>("Internal server error occured.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                            throw new ApiException<FileResponse>("JJDispute record not found. Update failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 405)
@@ -1333,6 +1474,16 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             throw new ApiException<FileResponse>("Method Not Allowed", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 500)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<FileResponse>("Internal server error occured.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 200)
@@ -1431,16 +1582,6 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                         ProcessResponse(client_, response_);
 
                         var status_ = (int)response_.StatusCode;
-                        if (status_ == 404)
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            throw new ApiException<FileResponse>("JJDispute record not found. Update failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
-                        }
-                        else
                         if (status_ == 400)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
@@ -1451,14 +1592,14 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                             throw new ApiException<FileResponse>("Bad Request.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
-                        if (status_ == 500)
+                        if (status_ == 404)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
                             if (objectResponse_.Object == null)
                             {
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
-                            throw new ApiException<FileResponse>("Internal server error occured.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                            throw new ApiException<FileResponse>("JJDispute record not found. Update failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 405)
@@ -1469,6 +1610,16 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             throw new ApiException<FileResponse>("A JJDispute status can only be set to ACCEPTED iff status is CONFIRMED. Update failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 500)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<FileResponse>("Internal server error occured.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 200)
@@ -1560,16 +1711,6 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                         ProcessResponse(client_, response_);
 
                         var status_ = (int)response_.StatusCode;
-                        if (status_ == 404)
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            throw new ApiException<FileResponse>("JJDispute record(s) not found. Update failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
-                        }
-                        else
                         if (status_ == 400)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
@@ -1580,14 +1721,14 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                             throw new ApiException<FileResponse>("Bad Request.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
-                        if (status_ == 500)
+                        if (status_ == 404)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
                             if (objectResponse_.Object == null)
                             {
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
-                            throw new ApiException<FileResponse>("Internal server error occured.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                            throw new ApiException<FileResponse>("JJDispute record(s) not found. Update failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 405)
@@ -1598,6 +1739,16 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             throw new ApiException<FileResponse>("Method Not Allowed", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 500)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<FileResponse>("Internal server error occured.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 200)
@@ -1686,16 +1837,6 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                         ProcessResponse(client_, response_);
 
                         var status_ = (int)response_.StatusCode;
-                        if (status_ == 404)
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            throw new ApiException<FileResponse>("Dispute record not found. Update failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
-                        }
-                        else
                         if (status_ == 400)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
@@ -1706,14 +1847,14 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                             throw new ApiException<FileResponse>("Bad Request.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
-                        if (status_ == 500)
+                        if (status_ == 404)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
                             if (objectResponse_.Object == null)
                             {
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
-                            throw new ApiException<FileResponse>("Internal Server Error", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                            throw new ApiException<FileResponse>("Dispute record not found. Update failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 405)
@@ -1724,6 +1865,16 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             throw new ApiException<FileResponse>("Method Not Allowed", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 500)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<FileResponse>("Internal Server Error", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 409)
@@ -1819,16 +1970,6 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                         ProcessResponse(client_, response_);
 
                         var status_ = (int)response_.StatusCode;
-                        if (status_ == 404)
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            throw new ApiException<FileResponse>("Dispute record not found. Delete failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
-                        }
-                        else
                         if (status_ == 400)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
@@ -1839,14 +1980,14 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                             throw new ApiException<FileResponse>("Bad Request.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
-                        if (status_ == 500)
+                        if (status_ == 404)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
                             if (objectResponse_.Object == null)
                             {
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
-                            throw new ApiException<FileResponse>("Internal Server Error. Delete failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                            throw new ApiException<FileResponse>("Dispute record not found. Delete failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 405)
@@ -1857,6 +1998,16 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             throw new ApiException<FileResponse>("Method Not Allowed", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 500)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<FileResponse>("Internal Server Error. Delete failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 200)
@@ -1939,16 +2090,6 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                         ProcessResponse(client_, response_);
 
                         var status_ = (int)response_.StatusCode;
-                        if (status_ == 404)
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            throw new ApiException<FileResponse>("Dispute record not found. Update failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
-                        }
-                        else
                         if (status_ == 400)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
@@ -1959,14 +2100,14 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                             throw new ApiException<FileResponse>("Bad Request.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
-                        if (status_ == 500)
+                        if (status_ == 404)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
                             if (objectResponse_.Object == null)
                             {
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
-                            throw new ApiException<FileResponse>("Internal Server Error", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                            throw new ApiException<FileResponse>("Dispute record not found. Update failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 405)
@@ -1977,6 +2118,16 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             throw new ApiException<FileResponse>("A Dispute status can only be set to VALIDATED iff status is NEW. Update failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 500)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<FileResponse>("Internal Server Error", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 200)
@@ -2074,16 +2225,6 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                         ProcessResponse(client_, response_);
 
                         var status_ = (int)response_.StatusCode;
-                        if (status_ == 404)
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            throw new ApiException<FileResponse>("Dispute record not found. Update failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
-                        }
-                        else
                         if (status_ == 400)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
@@ -2094,14 +2235,14 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                             throw new ApiException<FileResponse>("Bad Request.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
-                        if (status_ == 500)
+                        if (status_ == 404)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
                             if (objectResponse_.Object == null)
                             {
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
-                            throw new ApiException<FileResponse>("Internal Server Error", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                            throw new ApiException<FileResponse>("Dispute record not found. Update failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 405)
@@ -2112,6 +2253,16 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             throw new ApiException<FileResponse>("A Dispute status can only be set to PROCESSING iff status is NEW or REJECTED. Update failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 500)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<FileResponse>("Internal Server Error", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 200)
@@ -2215,16 +2366,6 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                         ProcessResponse(client_, response_);
 
                         var status_ = (int)response_.StatusCode;
-                        if (status_ == 404)
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            throw new ApiException<FileResponse>("Dispute record not found. Update failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
-                        }
-                        else
                         if (status_ == 400)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
@@ -2235,14 +2376,14 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                             throw new ApiException<FileResponse>("Bad Request.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
-                        if (status_ == 500)
+                        if (status_ == 404)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
                             if (objectResponse_.Object == null)
                             {
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
-                            throw new ApiException<FileResponse>("Internal Server Error", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                            throw new ApiException<FileResponse>("Dispute record not found. Update failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 405)
@@ -2253,6 +2394,16 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             throw new ApiException<FileResponse>("A Dispute status can only be set to REJECTED iff status is NEW or VALIDATED and the rejected reason must be <= 256 characters. Update failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 500)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<FileResponse>("Internal Server Error", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 200)
@@ -2351,16 +2502,6 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                         ProcessResponse(client_, response_);
 
                         var status_ = (int)response_.StatusCode;
-                        if (status_ == 404)
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            throw new ApiException<FileResponse>("Dispute with specified id not found", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
-                        }
-                        else
                         if (status_ == 400)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
@@ -2371,14 +2512,14 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                             throw new ApiException<FileResponse>("Bad Request", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
-                        if (status_ == 500)
+                        if (status_ == 404)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
                             if (objectResponse_.Object == null)
                             {
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
-                            throw new ApiException<FileResponse>("Internal server error occured.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                            throw new ApiException<FileResponse>("Dispute with specified id not found", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 405)
@@ -2389,6 +2530,16 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             throw new ApiException<FileResponse>("Method Not Allowed", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 500)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<FileResponse>("Internal server error occured.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 200)
@@ -2480,16 +2631,6 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                         ProcessResponse(client_, response_);
 
                         var status_ = (int)response_.StatusCode;
-                        if (status_ == 404)
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            throw new ApiException<FileResponse>("Dispute with specified id not found", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
-                        }
-                        else
                         if (status_ == 400)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
@@ -2500,14 +2641,14 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                             throw new ApiException<FileResponse>("If the email address is > 100 characters", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
-                        if (status_ == 500)
+                        if (status_ == 404)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
                             if (objectResponse_.Object == null)
                             {
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
-                            throw new ApiException<FileResponse>("Internal server error occured.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                            throw new ApiException<FileResponse>("Dispute with specified id not found", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 405)
@@ -2518,6 +2659,16 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             throw new ApiException<FileResponse>("Method Not Allowed", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 500)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<FileResponse>("Internal server error occured.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 200)
@@ -2611,16 +2762,6 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                         ProcessResponse(client_, response_);
 
                         var status_ = (int)response_.StatusCode;
-                        if (status_ == 404)
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            throw new ApiException<FileResponse>("Dispute record not found. Update failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
-                        }
-                        else
                         if (status_ == 400)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
@@ -2631,14 +2772,14 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                             throw new ApiException<FileResponse>("Bad Request.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
-                        if (status_ == 500)
+                        if (status_ == 404)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
                             if (objectResponse_.Object == null)
                             {
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
-                            throw new ApiException<FileResponse>("Internal Server Error", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                            throw new ApiException<FileResponse>("Dispute record not found. Update failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 405)
@@ -2649,6 +2790,16 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             throw new ApiException<FileResponse>("A Dispute status can only be set to CANCELLED iff status is NEW, REJECTED or PROCESSING. Update failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 500)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<FileResponse>("Internal Server Error", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 200)
@@ -2755,16 +2906,6 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                         ProcessResponse(client_, response_);
 
                         var status_ = (int)response_.StatusCode;
-                        if (status_ == 404)
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            throw new ApiException<FileResponse>("DisputeUpdateRequest could not be found.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
-                        }
-                        else
                         if (status_ == 400)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
@@ -2775,14 +2916,14 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                             throw new ApiException<FileResponse>("Bad Request", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
-                        if (status_ == 500)
+                        if (status_ == 404)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
                             if (objectResponse_.Object == null)
                             {
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
-                            throw new ApiException<FileResponse>("Internal Server Error. Save failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                            throw new ApiException<FileResponse>("DisputeUpdateRequest could not be found.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 405)
@@ -2793,6 +2934,16 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             throw new ApiException<FileResponse>("Method Not Allowed", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 500)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<FileResponse>("Internal Server Error. Save failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 200)
@@ -2882,16 +3033,6 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                         ProcessResponse(client_, response_);
 
                         var status_ = (int)response_.StatusCode;
-                        if (status_ == 404)
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            throw new ApiException<FileResponse>("An invalid file history record provided. Insert failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
-                        }
-                        else
                         if (status_ == 400)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
@@ -2902,14 +3043,14 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                             throw new ApiException<FileResponse>("Bad Request.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
-                        if (status_ == 500)
+                        if (status_ == 404)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
                             if (objectResponse_.Object == null)
                             {
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
-                            throw new ApiException<FileResponse>("Internal Server Error", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                            throw new ApiException<FileResponse>("An invalid file history record provided. Insert failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 405)
@@ -2920,6 +3061,16 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             throw new ApiException<FileResponse>("Method Not Allowed", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 500)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<FileResponse>("Internal Server Error", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 200)
@@ -3009,16 +3160,6 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                         ProcessResponse(client_, response_);
 
                         var status_ = (int)response_.StatusCode;
-                        if (status_ == 404)
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            throw new ApiException<FileResponse>("An invalid email history record provided. Insert failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
-                        }
-                        else
                         if (status_ == 400)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
@@ -3029,14 +3170,14 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                             throw new ApiException<FileResponse>("Bad Request.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
-                        if (status_ == 500)
+                        if (status_ == 404)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
                             if (objectResponse_.Object == null)
                             {
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
-                            throw new ApiException<FileResponse>("Internal Server Error", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                            throw new ApiException<FileResponse>("An invalid email history record provided. Insert failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 405)
@@ -3047,6 +3188,16 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             throw new ApiException<FileResponse>("Method Not Allowed", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 500)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<FileResponse>("Internal Server Error", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 200)
@@ -3130,16 +3281,6 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                         ProcessResponse(client_, response_);
 
                         var status_ = (int)response_.StatusCode;
-                        if (status_ == 404)
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            throw new ApiException<FileResponse>("Not Found", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
-                        }
-                        else
                         if (status_ == 400)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
@@ -3150,14 +3291,14 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                             throw new ApiException<FileResponse>("Bad Request", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
-                        if (status_ == 500)
+                        if (status_ == 404)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
                             if (objectResponse_.Object == null)
                             {
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
-                            throw new ApiException<FileResponse>("Internal Server Error", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                            throw new ApiException<FileResponse>("Not Found", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 405)
@@ -3168,6 +3309,16 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             throw new ApiException<FileResponse>("Method Not Allowed", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 500)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<FileResponse>("Internal Server Error", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 200)
@@ -3263,16 +3414,6 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                         ProcessResponse(client_, response_);
 
                         var status_ = (int)response_.StatusCode;
-                        if (status_ == 404)
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            throw new ApiException<FileResponse>("Dispute could not be found.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
-                        }
-                        else
                         if (status_ == 400)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
@@ -3283,14 +3424,14 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                             throw new ApiException<FileResponse>("Bad Request", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
-                        if (status_ == 500)
+                        if (status_ == 404)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
                             if (objectResponse_.Object == null)
                             {
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
-                            throw new ApiException<FileResponse>("Internal Server Error. Save failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                            throw new ApiException<FileResponse>("Dispute could not be found.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 405)
@@ -3301,6 +3442,16 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             throw new ApiException<FileResponse>("Method Not Allowed", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 500)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<FileResponse>("Internal Server Error. Save failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 200)
@@ -3390,16 +3541,6 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                         ProcessResponse(client_, response_);
 
                         var status_ = (int)response_.StatusCode;
-                        if (status_ == 404)
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            throw new ApiException<FileResponse>("Not Found", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
-                        }
-                        else
                         if (status_ == 400)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
@@ -3410,14 +3551,14 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                             throw new ApiException<FileResponse>("Bad Request", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
-                        if (status_ == 500)
+                        if (status_ == 404)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
                             if (objectResponse_.Object == null)
                             {
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
-                            throw new ApiException<FileResponse>("Internal Server Error", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                            throw new ApiException<FileResponse>("Not Found", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 405)
@@ -3428,6 +3569,16 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             throw new ApiException<FileResponse>("Method Not Allowed", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 500)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<FileResponse>("Internal Server Error", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 200)
@@ -3514,16 +3665,6 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                         ProcessResponse(client_, response_);
 
                         var status_ = (int)response_.StatusCode;
-                        if (status_ == 404)
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            throw new ApiException<FileResponse>("Not Found", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
-                        }
-                        else
                         if (status_ == 400)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
@@ -3534,14 +3675,14 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                             throw new ApiException<FileResponse>("Bad Request", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
-                        if (status_ == 500)
+                        if (status_ == 404)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
                             if (objectResponse_.Object == null)
                             {
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
-                            throw new ApiException<FileResponse>("Internal Server Error", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                            throw new ApiException<FileResponse>("Not Found", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 405)
@@ -3552,6 +3693,16 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             throw new ApiException<FileResponse>("Method Not Allowed", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 500)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<FileResponse>("Internal Server Error", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 200)
@@ -3636,16 +3787,6 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                         ProcessResponse(client_, response_);
 
                         var status_ = (int)response_.StatusCode;
-                        if (status_ == 404)
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            throw new ApiException<FileResponse>("Not Found", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
-                        }
-                        else
                         if (status_ == 400)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
@@ -3656,14 +3797,14 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                             throw new ApiException<FileResponse>("Bad Request", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
-                        if (status_ == 500)
+                        if (status_ == 404)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
                             if (objectResponse_.Object == null)
                             {
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
-                            throw new ApiException<FileResponse>("Internal Server Error", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                            throw new ApiException<FileResponse>("Not Found", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 405)
@@ -3674,6 +3815,16 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             throw new ApiException<FileResponse>("Method Not Allowed", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 500)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<FileResponse>("Internal Server Error", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 200)
@@ -3756,16 +3907,6 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                         ProcessResponse(client_, response_);
 
                         var status_ = (int)response_.StatusCode;
-                        if (status_ == 404)
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            throw new ApiException<FileResponse>("Not Found", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
-                        }
-                        else
                         if (status_ == 400)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
@@ -3776,14 +3917,14 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                             throw new ApiException<FileResponse>("Bad Request", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
-                        if (status_ == 500)
+                        if (status_ == 404)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
                             if (objectResponse_.Object == null)
                             {
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
-                            throw new ApiException<FileResponse>("Internal Server Error", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                            throw new ApiException<FileResponse>("Not Found", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 405)
@@ -3794,6 +3935,16 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             throw new ApiException<FileResponse>("Method Not Allowed", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 500)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<FileResponse>("Internal Server Error", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 200)
@@ -3876,16 +4027,6 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                         ProcessResponse(client_, response_);
 
                         var status_ = (int)response_.StatusCode;
-                        if (status_ == 404)
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            throw new ApiException<FileResponse>("Not Found", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
-                        }
-                        else
                         if (status_ == 400)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
@@ -3896,14 +4037,14 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                             throw new ApiException<FileResponse>("Bad Request", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
-                        if (status_ == 500)
+                        if (status_ == 404)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
                             if (objectResponse_.Object == null)
                             {
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
-                            throw new ApiException<FileResponse>("Internal Server Error", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                            throw new ApiException<FileResponse>("Not Found", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 405)
@@ -3914,6 +4055,16 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             throw new ApiException<FileResponse>("Method Not Allowed", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 500)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<FileResponse>("Internal Server Error", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 200)
@@ -4009,16 +4160,6 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                         ProcessResponse(client_, response_);
 
                         var status_ = (int)response_.StatusCode;
-                        if (status_ == 404)
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            throw new ApiException<FileResponse>("Not Found", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
-                        }
-                        else
                         if (status_ == 400)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
@@ -4029,14 +4170,14 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                             throw new ApiException<FileResponse>("Bad Request.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
-                        if (status_ == 500)
+                        if (status_ == 404)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
                             if (objectResponse_.Object == null)
                             {
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
-                            throw new ApiException<FileResponse>("Internal Server Error. Getting disputes failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                            throw new ApiException<FileResponse>("Not Found", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 405)
@@ -4047,6 +4188,16 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             throw new ApiException<FileResponse>("Method Not Allowed", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 500)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<FileResponse>("Internal Server Error. Getting disputes failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 200)
@@ -4134,16 +4285,6 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                         ProcessResponse(client_, response_);
 
                         var status_ = (int)response_.StatusCode;
-                        if (status_ == 404)
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            throw new ApiException<FileResponse>("Not Found", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
-                        }
-                        else
                         if (status_ == 400)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
@@ -4154,14 +4295,14 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                             throw new ApiException<FileResponse>("Bad Request", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
-                        if (status_ == 500)
+                        if (status_ == 404)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
                             if (objectResponse_.Object == null)
                             {
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
-                            throw new ApiException<FileResponse>("Internal Server Error. Unassigned failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                            throw new ApiException<FileResponse>("Not Found", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 405)
@@ -4172,6 +4313,16 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             throw new ApiException<FileResponse>("Method Not Allowed", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 500)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<FileResponse>("Internal Server Error. Unassigned failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 200)
@@ -4251,16 +4402,6 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                         ProcessResponse(client_, response_);
 
                         var status_ = (int)response_.StatusCode;
-                        if (status_ == 404)
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            throw new ApiException<FileResponse>("Not Found", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
-                        }
-                        else
                         if (status_ == 400)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
@@ -4271,14 +4412,14 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                             throw new ApiException<FileResponse>("Bad Request", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
-                        if (status_ == 500)
+                        if (status_ == 404)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
                             if (objectResponse_.Object == null)
                             {
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
-                            throw new ApiException<FileResponse>("Internal Server Error", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                            throw new ApiException<FileResponse>("Not Found", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 405)
@@ -4289,6 +4430,16 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             throw new ApiException<FileResponse>("Method Not Allowed", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 500)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<FileResponse>("Internal Server Error", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 200)
@@ -4384,16 +4535,6 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                         ProcessResponse(client_, response_);
 
                         var status_ = (int)response_.StatusCode;
-                        if (status_ == 404)
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            throw new ApiException<FileResponse>("Not Found", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
-                        }
-                        else
                         if (status_ == 400)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
@@ -4404,14 +4545,14 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                             throw new ApiException<FileResponse>("Bad Request", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
-                        if (status_ == 500)
+                        if (status_ == 404)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
                             if (objectResponse_.Object == null)
                             {
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
-                            throw new ApiException<FileResponse>("Internal Server Error. retrieve update requests failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                            throw new ApiException<FileResponse>("Not Found", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 405)
@@ -4422,6 +4563,16 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             throw new ApiException<FileResponse>("Method Not Allowed", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 500)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<FileResponse>("Internal Server Error. retrieve update requests failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 200)
@@ -4523,16 +4674,6 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                         ProcessResponse(client_, response_);
 
                         var status_ = (int)response_.StatusCode;
-                        if (status_ == 404)
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            throw new ApiException<FileResponse>("Not Found", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
-                        }
-                        else
                         if (status_ == 400)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
@@ -4543,14 +4684,14 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                             throw new ApiException<FileResponse>("Bad Request, check parameters.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
-                        if (status_ == 500)
+                        if (status_ == 404)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
                             if (objectResponse_.Object == null)
                             {
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
-                            throw new ApiException<FileResponse>("Internal Server Error. Search failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                            throw new ApiException<FileResponse>("Not Found", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 405)
@@ -4561,6 +4702,16 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             throw new ApiException<FileResponse>("Method Not Allowed", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 500)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<FileResponse>("Internal Server Error. Search failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 200)
@@ -4649,16 +4800,6 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                         ProcessResponse(client_, response_);
 
                         var status_ = (int)response_.StatusCode;
-                        if (status_ == 404)
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            throw new ApiException<FileResponse>("Dispute could not be found.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
-                        }
-                        else
                         if (status_ == 400)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
@@ -4669,14 +4810,14 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                             throw new ApiException<FileResponse>("Bad Request", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
-                        if (status_ == 500)
+                        if (status_ == 404)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
                             if (objectResponse_.Object == null)
                             {
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
-                            throw new ApiException<FileResponse>("Internal server error occured.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                            throw new ApiException<FileResponse>("Dispute could not be found.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 405)
@@ -4687,6 +4828,16 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             throw new ApiException<FileResponse>("Method Not Allowed", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 500)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<FileResponse>("Internal server error occured.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 200)
@@ -4774,16 +4925,6 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                         ProcessResponse(client_, response_);
 
                         var status_ = (int)response_.StatusCode;
-                        if (status_ == 404)
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            throw new ApiException<FileResponse>("Not Found", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
-                        }
-                        else
                         if (status_ == 400)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
@@ -4794,14 +4935,14 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                             throw new ApiException<FileResponse>("Bad Request", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
-                        if (status_ == 500)
+                        if (status_ == 404)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
                             if (objectResponse_.Object == null)
                             {
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
-                            throw new ApiException<FileResponse>("Internal Server Error", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                            throw new ApiException<FileResponse>("Not Found", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 405)
@@ -4812,6 +4953,16 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             throw new ApiException<FileResponse>("Method Not Allowed", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 500)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<FileResponse>("Internal Server Error", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 200)
@@ -4901,16 +5052,6 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                         ProcessResponse(client_, response_);
 
                         var status_ = (int)response_.StatusCode;
-                        if (status_ == 404)
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            throw new ApiException<FileResponse>("Not Found", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
-                        }
-                        else
                         if (status_ == 400)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
@@ -4921,14 +5062,14 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                             throw new ApiException<FileResponse>("Bad Request.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
-                        if (status_ == 500)
+                        if (status_ == 404)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
                             if (objectResponse_.Object == null)
                             {
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
-                            throw new ApiException<FileResponse>("Internal Server Error. Delete failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                            throw new ApiException<FileResponse>("Not Found", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 405)
@@ -4939,6 +5080,16 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             throw new ApiException<FileResponse>("Method Not Allowed", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 500)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<FileResponse>("Internal Server Error. Delete failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 200)
@@ -7305,35 +7456,41 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
         [System.Runtime.Serialization.EnumMember(Value = @"JPRG")]
         JPRG = 37,
 
+        [System.Runtime.Serialization.EnumMember(Value = @"OCNT")]
+        OCNT = 38,
+
         [System.Runtime.Serialization.EnumMember(Value = @"RECN")]
-        RECN = 38,
+        RECN = 39,
+
+        [System.Runtime.Serialization.EnumMember(Value = @"SADM")]
+        SADM = 40,
 
         [System.Runtime.Serialization.EnumMember(Value = @"SCAN")]
-        SCAN = 39,
+        SCAN = 41,
 
         [System.Runtime.Serialization.EnumMember(Value = @"SPRC")]
-        SPRC = 40,
+        SPRC = 42,
 
         [System.Runtime.Serialization.EnumMember(Value = @"SREJ")]
-        SREJ = 41,
+        SREJ = 43,
 
         [System.Runtime.Serialization.EnumMember(Value = @"SUB")]
-        SUB = 42,
+        SUB = 44,
 
         [System.Runtime.Serialization.EnumMember(Value = @"SUPL")]
-        SUPL = 43,
+        SUPL = 45,
 
         [System.Runtime.Serialization.EnumMember(Value = @"SVAL")]
-        SVAL = 44,
+        SVAL = 46,
 
         [System.Runtime.Serialization.EnumMember(Value = @"URSR")]
-        URSR = 45,
+        URSR = 47,
 
         [System.Runtime.Serialization.EnumMember(Value = @"VREV")]
-        VREV = 46,
+        VREV = 48,
 
         [System.Runtime.Serialization.EnumMember(Value = @"VSUB")]
-        VSUB = 47,
+        VSUB = 49,
 
     }
 

--- a/src/backend/TrafficCourts/Messaging/MessageContracts/SaveFileHistory.cs
+++ b/src/backend/TrafficCourts/Messaging/MessageContracts/SaveFileHistory.cs
@@ -1,4 +1,4 @@
-﻿using TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0;
+using TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0;
 
 namespace TrafficCourts.Messaging.MessageContracts
 {

--- a/src/backend/TrafficCourts/Staff.Service/Authentication/Scopes.cs
+++ b/src/backend/TrafficCourts/Staff.Service/Authentication/Scopes.cs
@@ -19,5 +19,6 @@ public static class Scopes
     public const string Create = "create";
     public const string Read = "read";
     public const string Update = "update";
+    public const string UpdateAdmin = "update-admin";
     public const string Delete = "delete";
 }

--- a/src/backend/TrafficCourts/Staff.Service/Services/IJJDisputeService.cs
+++ b/src/backend/TrafficCourts/Staff.Service/Services/IJJDisputeService.cs
@@ -30,6 +30,15 @@ public interface IJJDisputeService
     /// <exception cref="ArgumentNullException">Thrown if id is null</exception>
     Task<TicketImageDataJustinDocument> GetJustinDocumentAsync(string ticketNumber, DocumentType documentType, CancellationToken cancellationToken);
 
+    /// <summary>Updates the properties of a particular JJ Dispute record based on the given values as well as certain Dispute related data.</summary>
+    /// <param name="jjDispute">A modified version of the JJ Dispute record to save.</param>    
+    /// <param name="user">The user executing the operation</param>    
+    /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+    /// <returns>The submitted/updated JJ Dispute record.</returns>
+    /// <exception cref="ApiException">A server side error occurred.</exception>
+    /// <exception cref="ArgumentNullException">Thrown if ticketNumber is null</exception>
+    Task<JJDispute> UpdateJJDisputeCascadeAsync(JJDispute jjDispute, ClaimsPrincipal user, CancellationToken cancellationToken);
+
     /// <summary>Updates the properties of a particular JJ Dispute record based on the given values.</summary>
     /// <param name="jjDisputeId">Unique identifier of a JJ Dispute record to modify.</param>
     /// <param name="checkVTC">Boolean to indicate need to check VTC assigned</param>

--- a/src/backend/TrafficCourts/Staff.Service/Services/JJDisputeService.cs
+++ b/src/backend/TrafficCourts/Staff.Service/Services/JJDisputeService.cs
@@ -86,6 +86,18 @@ public class JJDisputeService : IJJDisputeService
         return justinDocument;
     }
 
+    public async Task<JJDispute> UpdateJJDisputeCascadeAsync(JJDispute jjDispute, ClaimsPrincipal user, CancellationToken cancellationToken) {
+        JJDispute dispute = await _oracleDataApi.UpdateJJDisputeCascadeAsync(jjDispute.TicketNumber, true, jjDispute, cancellationToken);
+
+        // TCVP-2522 save FileHistory
+        SaveFileHistoryRecord fileHistoryRecord = new();
+        fileHistoryRecord.TicketNumber = jjDispute.TicketNumber;
+        fileHistoryRecord.AuditLogEntryType = FileHistoryAuditLogEntryType.SADM; // Dispute updated by Support Admin Staff 
+        fileHistoryRecord.ActionByApplicationUser = GetUserName(user);
+        await _bus.PublishWithLog(_logger, fileHistoryRecord, cancellationToken);
+
+        return dispute;
+    }
 
     public async Task<JJDispute> SubmitAdminResolutionAsync(long disputeId, bool checkVTC, JJDispute jjDispute, ClaimsPrincipal user, CancellationToken cancellationToken)
     {

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/controller/v1_0/JJDisputeController.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/controller/v1_0/JJDisputeController.java
@@ -116,6 +116,37 @@ public class JJDisputeController {
 	}
 
 	/**
+	 * PUT endpoint that updates a JJ Dispute as well as underlying Dispute data.
+	 *
+	 * @param jj dispute to be updated
+	 * @param ticketNumber unique key of the saved {@link JJDispute} to update
+	 * @param principal user doing the updating
+	 * @param boolean (optional) check assignment to VTC
+	 * @return updated {@link JJDispute}
+	 */
+	@Operation(summary = "Updates the properties of a particular JJ Dispute record as well as cascading to underlying related Dispute data.")
+	@ApiResponses({
+		@ApiResponse(responseCode = "200", description = "Ok"),
+		@ApiResponse(responseCode = "400", description = "Bad Request."),
+		@ApiResponse(responseCode = "404", description = "JJDispute record not found. Update failed."),
+		@ApiResponse(responseCode = "405", description = "An invalid JJ Dispute status is provided. Update failed.")
+	})
+	@PutMapping("/dispute/{ticketNumber}/cascade")
+	public ResponseEntity<JJDispute> updateJJDisputeCascade(
+			@PathVariable("ticketNumber") String ticketNumber,
+			boolean checkVTCAssigned,
+			Principal principal,
+			@RequestBody JJDispute jjDispute) {
+		logger.debug("PUT /jj/dispute/{}/cascade called", StructuredArguments.value("ticketNumber", ticketNumber));
+
+		if (checkVTCAssigned && !jjDisputeService.assignJJDisputeToVtc(ticketNumber, principal)) {
+			return new ResponseEntity<>(null, HttpStatus.CONFLICT);
+		}
+
+		return new ResponseEntity<JJDispute>(jjDisputeService.updateJJDisputeCascade(ticketNumber, jjDispute, principal), HttpStatus.OK);
+	}
+
+	/**
 	 * PUT endpoint that updates each JJ Dispute based on the passed in ticket number to assign them to a specific JJ or unassign them if JJ not specified.
 	 *
 	 * @param ticketNumberList unique keys of JJ Dispute(s) to be updated/assigned

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/model/AuditLogEntryType.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/model/AuditLogEntryType.java
@@ -7,52 +7,151 @@ package ca.bc.gov.open.jag.tco.oracledataapi.model;
 public enum AuditLogEntryType {
 	/** Unknown type (undefined). Must be index 0. */
 	UNKNOWN,
+
+	/** Auto reconciliation failed in Justin VT Inbox **/
 	ARFL,
+
+	/** Citizen adds an interpreter request to their hybrid/hearing dispute **/
 	CAIN,
+
+	/** Citizen adds witnesses to their hybrid/hearing dispute **/
 	CAWT,
+
+	/** Citizen has canceled the dispute, status of dispute changed to Cancelled **/
 	CCAN,
+
+	/** Citizen has submitted an update to their contact information **/
 	CCON,
+
+	/** Citizen has changed their Hearing dispute to Written Reasons, all counts **/
 	CCWR,
+
+	/** Citizen adds legal representation information to their hybrid/hearing dispute **/
 	CLEG,
+
+	/** Citizen changes the email associated with their dispute **/
 	CUEM,
+
+	/** Citizen's updated email address has been verified **/
 	CUEV,
+
+	/** Citizen changes the interpreter request in their hybrid/hearing dispute **/
 	CUIN,
+
+	/** Citizen modifies their legal representation information to their hybrid/hearing dispute **/
 	CULG,
+
+	/** Citizen updates their contact information (mailing address, phone number, contact name, contact type) **/
 	CUPD,
+
+	/** Citizen has updated/modified their Written Reasons **/
 	CUWR,
+
+	/** Citizen changes # of witnesses in their hybrid/hearing dispute **/
 	CUWT,
+
+	/** Dispute update request accepted **/
 	DURA,
+
+	/** Dispute update request rejected **/
 	DURR,
+
+	/** Automated cancellation email sent to citizen **/
 	EMCA,
+
+	/** Automated confirmation of submission email sent to citizen **/
 	EMCF,
+
+	/** Automated notification email sent to citizen  **/
 	EMCR,
+
+	/** Automated decision email sent to citizen (includes ROP/decision details) **/
 	EMDC,
+
+	/** Email to citizen was unsuccessful **/
 	EMFD,
+
+	/** Automated processing email sent to citizen (after staff submits to ARC) **/
 	EMPR,
+
+	/** Automated rejection email sent to citizen **/
 	EMRJ,
+
+	/** Citizen has been sent a notification (via email) to prompt them to verify their updated email address **/
 	EMRV,
+
+	/** Citizen/user has been sent a notification (via email) to prompt them to verify their email address **/
 	EMST,
+
+	/** Automated notification sent to citizen to verify the updates/changes to their dispute **/
 	EMUP,
+
+	/** Citizen's email address has been verified **/
 	EMVF,
+
+	/** Email sent to notify Disputant regarding their update request(s) received **/
 	ESUR,
+
+	/** File was deleted by disputant **/
 	FDLD,
+
+	/** File was deleted by staff **/
 	FDLS,
+
+	/** File was uploaded by disputant **/
 	FUPD,
+
+	/** File was uploaded by staff **/
 	FUPS,
+
+	/** Citizen/user submits their ticket resolution request / notice of dispute via TCO **/
 	INIT,
+
+	/** Admin JJ has assigned a dispute to an individual JJ for actioning **/
 	JASG,
+
+	/** JJ has entered their dispute decision, status changed to Confirmed **/
 	JCNF,
+
+	/** JJ has diverted the dispute to a court appearance, status changed to JJ Divert to Court Appearance **/
 	JDIV,
+
+	/** JJ has chosen to save and finish later, status changed to In Progress **/
 	JPRG,
+
+	/** JUSTIN count not found in OCCAM - Counts not added to TCO **/
 	OCNT,
+
+	/** Data reconciliation complete, dispute is visible in JJ workbench, status is New **/
 	RECN,
+
+	/** Dispute updated by Staff Admin Support **/
+	SADM,
+
+	/** Staff have cancelled the dispute, status of dispute changed to Cancelled **/
 	SCAN,
+
+	/** Staff has submitted the dispute to ARC, status of dispute changed to Processing **/
 	SPRC,
+
+	/** Staff has rejected the dispute, status of dispute changed to Rejected **/
 	SREJ,
+
+	/** Citizen has submitted the dispute via the Citizen Portal, status has been changed to New **/
 	SUB,
+
+	/** Staff user scans and uploads a paper document to JUSTIN **/
 	SUPL,
+
+	/** Staff has validated the OCR details, status of dispute changed to Validated **/
 	SVAL,
+
+	/** Update request(s) submitted for staff review **/
 	URSR,
+
+	/** VTC staff have sent a dispute decision back to a JJ for review, status changed to Review Required **/
 	VREV,
+
+	/** VTC staff have reviewed a dispute decision and chosen to submit it to JUSTIN, status changed to Accepted **/
 	VSUB
 }

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/service/JJDisputeService.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/service/JJDisputeService.java
@@ -34,6 +34,7 @@ import ca.bc.gov.open.jag.tco.oracledataapi.model.JJDisputeStatus;
 import ca.bc.gov.open.jag.tco.oracledataapi.model.TicketImageDataDocumentType;
 import ca.bc.gov.open.jag.tco.oracledataapi.model.TicketImageDataJustinDocument;
 import ca.bc.gov.open.jag.tco.oracledataapi.model.YesNo;
+import ca.bc.gov.open.jag.tco.oracledataapi.repository.DisputeRepository;
 import ca.bc.gov.open.jag.tco.oracledataapi.repository.JJDisputeRemarkRepository;
 import ca.bc.gov.open.jag.tco.oracledataapi.repository.JJDisputeRepository;
 import ca.bc.gov.open.jag.tco.oracledataapi.repository.TicketImageDataRepository;
@@ -47,6 +48,9 @@ public class JJDisputeService {
 
 	@Autowired
 	private JJDisputeRepository jjDisputeRepository;
+
+	@Autowired
+	private DisputeRepository disputeRepository;
 
 	@Autowired
 	private TicketImageDataRepository ticketImageDataRepository;
@@ -151,7 +155,7 @@ public class JJDisputeService {
 							.collect(Collectors.toList())
 					);
 		}
-		
+
 
 		if (jjDispute.getRemarks() != null && jjDispute.getRemarks().size() > 0) {
 
@@ -170,6 +174,26 @@ public class JJDisputeService {
 		}
 
 		return jjDisputeRepository.saveAndFlush(jjDisputeToUpdate);
+	}
+
+
+	/**
+	 * Updates the properties of a specific {@link JJDispute} as well as related {@link Dispute} data
+	 *
+	 * @param ticketNumber
+	 * @param {@link JJDispute}
+	 * @return
+	 */
+	@Transactional
+	public JJDispute updateJJDisputeCascade(String ticketNumber, JJDispute jjDispute, Principal principal) {
+
+		// TCVP-1981 Update certain fields on the related OCCAM Dispute as well.
+		Dispute dispute = disputeRepository.findById(jjDispute.getOccamDisputeId()).orElseThrow();
+		dispute.setDisputantSurname(jjDispute.getOccamDisputantSurnameNm());
+		// TODO: add many more other fields
+		disputeRepository.update(dispute);
+
+		return updateJJDispute(ticketNumber, jjDispute, principal);
 	}
 
 	/**


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

TCVP-2525
- Added a new endpoint that will cascade update a JJDispute and related Dispute data (only implemented one field so far, more coming).
- Added comments to AuditLogEntryType enum values

`/api/v1.0/jj/dispute/{ticketNumber}/cascade`

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
