### PR TITLE
TCVP-2629 Added new error message for duplicate disputes

### DIFF
--- a/src/frontend/citizen-portal/src/app/shared/dialogs/image-ticket-not-found-dialog/image-ticket-not-found-dialog.component.html
+++ b/src/frontend/citizen-portal/src/app/shared/dialogs/image-ticket-not-found-dialog/image-ticket-not-found-dialog.component.html
@@ -74,6 +74,12 @@
       for more options for submitting your dispute or request.
     </p>
   </div>
+  <div *ngIf="options.messageKey === 'error7'">
+    <span class="flex-grow-1"></span>
+    <p>A dispute for this violation ticket already exists. If you need to make updates to your dispute, use Update Dispute or contact 
+      <a href="mailto:Courts.TCO@gov.bc.ca" target="blank">Courts.TCO@gov.bc.ca <img class="me-2" src="/assets/mail-icon.svg" style="width: 15px; height: 13px; vertical-align: text-top;"/></a>
+    </p>
+  </div>
 </mat-dialog-content>
 <mat-dialog-actions>
   <span class="flex-grow-1"></span>


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

TCVP-2629

Added new UI error popup if the user attempts to Dispute a dispute that is already in the system (tickets that start with E, S, or A).

![image](https://github.com/bcgov/jag-traffic-courts-online/assets/55215368/14dafbab-be5f-403d-b334-9a6d3e8f2961)


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
