### PR TITLE
TCVP-2524 Made DCF tab editable

### DIFF
--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/service/JJDisputeService.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/service/JJDisputeService.java
@@ -25,6 +25,7 @@ import ca.bc.gov.open.jag.tco.oracledataapi.error.NotAllowedException;
 import ca.bc.gov.open.jag.tco.oracledataapi.model.ContactType;
 import ca.bc.gov.open.jag.tco.oracledataapi.model.CustomUserDetails;
 import ca.bc.gov.open.jag.tco.oracledataapi.model.Dispute;
+import ca.bc.gov.open.jag.tco.oracledataapi.model.DisputeCount;
 import ca.bc.gov.open.jag.tco.oracledataapi.model.JJDispute;
 import ca.bc.gov.open.jag.tco.oracledataapi.model.JJDisputeCourtAppearanceAPP;
 import ca.bc.gov.open.jag.tco.oracledataapi.model.JJDisputeCourtAppearanceDATT;
@@ -32,6 +33,7 @@ import ca.bc.gov.open.jag.tco.oracledataapi.model.JJDisputeCourtAppearanceRoP;
 import ca.bc.gov.open.jag.tco.oracledataapi.model.JJDisputeHearingType;
 import ca.bc.gov.open.jag.tco.oracledataapi.model.JJDisputeRemark;
 import ca.bc.gov.open.jag.tco.oracledataapi.model.JJDisputeStatus;
+import ca.bc.gov.open.jag.tco.oracledataapi.model.JJDisputedCount;
 import ca.bc.gov.open.jag.tco.oracledataapi.model.TicketImageDataDocumentType;
 import ca.bc.gov.open.jag.tco.oracledataapi.model.TicketImageDataJustinDocument;
 import ca.bc.gov.open.jag.tco.oracledataapi.model.YesNo;
