### PR TITLE
TCVP-2548 Block Submitting Multiple Disputes for a Violation Ticket

### DIFF
--- a/src/backend/TrafficCourts/Citizen.Service/Services/Tickets/Search/ITicketSearchService.cs
+++ b/src/backend/TrafficCourts/Citizen.Service/Services/Tickets/Search/ITicketSearchService.cs
@@ -1,5 +1,4 @@
-﻿using Microsoft.AspNetCore.Mvc;
-using TrafficCourts.Citizen.Service.Models.Tickets;
+﻿using TrafficCourts.Citizen.Service.Models.Tickets;
 
 namespace TrafficCourts.Citizen.Service.Services.Tickets.Search;
 

--- a/src/backend/TrafficCourts/Citizen.Service/Services/Tickets/Search/ITicketSearchService.cs
+++ b/src/backend/TrafficCourts/Citizen.Service/Services/Tickets/Search/ITicketSearchService.cs
@@ -1,4 +1,5 @@
-﻿using TrafficCourts.Citizen.Service.Models.Tickets;
+﻿using Microsoft.AspNetCore.Mvc;
+using TrafficCourts.Citizen.Service.Models.Tickets;
 
 namespace TrafficCourts.Citizen.Service.Services.Tickets.Search;
 
@@ -17,4 +18,12 @@ public interface ITicketSearchService
     /// <exception cref="TicketSearchErrorException">An error occurred executing the search.</exception>
     /// <returns>The found <see cref="ViolationTicket"/> or null if the ticket was not found.</returns>
     Task<ViolationTicket?> SearchAsync(string ticketNumber, TimeOnly issuedTime, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Searches for the dispute in OCCAM database by <paramref name="ticketNumber"/> to check if a dispute submitted for the violation ticket before.
+    /// </summary>
+    /// <param name="ticketNumber"></param>
+    /// <param name="cancellationToken"></param>
+    /// <returns></returns>
+    Task<bool> IsDisputeSubmittedBefore(string ticketNumber, CancellationToken cancellationToken);
 }

--- a/src/backend/TrafficCourts/Citizen.Service/Services/Tickets/Search/TicketSearchService.cs
+++ b/src/backend/TrafficCourts/Citizen.Service/Services/Tickets/Search/TicketSearchService.cs
@@ -1,23 +1,26 @@
-﻿using System.Diagnostics;
+﻿using MassTransit;
+using System.Diagnostics;
 using System.Globalization;
-using TrafficCourts.Citizen.Service.Models.Tickets;
 using TrafficCourts.Citizen.Service.Services.Tickets.Search.Common;
