### PR TITLE
TCVP-2523 DCF editing should only be allowed on staff workbench

### DIFF
--- a/src/frontend/staff-portal/src/app/components/jj-dispute-info/jj-dispute/jj-dispute.component.ts
+++ b/src/frontend/staff-portal/src/app/components/jj-dispute-info/jj-dispute/jj-dispute.component.ts
@@ -31,6 +31,7 @@ export class JJDisputeComponent implements OnInit {
   @Input() jjDisputeInfo: JJDispute
   @Input() type: string;
   @Input() isViewOnly = false;
+  @Input() enableStaffSupport = false;
   @Output() backInbox: EventEmitter<any> = new EventEmitter();
   printOptions: PrintOptions = new PrintOptions();
   isSupportStaff: boolean = false;
@@ -138,7 +139,7 @@ export class JJDisputeComponent implements OnInit {
       }
     });
 
-    this.isSupportStaff = this.authService.checkRole("support-staff");
+    this.isSupportStaff = this.enableStaffSupport && this.authService.checkRole("support-staff");
     this.provinces = this.lookupsService.provinces;
     this.languages = this.lookupsService.languages;
   }

--- a/src/frontend/staff-portal/src/app/components/jj-workbench/jj-workbench-dashboard/jj-workbench-dashboard.component.html
+++ b/src/frontend/staff-portal/src/app/components/jj-workbench/jj-workbench-dashboard/jj-workbench-dashboard.component.html
@@ -34,5 +34,5 @@
 </app-page>
 <ng-container *ngIf="showDispute">
   <app-jj-dispute (backInbox)="backInbox()" [jjDisputeInfo]="jjDisputeInfo"
-    [isViewOnly]="!isInfoEditable"></app-jj-dispute>
+    [isViewOnly]="!isInfoEditable" [enableStaffSupport]="false"></app-jj-dispute>
 </ng-container>

--- a/src/frontend/staff-portal/src/app/components/staff-workbench/staff-workbench-dashboard/staff-workbench-dashboard.component.html
+++ b/src/frontend/staff-portal/src/app/components/staff-workbench/staff-workbench-dashboard/staff-workbench-dashboard.component.html
@@ -53,5 +53,5 @@
   <app-update-request-info *ngIf="tabSelected.value === 2" (backInbox)="backInbox()"
     [disputeInfo]="disputeInfo"></app-update-request-info>
   <app-jj-dispute *ngIf="tabSelected.value === 1 || tabSelected.value === 3" (backInbox)="backInbox()"
-    [jjDisputeInfo]="jjDisputeInfo" [type]="'ticket'" [isViewOnly]="true"></app-jj-dispute>
+    [jjDisputeInfo]="jjDisputeInfo" [type]="'ticket'" [isViewOnly]="true" [enableStaffSupport]="true"></app-jj-dispute>
 </ng-container>


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

TCVP-2523
Per requirements, the new DCF editing feature for support-staff should only be available to the staff workbench, not the jj workbench, but the same component is used on both screens.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
