### PR TITLE
Change default log level for EF and Polly to Warning

### DIFF
--- a/src/backend/TrafficCourts/Citizen.Service/appsettings.Development.json
+++ b/src/backend/TrafficCourts/Citizen.Service/appsettings.Development.json
@@ -19,7 +19,14 @@
   "Redis": {
     "ConnectionString": "localhost:6379,password=password"
   },
-
+  "Serilog": {
+    "MinimumLevel": {
+      "Override": {
+        "Microsoft.EntityFrameworkCore": "Information",
+        "Polly": "Information"
+      }
+    }
+  },
   "Swagger": {
     "Enabled": true
   },

--- a/src/backend/TrafficCourts/Citizen.Service/appsettings.json
+++ b/src/backend/TrafficCourts/Citizen.Service/appsettings.json
@@ -11,8 +11,9 @@
     "MinimumLevel": {
       "Default": "Information",
       "Override": {
-        "System": "Warning",
-        "Microsoft.AspNetCore": "Warning"
+        "Microsoft.AspNetCore": "Warning",
+        "Polly": "Warning",
+        "System": "Warning"
       }
     },
     "Properties": {

--- a/src/backend/TrafficCourts/Staff.Service/appsettings.Development.json
+++ b/src/backend/TrafficCourts/Staff.Service/appsettings.Development.json
@@ -1,4 +1,12 @@
 {
+  "Serilog": {
+    "MinimumLevel": {
+      "Override": {
+        "Microsoft.EntityFrameworkCore": "Information",
+        "Polly": "Information",
+      }
+    }
+  },
   "Swagger": {
     "Enabled": true
   }

--- a/src/backend/TrafficCourts/Staff.Service/appsettings.json
+++ b/src/backend/TrafficCourts/Staff.Service/appsettings.json
@@ -11,8 +11,10 @@
     "MinimumLevel": {
       "Default": "Information",
       "Override": {
-        "System": "Warning",
-        "Microsoft.AspNetCore": "Warning"
+        "Microsoft.AspNetCore": "Warning",
+        "Microsoft.EntityFrameworkCore": "Warning",
+        "Polly": "Warning",
+        "System": "Warning"
       }
     },
     "Properties": {

--- a/src/backend/TrafficCourts/Workflow.Service/appsettings.Development.json
+++ b/src/backend/TrafficCourts/Workflow.Service/appsettings.Development.json
@@ -6,6 +6,14 @@
   "OracleDataApi": {
     "BaseUrl": "http://localhost:5010/"
   },
+  "Serilog": {
+    "MinimumLevel": {
+      "Override": {
+        "Microsoft.EntityFrameworkCore": "Information",
+        "Polly": "Information"
+      }
+    }
+  },
   "SmtpConfiguration": {
     "Host": "localhost",
     "Port": "25"

--- a/src/backend/TrafficCourts/Workflow.Service/appsettings.json
+++ b/src/backend/TrafficCourts/Workflow.Service/appsettings.json
@@ -11,8 +11,10 @@
     "MinimumLevel": {
       "Default": "Information",
       "Override": {
-        "System": "Warning",
-        "Microsoft.AspNetCore": "Warning"
+        "Microsoft.AspNetCore": "Warning",
+        "Microsoft.EntityFrameworkCore": "Warning",
+        "Polly": "Warning",
+        "System": "Warning"
       }
     },
     "Properties": {


### PR DESCRIPTION
# Description

The reduce the amount of unnecessary logs being written to splunk the log levels for EF and Polly changed to Warning.

This PR includes the following proposed change(s):

- set the log level of EF and Polly to `Warning` in appsettings.json
- set the log level of EF and Polly to `Information` in appsettings.Development.json

Examples logs that will be filtered out,

Polly
```
Execution attempt. Source: '"CDOGS-standard"/""/"Standard-Retry"', Operation Key: 'null', Result: '200', Handled: 'False', Attempt: '0', Execution Time: '85.2706'
```

EF Core
```
Executed DbCommand ("25"ms) [Parameters=["@p0='?' (DbType = Guid), @p1='?', @p2='?' (DbType = Int64), @p3='?', @p4='?' (DbType = Boolean), @p5='?', @p6='?' (DbType = Guid), @p7='?' (DbType = Boolean), @p8='?' (DbType = DateTime)"], CommandType='Text', CommandTimeout='30']"
""INSERT INTO \"VerifyEmailAddressState\" (\"CorrelationId\", \"CurrentState\", \"DisputeId\", \"EmailAddress\", \"IsUpdateEmailVerification\", \"TicketNumber\", \"Token\", \"Verified\", \"VerifiedAt\")
VALUES (@p0, @p1, @p2, @p3, @p4, @p5, @p6, @p7, @p8)
RETURNING xmin;"
```

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [ ] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