+using TrafficCourts.Messaging.MessageContracts;
 
 namespace TrafficCourts.Citizen.Service.Services.Tickets.Search;
 
 public class TicketSearchService : ITicketSearchService
 {
+    private readonly IBus _bus;
     private readonly ITicketInvoiceSearchService _invoiceSearchService;
     private readonly ILogger<TicketSearchService> _logger;
     private static readonly DateTime _validVT2TicketEffectiveDate = new(2024, 4, 9);
 
-    public TicketSearchService(ITicketInvoiceSearchService invoiceSearchService, ILogger<TicketSearchService> logger)
+    public TicketSearchService(IBus bus, ITicketInvoiceSearchService invoiceSearchService, ILogger<TicketSearchService> logger)
     {
+        _bus = bus ?? throw new ArgumentNullException(nameof(bus));
         _invoiceSearchService = invoiceSearchService ?? throw new ArgumentNullException(nameof(invoiceSearchService));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
-    public async Task<ViolationTicket?> SearchAsync(string ticketNumber, TimeOnly issuedTime, CancellationToken cancellationToken)
+    public async Task<Models.Tickets.ViolationTicket?> SearchAsync(string ticketNumber, TimeOnly issuedTime, CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(ticketNumber);
 
@@ -63,7 +66,7 @@ public class TicketSearchService : ITicketSearchService
         }
     }
 
-    private ViolationTicket AssemblyViolationTicket(string ticketNumber, TimeOnly issuedTime, List<Invoice> invoices)
+    private Models.Tickets.ViolationTicket AssemblyViolationTicket(string ticketNumber, TimeOnly issuedTime, List<Invoice> invoices)
     {
         Debug.Assert(invoices.Count != 0);
 
@@ -72,8 +75,10 @@ public class TicketSearchService : ITicketSearchService
             _logger.LogInformation("Violation date and time is empty");
         }
 
-        ViolationTicket ticket = new ViolationTicket();
-        ticket.TicketNumber = ticketNumber;
+        Models.Tickets.ViolationTicket ticket = new()
+        {
+            TicketNumber = ticketNumber
+        };
 
         if (DateTime.TryParseExact(invoices[0].ViolationDateTime, "yyyy-MM-ddTHH:mm", CultureInfo.InvariantCulture, DateTimeStyles.AssumeLocal, out DateTime violationDateTime))
         {
@@ -90,7 +95,7 @@ public class TicketSearchService : ITicketSearchService
 
         foreach (var invoice in invoices)
         {
-            ViolationTicketCount count = new ViolationTicketCount();
+            Models.Tickets.ViolationTicketCount count = new Models.Tickets.ViolationTicketCount();
             if (!string.IsNullOrEmpty(invoice.InvoiceNumber))
             {
                 count.CountNo = (short)char.GetNumericValue(invoice.InvoiceNumber[^1]);
@@ -104,6 +109,30 @@ public class TicketSearchService : ITicketSearchService
 
         return ticket;
     }
+
+    public async Task<bool> IsDisputeSubmittedBefore(string ticketNumber, CancellationToken cancellationToken)
+    {
+        // Check if a dispute has been submitted before for the given ticket number by verfying any Dispute exists associated to the provided ticket number
+        SearchDisputeRequest searchRequest = new() { TicketNumber = ticketNumber };
+        Response<SearchDisputeResponse> response = await _bus.Request<SearchDisputeRequest, SearchDisputeResponse>(searchRequest, cancellationToken);
+
+        var searchResponse = response.Message;
+
+        if (!searchResponse.IsNotFound)
+        {
+            _logger.LogDebug("Found a dispute for the given ticket number: {ticketNumber}, returning bad request", ticketNumber);
+            return true;
+        }
+
+        if (searchResponse.IsError)
+        {
+            _logger.LogError("Search returned error, throwing DisputeSearchFailedException");
+            throw new DisputeSearchFailedException(ticketNumber);
+        }
+
+        _logger.LogDebug("Dispute not submitted before, returning false");
+        return false;
+    }
 }
 
 [Serializable]
@@ -115,5 +144,16 @@ public class InvalidTicketVersionException : Exception
     }
 
     public DateTime ViolationDate { get; init; }
+}
+
+[Serializable]
+public class DisputeSearchFailedException : Exception
+{
+    public DisputeSearchFailedException(string ticketNumber) : base($"Dispute search failed. Dispute search response returned an error for: {ticketNumber}.")
+    {
+        TicketNumber = ticketNumber;
+    }
+
+    public string TicketNumber { get; set; }
 }
 

--- a/src/backend/TrafficCourts/Test/Citizen.Service/Controllers/TicketsControllerTests.cs
+++ b/src/backend/TrafficCourts/Test/Citizen.Service/Controllers/TicketsControllerTests.cs
@@ -12,8 +12,6 @@ using TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0;
 using MassTransit;
 using System.Collections.Generic;
 using TrafficCourts.Citizen.Service.Services.Tickets.Search;
-using static TrafficCourts.Citizen.Service.Features.Tickets.AnalyseHandler;
-using System;
 
 namespace TrafficCourts.Test.Citizen.Service.Controllers;
 

--- a/src/backend/TrafficCourts/Test/Citizen.Service/Controllers/TicketsControllerTests.cs
+++ b/src/backend/TrafficCourts/Test/Citizen.Service/Controllers/TicketsControllerTests.cs
@@ -9,6 +9,11 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using System.Net;
 using TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0;
+using MassTransit;
+using System.Collections.Generic;
+using TrafficCourts.Citizen.Service.Services.Tickets.Search;
+using static TrafficCourts.Citizen.Service.Features.Tickets.AnalyseHandler;
+using System;
 
 namespace TrafficCourts.Test.Citizen.Service.Controllers;
 
