### PR TITLE
TCVP-2554 Fixed invalid statue validation error

### DIFF
--- a/src/frontend/staff-portal/src/app/components/staff-workbench/ticket-info/ticket-info.component.html
+++ b/src/frontend/staff-portal/src/app/components/staff-workbench/ticket-info/ticket-info.component.html
@@ -40,9 +40,8 @@
                 <h3>Ticket Image</h3>
               </ng-container>
               <div width="150 !important" *ngIf="imageToShow">
-                <img [src]="imageToShow" width="150" height="200"><br />
-                <span style="font-size:10px; color:#009cde; align-content: center;" width="150"
-                  (click)="onExpandTicketImage()">
+                <img [src]="imageToShow" width="150" height="200" (click)="onExpandTicketImage()" class="ticket-image"><br />
+                <span style="font-size:10px; color:#009cde; align-content: center;" width="150" (click)="onExpandTicketImage()" class="ticket-image">
                   <i class="fa fa-plus-circle" style="font-size:18px; color:#009cde"></i>
                   <strong> Click to expand ticket image</strong>
                 </span>
@@ -64,14 +63,12 @@
                           <mat-form-field class="w-100 mb-2"
                             [ngClass]="{'underErrThreshold': applyUnderErrThreshold('ticket_number'), 'overErrThreshold': applyOverErrThreshold('ticket_number')}">
                             <mat-label>Ticket number</mat-label>
-                            <input formControlName="ticketNumber" matInput type="text"
-                              oninput="this.value = this.value.toUpperCase()" mask="SS00000000" autocomplete="off"
-                              [readonly]="lastUpdatedDispute.status === DispStatus.Validated" />
-                            <mat-error *ngIf="form.get('violationTicket').get('ticketNumber').hasError('required')">
+                            <input formControlName="ticketNumber" matInput type="text" oninput="this.value = this.value.toUpperCase()" mask="SS00000000" autocomplete="off"
+                              [readonly]="isTicketInformationReadOnly" />
+                            <mat-error *ngIf="!isTicketInformationReadOnly && form.get('violationTicket').get('ticketNumber').hasError('required')">
                               {{ "error.required" | translate }}
                             </mat-error>
-                            <mat-error
-                              *ngIf="form.get('violationTicket').get('ticketNumber').value && form.get('violationTicket').get('ticketNumber').hasError('mask')">
+                            <mat-error *ngIf="!isTicketInformationReadOnly && form.get('violationTicket').get('ticketNumber').value && form.get('violationTicket').get('ticketNumber').hasError('mask')">
                               This ticket number is not valid. It must be 2 letters and 8 numbers.
                             </mat-error>
                           </mat-form-field>
@@ -82,9 +79,8 @@
                           <mat-form-field class="w-100"
                             [ngClass]="{'underErrThreshold': applyUnderErrThreshold('violation_date'), 'overErrThreshold': applyOverErrThreshold('violation_date')}">
                             <mat-label>Date</mat-label>
-                            <input matInput type="date" placeholder="yyyy-MM-DD" formControlName="violationDate"
-                              [max]="todayDate" [readonly]="lastUpdatedDispute.status === DispStatus.Validated" />
-                            <mat-error *ngIf="form.get('violationTicket').get('violationDate').hasError('required')">
+                            <input matInput type="date" placeholder="yyyy-MM-DD" formControlName="violationDate" [max]="todayDate" [readonly]="isTicketInformationReadOnly" />
+                            <mat-error *ngIf="!isTicketInformationReadOnly && form.get('violationTicket').get('violationDate').hasError('required')">
                               {{ "error.required" | translate }}
                             </mat-error>
                           </mat-form-field>
@@ -95,11 +91,11 @@
                           <mat-form-field class="w-100"
                             [ngClass]="{'underErrThreshold': applyUnderErrThreshold('violation_time'), 'overErrThreshold': applyOverErrThreshold('violation_time')}">
                             <mat-label>Time</mat-label>
