### PR TITLE
TCVP-2586 simple wording change on citizen-portal

### DIFF
--- a/src/frontend/citizen-portal/src/app/components/dispute-stepper/dispute-stepper.component.html
+++ b/src/frontend/citizen-portal/src/app/components/dispute-stepper/dispute-stepper.component.html
@@ -419,7 +419,8 @@
               <ng-container #alertContent class="alert-content">
                 <strong>If you want a lawyer to represent you at your hearing, you should hire a lawyer prior to
                   submitting your Notice of Dispute. The lawyer’s schedule will have to be considered when a date
-                  is set for your hearing and many lawyers are not available on short notice.<br /> If you hire a
+                  is set for your hearing and many lawyers are not available on short notice. If you hire a lawyer 
+                  after submitting your dispute, please update your dispute information online.<br /> If you hire a
                   lawyer they will generally give the Violation Ticket Center dates when they are available for
                   your hearing.</strong>
               </ng-container>

--- a/src/frontend/citizen-portal/src/app/shared/components/alert/alert.component.scss
+++ b/src/frontend/citizen-portal/src/app/shared/components/alert/alert.component.scss
@@ -11,4 +11,5 @@
 
 .mat-icon {
   width:50px !important;
+  overflow: visible;
 }


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

TCVP-2586
- simple wording change
- css fix for warning icon was cut off (only half visible)

![image](https://github.com/bcgov/jag-traffic-courts-online/assets/55215368/ed5a65a7-e32f-43ca-91cf-fc30d22527f0)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
