### PR TITLE
DevOps - enable debug-level logging for .NET APIs

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,7 +38,8 @@ services:
       SERILOG__USING__0: Serilog.Sinks.Console
       SERILOG__WRITETO__0__ARGS__OUTPUTTEMPLATE: "[{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj} <s:{SourceContext}>{NewLine}{Exception}"
       SERILOG__WRITETO__0__ARGS__THEME: Serilog.Sinks.SystemConsole.Themes.ConsoleTheme::None, Serilog.Sinks.Console
-      SERILOG__WRITETO__0__NAME: Console
+      SERILOG__WRITETO__0__NAME: Console      
+      SERILOG__MINIMUMLEVEL__DEFAULT: ${SERILOG__MINIMUMLEVEL__DEFAULT:-Information} 
     ports:
       - "5080:8080"
     restart: always
@@ -85,6 +86,7 @@ services:
       SERILOG__WRITETO__0__ARGS__OUTPUTTEMPLATE: "[{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj} <s:{SourceContext}>{NewLine}{Exception}"
       SERILOG__WRITETO__0__ARGS__THEME: Serilog.Sinks.SystemConsole.Themes.ConsoleTheme::None, Serilog.Sinks.Console
       SERILOG__WRITETO__0__NAME: Console
+      SERILOG__MINIMUMLEVEL__DEFAULT: ${SERILOG__MINIMUMLEVEL__DEFAULT:-Information} 
       CDOGS__CLIENTID: ${CDOGS__CLIENTID:-cdogs}
       CDOGS__CLIENTSECRET: ${CDOGS__CLIENTSECRET:-}
       CDOGS__ENDPOINT: ${CDOGS__ENDPOINT:-https://cdogs-dev.api.gov.bc.ca/api}
@@ -166,7 +168,7 @@ services:
       SERILOG__WRITETO__0__ARGS__OUTPUTTEMPLATE: "[{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj} <s:{SourceContext}>{NewLine}{Exception}"
       SERILOG__WRITETO__0__ARGS__THEME: Serilog.Sinks.SystemConsole.Themes.ConsoleTheme::None, Serilog.Sinks.Console
       SERILOG__WRITETO__0__NAME: Console
-      #SERILOG__MINIMUMLEVEL__DEFAULT: Debug
+      SERILOG__MINIMUMLEVEL__DEFAULT: ${SERILOG__MINIMUMLEVEL__DEFAULT:-Information} 
     ports:
       - "5020:8080"
     restart: always

--- a/tools/port-forward-jaeger.bat
+++ b/tools/port-forward-jaeger.bat
@@ -20,7 +20,7 @@ set server=0198bb-%env%
 set port=16686
 
 REM find podname
-for /F %%i in ('oc get pods -n %server% -o "custom-columns=POD:.metadata.name" --no-headers --selector "app.kubernetes.io/instance=jaeger-%env%"') do set podname=%%i
+for /F %%i in ('oc get pods -n %server% -o "custom-columns=POD:.metadata.name" --no-headers --selector "app.kubernetes.io/instance=jaeger"') do set podname=%%i
 
 REM run port-forward OpenShift command
 echo oc -n %server% port-forward %podname% %port%:16686


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

Up until now, .NET applications only showed Info level logging in docker, which is not useful during development. 

This allows one to set an override to Debug in the three .NET projects: **citizen-api**, **staff-api**, **workflow-service**


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Verified that setting this env var, logging now works in the mentioned projects.
`SERILOG__MINIMUMLEVEL__DEFAULT=Debug`

## Does the change impact or break the Docker build?

- [x] Yes
- [ ] No

If Yes: Has Docker been updated accordingly?

- [x] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