-                            <input matInput type="text" mask="00:00" formControlName="violationTime"
-                              [readonly]="lastUpdatedDispute.status === DispStatus.Validated" />
-                            <mat-error *ngIf="form.get('violationTicket').get('violationTime').hasError('required')">
-                              {{ "error.required" | translate }}</mat-error>
-                            <mat-error *ngIf="form.get('violationTicket').get('violationTime').hasError('pattern')">
+                            <input matInput type="text" mask="00:00" formControlName="violationTime" [readonly]="isTicketInformationReadOnly" />
+                            <mat-error *ngIf="!isTicketInformationReadOnly && form.get('violationTicket').get('violationTime').hasError('required')">
+                              {{ "error.required" | translate }}
+                            </mat-error>
+                            <mat-error *ngIf="!isTicketInformationReadOnly && form.get('violationTicket').get('violationTime').hasError('pattern')">
                               Invalid time. Use 24hr format.
                             </mat-error>
                           </mat-form-field>
@@ -119,14 +115,13 @@
                           <mat-form-field class="w-100"
                             [ngClass]="{'underErrThreshold': applyUnderErrThreshold('disputant_surname'), 'overErrThreshold': applyOverErrThreshold('disputant_surname')}">
                             <mat-label>Surname</mat-label>
-                            <input matInput formControlName="disputantSurname"
-                              [readonly]="lastUpdatedDispute.status === DispStatus.Validated" />
-                            <mat-error
-                              *ngIf="form.get('violationTicket').get('disputantSurname').hasError('required')">{{
-                              "error.required" | translate }}</mat-error>
-                            <mat-error
-                              *ngIf="form.get('violationTicket').get('disputantSurname').hasError('maxlength')">{{
-                              "error.max_length" | translate }}30</mat-error>
+                            <input matInput formControlName="disputantSurname" [readonly]="isTicketInformationReadOnly" />
+                            <mat-error *ngIf="!isTicketInformationReadOnly && form.get('violationTicket').get('disputantSurname').hasError('required')">
+                              {{ "error.required" | translate }}
+                            </mat-error>
+                            <mat-error *ngIf="!isTicketInformationReadOnly && form.get('violationTicket').get('disputantSurname').hasError('maxlength')">
+                              {{ "error.max_length" | translate }}30
+                            </mat-error>
                           </mat-form-field>
                         </div>
 
@@ -135,14 +130,13 @@
                           <mat-form-field class="w-100"
                             [ngClass]="{'underErrThreshold': applyUnderErrThreshold('disputant_given_names'), 'overErrThreshold': applyOverErrThreshold('disputant_given_names')}">
                             <mat-label>Given name(s)</mat-label>
-                            <input matInput formControlName="disputantGivenNames"
-                              [readonly]="lastUpdatedDispute.status === DispStatus.Validated" />
-                            <mat-error
-                              *ngIf="form.get('violationTicket').get('disputantGivenNames').hasError('required')">{{
-                              "error.required" | translate }}</mat-error>
-                            <mat-error
-                              *ngIf="form.get('violationTicket').get('disputantGivenNames').hasError('maxlength')">{{
-                              "error.max_length" | translate }}30 per name}</mat-error>
+                            <input matInput formControlName="disputantGivenNames" [readonly]="isTicketInformationReadOnly" />
+                            <mat-error *ngIf="!isTicketInformationReadOnly && form.get('violationTicket').get('disputantGivenNames').hasError('required')">
+                              {{ "error.required" | translate }}
+                            </mat-error>
+                            <mat-error *ngIf="!isTicketInformationReadOnly && form.get('violationTicket').get('disputantGivenNames').hasError('maxlength')">
+                              {{ "error.max_length" | translate }}30 per name
+                            </mat-error>
                           </mat-form-field>
                         </div>
                       </div>
@@ -152,9 +146,7 @@
                           <mat-form-field class="w-100"
                             [ngClass]="{'underErrThreshold': applyUnderErrThreshold('drivers_licence_province'), 'overErrThreshold': applyOverErrThreshold('drivers_licence_province')}">
                             <mat-label>Prov/State of DL</mat-label>
