### PR TITLE
TCVP-2524 Made Contact Information fields editable

### DIFF
--- a/src/frontend/staff-portal/src/app/components/jj-dispute-info/jj-dispute/jj-dispute.component.html
+++ b/src/frontend/staff-portal/src/app/components/jj-dispute-info/jj-dispute/jj-dispute.component.html
@@ -142,13 +142,32 @@
           <div style="display: grid; grid-template-columns: auto auto auto auto">
             <span class="section-grid-cell">
               <p class="section-grid-header">Surname</p>
-              <p class="section-grid-text">{{ lastUpdatedJJDispute.contactType === ContactType.Individual ?
+              <p class="section-grid-text" *ngIf="!(isCIEditMode && lastUpdatedJJDispute.contactType !== ContactType.Individual)">{{ lastUpdatedJJDispute.contactType === ContactType.Individual ?
                 lastUpdatedJJDispute.occamDisputantSurnameNm : lastUpdatedJJDispute.contactSurname }}</p>
+              <mat-form-field appearance="outline" *ngIf="(isCIEditMode && lastUpdatedJJDispute.contactType !== ContactType.Individual)">
+                <input matInput formControlName="contactSurname">
+                <mat-error *ngIf="contactInformationForm.controls.contactSurname.hasError('maxlength')">{{ "error.max_length" | translate }}30</mat-error>
+              </mat-form-field>
             </span>
             <span class="section-grid-cell">
-              <p class="section-grid-header">Given Name(s)</p>
-              <p class="section-grid-text">{{ lastUpdatedJJDispute.contactType === ContactType.Individual ?
+              <p class="section-grid-header" *ngIf="!(isCIEditMode && lastUpdatedJJDispute.contactType !== ContactType.Individual)">Given Name(s)</p>
+              <p class="section-grid-text" *ngIf="!(isCIEditMode && lastUpdatedJJDispute.contactType !== ContactType.Individual)">{{ lastUpdatedJJDispute.contactType === ContactType.Individual ?
                 lastUpdatedJJDispute.occamDisputantGivenNames : lastUpdatedJJDispute.contactGivenNames }}</p>
+              <p class="section-grid-header" *ngIf="(isCIEditMode && lastUpdatedJJDispute.contactType !== ContactType.Individual)">Given Name 1</p>
+              <mat-form-field appearance="outline" *ngIf="(isCIEditMode && lastUpdatedJJDispute.contactType !== ContactType.Individual)">
+                <input matInput formControlName="contactGivenName1">
+                <mat-error *ngIf="contactInformationForm.controls.contactGivenName1.hasError('maxlength')">{{ "error.max_length" | translate }}30</mat-error>
+              </mat-form-field>
+              <p class="section-grid-header" *ngIf="(isCIEditMode && lastUpdatedJJDispute.contactType !== ContactType.Individual)">Given Name 2</p>
+              <mat-form-field appearance="outline" *ngIf="(isCIEditMode && lastUpdatedJJDispute.contactType !== ContactType.Individual)">
+                <input matInput formControlName="contactGivenName2">
+                <mat-error *ngIf="contactInformationForm.controls.contactGivenName2.hasError('maxlength')">{{ "error.max_length" | translate }}30</mat-error>
+              </mat-form-field>
+              <p class="section-grid-header" *ngIf="(isCIEditMode && lastUpdatedJJDispute.contactType !== ContactType.Individual)">Given Name 3</p>
+              <mat-form-field appearance="outline" *ngIf="(isCIEditMode && lastUpdatedJJDispute.contactType !== ContactType.Individual)">
+                <input matInput formControlName="contactGivenName3">
+                <mat-error *ngIf="contactInformationForm.controls.contactGivenName3.hasError('maxlength')">{{ "error.max_length" | translate }}30</mat-error>
+              </mat-form-field>
             </span>
             <span class="section-grid-cell" style="grid-column: span 2">
               <p class="section-grid-header" *ngIf="!isCIEditMode">Address</p>

--- a/src/frontend/staff-portal/src/app/components/jj-dispute-info/jj-dispute/jj-dispute.component.html
+++ b/src/frontend/staff-portal/src/app/components/jj-dispute-info/jj-dispute/jj-dispute.component.html
@@ -191,7 +191,14 @@
             </span>
             <span class="section-grid-cell">
               <p class="section-grid-header">Prov / State of DL</p>
-              <p class="section-grid-text">{{ lastUpdatedJJDispute.driversLicenceProvince }}</p>
+              <p class="section-grid-text" *ngIf="!isCIEditMode">{{ lastUpdatedJJDispute.driversLicenceProvince }}</p>
+              <mat-form-field appearance="select-box-only" *ngIf="isCIEditMode">
+                <mat-select formControlName="driversLicenceProvince" placeholder="Province">
+                  <mat-option [value]=""></mat-option>
+                  <mat-option *ngFor="let prov of provinces" [value]="prov.ctryId + ',' + prov.provSeqNo">{{ prov.provNm }}
+                  </mat-option>
+                </mat-select>
+              </mat-form-field>
             </span>
             <span class="section-grid-cell">
               <p class="section-grid-header">Driver's Licence #</p>

--- a/src/frontend/staff-portal/src/app/components/jj-dispute-info/jj-dispute/jj-dispute.component.html
+++ b/src/frontend/staff-portal/src/app/components/jj-dispute-info/jj-dispute/jj-dispute.component.html
@@ -67,27 +67,27 @@
           <div style="display: grid; grid-template-columns: auto auto auto auto">
             <span class="section-grid-cell">
               <p class="section-grid-header">Surname</p>
-              <p class="section-grid-text" *ngIf="!isEditMode">{{ lastUpdatedJJDispute.occamDisputantSurnameNm }}</p>
-              <mat-form-field appearance="outline" *ngIf="isEditMode">
+              <p class="section-grid-text" *ngIf="!isTIEditMode">{{ lastUpdatedJJDispute.occamDisputantSurnameNm }}</p>
+              <mat-form-field appearance="outline" *ngIf="isTIEditMode">
                 <input matInput formControlName="occamDisputantSurnameNm">
                 <mat-error *ngIf="ticketInformationForm.controls.occamDisputantSurnameNm.hasError('maxlength')">{{ "error.max_length" | translate }}30</mat-error>
               </mat-form-field>
             </span>
             <span class="section-grid-cell">
-              <p class="section-grid-header" *ngIf="!isEditMode">Given Name(s)</p>
-              <p class="section-grid-text" *ngIf="!isEditMode">{{ lastUpdatedJJDispute.occamDisputantGivenNames }}</p>
-              <p class="section-grid-header" *ngIf="isEditMode">Given Name 1</p>
-              <mat-form-field appearance="outline" *ngIf="isEditMode">
+              <p class="section-grid-header" *ngIf="!isTIEditMode">Given Name(s)</p>
+              <p class="section-grid-text" *ngIf="!isTIEditMode">{{ lastUpdatedJJDispute.occamDisputantGivenNames }}</p>
+              <p class="section-grid-header" *ngIf="isTIEditMode">Given Name 1</p>
+              <mat-form-field appearance="outline" *ngIf="isTIEditMode">
                 <input matInput formControlName="occamDisputantGiven1Nm">
                 <mat-error *ngIf="ticketInformationForm.controls.occamDisputantGiven1Nm.hasError('maxlength')">{{ "error.max_length" | translate }}30</mat-error>
               </mat-form-field>
-              <p class="section-grid-header" *ngIf="isEditMode">Given Name 2</p>
-              <mat-form-field appearance="outline" *ngIf="isEditMode">
+              <p class="section-grid-header" *ngIf="isTIEditMode">Given Name 2</p>
+              <mat-form-field appearance="outline" *ngIf="isTIEditMode">
                 <input matInput formControlName="occamDisputantGiven2Nm">
                 <mat-error *ngIf="ticketInformationForm.controls.occamDisputantGiven2Nm.hasError('maxlength')">{{ "error.max_length" | translate }}30</mat-error>
               </mat-form-field>
-              <p class="section-grid-header" *ngIf="isEditMode">Given Name 3</p>
-              <mat-form-field appearance="outline" *ngIf="isEditMode">
+              <p class="section-grid-header" *ngIf="isTIEditMode">Given Name 3</p>
+              <mat-form-field appearance="outline" *ngIf="isTIEditMode">
                 <input matInput formControlName="occamDisputantGiven3Nm">
                 <mat-error *ngIf="ticketInformationForm.controls.occamDisputantGiven3Nm.hasError('maxlength')">{{ "error.max_length" | translate }}30</mat-error>
               </mat-form-field>
@@ -127,9 +127,9 @@
               </span>
             </ng-container>
           </div>
-          <button mat-raised-button *ngIf="isSupportStaff && !isEditMode" (click)="isEditMode=true" class="form-button">Edit</button>
-          <button mat-raised-button *ngIf="isEditMode" (click)="onSaveTicketInformation()" class="form-button" [disabled]="!ticketInformationForm.valid">Save</button>
-          <button mat-raised-button *ngIf="isEditMode" (click)="onCancelTicketInformation()" class="form-button">Cancel</button>
+          <button mat-raised-button *ngIf="isSupportStaff && !isTIEditMode" (click)="isTIEditMode=true" class="form-button" [disabled]="isCIEditMode">Edit</button>
+          <button mat-raised-button *ngIf="isTIEditMode" (click)="onSaveTicketInformation()" class="form-button" [disabled]="!ticketInformationForm.valid">Save</button>
+          <button mat-raised-button *ngIf="isTIEditMode" (click)="onCancelTicketInformation()" class="form-button">Cancel</button>
         </form>
       </section><br />
       <section>
@@ -138,34 +138,78 @@
             <h3>Contact Information</h3>
           </span>
         </ng-container>
-        <div style="display: grid; grid-template-columns: auto auto auto auto">
-          <span class="section-grid-cell">
-            <p class="section-grid-header">Surname</p>
-            <p class="section-grid-text">{{ lastUpdatedJJDispute.contactType === ContactType.Individual ?
-              lastUpdatedJJDispute.occamDisputantSurnameNm : lastUpdatedJJDispute.contactSurname }}</p>
-          </span>
-          <span class="section-grid-cell">
-            <p class="section-grid-header">Given Name(s)</p>
-            <p class="section-grid-text">{{ lastUpdatedJJDispute.contactType === ContactType.Individual ?
-              lastUpdatedJJDispute.occamDisputantGivenNames : lastUpdatedJJDispute.contactGivenNames }}</p>
-          </span>
-          <span class="section-grid-cell" style="grid-column: span 2">
-            <p class="section-grid-header">Address</p>
-            <p class="section-grid-text">{{ lastUpdatedJJDispute.address }}</p>
-          </span>
-          <span class="section-grid-cell">
-            <p class="section-grid-header">Prov / State of DL</p>
-            <p class="section-grid-text">{{ lastUpdatedJJDispute.driversLicenceProvince }}</p>
-          </span>
-          <span class="section-grid-cell">
-            <p class="section-grid-header">Driver's Licence #</p>
-            <p class="section-grid-text">{{ lastUpdatedJJDispute.driversLicenceNumber }}</p>
-          </span>
-          <span class="section-grid-cell">
-            <p class="section-grid-header">Email</p>
-            <p class="section-grid-text">{{ lastUpdatedJJDispute.emailAddress }}</p>
-          </span>
-        </div>
+        <form [formGroup]="contactInformationForm">
+          <div style="display: grid; grid-template-columns: auto auto auto auto">
+            <span class="section-grid-cell">
+              <p class="section-grid-header">Surname</p>
+              <p class="section-grid-text">{{ lastUpdatedJJDispute.contactType === ContactType.Individual ?
+                lastUpdatedJJDispute.occamDisputantSurnameNm : lastUpdatedJJDispute.contactSurname }}</p>
+            </span>
+            <span class="section-grid-cell">
+              <p class="section-grid-header">Given Name(s)</p>
+              <p class="section-grid-text">{{ lastUpdatedJJDispute.contactType === ContactType.Individual ?
+                lastUpdatedJJDispute.occamDisputantGivenNames : lastUpdatedJJDispute.contactGivenNames }}</p>
+            </span>
+            <span class="section-grid-cell" style="grid-column: span 2">
+              <p class="section-grid-header" *ngIf="!isCIEditMode">Address</p>
+              <p class="section-grid-text" *ngIf="!isCIEditMode">{{ lastUpdatedJJDispute.address }}</p>
+              <p class="section-grid-header" *ngIf="isCIEditMode">Address Line 1</p>
+              <mat-form-field appearance="outline" *ngIf="isCIEditMode">
+                <input matInput formControlName="addressLine1">
+                <mat-error *ngIf="contactInformationForm.controls.addressLine1.hasError('maxlength')">{{ "error.max_length" | translate }}100</mat-error>
+              </mat-form-field>
+              <p class="section-grid-header" *ngIf="isCIEditMode">Address Line 2</p>
+              <mat-form-field appearance="outline" *ngIf="isCIEditMode">
+                <input matInput formControlName="addressLine2">
+                <mat-error *ngIf="contactInformationForm.controls.addressLine2.hasError('maxlength')">{{ "error.max_length" | translate }}100</mat-error>
+              </mat-form-field>
+              <p class="section-grid-header" *ngIf="isCIEditMode">Address Line 3</p>
+              <mat-form-field appearance="outline" *ngIf="isCIEditMode">
+                <input matInput formControlName="addressLine3">
+                <mat-error *ngIf="contactInformationForm.controls.addressLine3.hasError('maxlength')">{{ "error.max_length" | translate }}100</mat-error>
+              </mat-form-field>
+              <p class="section-grid-header" *ngIf="isCIEditMode">City</p>
+              <mat-form-field appearance="outline" *ngIf="isCIEditMode">
+                <input matInput formControlName="addressCity">
+                <mat-error *ngIf="contactInformationForm.controls.addressCity.hasError('maxlength')">{{ "error.max_length" | translate }}100</mat-error>
+              </mat-form-field>
+              <p class="section-grid-header" *ngIf="isCIEditMode">Province</p>
+              <mat-form-field appearance="outline" *ngIf="isCIEditMode">
+                <input matInput formControlName="addressProvince">
+                <mat-error *ngIf="contactInformationForm.controls.addressProvince.hasError('maxlength')">{{ "error.max_length" | translate }}100</mat-error>
+              </mat-form-field>
+              <p class="section-grid-header" *ngIf="isCIEditMode">Country</p>
+              <mat-form-field appearance="outline" *ngIf="isCIEditMode">
+                <input matInput formControlName="addressCountry">
+                <mat-error *ngIf="contactInformationForm.controls.addressCountry.hasError('maxlength')">{{ "error.max_length" | translate }}100</mat-error>
+              </mat-form-field>
+              <p class="section-grid-header" *ngIf="isCIEditMode">Postal Code</p>
+              <mat-form-field appearance="outline" *ngIf="isCIEditMode">
+                <input matInput formControlName="addressPostalCode">
+                <mat-error *ngIf="contactInformationForm.controls.addressPostalCode.hasError('maxlength')">{{ "error.max_length" | translate }}10</mat-error>
+              </mat-form-field>
+            </span>
+            <span class="section-grid-cell">
+              <p class="section-grid-header">Prov / State of DL</p>
+              <p class="section-grid-text">{{ lastUpdatedJJDispute.driversLicenceProvince }}</p>
+            </span>
+            <span class="section-grid-cell">
+              <p class="section-grid-header">Driver's Licence #</p>
+              <p class="section-grid-text" *ngIf="!isCIEditMode">{{ lastUpdatedJJDispute.driversLicenceNumber }}</p>
+              <mat-form-field appearance="outline" *ngIf="isCIEditMode">
+                <input matInput formControlName="driversLicenceNumber">
+                <mat-error *ngIf="contactInformationForm.controls.driversLicenceNumber.hasError('maxlength')">{{ "error.max_length" | translate }}30</mat-error>
+              </mat-form-field>
+            </span>
+            <span class="section-grid-cell">
+              <p class="section-grid-header">Email</p>
+              <p class="section-grid-text">{{ lastUpdatedJJDispute.emailAddress }}</p>
+            </span>
+          </div>
+          <button mat-raised-button *ngIf="isSupportStaff && !isCIEditMode" (click)="isCIEditMode=true" class="form-button" [disabled]="isTIEditMode">Edit</button>
+          <button mat-raised-button *ngIf="isCIEditMode" (click)="onSaveContactInformation()" class="form-button" [disabled]="!contactInformationForm.valid">Save</button>
+          <button mat-raised-button *ngIf="isCIEditMode" (click)="onCancelContactInformation()" class="form-button">Cancel</button>
+        </form>
       </section><br />
       <section *ngIf="jjDisputeInfo.hearingType === HearingType.CourtAppearance">
         <ng-container subHeader>

--- a/src/frontend/staff-portal/src/app/components/jj-dispute-info/jj-dispute/jj-dispute.component.scss
+++ b/src/frontend/staff-portal/src/app/components/jj-dispute-info/jj-dispute/jj-dispute.component.scss
@@ -168,8 +168,13 @@ p {
           padding: 0px 0px 7px 0px !important;
           line-height: 0px;
 
-          input {
+          input, .mat-select {
             line-height: 18px !important;
+          }
+
+          .mat-select {
+            border-top: none;
+            padding: 0px 0px 0px 0px !important;
           }
         }
       }
@@ -182,28 +187,24 @@ p {
     }
   }
 
-  .select-box-only {
-    margin-top: 1em;
-    margin-bottom: 0 !important;
+  .mat-form-field-type-mat-select {
+    margin: 4px 0px 0px 0px;
+    border: 1px solid rgb(224, 224, 224);
+    border-radius: 5px;
+    padding: 6px 0px 0px 10px;
 
-    .mat-form-field-wrapper {
-      padding-bottom: 0 !important;
-
+    .mat-form-field-wrapper {      
       .mat-form-field-flex {
-        padding-top: 0 !important;
+        .mat-form-field-infix {
+          border: none !important;
+          .mat-select-value {
+            line-height: normal;
+          }
+        }
       }
-
-      .mat-select-trigger .mat-select-arrow-wrapper {
-        transform: none !important;
-      }
     }
-
-    .mat-form-field-underline {
-      bottom: 0;
-    }
-
-    .mat-form-field-subscript-wrapper {
-      display: none;
-    }
+  }
+  .mat-form-field-type-mat-select:hover {
+    border: 1px solid rgb(0, 0, 0);
   }
 }

--- a/src/frontend/staff-portal/src/app/components/jj-dispute-info/jj-dispute/jj-dispute.component.ts
+++ b/src/frontend/staff-portal/src/app/components/jj-dispute-info/jj-dispute/jj-dispute.component.ts
@@ -58,6 +58,10 @@ export class JJDisputeComponent implements OnInit {
     occamDisputantGiven3Nm: [null, Validators.maxLength(30)]
   });
   contactInformationForm: FormGroup = this.formBuilder.group({
+    contactSurname: [null, Validators.maxLength(30)],
+    contactGivenName1: [null, Validators.maxLength(30)],
+    contactGivenName2: [null, Validators.maxLength(30)],
+    contactGivenName3: [null, Validators.maxLength(30)],
     addressLine1: [null, Validators.maxLength(100)],
     addressLine2: [null, Validators.maxLength(100)],
     addressLine3: [null, Validators.maxLength(100)],

--- a/src/frontend/staff-portal/src/app/components/jj-dispute-info/jj-dispute/jj-dispute.component.ts
+++ b/src/frontend/staff-portal/src/app/components/jj-dispute-info/jj-dispute/jj-dispute.component.ts
@@ -2,7 +2,7 @@ import { Component, ElementRef, EventEmitter, Input, OnInit, Output, ViewChild }
 import { LoggerService } from '@core/services/logger.service';
 import { JJDisputeService, JJDispute } from '../../../services/jj-dispute.service';
 import { Observable, map } from 'rxjs';
-import { JJDisputedCount, JJDisputeStatus, JJDisputedCountRequestReduction, JJDisputedCountRequestTimeToPay, JJDisputeHearingType, JJDisputeCourtAppearanceRoPAppCd, JJDisputeCourtAppearanceRoPCrown, JJDisputeCourtAppearanceRoPDattCd, JJDisputeCourtAppearanceRoPJjSeized, FileMetadata, JJDisputeElectronicTicketYn, JJDisputeNoticeOfHearingYn, TicketImageDataJustinDocumentReportType, DocumentType, JJDisputeContactType, JJDisputedCountRoPFinding } from 'app/api/model/models';
+import { JJDisputedCount, JJDisputeStatus, JJDisputedCountRequestReduction, JJDisputedCountRequestTimeToPay, JJDisputeHearingType, JJDisputeCourtAppearanceRoPAppCd, JJDisputeCourtAppearanceRoPCrown, JJDisputeCourtAppearanceRoPDattCd, JJDisputeCourtAppearanceRoPJjSeized, FileMetadata, JJDisputeElectronicTicketYn, JJDisputeNoticeOfHearingYn, TicketImageDataJustinDocumentReportType, DocumentType, JJDisputeContactType, JJDisputedCountRoPFinding, Province } from 'app/api/model/models';
 import { DialogOptions } from '@shared/dialogs/dialog-options.model';
 import { MatLegacyDialog as MatDialog } from '@angular/material/legacy-dialog';
 import { AuthService, UserRepresentation } from 'app/services/auth.service';
@@ -65,6 +65,7 @@ export class JJDisputeComponent implements OnInit {
     addressProvince: [null, Validators.maxLength(100)],
     addressCountry: [null, Validators.maxLength(100)],
     addressPostalCode: [null, Validators.maxLength(10)],
+    driversLicenceProvince: [null],
     driversLicenceNumber: [null, Validators.maxLength(30)]    
   });
   courtAppearanceForm: FormGroup = this.formBuilder.group({
@@ -93,6 +94,7 @@ export class JJDisputeComponent implements OnInit {
   fineReductionCountsHeading: string = "";
   remarks: string = "";
   jjList: UserRepresentation[];
+  provinces: Province[];
   selectedJJ: string;
   fileTypeToUpload: string = "Certified Extract";
   filesToUpload: any[] = [];
@@ -107,7 +109,7 @@ export class JJDisputeComponent implements OnInit {
     private jjDisputeService: JJDisputeService,
     private dialog: MatDialog,
     private logger: LoggerService,
-    private lookups: LookupsService,
+    private lookupsService: LookupsService,
     private config: ConfigService,
     private documentService: DocumentService,
     private historyRecordService: HistoryRecordService,
@@ -129,6 +131,7 @@ export class JJDisputeComponent implements OnInit {
     });
 
     this.isSupportStaff = this.authService.checkRole("support-staff");
+    this.provinces = this.lookupsService.provinces;
   }
 
   // get dispute by id
@@ -159,7 +162,7 @@ export class JJDisputeComponent implements OnInit {
       let dLProvinceFound = this.config.provincesAndStates.filter(x => x.ctryId == +this.lastUpdatedJJDispute.drvLicIssuedCtryId && x.provSeqNo == +this.lastUpdatedJJDispute.drvLicIssuedProvSeqNo);
       this.lastUpdatedJJDispute.driversLicenceProvince = dLProvinceFound.length > 0 ? dLProvinceFound[0].provNm : "Unknown";
 
-      this.lastUpdatedJJDispute.interpreterLanguage = this.lookups.getLanguageDescription(this.lastUpdatedJJDispute.interpreterLanguageCd);
+      this.lastUpdatedJJDispute.interpreterLanguage = this.lookupsService.getLanguageDescription(this.lastUpdatedJJDispute.interpreterLanguageCd);
 
       if (this.lastUpdatedJJDispute?.mostRecentCourtAppearance) {
         if (!this.lastUpdatedJJDispute.mostRecentCourtAppearance.jjSeized) this.lastUpdatedJJDispute.mostRecentCourtAppearance.jjSeized = 'N';
@@ -179,6 +182,9 @@ export class JJDisputeComponent implements OnInit {
 
       this.ticketInformationForm.patchValue(this.lastUpdatedJJDispute);
       this.contactInformationForm.patchValue(this.lastUpdatedJJDispute);
+      this.contactInformationForm.patchValue({
+        "driversLicenceProvince" : this.lastUpdatedJJDispute.drvLicIssuedCtryId + "," + this.lastUpdatedJJDispute.drvLicIssuedProvSeqNo
+      });
     });
   }
 
@@ -320,10 +326,18 @@ export class JJDisputeComponent implements OnInit {
   }
 
   /**
-   * Called by support-staff when editing the Ticket Information form (user must have update-admin permissions on the JJDispute resource).
+   * Called by support-staff when editing the Contact Information form (user must have update-admin permissions on the JJDispute resource).
    */
   onSaveContactInformation(): void {
     this.lastUpdatedJJDispute = { ...this.lastUpdatedJJDispute, ...this.contactInformationForm.value };
+
+    // extract ctryId and provSeqNo from Province select list (composite key value should be 2 digits separated by a comma)
+    let drvLicIssuedProv = this.contactInformationForm.controls.driversLicenceProvince.value + "";
+    const [ctryId, provSeqNo] = drvLicIssuedProv.split(",").map(Number);
+    if (!isNaN(ctryId) && !isNaN(provSeqNo)) {
+      this.lastUpdatedJJDispute.drvLicIssuedCtryId = ctryId + "";
+      this.lastUpdatedJJDispute.drvLicIssuedProvSeqNo = provSeqNo + "";
+    }
 
     this.jjDisputeService.apiJjTicketNumberCascadePut(this.lastUpdatedJJDispute.ticketNumber, this.lastUpdatedJJDispute).subscribe(response => {      
       // refresh JJDispute data
@@ -334,10 +348,13 @@ export class JJDisputeComponent implements OnInit {
   }
 
   /**
-   * Called by support-staff when reverting any changes they may have made to the Ticket Information form.
+   * Called by support-staff when reverting any changes they may have made to the Contact Information form.
    */
   onCancelContactInformation(): void {
     this.contactInformationForm.patchValue(this.lastUpdatedJJDispute);
+    this.contactInformationForm.patchValue({
+      "driversLicenceProvince" : this.lastUpdatedJJDispute.drvLicIssuedCtryId + "," + this.lastUpdatedJJDispute.drvLicIssuedProvSeqNo
+    });
     this.isCIEditMode = false;
   }
 

--- a/src/frontend/staff-portal/src/app/components/jj-dispute-info/jj-dispute/jj-dispute.component.ts
+++ b/src/frontend/staff-portal/src/app/components/jj-dispute-info/jj-dispute/jj-dispute.component.ts
@@ -33,7 +33,8 @@ export class JJDisputeComponent implements OnInit {
   @Output() backInbox: EventEmitter<any> = new EventEmitter();
   printOptions: PrintOptions = new PrintOptions();
   isSupportStaff: boolean = false;
-  isEditMode: boolean = false;
+  isTIEditMode: boolean = false;
+  isCIEditMode: boolean = false;
 
   RequestTimeToPay = JJDisputedCountRequestTimeToPay;
   Finding = JJDisputedCountRoPFinding;
@@ -55,6 +56,16 @@ export class JJDisputeComponent implements OnInit {
     occamDisputantGiven1Nm: [null, Validators.maxLength(30)],
     occamDisputantGiven2Nm: [null, Validators.maxLength(30)],
     occamDisputantGiven3Nm: [null, Validators.maxLength(30)]
+  });
+  contactInformationForm: FormGroup = this.formBuilder.group({
+    addressLine1: [null, Validators.maxLength(100)],
+    addressLine2: [null, Validators.maxLength(100)],
+    addressLine3: [null, Validators.maxLength(100)],
+    addressCity: [null, Validators.maxLength(100)],
+    addressProvince: [null, Validators.maxLength(100)],
+    addressCountry: [null, Validators.maxLength(100)],
+    addressPostalCode: [null, Validators.maxLength(10)],
+    driversLicenceNumber: [null, Validators.maxLength(30)]    
   });
   courtAppearanceForm: FormGroup = this.formBuilder.group({
     appCd: [{ value: null, disabled: true }],
@@ -167,6 +178,7 @@ export class JJDisputeComponent implements OnInit {
       }
 
       this.ticketInformationForm.patchValue(this.lastUpdatedJJDispute);
+      this.contactInformationForm.patchValue(this.lastUpdatedJJDispute);
     });
   }
 
@@ -295,7 +307,7 @@ export class JJDisputeComponent implements OnInit {
       // refresh JJDispute data
       this.getJJDispute();
 
-      this.isEditMode = false;
+      this.isTIEditMode = false;
     });
   }
 
@@ -304,7 +316,29 @@ export class JJDisputeComponent implements OnInit {
    */
   onCancelTicketInformation(): void {
     this.ticketInformationForm.patchValue(this.lastUpdatedJJDispute);
-    this.isEditMode = false;
+    this.isTIEditMode = false;
+  }
+
+  /**
+   * Called by support-staff when editing the Ticket Information form (user must have update-admin permissions on the JJDispute resource).
+   */
+  onSaveContactInformation(): void {
+    this.lastUpdatedJJDispute = { ...this.lastUpdatedJJDispute, ...this.contactInformationForm.value };
+
+    this.jjDisputeService.apiJjTicketNumberCascadePut(this.lastUpdatedJJDispute.ticketNumber, this.lastUpdatedJJDispute).subscribe(response => {      
+      // refresh JJDispute data
+      this.getJJDispute();
+
+      this.isCIEditMode = false;
+    });
+  }
+
+  /**
+   * Called by support-staff when reverting any changes they may have made to the Ticket Information form.
+   */
+  onCancelContactInformation(): void {
+    this.contactInformationForm.patchValue(this.lastUpdatedJJDispute);
+    this.isCIEditMode = false;
   }
 
   onAccept(): void {

--- a/src/frontend/staff-portal/src/app/config/config.service.ts
+++ b/src/frontend/staff-portal/src/app/config/config.service.ts
@@ -27,6 +27,7 @@ export class ConfigService {
     new BehaviorSubject<string>('');
   private statuteError: BehaviorSubject<string> = new BehaviorSubject<string>('');
   private languageError: BehaviorSubject<string> = new BehaviorSubject<string>('');
+  private provinceError: BehaviorSubject<string> = new BehaviorSubject<string>('');
   private agencyError: BehaviorSubject<string> = new BehaviorSubject<string>('');
 
   private _countries: CountryCodeValue[] = [];
@@ -123,6 +124,13 @@ export class ConfigService {
   }
   public get language_error(): string {
     return this.languageError.value;
+  }
+
+  public get province_error$(): BehaviorSubject<string> {
+    return this.provinceError;
+  }
+  public get province_error(): string {
+    return this.provinceError.value;
   }
 
   public get agency_error$(): BehaviorSubject<string> {


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

TCVP-2524
Several of the form fields on the Contact Information section of the DCF tab now display as editable.
- When the Contact Information section is editable, the Ticket Information section is not.
- Added a new LookupService.getProvinces() to deal with the Province select list.

Note: The ORDs backend does not actually persist the values in the database yet on the PUT JJDispute endpoint (coming...)

![image](https://github.com/bcgov/jag-traffic-courts-online/assets/55215368/e4139dcc-d0de-45d1-a822-bd55bae45287)

![image](https://github.com/bcgov/jag-traffic-courts-online/assets/55215368/b35b4477-e29f-4b2a-b3be-ee06ef095387)


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
