### PR TITLE
TCVP-2524 Only Contact name is editable

### DIFF
--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/service/JJDisputeService.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/service/JJDisputeService.java
@@ -22,6 +22,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import ca.bc.gov.open.jag.tco.oracledataapi.error.NotAllowedException;
+import ca.bc.gov.open.jag.tco.oracledataapi.model.ContactType;
 import ca.bc.gov.open.jag.tco.oracledataapi.model.CustomUserDetails;
 import ca.bc.gov.open.jag.tco.oracledataapi.model.Dispute;
 import ca.bc.gov.open.jag.tco.oracledataapi.model.JJDispute;
@@ -189,10 +190,16 @@ public class JJDisputeService {
 
 		// TCVP-1981 Update certain fields on the related OCCAM Dispute as well.
 		Dispute dispute = disputeRepository.findById(jjDispute.getOccamDisputeId()).orElseThrow();
-		dispute.setDisputantSurname(jjDispute.getOccamDisputantSurnameNm());
 		dispute.setDisputantGivenName1(jjDispute.getOccamDisputantGiven1Nm());
 		dispute.setDisputantGivenName2(jjDispute.getOccamDisputantGiven2Nm());
 		dispute.setDisputantGivenName3(jjDispute.getOccamDisputantGiven3Nm());
+		dispute.setDisputantSurname(jjDispute.getOccamDisputantSurnameNm());
+		if (!ContactType.INDIVIDUAL.equals(dispute.getContactTypeCd())) {
+			dispute.setContactGiven1Nm(jjDispute.getContactGivenName1());
+			dispute.setContactGiven2Nm(jjDispute.getContactGivenName2());
+			dispute.setContactGiven3Nm(jjDispute.getContactGivenName3());
+			dispute.setContactSurnameNm(jjDispute.getContactSurname());
+		}
 		dispute.setLawyerGivenName1(jjDispute.getLawyerGivenName1());
 		dispute.setLawyerGivenName2(jjDispute.getLawyerGivenName2());
 		dispute.setLawyerGivenName3(jjDispute.getLawyerGivenName3());

--- a/src/frontend/staff-portal/src/app/components/jj-dispute-info/jj-dispute/jj-dispute.component.html
+++ b/src/frontend/staff-portal/src/app/components/jj-dispute-info/jj-dispute/jj-dispute.component.html
@@ -170,71 +170,25 @@
               </mat-form-field>
             </span>
             <span class="section-grid-cell" style="grid-column: span 2">
-              <p class="section-grid-header" *ngIf="!isCIEditMode">Address</p>
-              <p class="section-grid-text" *ngIf="!isCIEditMode">{{ lastUpdatedJJDispute.address }}</p>
-              <p class="section-grid-header" *ngIf="isCIEditMode">Address Line 1</p>
-              <mat-form-field appearance="outline" *ngIf="isCIEditMode">
-                <input matInput formControlName="addressLine1">
-                <mat-error *ngIf="contactInformationForm.controls.addressLine1.hasError('maxlength')">{{ "error.max_length" | translate }}100</mat-error>
-              </mat-form-field>
-              <p class="section-grid-header" *ngIf="isCIEditMode">Address Line 2</p>
-              <mat-form-field appearance="outline" *ngIf="isCIEditMode">
-                <input matInput formControlName="addressLine2">
-                <mat-error *ngIf="contactInformationForm.controls.addressLine2.hasError('maxlength')">{{ "error.max_length" | translate }}100</mat-error>
-              </mat-form-field>
-              <p class="section-grid-header" *ngIf="isCIEditMode">Address Line 3</p>
-              <mat-form-field appearance="outline" *ngIf="isCIEditMode">
-                <input matInput formControlName="addressLine3">
-                <mat-error *ngIf="contactInformationForm.controls.addressLine3.hasError('maxlength')">{{ "error.max_length" | translate }}100</mat-error>
-              </mat-form-field>
-              <p class="section-grid-header" *ngIf="isCIEditMode">City</p>
-              <mat-form-field appearance="outline" *ngIf="isCIEditMode">
-                <input matInput formControlName="addressCity">
-                <mat-error *ngIf="contactInformationForm.controls.addressCity.hasError('maxlength')">{{ "error.max_length" | translate }}100</mat-error>
-              </mat-form-field>
-              <p class="section-grid-header" *ngIf="isCIEditMode">Province</p>
-              <mat-form-field appearance="outline" *ngIf="isCIEditMode">
-                <input matInput formControlName="addressProvince">
-                <mat-error *ngIf="contactInformationForm.controls.addressProvince.hasError('maxlength')">{{ "error.max_length" | translate }}100</mat-error>
-              </mat-form-field>
-              <p class="section-grid-header" *ngIf="isCIEditMode">Country</p>
-              <mat-form-field appearance="outline" *ngIf="isCIEditMode">
-                <input matInput formControlName="addressCountry">
-                <mat-error *ngIf="contactInformationForm.controls.addressCountry.hasError('maxlength')">{{ "error.max_length" | translate }}100</mat-error>
-              </mat-form-field>
-              <p class="section-grid-header" *ngIf="isCIEditMode">Postal Code</p>
-              <mat-form-field appearance="outline" *ngIf="isCIEditMode">
-                <input matInput formControlName="addressPostalCode">
-                <mat-error *ngIf="contactInformationForm.controls.addressPostalCode.hasError('maxlength')">{{ "error.max_length" | translate }}10</mat-error>
-              </mat-form-field>
+              <p class="section-grid-header">Address</p>
+              <p class="section-grid-text">{{ lastUpdatedJJDispute.address }}</p>
             </span>
             <span class="section-grid-cell">
               <p class="section-grid-header">Prov / State of DL</p>
-              <p class="section-grid-text" *ngIf="!isCIEditMode">{{ lastUpdatedJJDispute.driversLicenceProvince }}</p>
-              <mat-form-field appearance="select-box-only" *ngIf="isCIEditMode">
-                <mat-select formControlName="driversLicenceProvince" placeholder="Province">
-                  <mat-option [value]=""></mat-option>
-                  <mat-option *ngFor="let prov of provinces" [value]="prov.ctryId + ',' + prov.provSeqNo">{{ prov.provNm }}
-                  </mat-option>
-                </mat-select>
-              </mat-form-field>
+              <p class="section-grid-text">{{ lastUpdatedJJDispute.driversLicenceProvince }}</p>
             </span>
             <span class="section-grid-cell">
               <p class="section-grid-header">Driver's Licence #</p>
-              <p class="section-grid-text" *ngIf="!isCIEditMode">{{ lastUpdatedJJDispute.driversLicenceNumber }}</p>
-              <mat-form-field appearance="outline" *ngIf="isCIEditMode">
-                <input matInput formControlName="driversLicenceNumber">
-                <mat-error *ngIf="contactInformationForm.controls.driversLicenceNumber.hasError('maxlength')">{{ "error.max_length" | translate }}30</mat-error>
-              </mat-form-field>
+              <p class="section-grid-text">{{ lastUpdatedJJDispute.driversLicenceNumber }}</p>
             </span>
             <span class="section-grid-cell">
               <p class="section-grid-header">Email</p>
               <p class="section-grid-text">{{ lastUpdatedJJDispute.emailAddress }}</p>
             </span>
           </div>
-          <button mat-raised-button *ngIf="isSupportStaff && !isCIEditMode" (click)="isCIEditMode=true" class="form-button" [disabled]="isTIEditMode || isCOEditMode">Edit</button>
-          <button mat-raised-button *ngIf="isCIEditMode" (click)="onSaveContactInformation()" class="form-button" [disabled]="!contactInformationForm.valid">Save</button>
-          <button mat-raised-button *ngIf="isCIEditMode" (click)="onCancelContactInformation()" class="form-button">Cancel</button>
+          <button mat-raised-button *ngIf="isSupportStaff && !isCIEditMode && lastUpdatedJJDispute.contactType !== ContactType.Individual" (click)="isCIEditMode=true" class="form-button" [disabled]="isTIEditMode || isCOEditMode">Edit</button>
+          <button mat-raised-button *ngIf="isCIEditMode && lastUpdatedJJDispute.contactType !== ContactType.Individual" (click)="onSaveContactInformation()" class="form-button" [disabled]="!contactInformationForm.valid">Save</button>
+          <button mat-raised-button *ngIf="isCIEditMode && lastUpdatedJJDispute.contactType !== ContactType.Individual" (click)="onCancelContactInformation()" class="form-button">Cancel</button>
         </form>
       </section><br />
       <section *ngIf="jjDisputeInfo.hearingType === HearingType.CourtAppearance">

--- a/src/frontend/staff-portal/src/app/components/jj-dispute-info/jj-dispute/jj-dispute.component.ts
+++ b/src/frontend/staff-portal/src/app/components/jj-dispute-info/jj-dispute/jj-dispute.component.ts
@@ -64,16 +64,7 @@ export class JJDisputeComponent implements OnInit {
     contactSurname: [null, Validators.maxLength(30)],
     contactGivenName1: [null, Validators.maxLength(30)],
     contactGivenName2: [null, Validators.maxLength(30)],
-    contactGivenName3: [null, Validators.maxLength(30)],
-    addressLine1: [null, Validators.maxLength(100)],
-    addressLine2: [null, Validators.maxLength(100)],
-    addressLine3: [null, Validators.maxLength(100)],
-    addressCity: [null, Validators.maxLength(100)],
-    addressProvince: [null, Validators.maxLength(100)],
-    addressCountry: [null, Validators.maxLength(100)],
-    addressPostalCode: [null, Validators.maxLength(10)],
-    driversLicenceProvince: [null],
-    driversLicenceNumber: [null, Validators.maxLength(30)]    
+    contactGivenName3: [null, Validators.maxLength(30)]  
   });
   courtOptionsForm: FormGroup = this.formBuilder.group({
     lawyerGivenName1: [null, Validators.maxLength(30)],
@@ -202,10 +193,8 @@ export class JJDisputeComponent implements OnInit {
 
       this.ticketInformationForm.patchValue(this.lastUpdatedJJDispute);
       this.contactInformationForm.patchValue(this.lastUpdatedJJDispute);
-      this.contactInformationForm.patchValue({
-        "driversLicenceProvince" : this.lastUpdatedJJDispute.drvLicIssuedCtryId + "," + this.lastUpdatedJJDispute.drvLicIssuedProvSeqNo
-      });
       this.courtOptionsForm.patchValue(this.lastUpdatedJJDispute);
+
       if(this.jjIDIR===this.lastUpdatedJJDispute.lockedBy){
         this.startTimer(this.lastUpdatedJJDispute.lockExpiresAtUtc, this.lastUpdatedJJDispute.lockId);
       }
@@ -355,14 +344,6 @@ export class JJDisputeComponent implements OnInit {
   onSaveContactInformation(): void {
     this.lastUpdatedJJDispute = { ...this.lastUpdatedJJDispute, ...this.contactInformationForm.value };
 
-    // extract ctryId and provSeqNo from Province select list (composite key value should be 2 digits separated by a comma)
-    let drvLicIssuedProv = this.contactInformationForm.controls.driversLicenceProvince.value + "";
-    const [ctryId, provSeqNo] = drvLicIssuedProv.split(",").map(Number);
-    if (!isNaN(ctryId) && !isNaN(provSeqNo)) {
-      this.lastUpdatedJJDispute.drvLicIssuedCtryId = ctryId + "";
-      this.lastUpdatedJJDispute.drvLicIssuedProvSeqNo = provSeqNo + "";
-    }
-
     this.jjDisputeService.apiJjTicketNumberCascadePut(this.lastUpdatedJJDispute.ticketNumber, this.lastUpdatedJJDispute).subscribe(response => {      
       // refresh JJDispute data
       this.getJJDispute();
@@ -376,9 +357,6 @@ export class JJDisputeComponent implements OnInit {
    */
   onCancelContactInformation(): void {
     this.contactInformationForm.patchValue(this.lastUpdatedJJDispute);
-    this.contactInformationForm.patchValue({
-      "driversLicenceProvince" : this.lastUpdatedJJDispute.drvLicIssuedCtryId + "," + this.lastUpdatedJJDispute.drvLicIssuedProvSeqNo
-    });
     this.isCIEditMode = false;
   }
 


### PR DESCRIPTION
TCVP-2524
Change of requirements. Removed editing of address, province, and driver's licence as these are pulled directly from JUSTIN. Only the contact name fields are editible now in the Contact Information section.

![image](https://github.com/bcgov/jag-traffic-courts-online/assets/55215368/b2178874-1a6d-4e86-9dc2-676268bd7ba6)