-                            <mat-select formControlName="driversLicenceProvince"
-                              (selectionChange)="onViolationTicketDLProvinceChange($event.value)"
-                              [readonly]="lastUpdatedDispute.status === DispStatus.Validated">
+                            <mat-select formControlName="driversLicenceProvince" (selectionChange)="onViolationTicketDLProvinceChange($event.value)" [readonly]="isTicketInformationReadOnly">
                               <mat-option [value]="bc.provAbbreviationCd">{{bc.provNm}}</mat-option>
                               <mat-option *ngFor="let province of provinces" [value]="province.provAbbreviationCd">{{
                                 province.provNm }}
@@ -163,7 +155,7 @@
                                 state.provNm }}
                               </mat-option>
                             </mat-select>
-                            <mat-error>{{ "error.required" | translate }}</mat-error>
+                            <mat-error *ngIf="!isTicketInformationReadOnly">{{ "error.required" | translate }}</mat-error>
                           </mat-form-field>
                         </div>
 
@@ -174,18 +166,15 @@
                             <mat-label>DL number</mat-label>
                             <input matInput formControlName="disputantDriversLicenceNumber"
                               (keypress)="($event.charCode >= 48 && $event.charCode < 58)" minlength="7" maxlength="9"
-                              autocomplete="off" [readonly]="lastUpdatedDispute.status === DispStatus.Validated"
+                              autocomplete="off" [readonly]="isTicketInformationReadOnly"
                               *ngIf="form.get('violationTicket').get('driversLicenceProvince').value === bc.provAbbreviationCd" />
                             <input matInput formControlName="disputantDriversLicenceNumber" autocomplete="off"
                               *ngIf="form.get('violationTicket').get('driversLicenceProvince').value !== bc.provAbbreviationCd"
-                              [readonly]="lastUpdatedDispute.status === DispStatus.Validated" />
-                            <mat-error
-                              *ngIf="form.get('violationTicket').get('disputantDriversLicenceNumber').hasError('required')">{{
-                              "error.required" |
-                              translate }}</mat-error>
-                            <mat-error *ngIf="
-                            form.get('violationTicket').get('disputantDriversLicenceNumber')?.errors?.minlength ||
-                            form.get('violationTicket').get('disputantDriversLicenceNumber').hasError('maxlength')">
+                              [readonly]="isTicketInformationReadOnly" />
+                            <mat-error *ngIf="!isTicketInformationReadOnly && form.get('violationTicket').get('disputantDriversLicenceNumber').hasError('required')">
+                              {{ "error.required" | translate }}
+                            </mat-error>
+                            <mat-error *ngIf="!isTicketInformationReadOnly && (form.get('violationTicket').get('disputantDriversLicenceNumber')?.errors?.minlength || form.get('violationTicket').get('disputantDriversLicenceNumber').hasError('maxlength'))">
                               Must be a valid BC driver's licence number of seven to nine digits
                             </mat-error>
                           </mat-form-field>
@@ -207,7 +196,7 @@
                             <input matInput formControlName="fullDescription" [matAutocomplete]="auto"
                               (keyup)="onFullDescription1Keyup()" (change)="onChangeCount(1, $event.target.value)"
                               [matTooltip]="form.get('violationTicket').get('violationTicketCount1').get('fullDescription').value"
-                              [readonly]="lastUpdatedDispute.status === DispStatus.Validated" />
+                              [readonly]="isTicketInformationReadOnly" />
                             <mat-autocomplete #auto="matAutocomplete" panelWidth="750"
                               (optionSelected)="onChangeCount(1, $event.option.value)">
                               <mat-option
@@ -217,9 +206,8 @@
                                 [value]="statute.__statuteString">
                                 {{ statute.__statuteString }}</mat-option>
                             </mat-autocomplete>
