### PR TITLE
TCVP-2523 Added Edit button to DCF screen

### DIFF
--- a/src/frontend/staff-portal/src/app/components/jj-dispute-info/jj-dispute/jj-dispute.component.html
+++ b/src/frontend/staff-portal/src/app/components/jj-dispute-info/jj-dispute/jj-dispute.component.html
@@ -7,6 +7,7 @@
         </button>
       </div>
       <div>
+        <button mat-raised-button *ngIf="isSupportStaff && !isEditMode" (click)="isEditMode=true" class="edit-button">Edit</button>
         <button mat-raised-button [matMenuTriggerFor]="gotoMenu">Go to</button>
         <mat-menu #gotoMenu="matMenu" yPosition="below">
           <button mat-menu-item (click)="goTo('disputeDetails')">Dispute Details</button>

--- a/src/frontend/staff-portal/src/app/components/jj-dispute-info/jj-dispute/jj-dispute.component.scss
+++ b/src/frontend/staff-portal/src/app/components/jj-dispute-info/jj-dispute/jj-dispute.component.scss
@@ -12,6 +12,19 @@
   cursor: pointer;
 }
 
+.edit-button {
+  color: #fff;
+  background-color: #38598a;
+  border-color: #38598a;  
+  font-size: 14px;
+  margin-right: 20px;
+
+  &:hover {
+    background-color: #2d476f;
+    border-color: #294266;
+  }
+}
+
 h3 {
   font-weight: bold;
   color: black !important;

--- a/src/frontend/staff-portal/src/app/components/jj-dispute-info/jj-dispute/jj-dispute.component.ts
+++ b/src/frontend/staff-portal/src/app/components/jj-dispute-info/jj-dispute/jj-dispute.component.ts
@@ -32,6 +32,8 @@ export class JJDisputeComponent implements OnInit {
   @Input() isViewOnly = false;
   @Output() backInbox: EventEmitter<any> = new EventEmitter();
   printOptions: PrintOptions = new PrintOptions();
+  isSupportStaff: boolean = false;
+  isEditMode: boolean = false;
 
   RequestTimeToPay = JJDisputedCountRequestTimeToPay;
   Finding = JJDisputedCountRoPFinding;
@@ -107,7 +109,9 @@ export class JJDisputeComponent implements OnInit {
         this.jjIDIR = userProfile.idir;
         this.jjName = userProfile.fullName;
       }
-    })
+    });
+
+    this.isSupportStaff = this.authService.checkRole("support-staff");
   }
 
   // get dispute by id


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

TCVP-2523
On the Staff Workbench (DCF tab), added a new Edit button (that only appears if the user is a member of the staff-support group) that will put the DCF form into admin edit mode. When clicked, the button disappears.

![image](https://github.com/bcgov/jag-traffic-courts-online/assets/55215368/ed414b81-be44-4717-a4c7-1ed471a8c1be)

Note: this PR doesn't implement any of the form changes that will occur once the form is in edit mode (that's TCVP-2524, coming shortly).

When TCVP-2524 is implemented, there will be a Save and Cancel buttons somewhere to persist the changes to staff-api, afterwhich, the Edit button should reappear.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
