### PR TITLE
TCVP-2560 Block VT1 ISC Tickets

### DIFF
--- a/src/backend/TrafficCourts/Citizen.Service/Services/Tickets/Search/TicketSearchService.cs
+++ b/src/backend/TrafficCourts/Citizen.Service/Services/Tickets/Search/TicketSearchService.cs
@@ -79,8 +79,8 @@ public class TicketSearchService : ITicketSearchService
         {
             var issuedTs = DateTime.SpecifyKind(violationDateTime, DateTimeKind.Unspecified);
             
-            // TCVP-2560 all tickets before April 9, 2024 (VT1) will be ineligible for TCO
-            if (issuedTs < _validVT2TicketEffectiveDate)
+            // TCVP-2560 all ISC tickets that always start with the letter 'S' and have a violation date before April 9, 2024 (VT1) are ineligible for TCO
+            if (ticketNumber.ToUpper().StartsWith("S") && issuedTs < _validVT2TicketEffectiveDate)
             {
                 _logger.LogInformation("Ticket found is not a valid VT2 type");
                 throw new InvalidTicketVersionException(issuedTs);

--- a/src/backend/TrafficCourts/Test/Citizen.Service/Features/Tickets/SearchHandlerTest.cs
+++ b/src/backend/TrafficCourts/Test/Citizen.Service/Features/Tickets/SearchHandlerTest.cs
@@ -9,6 +9,7 @@ using TrafficCourts.Citizen.Service.Models.Tickets;
 using TrafficCourts.Citizen.Service.Services.Tickets.Search;
 using Xunit;
 using Xunit.Abstractions;
+using TrafficCourts.Citizen.Service.Services.Tickets.Search.Common;
 
 namespace TrafficCourts.Test.Citizen.Service.Features.Tickets
 {
@@ -102,7 +103,7 @@ namespace TrafficCourts.Test.Citizen.Service.Features.Tickets
                 .Setup(_ => _.SearchAsync(It.IsAny<string>(), It.IsAny<TimeOnly>(), It.IsAny<CancellationToken>()))
                 .ThrowsAsync(exception);
 
-            var request = new Search.Request("AA00000000", "00:00");
+            var request = new Search.Request("SA00000000", "00:00");
 
             var sut = new Search.Handler(_serviceMock.Object, _loggerMock.Object, _redisCacheServiceMock.Object);
 


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- TCVP-2560
- Fixed the search blocking logic for VT1 RSI looked-up tickets to block only ISC tickets that always start with the letter 'S'.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