-                            <mat-error>{{ "error.required" | translate }}</mat-error>
-                            <mat-hint *ngIf="!isStatuteValid(1)" style="color:red; font-weight: bold;">Invalid statute
-                              selection.</mat-hint>
+                            <mat-error *ngIf="!isTicketInformationReadOnly">{{ "error.required" | translate }}</mat-error>
+                            <mat-hint *ngIf="!isTicketInformationReadOnly && !isStatuteValid(1)" style="color:red; font-weight: bold;">Invalid statute selection.</mat-hint>
                           </mat-form-field>
                         </div>
                         <!-- Violation Ticket Count 1 Fine Amount -->
@@ -227,9 +215,8 @@
                           <mat-form-field class="w-100"
                             [ngClass]="{'underErrThreshold': applyUnderErrThreshold('counts.count_no_1.ticketed_amount'), 'overErrThreshold': applyOverErrThreshold('counts.count_no_1.ticketed_amount')}">
                             <mat-label>Fine amount ($)</mat-label>
-                            <input matInput formControlName="ticketedAmount"
-                              [readonly]="lastUpdatedDispute.status === DispStatus.Validated" />
-                            <mat-error>{{ "error.required" | translate }}</mat-error>
+                            <input matInput formControlName="ticketedAmount" [readonly]="isTicketInformationReadOnly" />
+                            <mat-error *ngIf="!isTicketInformationReadOnly">{{ "error.required" | translate }}</mat-error>
                           </mat-form-field>
                         </div>
                       </div>
@@ -249,19 +236,18 @@
                             <input matInput formControlName="fullDescription" [matAutocomplete]="auto2"
                               [matTooltip]="form.get('violationTicket').get('violationTicketCount2').get('fullDescription').value"
                               (change)="onChangeCount(2, $event.target.value)" (keyup)="onFullDescription2Keyup()"
-                              [readonly]="lastUpdatedDispute.status === DispStatus.Validated" />
+                              [readonly]="isTicketInformationReadOnly" />
                             <mat-autocomplete #auto2="matAutocomplete" panelWidth="750"
-                              (optionSelected)="onChangeCount(2, $event.option.value)">
-                              <mat-option
-                                [value]="getCountLegalParagraphing(2, initialDisputeValues.violationTicket)">{{
-                                getCountLegalParagraphing(2, initialDisputeValues.violationTicket) }}</mat-option>
+                            (optionSelected)="onChangeCount(2, $event.option.value)">
+                            <mat-option
+                            [value]="getCountLegalParagraphing(2, initialDisputeValues.violationTicket)">{{
+                              getCountLegalParagraphing(2, initialDisputeValues.violationTicket) }}</mat-option>
                               <mat-option *ngFor="let statute of filteredCount2Statutes"
-                                [value]="statute.__statuteString">
-                                {{ statute.__statuteString }}</mat-option>
+                              [value]="statute.__statuteString">
+                              {{ statute.__statuteString }}</mat-option>
                             </mat-autocomplete>
-                            <mat-error>{{ "error.required" | translate }}</mat-error>
-                            <mat-hint *ngIf="!isStatuteValid(2)" style="color:red; font-weight: bold;">Invalid statute
-                              selection.</mat-hint>
+                            <mat-error *ngIf="!isTicketInformationReadOnly">{{ "error.required" | translate }}</mat-error>
+                            <mat-hint *ngIf="!isTicketInformationReadOnly && !isStatuteValid(2)" style="color:red; font-weight: bold;">Invalid statute selection.</mat-hint>
                           </mat-form-field>
                         </div>
                         <!-- Violation Ticket Count 2 Fine Amount -->
@@ -269,9 +255,8 @@
                           <mat-form-field class="w-100"
                             [ngClass]="{'underErrThreshold': applyUnderErrThreshold('counts.count_no_2.ticketed_amount'), 'overErrThreshold': applyOverErrThreshold('counts.count_no_2.ticketed_amount')}">
                             <mat-label>Fine amount ($)</mat-label>
