### PR TITLE
Oracle Data API added root url for easy redirect to swagger UI

### DIFF
--- a/src/backend/oracle-data-api/src/main/resources/application.yml
+++ b/src/backend/oracle-data-api/src/main/resources/application.yml
@@ -15,7 +15,7 @@ spring:
     sentinel:
       master: ${REDIS_SENTINAL_MASTER:}
       nodes: ${REDIS_SENTINAL_NODES:}
-  
+
 management:
   trace:
     http:
@@ -34,6 +34,7 @@ metrics:
 
 springdoc:
   swagger-ui:
+    path: /
     tagsSorter: alpha
     # Configure swagger to list by sorted endpoint
     operations-sorter: alpha


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

Defaulted the Swagger UI to be the root URL.
i.e.
`http://localhost:5010/`
redirects to 
`http://localhost:5010/swagger-ui/index.html`

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