@@ -21,9 +26,23 @@ public class TicketsControllerTests
         var mockImage = new Mock<IFormFile>();
         var mockMediator = new Mock<IMediator>();
         var mockLogger = new Mock<ILogger<TicketsController>>();
-        var ticketController = new TicketsController(mockMediator.Object, mockLogger.Object);
+        var mockTicketSearchService = new Mock<ITicketSearchService>();
+        var ticketController = new TicketsController(mockMediator.Object, mockTicketSearchService.Object, mockLogger.Object);
         var request = new AnalyseHandler.AnalyseRequest(mockImage.Object);
-        var analyseResponse = new AnalyseHandler.AnalyseResponse(new OcrViolationTicket());
+        OcrViolationTicket ticket = new OcrViolationTicket();
+        Dictionary<string, Field> fields = new Dictionary<string, Field>();
+        Field field = new();
+        string ticketNumber = "AC63378564";
+        field.JsonName = "ticket_number";
+        field.Value = ticketNumber;
+        fields.Add(OcrViolationTicket.ViolationTicketNumber, field);
+        ticket.Fields = fields;
+        var analyseResponse = new AnalyseHandler.AnalyseResponse(ticket);
+
+        mockTicketSearchService
+                 .Setup(_ => _.IsDisputeSubmittedBefore(ticketNumber, It.IsAny<CancellationToken>()))
+                 .ReturnsAsync(false);
+
         mockMediator
             .Setup(_ => _.Send<AnalyseHandler.AnalyseResponse>(It.IsAny<AnalyseHandler.AnalyseRequest>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(analyseResponse);
@@ -43,7 +62,9 @@ public class TicketsControllerTests
         var mockImage = new Mock<IFormFile>();
         var mockMediator = new Mock<IMediator>();
         var mockLogger = new Mock<ILogger<TicketsController>>();
-        var ticketController = new TicketsController(mockMediator.Object, mockLogger.Object);
+        var mockBus = new Mock<IBus>();
+        var mockTicketSearchService = new Mock<ITicketSearchService>();
+        var ticketController = new TicketsController(mockMediator.Object, mockTicketSearchService.Object, mockLogger.Object);
         var request = new AnalyseHandler.AnalyseRequest(mockImage.Object);
         OcrViolationTicket violationTicket = new();
         violationTicket.GlobalValidationErrors.Add("Some validation error");
@@ -60,5 +81,188 @@ public class TicketsControllerTests
         var problemDetails = Assert.IsType<ProblemDetails>(objectResult.Value);
         Assert.Equal((int)HttpStatusCode.BadRequest, problemDetails.Status);
         Assert.True(problemDetails?.Title?.StartsWith("Violation Ticket is not valid"));
+    }
+
+    [Fact]
+    public async void TestAnalyseBadRequest_DisputeSubmittedBefore()
+    {
+        // Arrange
+        var mockImage = new Mock<IFormFile>();
+        var mockMediator = new Mock<IMediator>();
+        var mockLogger = new Mock<ILogger<TicketsController>>();
+        var mockBus = new Mock<IBus>();
+        var mockTicketSearchService = new Mock<ITicketSearchService>();
+        var ticketController = new TicketsController(mockMediator.Object, mockTicketSearchService.Object, mockLogger.Object);
+        var request = new AnalyseHandler.AnalyseRequest(mockImage.Object);
+        OcrViolationTicket violationTicket = new();
+        Dictionary<string, Field> fields = new Dictionary<string, Field>();
+        List<string> errors = new List<string>();
+        Field field = new();
+        string ticketNumber = "AC63378564";
+        field.JsonName = "ticket_number";
+        field.Value = ticketNumber;
+        fields.Add(OcrViolationTicket.ViolationTicketNumber, field);
+        violationTicket.Fields = fields;
+        violationTicket.GlobalValidationErrors = errors;
+        var analyseResponse = new AnalyseHandler.AnalyseResponse(violationTicket);
+
+        mockMediator
+            .Setup(_ => _.Send<AnalyseHandler.AnalyseResponse>(It.IsAny<AnalyseHandler.AnalyseRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(analyseResponse);
+
+        mockTicketSearchService
+                 .Setup(_ => _.IsDisputeSubmittedBefore(ticketNumber, It.IsAny<CancellationToken>()))
+                 .ReturnsAsync(true);
+
+        // Act
+        var result = await ticketController.AnalyseAsync(mockImage.Object, CancellationToken.None, false, false);
+
+        // Assert
+        var badRequestResult = Assert.IsType<BadRequestObjectResult>(result);
+        var errorMsg = Assert.IsType<string>(badRequestResult.Value);
+        Assert.Equal((int)HttpStatusCode.BadRequest, badRequestResult.StatusCode);
+        Assert.StartsWith("A dispute has already been submitted", errorMsg);
+    }
+
+    [Fact]
+    public async void TestAnalyseInternalError_DisputeSearchFailed()
+    {
+        // Arrange
+        var mockImage = new Mock<IFormFile>();
+        var mockMediator = new Mock<IMediator>();
+        var mockLogger = new Mock<ILogger<TicketsController>>();
+        var mockBus = new Mock<IBus>();
+        var mockTicketSearchService = new Mock<ITicketSearchService>();
+        var ticketController = new TicketsController(mockMediator.Object, mockTicketSearchService.Object, mockLogger.Object);
+        var request = new AnalyseHandler.AnalyseRequest(mockImage.Object);
+        OcrViolationTicket violationTicket = new();
+        Dictionary<string, Field> fields = new Dictionary<string, Field>();
+        List<string> errors = new List<string>();
+        Field field = new();
+        string ticketNumber = "AC63378564";
+        field.JsonName = "ticket_number";
+        field.Value = ticketNumber;
+        fields.Add(OcrViolationTicket.ViolationTicketNumber, field);
+        violationTicket.Fields = fields;
+        violationTicket.GlobalValidationErrors = errors;
+        var analyseResponse = new AnalyseHandler.AnalyseResponse(violationTicket);
+
+        DisputeSearchFailedException exception = new DisputeSearchFailedException(ticketNumber);
+
+        mockMediator
+            .Setup(_ => _.Send<AnalyseHandler.AnalyseResponse>(It.IsAny<AnalyseHandler.AnalyseRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(analyseResponse);
+
+        mockTicketSearchService
+                 .Setup(_ => _.IsDisputeSubmittedBefore(ticketNumber, It.IsAny<CancellationToken>()))
+                 .ThrowsAsync(exception);
+
+        // Act
+        var result = await ticketController.AnalyseAsync(mockImage.Object, CancellationToken.None, false, false);
+
+        // Assert
+        var objectResult = Assert.IsType<ObjectResult>(result);
+        var problemDetails = Assert.IsType<ProblemDetails>(objectResult.Value);
+        Assert.Equal(StatusCodes.Status500InternalServerError, problemDetails.Status);
+        Assert.True(problemDetails?.Title?.Contains("Error searching dispute"));
+    }
+
+    [Fact]
+    public async void TestSearchOkResult()
+    {
+        // Arrange
+        var mockImage = new Mock<IFormFile>();
+        var mockMediator = new Mock<IMediator>();
+        var mockLogger = new Mock<ILogger<TicketsController>>();
+        var mockTicketSearchService = new Mock<ITicketSearchService>();
+        var ticketController = new TicketsController(mockMediator.Object, mockTicketSearchService.Object, mockLogger.Object);
+        string ticketNumber = "AC63378564";
+        string time = "12:15";
+        TrafficCourts.Citizen.Service.Models.Tickets.ViolationTicket violationTicket = new TrafficCourts.Citizen.Service.Models.Tickets.ViolationTicket();
+        violationTicket.TicketNumber = ticketNumber;
+        Search.Response response = new(violationTicket);
+
+        mockMediator
+            .Setup(_ => _.Send<Search.Response>(It.IsAny<Search.Request>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(response);
+
+        mockTicketSearchService
+                 .Setup(_ => _.IsDisputeSubmittedBefore(ticketNumber, It.IsAny<CancellationToken>()))
+                 .ReturnsAsync(false);
+
+        // Act
+        var result = await ticketController.SearchAsync(ticketNumber, time, CancellationToken.None);
+
+        // Assert
+        var okResult = Assert.IsType<OkObjectResult>(result);
+        Assert.Equal(violationTicket, okResult.Value);
+    }
+
+    [Fact]
+    public async void TestSearchBadRequest_DisputeSubmittedBefore()
+    {
+        // Arrange
+        var mockImage = new Mock<IFormFile>();
+        var mockMediator = new Mock<IMediator>();
+        var mockLogger = new Mock<ILogger<TicketsController>>();
+        var mockTicketSearchService = new Mock<ITicketSearchService>();
+        var ticketController = new TicketsController(mockMediator.Object, mockTicketSearchService.Object, mockLogger.Object);
+        string ticketNumber = "AC63378564";
+        string time = "12:15";
+        TrafficCourts.Citizen.Service.Models.Tickets.ViolationTicket violationTicket = new TrafficCourts.Citizen.Service.Models.Tickets.ViolationTicket();
+        violationTicket.TicketNumber = ticketNumber;
+        Search.Response response = new(violationTicket);
+
+        mockMediator
+            .Setup(_ => _.Send<Search.Response>(It.IsAny<Search.Request>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(response);
+
+        mockTicketSearchService
+                 .Setup(_ => _.IsDisputeSubmittedBefore(ticketNumber, It.IsAny<CancellationToken>()))
+                 .ReturnsAsync(true);
+
+        // Act
+        var result = await ticketController.SearchAsync(ticketNumber, time, CancellationToken.None);
+
+        // Assert
+        var badRequestResult = Assert.IsType<BadRequestObjectResult>(result);
+        var errorMsg = Assert.IsType<string>(badRequestResult.Value);
+        Assert.Equal((int)HttpStatusCode.BadRequest, badRequestResult.StatusCode);
+        Assert.StartsWith("A dispute has already been submitted", errorMsg);
+    }
+
+    [Fact]
+    public async void TestSearchInternalError_DisputeSearchFailed()
+    {
+        // Arrange
+        var mockImage = new Mock<IFormFile>();
+        var mockMediator = new Mock<IMediator>();
+        var mockLogger = new Mock<ILogger<TicketsController>>();
+        var mockTicketSearchService = new Mock<ITicketSearchService>();
+        var ticketController = new TicketsController(mockMediator.Object, mockTicketSearchService.Object, mockLogger.Object);
+        string ticketNumber = "AC63378564";
+        string time = "12:15";
+        TrafficCourts.Citizen.Service.Models.Tickets.ViolationTicket violationTicket = new TrafficCourts.Citizen.Service.Models.Tickets.ViolationTicket();
+        violationTicket.TicketNumber = ticketNumber;
+        Search.Response response = new(violationTicket);
+
+        DisputeSearchFailedException exception = new DisputeSearchFailedException(ticketNumber);
+
+        mockMediator
+            .Setup(_ => _.Send<Search.Response>(It.IsAny<Search.Request>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(response);
+
+        mockTicketSearchService
+                 .Setup(_ => _.IsDisputeSubmittedBefore(ticketNumber, It.IsAny<CancellationToken>()))
+                 .ThrowsAsync(exception);
+
+        // Act
+        var result = await ticketController.SearchAsync(ticketNumber, time, CancellationToken.None);
+
+        // Assert
+        var objectResult = Assert.IsType<ObjectResult>(result);
+        var problemDetails = Assert.IsType<ProblemDetails>(objectResult.Value);
+        Assert.Equal(StatusCodes.Status500InternalServerError, problemDetails.Status);
+        Assert.True(problemDetails?.Title?.Contains("Error searching dispute"));
     }
 }


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- TCVP-2548
- Added functionality to check if a dispute has been submitted before for the looked-up or OCR violation ticket and blocks it from submitting multiple times by searching for the ticket number in OCCAM database.
- Returns 400 Bad Request if the dispute is submitted before when disputant searches for a violation ticket or uploads an image of the ticket.
- Added XUnit tests to verify dispute search responses.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Tested searching previously submitted tickets locally and ran XUnit tests.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