-                            <input matInput formControlName="ticketedAmount"
-                              [readonly]="lastUpdatedDispute.status === DispStatus.Validated" />
-                            <mat-error>{{ "error.required" | translate }}</mat-error>
+                            <input matInput formControlName="ticketedAmount" [readonly]="isTicketInformationReadOnly" />
+                            <mat-error *ngIf="!isTicketInformationReadOnly">{{ "error.required" | translate }}</mat-error>
                           </mat-form-field>
                         </div>
                       </div>
@@ -291,7 +276,7 @@
                             <input matInput formControlName="fullDescription" [matAutocomplete]="auto3"
                               [matTooltip]="form.get('violationTicket').get('violationTicketCount3').get('fullDescription').value"
                               (change)="onChangeCount(3, $event.target.value)" (keyup)="onFullDescription3Keyup()"
-                              [readonly]="lastUpdatedDispute.status === DispStatus.Validated" />
+                              [readonly]="isTicketInformationReadOnly" />
                             <mat-autocomplete #auto3="matAutocomplete" panelWidth="750"
                               (optionSelected)="onChangeCount(3, $event.option.value)">
                               <mat-option
@@ -301,9 +286,8 @@
                                 [value]="statute.__statuteString">
                                 {{ statute.__statuteString }}</mat-option>
                             </mat-autocomplete>
-                            <mat-error>{{ "error.required" | translate }}</mat-error>
-                            <mat-hint *ngIf="!isStatuteValid(3)" style="color:red; font-weight: bold;">Invalid statute
-                              selection.</mat-hint>
+                            <mat-error *ngIf="!isTicketInformationReadOnly">{{ "error.required" | translate }}</mat-error>
+                            <mat-hint *ngIf="!isTicketInformationReadOnly && !isStatuteValid(3)" style="color:red; font-weight: bold;">Invalid statute selection.</mat-hint>
                           </mat-form-field>
                         </div>
                         <!-- Violation Ticket Count 3 Ticketed Amount -->
@@ -311,9 +295,8 @@
                           <mat-form-field class="w-100"
                             [ngClass]="{'underErrThreshold': applyUnderErrThreshold('counts.count_no_3.ticketed_amount'), 'overErrThreshold': applyOverErrThreshold('counts.count_no_3.ticketed_amount')}">
                             <mat-label>Fine amount ($)</mat-label>
-                            <input matInput formControlName="ticketedAmount"
-                              [readonly]="lastUpdatedDispute.status === DispStatus.Validated" />
-                            <mat-error>{{ "error.required" | translate }}</mat-error>
+                            <input matInput formControlName="ticketedAmount" [readonly]="isTicketInformationReadOnly" />
+                            <mat-error *ngIf="!isTicketInformationReadOnly">{{ "error.required" | translate }}</mat-error>
                           </mat-form-field>
                         </div>
                       </div>
@@ -329,15 +312,14 @@
                         <div class="col-lg-9">
                           <mat-form-field class="w-100"
                             [ngClass]="{'underErrThreshold': applyUnderErrThreshold('court_location'), 'overErrThreshold': applyOverErrThreshold('court_location')}">
-                            <mat-select [formControl]="form.get('violationTicket').get('courtLocation')"
-                              [readonly]="lastUpdatedDispute.status === DispStatus.Validated">
+                            <mat-select [formControl]="form.get('violationTicket').get('courtLocation')" [readonly]="isTicketInformationReadOnly">
                               <mat-option [value]="initialDisputeValues.violationTicket.courtLocation">{{
                                 initialDisputeValues.violationTicket.courtLocation }}</mat-option>
                               <mat-option *ngFor="let courtLocation of lookupsService.courthouseAgencies"
                                 [value]="courtLocation.name">{{
                                 courtLocation.name }}</mat-option>
                             </mat-select>
-                            <mat-error>{{ "error.required" | translate }}</mat-error>
+                            <mat-error *ngIf="!isTicketInformationReadOnly">{{ "error.required" | translate }}</mat-error>
                           </mat-form-field>
                         </div>
                       </div>