@@ -207,6 +209,17 @@ public class JJDisputeService {
 		dispute.setLawFirmName(jjDispute.getLawFirmName());
 		dispute.setWitnessNo(jjDispute.getWitnessNo());
 		dispute.setInterpreterLanguageCd(jjDispute.getInterpreterLanguageCd());
+		for (JJDisputedCount jjDisputedCount : jjDispute.getJjDisputedCounts()) {
+			for (DisputeCount disputeCount : dispute.getDisputeCounts()) {
+				if (disputeCount.getCountNo() == jjDisputedCount.getCount().intValue()) {
+					disputeCount.setRequestCourtAppearance(jjDisputedCount.getAppearInCourt());
+					disputeCount.setRequestTimeToPay(jjDisputedCount.getRequestTimeToPay());
+					disputeCount.setRequestReduction(jjDisputedCount.getRequestReduction());
+					break;
+				}
+			}
+		}
+
 		disputeRepository.update(dispute);
 
 		return updateJJDispute(ticketNumber, jjDispute, principal);

--- a/src/frontend/staff-portal/package.json
+++ b/src/frontend/staff-portal/package.json
@@ -38,6 +38,7 @@
     "@auth0/angular-jwt": "^5.2.0",
     "@azure/ai-form-recognizer": "^3.1.0",
     "@bcgov/bc-sans": "^1.0.1",
+    "@mat-datetimepicker/core": "^12.0.1",
     "@ngrx/effects": "16.3.0",
     "@ngrx/store": "16.3.0",
     "@ngx-translate/core": "^15.0.0",

--- a/src/frontend/staff-portal/src/app/components/jj-dispute-info/jj-count/jj-count.component.html
+++ b/src/frontend/staff-portal/src/app/components/jj-dispute-info/jj-count/jj-count.component.html
@@ -46,7 +46,7 @@
     <form [formGroup]="countForm">
       <div style="display: grid; grid-template-columns: auto auto">
         <span class="section-grid-cell" style="grid-column: span 2">
-          <p class="section-grid-header">For this count I would like to</p>
+          <p class="section-grid-header">{{ "label.appearInCourt" | translate }}</p>
           <p class="section-grid-text" *ngIf="!isSSEditMode && jjDisputedCount?.appearInCourt === AppearInCourt.Y">
             I want to appear in court</p>
           <p class="section-grid-text" *ngIf="!isSSEditMode && jjDisputedCount?.appearInCourt === AppearInCourt.N">
@@ -54,8 +54,8 @@
           <p class="section-grid-text" *ngIf="!isSSEditMode && !jjDisputedCount">&nbsp;</p>
           <mat-form-field appearance="outline" *ngIf="jjDisputedCount && isSSEditMode">
             <mat-select formControlName="appearInCourt">
-              <mat-option [value]="AppearInCourt.Y">I want to appear in court</mat-option>
-              <mat-option [value]="AppearInCourt.N">I do not want to appear in court</mat-option>
+              <mat-option [value]="AppearInCourt.Y">{{ "appearInCourtType.yes" | translate }}</mat-option>
+              <mat-option [value]="AppearInCourt.N">{{ "appearInCourtType.no" | translate }}</mat-option>
             </mat-select>
           </mat-form-field>
         </span>
@@ -69,8 +69,8 @@
             no</p>
           <mat-form-field appearance="outline" *ngIf="jjDisputedCount && isSSEditMode">
             <mat-select formControlName="requestReduction">
-              <mat-option [value]="RequestReduction.Y">Yes</mat-option>
-              <mat-option [value]="RequestReduction.N">No</mat-option>
+              <mat-option [value]="RequestReduction.Y">{{ "yesNo.yes" | translate }}</mat-option>
+              <mat-option [value]="RequestReduction.N">{{ "yesNo.no" | translate }}</mat-option>
             </mat-select>
           </mat-form-field>
         </span>
@@ -84,8 +84,8 @@
             no</p>
           <mat-form-field appearance="outline" *ngIf="jjDisputedCount && isSSEditMode">
             <mat-select formControlName="requestTimeToPay">
-              <mat-option [value]="RequestTimeToPay.Y">Yes</mat-option>
-              <mat-option [value]="RequestTimeToPay.N">No</mat-option>
+              <mat-option [value]="RequestTimeToPay.Y">{{ "yesNo.yes" | translate }}</mat-option>
+              <mat-option [value]="RequestTimeToPay.N">{{ "yesNo.no" | translate }}</mat-option>
             </mat-select>
           </mat-form-field>
         </span>
@@ -373,11 +373,11 @@
       <form [formGroup]="countRoPForm">
         <mat-form-field appearance="outline" *ngIf="jjDisputedCount">
           <mat-select formControlName="finding">
-            <mat-option [value]="Finding.Guilty">Guilty as charged</mat-option>
-            <mat-option [value]="Finding.GuiltyLesser">Not guilty as charged but guilty of lesser / included other offence</mat-option>
-            <mat-option [value]="Finding.NotGuilty">Not guilty</mat-option>
-            <mat-option [value]="Finding.PaidPriorToAppearance">Paid Prior to Appearance</mat-option>
-            <mat-option [value]="Finding.Cancelled">Cancelled</mat-option>
+            <mat-option [value]="Finding.Guilty">{{ "findingType.guilty" | translate }}</mat-option>
+            <mat-option [value]="Finding.GuiltyLesser">{{ "findingType.guilty_lesser" | translate }}</mat-option>
+            <mat-option [value]="Finding.NotGuilty">{{ "findingType.not_guilty" | translate }}</mat-option>
+            <mat-option [value]="Finding.PaidPriorToAppearance">{{ "findingType.paid_prior" | translate }}</mat-option>
+            <mat-option [value]="Finding.Cancelled">{{ "findingType.cancelled" | translate }}</mat-option>
           </mat-select>
         </mat-form-field>
       </form>

--- a/src/frontend/staff-portal/src/app/components/jj-dispute-info/jj-count/jj-count.component.html
+++ b/src/frontend/staff-portal/src/app/components/jj-dispute-info/jj-count/jj-count.component.html
@@ -6,33 +6,34 @@
         <h3>Count {{ count }} </h3>
       </span>
     </ng-container>
-    <div style="display: grid; grid-template-columns: auto auto">
-      <span class="section-grid-cell">
-        <p class="section-grid-header">Plea</p>
-        <p class="section-grid-text">{{ jjDisputedCount ? (jjDisputedCount.plea === Plea.G ? 'Guilty' : 'Not Guilty' ) :
-          '&nbsp;' }}</p>
-      </span>
-      <span class="section-grid-cell">
-        <p class="section-grid-header">Offence Date</p>
-        <p class="section-grid-text">{{ jjDisputedCount ? (jjDisputeInfo.issuedTs | date: "MMM dd, yyyy" : "UTC") :
-          '&nbsp;' }}</p>
-      </span>
-      <span class="section-grid-cell" style="grid-column: span 2">
-        <p class="section-grid-header">Description of offence</p>
-        <p class="section-grid-text">{{ jjDisputedCount ? jjDisputedCount.description : '&nbsp;' }}</p>
-      </span>
-      <span class="section-grid-cell">
-        <p class="section-grid-header">Due Date</p>
-        <p class="section-grid-text">{{ jjDisputedCount ? (jjDisputedCount.dueDate | date: "MMM dd, yyyy" : "UTC") :
-          '&nbsp;' }}
-        </p>
-      </span>
-      <span class="section-grid-cell">
-        <p class="section-grid-header">Fine amount</p>
-        <p class="section-grid-text">{{ jjDisputedCount?.ticketedFineAmount |currency:'CAD':'symbol-narrow':'1.0-0' }}
-        </p>
-      </span>
-    </div>
+    <form [formGroup]="countForm">
+      <div style="display: grid; grid-template-columns: auto auto">
+        <span class="section-grid-cell">
+          <p class="section-grid-header">{{ "label.plea" | translate }}</p>
+          <p class="section-grid-text">{{ jjDisputedCount ? (jjDisputedCount.plea === Plea.G ? 'Guilty' : 'Not Guilty' ) : '&nbsp;' }}</p>          
+        </span>
+        <span class="section-grid-cell">
+          <p class="section-grid-header">Offence Date</p>
+          <p class="section-grid-text">{{ jjDisputedCount ? (jjDisputeInfo.issuedTs | date: "MMM dd, yyyy" : "UTC") :
+            '&nbsp;' }}</p>
+        </span>
+        <span class="section-grid-cell" style="grid-column: span 2">
+          <p class="section-grid-header">Description of offence</p>
+          <p class="section-grid-text">{{ jjDisputedCount ? jjDisputedCount.description : '&nbsp;' }}</p>
+        </span>
+        <span class="section-grid-cell">
+          <p class="section-grid-header">Due Date</p>
+          <p class="section-grid-text">{{ jjDisputedCount ? (jjDisputedCount.dueDate | date: "MMM dd, yyyy" : "UTC") :
+            '&nbsp;' }}
+          </p>
+        </span>
+        <span class="section-grid-cell">
+          <p class="section-grid-header">Fine amount</p>
+          <p class="section-grid-text">{{ jjDisputedCount?.ticketedFineAmount |currency:'CAD':'symbol-narrow':'1.0-0' }}
+          </p>
+        </span>
+      </div>
+    </form>
     <hr style="margin: 0 0 0 0" />
   </section>
   <!-- Disputant Request -->
@@ -42,34 +43,54 @@
         <h3>Disputant Request</h3>
       </span>
     </ng-container>
-    <div style="display: grid; grid-template-columns: auto auto">
-      <span class="section-grid-cell" style="grid-column: span 2">
-        <p class="section-grid-header">For this count I would like to</p>
-        <p class="section-grid-text" *ngIf="jjDisputedCount?.appearInCourt === AppearInCourt.Y">
-          I want to appear in court</p>
-        <p class="section-grid-text" *ngIf="jjDisputedCount?.appearInCourt === AppearInCourt.N">
-          I do not want to appear in court</p>
-        <p class="section-grid-text" *ngIf="!jjDisputedCount">&nbsp;</p>
-      </span>
-      <span class="section-grid-cell">
-        <p class="section-grid-header">Request fine reduction</p>
-        <p class="section-grid-text" *ngIf="!jjDisputedCount">&nbsp;</p>
-        <p class="section-grid-text" *ngIf="jjDisputedCount?.requestReduction === RequestReduction.Y">
-          yes</p>
-        <p class="section-grid-text"
-          *ngIf="jjDisputedCount && jjDisputedCount?.requestReduction !== RequestReduction.Y">
-          no</p>
-      </span>
-      <span class="section-grid-cell">
-        <p class="section-grid-header">Request time to pay</p>
-        <p class="section-grid-text" *ngIf="!jjDisputedCount">&nbsp;</p>
-        <p class="section-grid-text" *ngIf="jjDisputedCount?.requestTimeToPay === RequestTimeToPay.Y">
-          yes</p>
-        <p class="section-grid-text"
-          *ngIf="jjDisputedCount && jjDisputedCount?.requestTimeToPay !== RequestTimeToPay.Y">
-          no</p>
-      </span>
-    </div>
+    <form [formGroup]="countForm">
+      <div style="display: grid; grid-template-columns: auto auto">
+        <span class="section-grid-cell" style="grid-column: span 2">
+          <p class="section-grid-header">For this count I would like to</p>
+          <p class="section-grid-text" *ngIf="!isSSEditMode && jjDisputedCount?.appearInCourt === AppearInCourt.Y">
+            I want to appear in court</p>
+          <p class="section-grid-text" *ngIf="!isSSEditMode && jjDisputedCount?.appearInCourt === AppearInCourt.N">
+            I do not want to appear in court</p>
+          <p class="section-grid-text" *ngIf="!isSSEditMode && !jjDisputedCount">&nbsp;</p>
+          <mat-form-field appearance="outline" *ngIf="jjDisputedCount && isSSEditMode">
+            <mat-select formControlName="appearInCourt">
+              <mat-option [value]="AppearInCourt.Y">I want to appear in court</mat-option>
+              <mat-option [value]="AppearInCourt.N">I do not want to appear in court</mat-option>
+            </mat-select>
+          </mat-form-field>
+        </span>
+        <span class="section-grid-cell">
+          <p class="section-grid-header">Request fine reduction</p>
+          <p class="section-grid-text" *ngIf="!isSSEditMode && !jjDisputedCount">&nbsp;</p>
+          <p class="section-grid-text" *ngIf="!isSSEditMode && jjDisputedCount?.requestReduction === RequestReduction.Y">
+            yes</p>
+          <p class="section-grid-text"
+            *ngIf="!isSSEditMode && jjDisputedCount && jjDisputedCount?.requestReduction !== RequestReduction.Y">
+            no</p>
+          <mat-form-field appearance="outline" *ngIf="jjDisputedCount && isSSEditMode">
+            <mat-select formControlName="requestReduction">
+              <mat-option [value]="RequestReduction.Y">Yes</mat-option>
+              <mat-option [value]="RequestReduction.N">No</mat-option>
+            </mat-select>
+          </mat-form-field>
+        </span>
+        <span class="section-grid-cell">
+          <p class="section-grid-header">Request time to pay</p>
+          <p class="section-grid-text" *ngIf="!isSSEditMode && !jjDisputedCount">&nbsp;</p>
+          <p class="section-grid-text" *ngIf="!isSSEditMode && jjDisputedCount?.requestTimeToPay === RequestTimeToPay.Y">
+            yes</p>
+          <p class="section-grid-text"
+            *ngIf="!isSSEditMode && jjDisputedCount && jjDisputedCount?.requestTimeToPay !== RequestTimeToPay.Y">
+            no</p>
+          <mat-form-field appearance="outline" *ngIf="jjDisputedCount && isSSEditMode">
+            <mat-select formControlName="requestTimeToPay">
+              <mat-option [value]="RequestTimeToPay.Y">Yes</mat-option>
+              <mat-option [value]="RequestTimeToPay.N">No</mat-option>
+            </mat-select>
+          </mat-form-field>
+        </span>
+      </div>
+    </form>
     <hr style="margin: 0 0 0 0" />
   </section>
   <!-- JJ Decision for Written Reasons -->
@@ -262,7 +283,7 @@
     <hr style="margin: 0 0 0 0" />
   </section>
   <!-- JJ RoP for Court Appearance -->
-  <section *ngIf="type !== 'ticket' && jjDisputeInfo.hearingType === HearingType.CourtAppearance"
+  <section *ngIf="type !== 'ticket' && jjDisputeInfo.hearingType === HearingType.CourtAppearance && !isSSEditMode"
     style="padding: 0 0.2rem;">
     <ng-container subHeader>
       <span class="count-text">
@@ -313,7 +334,7 @@
     <br>
     <hr style="margin: 0 0 0 0" />
   </section>
-  <section *ngIf="type === 'ticket' && jjDisputeInfo.hearingType === HearingType.CourtAppearance"
+  <section *ngIf="type === 'ticket' && jjDisputeInfo.hearingType === HearingType.CourtAppearance && !isSSEditMode"
     style="padding: 0 0.2rem;">
     <ng-container subHeader>
       <span class="count-text">
@@ -339,6 +360,27 @@
         <span class="section-grid-header">MVA Section&nbsp;</span>
         <span class="section-jj-grid-text">{{ form.get('jjDisputedCountRoP').get('lesserDescription').value }}</span>
       </div>
+    </div>
+  </section>
+  <section *ngIf="jjDisputeInfo.hearingType === HearingType.CourtAppearance && isSSEditMode">
+    <ng-container subHeader>
+      <span class="count-text">
+        <h3>Findings</h3>
+      </span>
+    </ng-container>
+    <div>
+      <div class="section-grid-header">Finding:</div>
+      <form [formGroup]="countRoPForm">
+        <mat-form-field appearance="outline" *ngIf="jjDisputedCount">
+          <mat-select formControlName="finding">
+            <mat-option [value]="Finding.Guilty">Guilty as charged</mat-option>
+            <mat-option [value]="Finding.GuiltyLesser">Not guilty as charged but guilty of lesser / included other offence</mat-option>
+            <mat-option [value]="Finding.NotGuilty">Not guilty</mat-option>
+            <mat-option [value]="Finding.PaidPriorToAppearance">Paid Prior to Appearance</mat-option>
+            <mat-option [value]="Finding.Cancelled">Cancelled</mat-option>
+          </mat-select>
+        </mat-form-field>
+      </form>
     </div>
   </section>
   <section>

--- a/src/frontend/staff-portal/src/app/components/jj-dispute-info/jj-count/jj-count.component.scss
+++ b/src/frontend/staff-portal/src/app/components/jj-dispute-info/jj-count/jj-count.component.scss
@@ -5,7 +5,7 @@ h3 {
   color: #1d4a77 !important;
 }
 
-::ng-deep .mat-radio-label-content {
+:host::ng-deep .mat-radio-label-content {
   font-size: small !important;
 
   .select-box-only {
@@ -30,6 +30,33 @@ h3 {
 
     .mat-form-field-subscript-wrapper {
       display: none;
+    }
+  }
+}
+
+:host::ng-deep {
+  .mat-form-field-type-mat-select {
+    margin: 0px !important;
+    padding: 0px !important;
+    border: none !important;
+
+    .mat-form-field-wrapper {      
+      .mat-form-field-flex {
+        padding: 10px 0px 0px 10px;
+
+        .mat-form-field-outline {
+          background-color: #ffffff;
+        }
+
+        .mat-form-field-infix {
+          .mat-select-value {
+            line-height: normal;
+          }
+          .mat-select-arrow-wrapper {
+            transform: none;
+          }
+        }
+      }
     }
   }
 }
@@ -150,6 +177,11 @@ p {
   border: 1px black;
   margin-bottom: 12%;
 
+  section {
+    padding-left: 10px;
+    padding-right: 10px;
+  }
+
   .contact-info {
 
     // margin-bottom: 60px;
@@ -216,7 +248,7 @@ p {
   }
 }
 
-::ng-deep .mat-tooltip {
+:host::ng-deep .mat-tooltip {
   /* your own custom styles here */ 
   /* e.g. */
   color: black !important;

--- a/src/frontend/staff-portal/src/app/components/jj-dispute-info/jj-count/jj-count.component.ts
+++ b/src/frontend/staff-portal/src/app/components/jj-dispute-info/jj-count/jj-count.component.ts
@@ -16,6 +16,7 @@ export class JJCountComponent implements OnInit {
   @Input() count: number;
   @Input() type: string;
   @Input() isViewOnly: boolean = false;
+  @Input() isSSEditMode: boolean = false;
   @Input() jjDisputedCount: JJDisputedCount;
   @Output() jjDisputedCountUpdate: EventEmitter<JJDisputedCount> = new EventEmitter<JJDisputedCount>();
 
@@ -37,6 +38,14 @@ export class JJCountComponent implements OnInit {
   // Variables
   todayDate: Date = new Date();
   form: FormGroup;
+  countForm: FormGroup = this.formBuilder.group({
+    appearInCourt: [null],
+    requestReduction: [null],
+    requestTimeToPay: [null]
+  });
+  countRoPForm: FormGroup = this.formBuilder.group({
+    finding: [null]
+  });
   timeToPay: string = "";
   fineReduction: string = "";
   inclSurcharge: string = "";
@@ -200,6 +209,18 @@ export class JJCountComponent implements OnInit {
         this.jjDisputedCount.includesSurcharge = (this.inclSurcharge === "yes" ? this.IncludesSurcharge.Y : this.IncludesSurcharge.N);
         this.jjDisputedCountUpdate.emit(this.jjDisputedCount);
       });
+
+      this.countForm.patchValue(this.jjDisputedCount);
+      this.countForm.valueChanges.subscribe(() => {
+        this.jjDisputedCount = { ...this.jjDisputedCount, ...this.countForm.value };
+        this.jjDisputedCountUpdate.emit(this.jjDisputedCount);
+      });
+      this.countRoPForm.patchValue(this.jjDisputedCount.jjDisputedCountRoP);
+      this.countRoPForm.valueChanges.subscribe(() => {
+        this.jjDisputedCount.jjDisputedCountRoP = { ...this.jjDisputedCount.jjDisputedCountRoP, ...this.countRoPForm.value };
+        this.jjDisputedCountUpdate.emit(this.jjDisputedCount);
+      });
+      
     }
   }
 

--- a/src/frontend/staff-portal/src/app/components/jj-dispute-info/jj-dispute/jj-dispute.component.html
+++ b/src/frontend/staff-portal/src/app/components/jj-dispute-info/jj-dispute/jj-dispute.component.html
@@ -127,7 +127,7 @@
               </span>
             </ng-container>
           </div>
-          <button mat-raised-button *ngIf="isSupportStaff && !isTIEditMode" (click)="isTIEditMode=true" class="form-button" [disabled]="isCIEditMode || isCOEditMode">Edit</button>
+          <button mat-raised-button *ngIf="isSupportStaff && !isTIEditMode" (click)="isTIEditMode=true" class="form-button" [disabled]="isCIEditMode || isCOEditMode || isCAEditMode">Edit</button>
           <button mat-raised-button *ngIf="isTIEditMode" (click)="onSaveTicketInformation()" class="form-button" [disabled]="!ticketInformationForm.valid">Save</button>
           <button mat-raised-button *ngIf="isTIEditMode" (click)="onCancelTicketInformation()" class="form-button">Cancel</button>
         </form>
@@ -186,7 +186,7 @@
               <p class="section-grid-text">{{ lastUpdatedJJDispute.emailAddress }}</p>
             </span>
           </div>
-          <button mat-raised-button *ngIf="isSupportStaff && !isCIEditMode && lastUpdatedJJDispute.contactType !== ContactType.Individual" (click)="isCIEditMode=true" class="form-button" [disabled]="isTIEditMode || isCOEditMode">Edit</button>
+          <button mat-raised-button *ngIf="isSupportStaff && !isCIEditMode && lastUpdatedJJDispute.contactType !== ContactType.Individual" (click)="isCIEditMode=true" class="form-button" [disabled]="isTIEditMode || isCOEditMode || isCAEditMode">Edit</button>
           <button mat-raised-button *ngIf="isCIEditMode && lastUpdatedJJDispute.contactType !== ContactType.Individual" (click)="onSaveContactInformation()" class="form-button" [disabled]="!contactInformationForm.valid">Save</button>
           <button mat-raised-button *ngIf="isCIEditMode && lastUpdatedJJDispute.contactType !== ContactType.Individual" (click)="onCancelContactInformation()" class="form-button">Cancel</button>
         </form>
@@ -256,6 +256,8 @@
               </mat-form-field>
             </span>
             <span class="section-grid-cell">
+              <!-- Comment out this field for now as BA thinks it may not be necessary and is not really used. -->
+              <!--                
               <p class="section-grid-header">Disputant Attendance Type</p>
               <p class="section-grid-text" *ngIf="!isCOEditMode">{{ lastUpdatedJJDispute.disputantAttendanceType }}</p>
               <mat-form-field appearance="select-box-only" *ngIf="isCOEditMode">
@@ -268,13 +270,14 @@
                   <mat-option [value]="AttendanceType.VideoConference">{{ "attendanceType.video_conference" | translate }}</mat-option>
                 </mat-select>
               </mat-form-field>
+              -->
             </span>
             <span class="section-grid-cell">
               <p class="section-grid-header">&nbsp;</p>
               <p class="section-grid-text">&nbsp;</p>
             </span>
           </div>
-          <button mat-raised-button *ngIf="isSupportStaff && !isCOEditMode" (click)="isCOEditMode=true" class="form-button" [disabled]="isTIEditMode || isCIEditMode">Edit</button>
+          <button mat-raised-button *ngIf="isSupportStaff && !isCOEditMode" (click)="isCOEditMode=true" class="form-button" [disabled]="isTIEditMode || isCIEditMode || isCAEditMode">Edit</button>
           <button mat-raised-button *ngIf="isCOEditMode" (click)="onSaveCourtOptions()" class="form-button" [disabled]="!courtOptionsForm.valid">Save</button>
           <button mat-raised-button *ngIf="isCOEditMode" (click)="onCancelCourtOptions()" class="form-button">Cancel</button>
         </form>
@@ -307,65 +310,74 @@
             <span class="section-grid-cell">
               <p class="section-grid-header">APP (P/N/A)</p>
               <p class="section-grid-text">
-                <mat-select *ngIf="!isViewOnly" formControlName="appCd" style="background:#fffee6"
-                  (selectionChange)="onUpdateAPPCd()">
-                  <mat-option [value]="RoPApp.P">{{ RoPApp.P }}</mat-option>
-                  <mat-option [value]="RoPApp.N">{{ RoPApp.N }}</mat-option>
-                  <mat-option [value]="RoPApp.A">{{ RoPApp.A }}</mat-option>
-                </mat-select>
-                <span *ngIf="isViewOnly">{{ courtAppearanceForm?.value.appCd }}</span>
+                <span *ngIf="isViewOnly && !isCAEditMode">{{ courtAppearanceForm?.value.appCd }}</span>
+                <mat-form-field appearance="select-box-only" *ngIf="!isViewOnly || isCAEditMode">
+                  <mat-select formControlName="appCd" (selectionChange)="onUpdateAPPCd()">
+                    <mat-option [value]="RoPApp.P">{{ RoPApp.P }}</mat-option>
+                    <mat-option [value]="RoPApp.N">{{ RoPApp.N }}</mat-option>
+                    <mat-option [value]="RoPApp.A">{{ RoPApp.A }}</mat-option>
+                  </mat-select>
+                </mat-form-field>
               </p>
             </span>
             <span class="section-grid-cell">
               <p class="section-grid-header">No APP</p>
               <p class="section-grid-text" style="padding-right: 5px !important;">
-                <span *ngIf="isViewOnly || !isNoAppEnabled">
-                  {{ courtAppearanceForm?.value.noAppTs | date: "MM/dd/YYYY HH:mm" : "UTC" }}
+                <span *ngIf="((isViewOnly && !isSSEditMode) || !isNoAppEnabled) && courtAppearanceForm.value.noAppTs">
+                  {{ courtAppearanceForm?.value.noAppTs | date: "yyyy-MM-dd HH:mm" : "UTC" }} UTC
                 </span>
-                <span *ngIf="!isViewOnly && isNoAppEnabled">
-                  <button type="button" style="background:#fffee6; width: 136px;" (click)="picker.open()">
-                    {{ courtAppearanceForm?.value.noAppTs | date: "MM/dd/YYYY HH:mm" : "UTC" }}
-                  </button>
-                  <input [ngxMatDatetimePicker]="picker" formControlName="_noAppTs" style="width: 0;"
-                    (ngModelChange)="updateNoAppDateTime($event)" />
-                  <ngx-mat-datetime-picker #picker></ngx-mat-datetime-picker>
-                  &nbsp;<button type="button" style="background:#fffee6" (click)="updateNoAppTsToNow()">Now</button>
+                <span *ngIf="(!isViewOnly || isSSEditMode) && isNoAppEnabled">
+                  <mat-form-field appearance="outline" class="datetime-picker">
+                    <mat-hint>mm/dd/yyyy, hh:mm</mat-hint>
+                    <mat-datetimepicker-toggle [for]="datetimePicker" matSuffix></mat-datetimepicker-toggle>
+                    <mat-datetimepicker #datetimePicker type="datetime" openOnFocus="true" timeInterval="5"> </mat-datetimepicker>
+                    <input matInput formControlName="noAppTs" [matDatetimepicker]="datetimePicker" autocomplete="false" />
+                  </mat-form-field>
+                  <button mat-raised-button class="form-button-secondary" (click)="updateNoAppTsToNow()">Now</button>
                 </span>
               </p>
             </span>
             <span class="section-grid-cell">
               <p class="section-grid-header">CLERK REC.</p>
               <p class="section-grid-text">
-                <input *ngIf="!isViewOnly" formControlName="clerkRecord" style="width:75px; background:#fffee6" />
-                <span *ngIf="isViewOnly">{{ courtAppearanceForm?.value.clerkRecord }}</span>
+                <span *ngIf="(isViewOnly && !isCAEditMode)">{{ courtAppearanceForm?.value.clerkRecord }}</span>
+                <mat-form-field appearance="outline" *ngIf="(!isViewOnly || isCAEditMode)">
+                  <input matInput formControlName="clerkRecord" maxlength="30">
+                  <mat-error *ngIf="courtAppearanceForm.controls.clerkRecord.hasError('maxlength')">{{ "error.max_length" | translate }}100</mat-error>
+                </mat-form-field>
               </p>
             </span>
             <span class="section-grid-cell">
               <p class="section-grid-header">DEF. COUNSEL</p>
               <p class="section-grid-text">
-                <input *ngIf="!isViewOnly" formControlName="defenceCounsel" style="width:75px; background:#fffee6" />
-                <span *ngIf="isViewOnly">{{ courtAppearanceForm?.value.defenceCounsel }}</span>
+                <span *ngIf="(isViewOnly && !isCAEditMode)">{{ courtAppearanceForm?.value.defenceCounsel }}</span>
+                <mat-form-field appearance="outline" *ngIf="(!isViewOnly || isCAEditMode)">
+                  <input matInput formControlName="defenceCounsel" maxlength="30">
+                  <mat-error *ngIf="courtAppearanceForm.controls.defenceCounsel.hasError('maxlength')">{{ "error.max_length" | translate }}100</mat-error>
+                </mat-form-field>
               </p>
             </span>
             <span class="section-grid-cell">
               <p class="section-grid-header">Def Att</p>
               <p class="section-grid-text">
+                <span *ngIf="isViewOnly">{{ courtAppearanceForm?.value.dattCd }}</span>
                 <mat-select *ngIf="!isViewOnly" formControlName="dattCd" style="background:#fffee6">
                   <mat-option [value]="RoPDatt.A">{{ RoPDatt.A }}</mat-option>
                   <mat-option [value]="RoPDatt.C">{{ RoPDatt.C }}</mat-option>
                   <mat-option [value]="RoPDatt.N">{{ RoPDatt.N }}</mat-option>
                 </mat-select>
-                <span *ngIf="isViewOnly">{{ courtAppearanceForm?.value.dattCd }}</span>
               </p>
             </span>
             <span class="section-grid-cell">
               <p class="section-grid-header">Crown</p>
               <p class="section-grid-text">
-                <mat-select *ngIf="!isViewOnly" formControlName="crown" style="background:#fffee6">
-                  <mat-option [value]="RoPCrown.P">{{ RoPCrown.P }}</mat-option>
-                  <mat-option [value]="RoPCrown.N">{{ RoPCrown.N }}</mat-option>
-                </mat-select>
-                <span *ngIf="isViewOnly">{{ courtAppearanceForm?.value.crown }}</span>
+                <span *ngIf="isViewOnly && !isCAEditMode">{{ courtAppearanceForm?.value.crown }}</span>
+                <mat-form-field appearance="select-box-only" *ngIf="!isViewOnly || isCAEditMode">
+                  <mat-select formControlName="crown">
+                    <mat-option [value]="RoPCrown.P">{{ RoPCrown.P }}</mat-option>
+                    <mat-option [value]="RoPCrown.N">{{ RoPCrown.N }}</mat-option>
+                  </mat-select>
+                </mat-form-field>
               </p>
             </span>
             <span class="section-grid-cell">
@@ -393,6 +405,9 @@
               </p>
             </span>
           </div>
+          <button mat-raised-button *ngIf="isSupportStaff && !isCAEditMode" (click)="isCAEditMode=true" class="form-button" [disabled]="isTIEditMode || isCIEditMode || isCOEditMode">Edit</button>
+          <button mat-raised-button *ngIf="isCAEditMode" (click)="onSaveCourtAppearance()" class="form-button" [disabled]="!courtAppearanceForm.valid">Save</button>
+          <button mat-raised-button *ngIf="isCAEditMode" (click)="onCancelCourtAppearance()" class="form-button">Cancel</button>
         </form>
       </section><br />
       <section *ngIf="jjDisputeInfo.hearingType === HearingType.CourtAppearance">

--- a/src/frontend/staff-portal/src/app/components/jj-dispute-info/jj-dispute/jj-dispute.component.html
+++ b/src/frontend/staff-portal/src/app/components/jj-dispute-info/jj-dispute/jj-dispute.component.html
@@ -6,7 +6,11 @@
           <mat-icon inline="true">arrow_back</mat-icon> Back
         </button>
       </div>
-      <div>
+      <div>        
+        <button mat-raised-button *ngIf="isSupportStaff && !isSSEditMode" (click)="isSSEditMode=true" class="form-button">Edit</button>
+        <button mat-raised-button *ngIf="isSSEditMode" (click)="onSupportStaffSave()" class="form-button" [disabled]="!ticketInformationForm.valid">Save</button>
+        <button mat-raised-button *ngIf="isSSEditMode" (click)="onSupportStaffCancel()" class="form-button">Cancel</button>
+
         <button mat-raised-button [matMenuTriggerFor]="gotoMenu">Go to</button>
         <mat-menu #gotoMenu="matMenu" yPosition="below">
           <button mat-menu-item (click)="goTo('disputeDetails')">Dispute Details</button>
@@ -67,27 +71,27 @@
           <div style="display: grid; grid-template-columns: auto auto auto auto">
             <span class="section-grid-cell">
               <p class="section-grid-header">Surname</p>
-              <p class="section-grid-text" *ngIf="!isTIEditMode">{{ lastUpdatedJJDispute.occamDisputantSurnameNm }}</p>
-              <mat-form-field appearance="outline" *ngIf="isTIEditMode">
+              <p class="section-grid-text" *ngIf="!isSSEditMode">{{ lastUpdatedJJDispute.occamDisputantSurnameNm }}</p>
+              <mat-form-field appearance="outline" *ngIf="isSSEditMode">
                 <input matInput formControlName="occamDisputantSurnameNm">
                 <mat-error *ngIf="ticketInformationForm.controls.occamDisputantSurnameNm.hasError('maxlength')">{{ "error.max_length" | translate }}30</mat-error>
               </mat-form-field>
             </span>
             <span class="section-grid-cell">
-              <p class="section-grid-header" *ngIf="!isTIEditMode">Given Name(s)</p>
-              <p class="section-grid-text" *ngIf="!isTIEditMode">{{ lastUpdatedJJDispute.occamDisputantGivenNames }}</p>
-              <p class="section-grid-header" *ngIf="isTIEditMode">Given Name 1</p>
-              <mat-form-field appearance="outline" *ngIf="isTIEditMode">
+              <p class="section-grid-header" *ngIf="!isSSEditMode">Given Name(s)</p>
+              <p class="section-grid-text" *ngIf="!isSSEditMode">{{ lastUpdatedJJDispute.occamDisputantGivenNames }}</p>
+              <p class="section-grid-header" *ngIf="isSSEditMode">Given Name 1</p>
+              <mat-form-field appearance="outline" *ngIf="isSSEditMode">
                 <input matInput formControlName="occamDisputantGiven1Nm">
                 <mat-error *ngIf="ticketInformationForm.controls.occamDisputantGiven1Nm.hasError('maxlength')">{{ "error.max_length" | translate }}30</mat-error>
               </mat-form-field>
-              <p class="section-grid-header" *ngIf="isTIEditMode">Given Name 2</p>
-              <mat-form-field appearance="outline" *ngIf="isTIEditMode">
+              <p class="section-grid-header" *ngIf="isSSEditMode">Given Name 2</p>
+              <mat-form-field appearance="outline" *ngIf="isSSEditMode">
                 <input matInput formControlName="occamDisputantGiven2Nm">
                 <mat-error *ngIf="ticketInformationForm.controls.occamDisputantGiven2Nm.hasError('maxlength')">{{ "error.max_length" | translate }}30</mat-error>
               </mat-form-field>
-              <p class="section-grid-header" *ngIf="isTIEditMode">Given Name 3</p>
-              <mat-form-field appearance="outline" *ngIf="isTIEditMode">
+              <p class="section-grid-header" *ngIf="isSSEditMode">Given Name 3</p>
+              <mat-form-field appearance="outline" *ngIf="isSSEditMode">
                 <input matInput formControlName="occamDisputantGiven3Nm">
                 <mat-error *ngIf="ticketInformationForm.controls.occamDisputantGiven3Nm.hasError('maxlength')">{{ "error.max_length" | translate }}30</mat-error>
               </mat-form-field>
@@ -127,9 +131,6 @@
               </span>
             </ng-container>
           </div>
-          <button mat-raised-button *ngIf="isSupportStaff && !isTIEditMode" (click)="isTIEditMode=true" class="form-button" [disabled]="isCIEditMode || isCOEditMode || isCAEditMode">Edit</button>
-          <button mat-raised-button *ngIf="isTIEditMode" (click)="onSaveTicketInformation()" class="form-button" [disabled]="!ticketInformationForm.valid">Save</button>
-          <button mat-raised-button *ngIf="isTIEditMode" (click)="onCancelTicketInformation()" class="form-button">Cancel</button>
         </form>
       </section><br />
       <section>
@@ -142,29 +143,29 @@
           <div style="display: grid; grid-template-columns: auto auto auto auto">
             <span class="section-grid-cell">
               <p class="section-grid-header">Surname</p>
-              <p class="section-grid-text" *ngIf="!(isCIEditMode && lastUpdatedJJDispute.contactType !== ContactType.Individual)">{{ lastUpdatedJJDispute.contactType === ContactType.Individual ?
+              <p class="section-grid-text" *ngIf="!(isSSEditMode && lastUpdatedJJDispute.contactType !== ContactType.Individual)">{{ lastUpdatedJJDispute.contactType === ContactType.Individual ?
                 lastUpdatedJJDispute.occamDisputantSurnameNm : lastUpdatedJJDispute.contactSurname }}</p>
-              <mat-form-field appearance="outline" *ngIf="(isCIEditMode && lastUpdatedJJDispute.contactType !== ContactType.Individual)">
+              <mat-form-field appearance="outline" *ngIf="(isSSEditMode && lastUpdatedJJDispute.contactType !== ContactType.Individual)">
                 <input matInput formControlName="contactSurname">
                 <mat-error *ngIf="contactInformationForm.controls.contactSurname.hasError('maxlength')">{{ "error.max_length" | translate }}30</mat-error>
               </mat-form-field>
             </span>
             <span class="section-grid-cell">
-              <p class="section-grid-header" *ngIf="!(isCIEditMode && lastUpdatedJJDispute.contactType !== ContactType.Individual)">Given Name(s)</p>
-              <p class="section-grid-text" *ngIf="!(isCIEditMode && lastUpdatedJJDispute.contactType !== ContactType.Individual)">{{ lastUpdatedJJDispute.contactType === ContactType.Individual ?
+              <p class="section-grid-header" *ngIf="!(isSSEditMode && lastUpdatedJJDispute.contactType !== ContactType.Individual)">Given Name(s)</p>
+              <p class="section-grid-text" *ngIf="!(isSSEditMode && lastUpdatedJJDispute.contactType !== ContactType.Individual)">{{ lastUpdatedJJDispute.contactType === ContactType.Individual ?
                 lastUpdatedJJDispute.occamDisputantGivenNames : lastUpdatedJJDispute.contactGivenNames }}</p>
-              <p class="section-grid-header" *ngIf="(isCIEditMode && lastUpdatedJJDispute.contactType !== ContactType.Individual)">Given Name 1</p>
-              <mat-form-field appearance="outline" *ngIf="(isCIEditMode && lastUpdatedJJDispute.contactType !== ContactType.Individual)">
+              <p class="section-grid-header" *ngIf="(isSSEditMode && lastUpdatedJJDispute.contactType !== ContactType.Individual)">Given Name 1</p>
+              <mat-form-field appearance="outline" *ngIf="(isSSEditMode && lastUpdatedJJDispute.contactType !== ContactType.Individual)">
                 <input matInput formControlName="contactGivenName1">
                 <mat-error *ngIf="contactInformationForm.controls.contactGivenName1.hasError('maxlength')">{{ "error.max_length" | translate }}30</mat-error>
               </mat-form-field>
-              <p class="section-grid-header" *ngIf="(isCIEditMode && lastUpdatedJJDispute.contactType !== ContactType.Individual)">Given Name 2</p>
-              <mat-form-field appearance="outline" *ngIf="(isCIEditMode && lastUpdatedJJDispute.contactType !== ContactType.Individual)">
+              <p class="section-grid-header" *ngIf="(isSSEditMode && lastUpdatedJJDispute.contactType !== ContactType.Individual)">Given Name 2</p>
+              <mat-form-field appearance="outline" *ngIf="(isSSEditMode && lastUpdatedJJDispute.contactType !== ContactType.Individual)">
                 <input matInput formControlName="contactGivenName2">
                 <mat-error *ngIf="contactInformationForm.controls.contactGivenName2.hasError('maxlength')">{{ "error.max_length" | translate }}30</mat-error>
               </mat-form-field>
-              <p class="section-grid-header" *ngIf="(isCIEditMode && lastUpdatedJJDispute.contactType !== ContactType.Individual)">Given Name 3</p>
-              <mat-form-field appearance="outline" *ngIf="(isCIEditMode && lastUpdatedJJDispute.contactType !== ContactType.Individual)">
+              <p class="section-grid-header" *ngIf="(isSSEditMode && lastUpdatedJJDispute.contactType !== ContactType.Individual)">Given Name 3</p>
+              <mat-form-field appearance="outline" *ngIf="(isSSEditMode && lastUpdatedJJDispute.contactType !== ContactType.Individual)">
                 <input matInput formControlName="contactGivenName3">
                 <mat-error *ngIf="contactInformationForm.controls.contactGivenName3.hasError('maxlength')">{{ "error.max_length" | translate }}30</mat-error>
               </mat-form-field>
@@ -186,9 +187,6 @@
               <p class="section-grid-text">{{ lastUpdatedJJDispute.emailAddress }}</p>
             </span>
           </div>
-          <button mat-raised-button *ngIf="isSupportStaff && !isCIEditMode && lastUpdatedJJDispute.contactType !== ContactType.Individual" (click)="isCIEditMode=true" class="form-button" [disabled]="isTIEditMode || isCOEditMode || isCAEditMode">Edit</button>
-          <button mat-raised-button *ngIf="isCIEditMode && lastUpdatedJJDispute.contactType !== ContactType.Individual" (click)="onSaveContactInformation()" class="form-button" [disabled]="!contactInformationForm.valid">Save</button>
-          <button mat-raised-button *ngIf="isCIEditMode && lastUpdatedJJDispute.contactType !== ContactType.Individual" (click)="onCancelContactInformation()" class="form-button">Cancel</button>
         </form>
       </section><br />
       <section *ngIf="jjDisputeInfo.hearingType === HearingType.CourtAppearance">
@@ -200,46 +198,46 @@
         <form [formGroup]="courtOptionsForm">
           <div style="display: grid; grid-template-columns: auto auto auto">
             <span class="section-grid-cell">
-              <p class="section-grid-header" *ngIf="!isCOEditMode">Legal Counsel Name</p>
-              <p class="section-grid-text" *ngIf="!isCOEditMode">
+              <p class="section-grid-header" *ngIf="!isSSEditMode">Legal Counsel Name</p>
+              <p class="section-grid-text" *ngIf="!isSSEditMode">
                 {{ lastUpdatedJJDispute.lawyerGivenName1 }}
                 {{ lastUpdatedJJDispute.lawyerGivenName2 }}
                 {{ lastUpdatedJJDispute.lawyerGivenName3 }}
                 {{ lastUpdatedJJDispute.lawyerSurname }}
               </p>
-              <p class="section-grid-header" *ngIf="isCOEditMode">Legal Counsel Given Name 1</p>
-              <mat-form-field appearance="outline" *ngIf="isCOEditMode">
+              <p class="section-grid-header" *ngIf="isSSEditMode">Legal Counsel Given Name 1</p>
+              <mat-form-field appearance="outline" *ngIf="isSSEditMode">
                 <input matInput formControlName="lawyerGivenName1">
                 <mat-error *ngIf="courtOptionsForm.controls.lawyerGivenName1.hasError('maxlength')">{{ "error.max_length" | translate }}30</mat-error>
               </mat-form-field>
-              <p class="section-grid-header" *ngIf="isCOEditMode">Legal Counsel Given Name 2</p>
-              <mat-form-field appearance="outline" *ngIf="isCOEditMode">
+              <p class="section-grid-header" *ngIf="isSSEditMode">Legal Counsel Given Name 2</p>
+              <mat-form-field appearance="outline" *ngIf="isSSEditMode">
                 <input matInput formControlName="lawyerGivenName2">
                 <mat-error *ngIf="courtOptionsForm.controls.lawyerGivenName2.hasError('maxlength')">{{ "error.max_length" | translate }}30</mat-error>
               </mat-form-field>
-              <p class="section-grid-header" *ngIf="isCOEditMode">Legal Counsel Given Name 3</p>
-              <mat-form-field appearance="outline" *ngIf="isCOEditMode">
+              <p class="section-grid-header" *ngIf="isSSEditMode">Legal Counsel Given Name 3</p>
+              <mat-form-field appearance="outline" *ngIf="isSSEditMode">
                 <input matInput formControlName="lawyerGivenName3">
                 <mat-error *ngIf="courtOptionsForm.controls.lawyerGivenName3.hasError('maxlength')">{{ "error.max_length" | translate }}30</mat-error>
               </mat-form-field>
-              <p class="section-grid-header" *ngIf="isCOEditMode">Legal Counsel Surname</p>
-              <mat-form-field appearance="outline" *ngIf="isCOEditMode">
+              <p class="section-grid-header" *ngIf="isSSEditMode">Legal Counsel Surname</p>
+              <mat-form-field appearance="outline" *ngIf="isSSEditMode">
                 <input matInput formControlName="lawyerSurname">
                 <mat-error *ngIf="courtOptionsForm.controls.lawyerSurname.hasError('maxlength')">{{ "error.max_length" | translate }}30</mat-error>
               </mat-form-field>
             </span>
             <span class="section-grid-cell">
               <p class="section-grid-header">Legal Counsel Firm</p>
-              <p class="section-grid-text" *ngIf="!isCOEditMode">{{ lastUpdatedJJDispute.lawFirmName }}</p>
-              <mat-form-field appearance="outline" *ngIf="isCOEditMode">
+              <p class="section-grid-text" *ngIf="!isSSEditMode">{{ lastUpdatedJJDispute.lawFirmName }}</p>
+              <mat-form-field appearance="outline" *ngIf="isSSEditMode">
                 <input matInput formControlName="lawFirmName">
                 <mat-error *ngIf="courtOptionsForm.controls.lawFirmName.hasError('maxlength')">{{ "error.max_length" | translate }}200</mat-error>
               </mat-form-field>
             </span>
             <span class="section-grid-cell">
               <p class="section-grid-header">Defence Witnesses</p>
-              <p class="section-grid-text" *ngIf="!isCOEditMode">{{ lastUpdatedJJDispute.witnessNo }}</p>
-              <mat-form-field appearance="outline" *ngIf="isCOEditMode">
+              <p class="section-grid-text" *ngIf="!isSSEditMode">{{ lastUpdatedJJDispute.witnessNo }}</p>
+              <mat-form-field appearance="outline" *ngIf="isSSEditMode">
                 <input matInput formControlName="witnessNo" maxlength="10" type="number">
                 <mat-error *ngIf="courtOptionsForm.controls.witnessNo.hasError('min')">{{ "error.min_value" | translate }}0</mat-error>
                 <mat-error *ngIf="courtOptionsForm.controls.witnessNo.hasError('max')">{{ "error.max_value" | translate }}2147483647</mat-error>
@@ -247,8 +245,8 @@
             </span>
             <span class="section-grid-cell">
               <p class="section-grid-header">Interpreter</p>
-              <p class="section-grid-text" *ngIf="!isCOEditMode">{{ lastUpdatedJJDispute.interpreterLanguage }}</p>
-              <mat-form-field appearance="select-box-only" *ngIf="isCOEditMode">
+              <p class="section-grid-text" *ngIf="!isSSEditMode">{{ lastUpdatedJJDispute.interpreterLanguage }}</p>
+              <mat-form-field appearance="select-box-only" *ngIf="isSSEditMode">
                 <mat-select formControlName="interpreterLanguageCd" placeholder="Language">
                   <mat-option [value]=""></mat-option>
                   <mat-option *ngFor="let lang of languages" [value]="lang.code">{{ lang.description }}</mat-option>
@@ -259,8 +257,8 @@
               <!-- Comment out this field for now as BA thinks it may not be necessary and is not really used. -->
               <!--                
               <p class="section-grid-header">Disputant Attendance Type</p>
-              <p class="section-grid-text" *ngIf="!isCOEditMode">{{ lastUpdatedJJDispute.disputantAttendanceType }}</p>
-              <mat-form-field appearance="select-box-only" *ngIf="isCOEditMode">
+              <p class="section-grid-text" *ngIf="!isSSEditMode">{{ lastUpdatedJJDispute.disputantAttendanceType }}</p>
+              <mat-form-field appearance="select-box-only" *ngIf="isSSEditMode">
                 <mat-select formControlName="disputantAttendanceType" placeholder="Attendance">
                   <mat-option [value]="AttendanceType.InPerson">{{ "attendanceType.in_person" | translate }}</mat-option>
                   <mat-option [value]="AttendanceType.MsteamsAudio">{{ "attendanceType.msteams_audio" | translate }}</mat-option>
@@ -277,9 +275,6 @@
               <p class="section-grid-text">&nbsp;</p>
             </span>
           </div>
-          <button mat-raised-button *ngIf="isSupportStaff && !isCOEditMode" (click)="isCOEditMode=true" class="form-button" [disabled]="isTIEditMode || isCIEditMode || isCAEditMode">Edit</button>
-          <button mat-raised-button *ngIf="isCOEditMode" (click)="onSaveCourtOptions()" class="form-button" [disabled]="!courtOptionsForm.valid">Save</button>
-          <button mat-raised-button *ngIf="isCOEditMode" (click)="onCancelCourtOptions()" class="form-button">Cancel</button>
         </form>
       </section><br />
       <section *ngIf="jjDisputeInfo.hearingType === HearingType.CourtAppearance">
@@ -310,8 +305,8 @@
             <span class="section-grid-cell">
               <p class="section-grid-header">APP (P/N/A)</p>
               <p class="section-grid-text">
-                <span *ngIf="isViewOnly && !isCAEditMode">{{ courtAppearanceForm?.value.appCd }}</span>
-                <mat-form-field appearance="select-box-only" *ngIf="!isViewOnly || isCAEditMode">
+                <span *ngIf="isViewOnly && !isSSEditMode">{{ courtAppearanceForm?.value.appCd }}</span>
+                <mat-form-field appearance="select-box-only" *ngIf="!isViewOnly || isSSEditMode">
                   <mat-select formControlName="appCd" (selectionChange)="onUpdateAPPCd()">
                     <mat-option [value]="RoPApp.P">{{ RoPApp.P }}</mat-option>
                     <mat-option [value]="RoPApp.N">{{ RoPApp.N }}</mat-option>
@@ -340,8 +335,8 @@
             <span class="section-grid-cell">
               <p class="section-grid-header">CLERK REC.</p>
               <p class="section-grid-text">
-                <span *ngIf="(isViewOnly && !isCAEditMode)">{{ courtAppearanceForm?.value.clerkRecord }}</span>
-                <mat-form-field appearance="outline" *ngIf="(!isViewOnly || isCAEditMode)">
+                <span *ngIf="(isViewOnly && !isSSEditMode)">{{ courtAppearanceForm?.value.clerkRecord }}</span>
+                <mat-form-field appearance="outline" *ngIf="(!isViewOnly || isSSEditMode)">
                   <input matInput formControlName="clerkRecord" maxlength="30">
                   <mat-error *ngIf="courtAppearanceForm.controls.clerkRecord.hasError('maxlength')">{{ "error.max_length" | translate }}100</mat-error>
                 </mat-form-field>
@@ -350,8 +345,8 @@
             <span class="section-grid-cell">
               <p class="section-grid-header">DEF. COUNSEL</p>
               <p class="section-grid-text">
-                <span *ngIf="(isViewOnly && !isCAEditMode)">{{ courtAppearanceForm?.value.defenceCounsel }}</span>
-                <mat-form-field appearance="outline" *ngIf="(!isViewOnly || isCAEditMode)">
+                <span *ngIf="(isViewOnly && !isSSEditMode)">{{ courtAppearanceForm?.value.defenceCounsel }}</span>
+                <mat-form-field appearance="outline" *ngIf="(!isViewOnly || isSSEditMode)">
                   <input matInput formControlName="defenceCounsel" maxlength="30">
                   <mat-error *ngIf="courtAppearanceForm.controls.defenceCounsel.hasError('maxlength')">{{ "error.max_length" | translate }}100</mat-error>
                 </mat-form-field>
@@ -371,8 +366,8 @@
             <span class="section-grid-cell">
               <p class="section-grid-header">Crown</p>
               <p class="section-grid-text">
-                <span *ngIf="isViewOnly && !isCAEditMode">{{ courtAppearanceForm?.value.crown }}</span>
-                <mat-form-field appearance="select-box-only" *ngIf="!isViewOnly || isCAEditMode">
+                <span *ngIf="isViewOnly && !isSSEditMode">{{ courtAppearanceForm?.value.crown }}</span>
+                <mat-form-field appearance="select-box-only" *ngIf="!isViewOnly || isSSEditMode">
                   <mat-select formControlName="crown">
                     <mat-option [value]="RoPCrown.P">{{ RoPCrown.P }}</mat-option>
                     <mat-option [value]="RoPCrown.N">{{ RoPCrown.N }}</mat-option>
@@ -405,9 +400,6 @@
               </p>
             </span>
           </div>
-          <button mat-raised-button *ngIf="isSupportStaff && !isCAEditMode" (click)="isCAEditMode=true" class="form-button" [disabled]="isTIEditMode || isCIEditMode || isCOEditMode">Edit</button>
-          <button mat-raised-button *ngIf="isCAEditMode" (click)="onSaveCourtAppearance()" class="form-button" [disabled]="!courtAppearanceForm.valid">Save</button>
-          <button mat-raised-button *ngIf="isCAEditMode" (click)="onCancelCourtAppearance()" class="form-button">Cancel</button>
         </form>
       </section><br />
       <section *ngIf="jjDisputeInfo.hearingType === HearingType.CourtAppearance">

--- a/src/frontend/staff-portal/src/app/components/jj-dispute-info/jj-dispute/jj-dispute.component.html
+++ b/src/frontend/staff-portal/src/app/components/jj-dispute-info/jj-dispute/jj-dispute.component.html
@@ -440,7 +440,7 @@
         <div style="display: grid; grid-template-columns: 33% 33% 33%">
           <span *ngFor="let i of [1,2,3]" style="border:1px solid black; ">
             <app-jj-count [count]="i" [jjDisputeInfo]="lastUpdatedJJDispute" [jjDisputedCount]="getJJDisputedCount(i)"
-              (jjDisputedCountUpdate)="updateFinalDispositionCount($event)" [type]="type" [isViewOnly]="isViewOnly">
+              (jjDisputedCountUpdate)="updateFinalDispositionCount($event)" [type]="type" [isViewOnly]="isViewOnly" [isSSEditMode]="isSSEditMode">
             </app-jj-count>
           </span>
         </div>

--- a/src/frontend/staff-portal/src/app/components/jj-dispute-info/jj-dispute/jj-dispute.component.html
+++ b/src/frontend/staff-portal/src/app/components/jj-dispute-info/jj-dispute/jj-dispute.component.html
@@ -7,9 +7,9 @@
         </button>
       </div>
       <div>        
-        <button mat-raised-button *ngIf="isSupportStaff && !isSSEditMode" (click)="isSSEditMode=true" class="form-button">Edit</button>
-        <button mat-raised-button *ngIf="isSSEditMode" (click)="onSupportStaffSave()" class="form-button" [disabled]="!ticketInformationForm.valid">Save</button>
-        <button mat-raised-button *ngIf="isSSEditMode" (click)="onSupportStaffCancel()" class="form-button">Cancel</button>
+        <button mat-raised-button *ngIf="isSupportStaff && !isSSEditMode" (click)="isSSEditMode=true" class="form-button">{{ "common.button.edit" | translate }}</button>
+        <button mat-raised-button *ngIf="isSSEditMode" (click)="onSupportStaffSave()" class="form-button" [disabled]="!ticketInformationForm.valid">{{ "common.button.save" | translate }}</button>
+        <button mat-raised-button *ngIf="isSSEditMode" (click)="onSupportStaffCancel()" class="form-button">{{ "common.button.cancel" | translate }}</button>
 
         <button mat-raised-button [matMenuTriggerFor]="gotoMenu">Go to</button>
         <mat-menu #gotoMenu="matMenu" yPosition="below">
@@ -70,7 +70,7 @@
         <form [formGroup]="ticketInformationForm">
           <div style="display: grid; grid-template-columns: auto auto auto auto">
             <span class="section-grid-cell">
-              <p class="section-grid-header">Surname</p>
+              <p class="section-grid-header">{{ "label.surname" | translate }}</p>
               <p class="section-grid-text" *ngIf="!isSSEditMode">{{ lastUpdatedJJDispute.occamDisputantSurnameNm }}</p>
               <mat-form-field appearance="outline" *ngIf="isSSEditMode">
                 <input matInput formControlName="occamDisputantSurnameNm">
@@ -78,19 +78,19 @@
               </mat-form-field>
             </span>
             <span class="section-grid-cell">
-              <p class="section-grid-header" *ngIf="!isSSEditMode">Given Name(s)</p>
+              <p class="section-grid-header" *ngIf="!isSSEditMode">{{ "label.given_names" | translate }}</p>
               <p class="section-grid-text" *ngIf="!isSSEditMode">{{ lastUpdatedJJDispute.occamDisputantGivenNames }}</p>
-              <p class="section-grid-header" *ngIf="isSSEditMode">Given Name 1</p>
+              <p class="section-grid-header" *ngIf="isSSEditMode">{{ "label.given_name_1" | translate }}</p>
               <mat-form-field appearance="outline" *ngIf="isSSEditMode">
                 <input matInput formControlName="occamDisputantGiven1Nm">
                 <mat-error *ngIf="ticketInformationForm.controls.occamDisputantGiven1Nm.hasError('maxlength')">{{ "error.max_length" | translate }}30</mat-error>
               </mat-form-field>
-              <p class="section-grid-header" *ngIf="isSSEditMode">Given Name 2</p>
+              <p class="section-grid-header" *ngIf="isSSEditMode">{{ "label.given_name_2" | translate }}</p>
               <mat-form-field appearance="outline" *ngIf="isSSEditMode">
                 <input matInput formControlName="occamDisputantGiven2Nm">
                 <mat-error *ngIf="ticketInformationForm.controls.occamDisputantGiven2Nm.hasError('maxlength')">{{ "error.max_length" | translate }}30</mat-error>
               </mat-form-field>
-              <p class="section-grid-header" *ngIf="isSSEditMode">Given Name 3</p>
+              <p class="section-grid-header" *ngIf="isSSEditMode">{{ "label.given_name_3" | translate }}</p>
               <mat-form-field appearance="outline" *ngIf="isSSEditMode">
                 <input matInput formControlName="occamDisputantGiven3Nm">
                 <mat-error *ngIf="ticketInformationForm.controls.occamDisputantGiven3Nm.hasError('maxlength')">{{ "error.max_length" | translate }}30</mat-error>
@@ -142,7 +142,7 @@
         <form [formGroup]="contactInformationForm">
           <div style="display: grid; grid-template-columns: auto auto auto auto">
             <span class="section-grid-cell">
-              <p class="section-grid-header">Surname</p>
+              <p class="section-grid-header">{{ "label.surname" | translate }}</p>
               <p class="section-grid-text" *ngIf="!(isSSEditMode && lastUpdatedJJDispute.contactType !== ContactType.Individual)">{{ lastUpdatedJJDispute.contactType === ContactType.Individual ?
                 lastUpdatedJJDispute.occamDisputantSurnameNm : lastUpdatedJJDispute.contactSurname }}</p>
               <mat-form-field appearance="outline" *ngIf="(isSSEditMode && lastUpdatedJJDispute.contactType !== ContactType.Individual)">
@@ -151,20 +151,20 @@
               </mat-form-field>
             </span>
             <span class="section-grid-cell">
-              <p class="section-grid-header" *ngIf="!(isSSEditMode && lastUpdatedJJDispute.contactType !== ContactType.Individual)">Given Name(s)</p>
+              <p class="section-grid-header" *ngIf="!(isSSEditMode && lastUpdatedJJDispute.contactType !== ContactType.Individual)">{{ "label.given_names" | translate }}</p>
               <p class="section-grid-text" *ngIf="!(isSSEditMode && lastUpdatedJJDispute.contactType !== ContactType.Individual)">{{ lastUpdatedJJDispute.contactType === ContactType.Individual ?
                 lastUpdatedJJDispute.occamDisputantGivenNames : lastUpdatedJJDispute.contactGivenNames }}</p>
-              <p class="section-grid-header" *ngIf="(isSSEditMode && lastUpdatedJJDispute.contactType !== ContactType.Individual)">Given Name 1</p>
+              <p class="section-grid-header" *ngIf="(isSSEditMode && lastUpdatedJJDispute.contactType !== ContactType.Individual)">{{ "label.given_name_1" | translate }}</p>
               <mat-form-field appearance="outline" *ngIf="(isSSEditMode && lastUpdatedJJDispute.contactType !== ContactType.Individual)">
                 <input matInput formControlName="contactGivenName1">
                 <mat-error *ngIf="contactInformationForm.controls.contactGivenName1.hasError('maxlength')">{{ "error.max_length" | translate }}30</mat-error>
               </mat-form-field>
-              <p class="section-grid-header" *ngIf="(isSSEditMode && lastUpdatedJJDispute.contactType !== ContactType.Individual)">Given Name 2</p>
+              <p class="section-grid-header" *ngIf="(isSSEditMode && lastUpdatedJJDispute.contactType !== ContactType.Individual)">{{ "label.given_name_2" | translate }}</p>
               <mat-form-field appearance="outline" *ngIf="(isSSEditMode && lastUpdatedJJDispute.contactType !== ContactType.Individual)">
                 <input matInput formControlName="contactGivenName2">
                 <mat-error *ngIf="contactInformationForm.controls.contactGivenName2.hasError('maxlength')">{{ "error.max_length" | translate }}30</mat-error>
               </mat-form-field>
-              <p class="section-grid-header" *ngIf="(isSSEditMode && lastUpdatedJJDispute.contactType !== ContactType.Individual)">Given Name 3</p>
+              <p class="section-grid-header" *ngIf="(isSSEditMode && lastUpdatedJJDispute.contactType !== ContactType.Individual)">{{ "label.given_name_3" | translate }}</p>
               <mat-form-field appearance="outline" *ngIf="(isSSEditMode && lastUpdatedJJDispute.contactType !== ContactType.Individual)">
                 <input matInput formControlName="contactGivenName3">
                 <mat-error *ngIf="contactInformationForm.controls.contactGivenName3.hasError('maxlength')">{{ "error.max_length" | translate }}30</mat-error>
@@ -198,36 +198,36 @@
         <form [formGroup]="courtOptionsForm">
           <div style="display: grid; grid-template-columns: auto auto auto">
             <span class="section-grid-cell">
-              <p class="section-grid-header" *ngIf="!isSSEditMode">Legal Counsel Name</p>
+              <p class="section-grid-header" *ngIf="!isSSEditMode">{{ "label.legal_counsel_name" | translate }}</p>
               <p class="section-grid-text" *ngIf="!isSSEditMode">
                 {{ lastUpdatedJJDispute.lawyerGivenName1 }}
                 {{ lastUpdatedJJDispute.lawyerGivenName2 }}
                 {{ lastUpdatedJJDispute.lawyerGivenName3 }}
                 {{ lastUpdatedJJDispute.lawyerSurname }}
               </p>
-              <p class="section-grid-header" *ngIf="isSSEditMode">Legal Counsel Given Name 1</p>
+              <p class="section-grid-header" *ngIf="isSSEditMode">{{ "label.legal_counsel_given_name_1" | translate }}</p>
               <mat-form-field appearance="outline" *ngIf="isSSEditMode">
                 <input matInput formControlName="lawyerGivenName1">
                 <mat-error *ngIf="courtOptionsForm.controls.lawyerGivenName1.hasError('maxlength')">{{ "error.max_length" | translate }}30</mat-error>
               </mat-form-field>
-              <p class="section-grid-header" *ngIf="isSSEditMode">Legal Counsel Given Name 2</p>
+              <p class="section-grid-header" *ngIf="isSSEditMode">{{ "label.legal_counsel_given_name_2" | translate }}</p>
               <mat-form-field appearance="outline" *ngIf="isSSEditMode">
                 <input matInput formControlName="lawyerGivenName2">
                 <mat-error *ngIf="courtOptionsForm.controls.lawyerGivenName2.hasError('maxlength')">{{ "error.max_length" | translate }}30</mat-error>
               </mat-form-field>
-              <p class="section-grid-header" *ngIf="isSSEditMode">Legal Counsel Given Name 3</p>
+              <p class="section-grid-header" *ngIf="isSSEditMode">{{ "label.legal_counsel_given_name_3" | translate }}</p>
               <mat-form-field appearance="outline" *ngIf="isSSEditMode">
                 <input matInput formControlName="lawyerGivenName3">
                 <mat-error *ngIf="courtOptionsForm.controls.lawyerGivenName3.hasError('maxlength')">{{ "error.max_length" | translate }}30</mat-error>
               </mat-form-field>
-              <p class="section-grid-header" *ngIf="isSSEditMode">Legal Counsel Surname</p>
+              <p class="section-grid-header" *ngIf="isSSEditMode">{{ "label.legal_counsel_surname" | translate }}</p>
               <mat-form-field appearance="outline" *ngIf="isSSEditMode">
                 <input matInput formControlName="lawyerSurname">
                 <mat-error *ngIf="courtOptionsForm.controls.lawyerSurname.hasError('maxlength')">{{ "error.max_length" | translate }}30</mat-error>
               </mat-form-field>
             </span>
             <span class="section-grid-cell">
-              <p class="section-grid-header">Legal Counsel Firm</p>
+              <p class="section-grid-header">{{ "label.legal_counsel_firm" | translate }}</p>
               <p class="section-grid-text" *ngIf="!isSSEditMode">{{ lastUpdatedJJDispute.lawFirmName }}</p>
               <mat-form-field appearance="outline" *ngIf="isSSEditMode">
                 <input matInput formControlName="lawFirmName">
@@ -235,7 +235,7 @@
               </mat-form-field>
             </span>
             <span class="section-grid-cell">
-              <p class="section-grid-header">Defence Witnesses</p>
+              <p class="section-grid-header">{{ "label.defence_witness" | translate }}</p>
               <p class="section-grid-text" *ngIf="!isSSEditMode">{{ lastUpdatedJJDispute.witnessNo }}</p>
               <mat-form-field appearance="outline" *ngIf="isSSEditMode">
                 <input matInput formControlName="witnessNo" maxlength="10" type="number">
@@ -244,7 +244,7 @@
               </mat-form-field>
             </span>
             <span class="section-grid-cell">
-              <p class="section-grid-header">Interpreter</p>
+              <p class="section-grid-header">{{ "label.interpreter" | translate }}</p>
               <p class="section-grid-text" *ngIf="!isSSEditMode">{{ lastUpdatedJJDispute.interpreterLanguage }}</p>
               <mat-form-field appearance="select-box-only" *ngIf="isSSEditMode">
                 <mat-select formControlName="interpreterLanguageCd" placeholder="Language">

--- a/src/frontend/staff-portal/src/app/components/jj-dispute-info/jj-dispute/jj-dispute.component.scss
+++ b/src/frontend/staff-portal/src/app/components/jj-dispute-info/jj-dispute/jj-dispute.component.scss
@@ -25,6 +25,19 @@
   }
 }
 
+.form-button-secondary {
+  color: #fff;
+  background-color: #6c757d;
+  border-color: #6c757d;  
+  font-size: 14px;
+  margin: 0px 10px 0px 10px;
+
+  &:hover {
+    background-color: #5a6268;
+    border-color: #5a6268;
+  }
+}
+
 h3 {
   font-weight: bold;
   color: black !important;
@@ -149,6 +162,21 @@ p {
   .subheader span {
     font-weight: 600;
     color: #1d4a77;
+  }
+    
+  .mat-form-field.datetime-picker {
+    width: 200px !important;
+    margin-right: 0px;
+    vertical-align: top;
+
+    .mat-form-field-flex {
+      margin-right: 0px;
+
+      .mat-form-field-suffix {
+        top: -2px;
+        height: 36px;
+      }
+    }
   }
 
   .mat-form-field {

--- a/src/frontend/staff-portal/src/app/components/jj-dispute-info/jj-dispute/jj-dispute.component.ts
+++ b/src/frontend/staff-portal/src/app/components/jj-dispute-info/jj-dispute/jj-dispute.component.ts
@@ -34,10 +34,7 @@ export class JJDisputeComponent implements OnInit {
   @Output() backInbox: EventEmitter<any> = new EventEmitter();
   printOptions: PrintOptions = new PrintOptions();
   isSupportStaff: boolean = false;
-  isTIEditMode: boolean = false;
-  isCIEditMode: boolean = false;
-  isCOEditMode: boolean = false;
-  isCAEditMode: boolean = false;
+  isSSEditMode: boolean = false;
 
   RequestTimeToPay = JJDisputedCountRequestTimeToPay;
   Finding = JJDisputedCountRoPFinding;
@@ -320,92 +317,30 @@ export class JJDisputeComponent implements OnInit {
   }
 
   /**
-   * Called by support-staff when editing the Ticket Information form (user must have update-admin permissions on the JJDispute resource).
+   * Called by support-staff when editing the form (user must have update-admin permissions on the JJDispute resource).
    */
-  onSaveTicketInformation(): void {
+  onSupportStaffSave(): void {
     this.lastUpdatedJJDispute = { ...this.lastUpdatedJJDispute, ...this.ticketInformationForm.value };
-
-    this.jjDisputeService.apiJjTicketNumberCascadePut(this.lastUpdatedJJDispute.ticketNumber, this.lastUpdatedJJDispute).subscribe(response => {      
-      // refresh JJDispute data
-      this.getJJDispute();
-
-      this.isTIEditMode = false;
-    });
-  }
-
-  /**
-   * Called by support-staff when reverting any changes they may have made to the Ticket Information form.
-   */
-  onCancelTicketInformation(): void {
-    this.ticketInformationForm.patchValue(this.lastUpdatedJJDispute);
-    this.isTIEditMode = false;
-  }
-
-  /**
-   * Called by support-staff when editing the Contact Information form (user must have update-admin permissions on the JJDispute resource).
-   */
-  onSaveContactInformation(): void {
     this.lastUpdatedJJDispute = { ...this.lastUpdatedJJDispute, ...this.contactInformationForm.value };
-
-    this.jjDisputeService.apiJjTicketNumberCascadePut(this.lastUpdatedJJDispute.ticketNumber, this.lastUpdatedJJDispute).subscribe(response => {      
-      // refresh JJDispute data
-      this.getJJDispute();
-
-      this.isCIEditMode = false;
-    });
-  }
-
-  /**
-   * Called by support-staff when reverting any changes they may have made to the Contact Information form.
-   */
-  onCancelContactInformation(): void {
-    this.contactInformationForm.patchValue(this.lastUpdatedJJDispute);
-    this.isCIEditMode = false;
-  }
-
-  /**
-   * Called by support-staff when editing the Court Options form (user must have update-admin permissions on the JJDispute resource).
-   */
-  onSaveCourtOptions(): void {
     this.lastUpdatedJJDispute = { ...this.lastUpdatedJJDispute, ...this.courtOptionsForm.value };
-
-    this.jjDisputeService.apiJjTicketNumberCascadePut(this.lastUpdatedJJDispute.ticketNumber, this.lastUpdatedJJDispute).subscribe(response => {      
-      // refresh JJDispute data
-      this.getJJDispute();
-
-      this.isCOEditMode = false;
-    });
-  }
-
-  /**
-   * Called by support-staff when reverting any changes they may have made to the Court Options form.
-   */
-  onCancelCourtOptions(): void {
-    this.courtOptionsForm.patchValue(this.lastUpdatedJJDispute);
-    this.isCOEditMode = false;
-  }
-
-  /**
-   * Called by support-staff when editing the Court Options form (user must have update-admin permissions on the JJDispute resource).
-   */
-  onSaveCourtAppearance(): void {
     this.lastUpdatedJJDispute.jjDisputeCourtAppearanceRoPs[0] = { ...this.lastUpdatedJJDispute.jjDisputeCourtAppearanceRoPs[0], ...this.courtAppearanceForm.value };
 
     this.jjDisputeService.apiJjTicketNumberCascadePut(this.lastUpdatedJJDispute.ticketNumber, this.lastUpdatedJJDispute).subscribe(response => {      
+      this.isSSEditMode = false;
+
       // refresh JJDispute data
       this.getJJDispute();
-
-      this.isCAEditMode = false;
     });
   }
 
   /**
-   * Called by support-staff when reverting any changes they may have made to the Court Options form.
+   * Called by support-staff when reverting any changes they may have made to the form.
    */
-  onCancelCourtAppearance(): void {
+  onSupportStaffCancel(): void {
+    this.isSSEditMode = false;
+    
     // refresh JJDispute data
     this.getJJDispute();
-    this.isCAEditMode = false;
   }
 
   onAccept(): void {

--- a/src/frontend/staff-portal/src/app/components/jj-dispute-info/jj-dispute/jj-dispute.component.ts
+++ b/src/frontend/staff-portal/src/app/components/jj-dispute-info/jj-dispute/jj-dispute.component.ts
@@ -415,7 +415,10 @@ export class JJDisputeComponent implements OnInit {
   updateFinalDispositionCount(updatedJJDisputedCount: JJDisputedCount) {
     this.lastUpdatedJJDispute.jjDisputedCounts.forEach(jjDisputedCount => {
       if (jjDisputedCount.count == updatedJJDisputedCount.count) {
-        jjDisputedCount = updatedJJDisputedCount;
+        jjDisputedCount.appearInCourt = updatedJJDisputedCount.appearInCourt;
+        jjDisputedCount.requestReduction = updatedJJDisputedCount.requestReduction;
+        jjDisputedCount.requestTimeToPay = updatedJJDisputedCount.requestTimeToPay;
+        jjDisputedCount.jjDisputedCountRoP.finding = updatedJJDisputedCount.jjDisputedCountRoP.finding;
       }
     });
     this.determineIfConcludeOrCancel();

--- a/src/frontend/staff-portal/src/app/shared/modules/ngx-material/ngx-material.module.ts
+++ b/src/frontend/staff-portal/src/app/shared/modules/ngx-material/ngx-material.module.ts
@@ -41,6 +41,7 @@ import { MatLegacyTooltipModule as MatTooltipModule } from '@angular/material/le
 import { MatSortModule } from '@angular/material/sort';
 import { MatLegacyTabsModule as MatTabsModule } from '@angular/material/legacy-tabs';
 import { MatButtonToggleModule } from '@angular/material/button-toggle';
+import { MatDatetimepickerModule, MatNativeDatetimeModule } from '@mat-datetimepicker/core';
 
 export const APP_DATE_FORMAT = 'D MMM YYYY';
 export const APP_DATE_FORMATS = {
@@ -82,6 +83,8 @@ export const GRI_DATE_FORMATS: MatDateFormats = {
     MatCheckboxModule,
     MatChipsModule,
     MatDatepickerModule,
+    MatDatetimepickerModule,
+    MatNativeDatetimeModule,
     MatDialogModule,
     MatExpansionModule,
     MatIconModule,

--- a/src/frontend/staff-portal/src/assets/i18n/en.json
+++ b/src/frontend/staff-portal/src/assets/i18n/en.json
@@ -141,22 +141,37 @@
     "heading": "BC Traffic Court Offence Dispute"
   },
   "label": {
-    "search": "Search",
+    "amount_due": "Amount Due",
+    "appearInCourt": "For this count I would like to",
     "back": "Back",
+    "count_number": "Count #",
+    "defence_witness": "Defence Witnesses",
+    "desc_of_offence": "Description of Offence",
+    "find_another_ticket": "Find Another Ticket",
+    "for_vehicle": "for Vehicle",
+    "given_names": "Given Names(s)",
+    "given_name_1": "Given Names 1",
+    "given_name_2": "Given Names 2",
+    "given_name_3": "Given Names 3",
+    "initiate_dispute": "Initiate Dispute",
+    "interpreter": "Interpreter",
+    "legal_counsel_firm": "Legal Counsel Firm",
+    "legal_counsel_name": "Legal Counsel Name",
+    "legal_counsel_given_name_1": "Legal Counsel Given Name 1",
+    "legal_counsel_given_name_2": "Legal Counsel Given Name 2",
+    "legal_counsel_given_name_3": "Legal Counsel Given Name 3",
+    "legal_counsel_surname": "Legal Counsel Surname",
+    "offence_amount": "Offence Amount",
     "pay_now": "Pay Now",
     "pay_count": "Pay Count",
     "pay_balance": "Pay Ticket Balance of",
-    "initiate_dispute": "Initiate Dispute",
-    "find_another_ticket": "Find Another Ticket",
+    "plea": "Plea",
+    "search": "Search",
+    "surname": "Surname",
+    "status": "Status",
     "violation_ticket_number": "Violation Ticket Number",
     "violation_ticket_number_hint": "A Violation Ticket Number is 2 letters and 8 numbers",
-    "violation_time": "Violation Time",
-    "count_number": "Count #",
-    "desc_of_offence": "Description of Offence",
-    "for_vehicle": "for Vehicle",
-    "offence_amount": "Offence Amount",
-    "amount_due": "Amount Due",
-    "status": "Status"
+    "violation_time": "Violation Time"
   },
   "submit_confirmation": {
     "heading": "Submit request",
@@ -197,5 +212,31 @@
     "telephone_conference": "Telephone Conference",
     "written_reasons": "Written Reasons",
     "video_conference": "Video Conference"
+  },
+  "pleaType": {
+    "guilty": "Guilty",
+    "not_guilty": "Not Guilty"
+  },
+  "appearInCourtType": {
+    "yes": "I want to appear in court",
+    "no": "I do not want to appear in court"
+  },
+  "findingType": {
+    "guilty": "Guilty as charged",
+    "guilty_lesser": "Not guilty as charged but guilty of lesser / included other offence",
+    "not_guilty": "Not guilty",
+    "paid_prior": "Paid Prior to Appearance",
+    "cancelled": "Cancelled"
+  },
+  "yesNo": {
+    "yes": "Yes",
+    "no": "No"
+  },
+  "common": {
+    "button": {
+      "edit": "Edit",
+      "save": "Save",
+      "cancel": "Cancel"
+    }
   }
 }

--- a/src/frontend/staff-portal/src/assets/i18n/fr.json
+++ b/src/frontend/staff-portal/src/assets/i18n/fr.json
@@ -140,22 +140,37 @@
     "heading": "Différend d'Infraction au Tribunal CB"
   },
   "label": {
-    "search": "Rechercher",
+    "amount_due": "Montant Dû",
+    "appearInCourt": "Pour ce compte, j'aimerais",
     "back": "Reculer",
+    "count_number": "Infraction #",
+    "defence_witness": "Témoins à décharge",
+    "desc_of_offence": "Description de l'Infraction",
+    "find_another_ticket": "Trouver un Autre Billet",
+    "for_vehicle": "pour Véhicule",
+    "given_names": "Prénom(s)",
+    "given_name_1": "Prénoms 1",
+    "given_name_2": "Prénoms 2",
+    "given_name_3": "Prénoms 3",
+    "initiate_dispute": "Lancer un Litige",
+    "interpreter": "Interprète",
+    "legal_counsel_firm": "Cabinet de conseiller juridique",
+    "legal_counsel_name": "Nom du conseiller juridique",
+    "legal_counsel_given_name_1": "Conseiller juridique Prénom 1",
+    "legal_counsel_given_name_2": "Conseiller juridique Prénom 2",
+    "legal_counsel_given_name_3": "Conseiller juridique Prénom 3",
+    "legal_counsel_surname": "Nom du conseiller juridique",
+    "offence_amount": "Montant de l'Infraction",
     "pay_now": "Payez Maintenant",
     "pay_count": "Payer l'Infraction",
     "pay_balance": "Payer le solde du billet de",
-    "initiate_dispute": "Lancer un Litige",
-    "find_another_ticket": "Trouver un Autre Billet",
+    "plea": "Plaidoyer",
+    "search": "Rechercher",
+    "surname": "Nom de famille",
+    "status": "Statut",
     "violation_ticket_number": "Numéro de Ticket de Violation",
     "violation_ticket_number_hint": "Un numéro de ticket de violation est composé de 2 lettres et 8 chiffres",
-    "violation_time": "Temps de Biolation",
-    "count_number": "Infraction #",
-    "desc_of_offence": "Description de l'Infraction",
-    "for_vehicle": "pour Véhicule",
-    "offence_amount": "Montant de l'Infraction",
-    "amount_due": "Montant Dû",
-    "status": "Statut"
+    "violation_time": "Temps de Biolation"
   },
   "submit_confirmation": {
     "heading": "Soumettre un Litige",
@@ -189,5 +204,31 @@
     "telephone_conference": "Conférence téléphonique",
     "written_reasons": "Motifs écrits",
     "video_conference": "Conférence vidéo"
+  },
+  "pleaType": {
+    "guilty": "Coupable",
+    "not_guilty": "Non Coupable"
+  },
+  "appearInCourtType": {
+    "yes": "Je veux comparaître au tribunal",
+    "no": "Je ne veux pas comparaître devant le tribunal"
+  },
+  "findingType": {
+    "guilty": "Coupable comme accusé",
+    "guilty_lesser": "Non coupable des accusations portées, mais coupable d'une autre infraction moindre/incluse",
+    "not_guilty": "Non coupable",
+    "paid_prior": "Payé avant la comparution",
+    "cancelled": "Annulé"
+  },
+  "yesNo": {
+    "yes": "Oui",
+    "no": "Non"
+  },
+  "common": {
+    "button": {
+      "edit": "Modifier",
+      "save": "Sauvegarder",
+      "cancel": "Annuler"
+    }
   }
 }

--- a/src/frontend/staff-portal/yarn.lock
+++ b/src/frontend/staff-portal/yarn.lock
@@ -1885,6 +1885,13 @@
   resolved "https://registry.yarnpkg.com/@lukeed/csprng/-/csprng-1.1.0.tgz#1e3e4bd05c1cc7a0b2ddbd8a03f39f6e4b5e6cfe"
   integrity sha512-Z7C/xXCiGWsg0KuKsHTKJxbWhpI3Vs5GwLfOean7MGyVFGqdRgBbAjOCh6u4bbjPc/8MJ2pZmK/0DLdCbivLDA==
 
+"@mat-datetimepicker/core@^12.0.1":
+  version "12.0.1"
+  resolved "https://registry.yarnpkg.com/@mat-datetimepicker/core/-/core-12.0.1.tgz#6233ad52dbf91125966af6689ba3610b1076cd86"
+  integrity sha512-52zZlangVSMvRyGk8GGqBbpzKS07b/zuqTAmhlVsd8lRmENdjy9W1yfjoMlh9/fBj7xrBJJcxqPG/9r78phL8Q==
+  dependencies:
+    tslib "^2.6.0"
+
 "@material/animation@15.0.0-canary.bc9ae6c9c.0":
   version "15.0.0-canary.bc9ae6c9c.0"
   resolved "https://registry.yarnpkg.com/@material/animation/-/animation-15.0.0-canary.bc9ae6c9c.0.tgz#7c27a42b027fcc2cd9a97c9d3b8f54a16b47333d"
@@ -11398,7 +11405,7 @@ tslib@^1.8.1, tslib@^1.9.0:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
-tslib@^2.0.0, tslib@^2.0.3, tslib@^2.1.0, tslib@^2.2.0, tslib@^2.3.0, tslib@^2.3.1, tslib@^2.4.0:
+tslib@^2.0.0, tslib@^2.0.3, tslib@^2.1.0, tslib@^2.2.0, tslib@^2.3.0, tslib@^2.3.1, tslib@^2.4.0, tslib@^2.6.0:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.2.tgz#703ac29425e7b37cd6fd456e92404d46d1f3e4ae"
   integrity sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==


### PR DESCRIPTION
TCVP-2524

This PR contains changes for the entire DCF tab. All requested fields should now be editable.
- added new `mat-datetimepicker` for the **noAppTs** field
- used i18n for touched fields
- moved Edit/Save/Cancel buttons to the header next to the Goto/Print/Print Options buttons.

![image](https://github.com/bcgov/jag-traffic-courts-online/assets/55215368/f34cc25f-94e8-4d79-b2ba-7062e3b4706d)

![image](https://github.com/bcgov/jag-traffic-courts-online/assets/55215368/a6c36e41-4d9f-4530-a883-859e85a106c4)