--- a/src/frontend/staff-portal/src/app/components/staff-workbench/ticket-info/ticket-info.component.scss
+++ b/src/frontend/staff-portal/src/app/components/staff-workbench/ticket-info/ticket-info.component.scss
@@ -17,6 +17,10 @@ h3 {
   width: 100%;
 }
 
+.ticket-image:hover {
+  cursor: pointer;
+}
+
 input[type="date"]::-webkit-calendar-picker-indicator {
   background: none;
 }

--- a/src/frontend/staff-portal/src/app/components/staff-workbench/ticket-info/ticket-info.component.ts
+++ b/src/frontend/staff-portal/src/app/components/staff-workbench/ticket-info/ticket-info.component.ts
@@ -50,6 +50,7 @@ export class TicketInfoComponent implements OnInit {
   public IsRegulation = ViolationTicketCountIsRegulation;
   public ContactType = DisputeContactTypeCd;
   public DispStatus = DisputeStatus;
+  public isTicketInformationReadOnly: boolean = false;
 
   /**
    * @description
@@ -269,7 +270,6 @@ export class TicketInfoComponent implements OnInit {
           });
       })
   }
-
 
   public onExpandTicketImage() {
     const dialogConfig = new MatDialogConfig();
@@ -841,6 +841,9 @@ export class TicketInfoComponent implements OnInit {
           this.form.controls.violationTicket.disable();
         }
         this.form.get('violationTicket').updateValueAndValidity();
+        
+        // TCVP-2554 make a static variable to indicate if the TicketInformation section is editable or not.
+        this.isTicketInformationReadOnly = this.lastUpdatedDispute.status === this.DispStatus.Validated;        
       }, (error: any) => {
         this.retrieving = false;
         if (error.status == 409) this.conflict = true;

--- a/src/frontend/staff-portal/src/app/components/staff-workbench/ticket-info/ticket-info.component.ts
+++ b/src/frontend/staff-portal/src/app/components/staff-workbench/ticket-info/ticket-info.component.ts
@@ -792,7 +792,10 @@ export class TicketInfoComponent implements OnInit {
           countForm.get('description').setValue(violationTicketCount.description);
 
           // lookup legal statute
-          let foundStatute = this.lookupsService.statutes?.filter(x => x.code === violationTicketCount.section && x.actCode === violationTicketCount.actOrRegulationNameCode).shift();
+          let foundStatute = this.lookupsService.statutes?.filter(x => {
+            return x.code === this.getSectionText(violationTicketCount)
+                && x.actCode === violationTicketCount.actOrRegulationNameCode;
+          }).shift();
           if (foundStatute) {
             countForm.get('section').setValue(foundStatute.sectionText);
             countForm.get('subsection').setValue(foundStatute.subsectionText);
@@ -848,5 +851,18 @@ export class TicketInfoComponent implements OnInit {
         this.retrieving = false;
         if (error.status == 409) this.conflict = true;
       });
+  }
+   
+  /**
+   * Returns the full section text from a ViolationTicketCount, ie 44(3)(a)(iii)
+   * @param vtc 
+   * @returns 
+   */
+  private getSectionText(vtc: ViolationTicketCount) : string {
+    let sectionText = vtc.section ?? "";
+    sectionText += vtc.subsection ? '(' + vtc.subsection + ')' : "";
+    sectionText += vtc.paragraph ? + '(' + vtc.paragraph + ')' : "";
+    sectionText += vtc.subparagraph ? + '(' + vtc.subparagraph + ')' : "";
+    return sectionText;
   }
 }


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

TCVP-2554

It used to be the case when viewing a previously validated dispute, the Ticket Information section was showing some fields as invalid. Since the fields were read-only there is no way to fix them.
- foreach field, hid error messages when form in read-only
- fixed statute lookup so that it matches the entire full section text instead of just the section code.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
