### PR TITLE
TCVP-2642 Use Token Cache consistently

### DIFF
--- a/src/backend/TrafficCourts/Citizen.Service/Services/Tickets/Search/Extensions.cs
+++ b/src/backend/TrafficCourts/Citizen.Service/Services/Tickets/Search/Extensions.cs
@@ -57,7 +57,7 @@ namespace TrafficCourts.Citizen.Service
             builder.Services.AddHostedService<RsiTokenRefreshService>(serviceProvider =>
             {
                 var factory = serviceProvider.GetRequiredService<IHttpClientFactory>();
-                var cache = serviceProvider.GetRequiredService<IMemoryCache>();
+                var cache = serviceProvider.GetRequiredService<ITokenCache>();
                 var options = GetConfiguration(serviceProvider, "TicketSearch");
                 var logger = serviceProvider.GetRequiredService<ILogger<RsiTokenRefreshService>>();
 

--- a/src/backend/TrafficCourts/Citizen.Service/Services/Tickets/Search/Rsi/Authentication/RsiTokenRefreshService.cs
+++ b/src/backend/TrafficCourts/Citizen.Service/Services/Tickets/Search/Rsi/Authentication/RsiTokenRefreshService.cs
@@ -1,5 +1,4 @@
-﻿using Microsoft.Extensions.Caching.Memory;
-using TrafficCourts.Core.Http;
+﻿using TrafficCourts.Core.Http;
 using TrafficCourts.Http;
 
 namespace TrafficCourts.Citizen.Service.Services.Tickets.Search.Rsi.Authentication;
@@ -10,9 +9,9 @@ public class RsiTokenRefreshService : TokenRefreshService<RsiTokenRefreshService
         IHttpClientFactory httpClientFactory,
         string httpClientName,
         TimeProvider timeProvider,
-        IMemoryCache memoryCache,
+        ITokenCache cache,
         OidcConfidentialClientConfiguration configuration,
-        ILogger<RsiTokenRefreshService> logger) : base(httpClientFactory, httpClientName, timeProvider, memoryCache, configuration, logger)
+        ILogger<RsiTokenRefreshService> logger) : base(httpClientFactory, httpClientName, timeProvider, cache, configuration, logger)
     {
     }
 }

--- a/src/backend/TrafficCourts/Common/Authentication/KeycloakExtension.cs
+++ b/src/backend/TrafficCourts/Common/Authentication/KeycloakExtension.cs
@@ -49,7 +49,7 @@ public static class KeycloakExtension
     private static KeycloakTokenRefreshService CreateTokenRefreshService(IServiceProvider serviceProvider, string sectionName)
     {
         var factory = serviceProvider.GetRequiredService<IHttpClientFactory>();
-        var cache = serviceProvider.GetRequiredService<IMemoryCache>();
+        var cache = serviceProvider.GetRequiredService<ITokenCache>();
         var configuration = GetConfiguration(serviceProvider, sectionName);
         var logger = serviceProvider.GetRequiredService<ILogger<KeycloakTokenRefreshService>>();
 

--- a/src/backend/TrafficCourts/Common/Authentication/KeycloakTokenRefreshService.cs
+++ b/src/backend/TrafficCourts/Common/Authentication/KeycloakTokenRefreshService.cs
@@ -11,9 +11,9 @@ public class KeycloakTokenRefreshService : TokenRefreshService<KeycloakTokenRefr
         IHttpClientFactory httpClientFactory,
         string httpClientName,
         TimeProvider timeProvider, 
-        IMemoryCache memoryCache, 
+        ITokenCache cache, 
         OidcConfidentialClientConfiguration configuration, 
-        ILogger<KeycloakTokenRefreshService> logger) : base(httpClientFactory, httpClientName, timeProvider, memoryCache, configuration, logger)
+        ILogger<KeycloakTokenRefreshService> logger) : base(httpClientFactory, httpClientName, timeProvider, cache, configuration, logger)
     {
     }
 }

--- a/src/backend/TrafficCourts/Test/Citizen.Service/Validators/Rules/DriversLicenceValidRuleTest.cs
+++ b/src/backend/TrafficCourts/Test/Citizen.Service/Validators/Rules/DriversLicenceValidRuleTest.cs
@@ -8,7 +8,6 @@ namespace TrafficCourts.Test.Citizen.Service.Validators.Rules;
 
 public class DriversLicenceValidRuleTest
 {
-
     [Theory]
     [InlineData("BC", "1234567", true, true)]
     [InlineData("BC", "1234567 ", true, false)]
@@ -20,7 +19,7 @@ public class DriversLicenceValidRuleTest
     [InlineData("AB", "1234567", false, true)]
     [InlineData(null, "1234567", true, true)]
     [InlineData("BC", null, true, true)]
-    public async Task TestDriversLicenceIsValid(string province, string licenceNumber, bool expectProvValid, bool expectLicValid)
+    public async Task TestDriversLicenceIsValid(string? province, string? licenceNumber, bool expectProvValid, bool expectLicValid)
     {
         // Given
         Field provinceField = new(province);

--- a/src/backend/TrafficCourts/Test/Citizen.Service/Validators/Rules/TimeRuleTest.cs
+++ b/src/backend/TrafficCourts/Test/Citizen.Service/Validators/Rules/TimeRuleTest.cs
@@ -19,7 +19,7 @@ public class TimeRuleTest
     [InlineData(null, false, 0, 0)]
     [InlineData("", false, 0, 0)]
     [InlineData("text", false, 0, 0)]
-    public void TestTimeParse(string timeStr, bool expectedValid, int expectedHour, int expectedMinute)
+    public void TestTimeParse(string? timeStr, bool expectedValid, int expectedHour, int expectedMinute)
     {
         // Given
         Field timeField = new();

--- a/src/backend/TrafficCourts/Test/Workflow.Service/Consumers/DisputeUpdateRequestConsumerTest.cs
+++ b/src/backend/TrafficCourts/Test/Workflow.Service/Consumers/DisputeUpdateRequestConsumerTest.cs
@@ -84,7 +84,7 @@ public class DisputeUpdateRequestConsumerTest
     [InlineData(null, "fname2", null, "lname", DisputeContactTypeCd.INDIVIDUAL, null)]
     [InlineData(null, null, "fname3", "lname", DisputeContactTypeCd.INDIVIDUAL, null)]
     [InlineData(null, null, null, "lname", DisputeContactTypeCd.INDIVIDUAL, "contactLawFirmName")]
-    public async Task TestDisputeUpdateRequestConsumer_Name(string fname1, string fname2, string fname3, string lname, DisputeContactTypeCd contactType, string contactLawFirmName)
+    public async Task TestDisputeUpdateRequestConsumer_Name(string? fname1, string? fname2, string? fname3, string lname, DisputeContactTypeCd contactType, string? contactLawFirmName)
     {
         // Arrange
         _message.DisputantGivenName1 = fname1;

--- a/src/backend/TrafficCourts/TrafficCourts.Cdogs.Client/Extensions.cs
+++ b/src/backend/TrafficCourts/TrafficCourts.Cdogs.Client/Extensions.cs
@@ -23,7 +23,7 @@ public static partial class Extensions
         services.AddHostedService<CdogsTokenRefreshService>(serviceProvider =>
         {
             var factory = serviceProvider.GetRequiredService<IHttpClientFactory>();
-            var cache = serviceProvider.GetRequiredService<IMemoryCache>();
+            var cache = serviceProvider.GetRequiredService<ITokenCache>();
             var options = GetOidcConfiguration(serviceProvider, section);
             var logger = serviceProvider.GetRequiredService<ILogger<CdogsTokenRefreshService>>();
 
@@ -97,9 +97,9 @@ public class CdogsTokenRefreshService : TokenRefreshService<CdogsTokenRefreshSer
         IHttpClientFactory httpClientFactory,
         string httpClientName,
         TimeProvider timeProvider, 
-        IMemoryCache memoryCache, 
+        ITokenCache cache, 
         OidcConfidentialClientConfiguration configuration, 
-        ILogger<CdogsTokenRefreshService> logger) : base(httpClientFactory, httpClientName, timeProvider, memoryCache, configuration, logger)
+        ILogger<CdogsTokenRefreshService> logger) : base(httpClientFactory, httpClientName, timeProvider, cache, configuration, logger)
     {
     }
 }


### PR DESCRIPTION
# Description

I am still confused why we are getting 401 unauthorized requests going to the keycloak api. In the logs I can see a cached token being found.  I am seeing a log of errors in the keycloak server logs such as 

```
2023-12-12 18:04:01,323 WARN [org.keycloak.events] (executor-thread-1816) type=REFRESH_TOKEN_ERROR, realmId=traffic-court, clientId=staff-portal, userId=null, ipAddress=<redacted>, error=invalid_token, grant_type=refresh_token, client_auth_method=client-secret
```

This PR includes the following proposed change(s):

- Be sure to use ITokenCache for both setting and getting cached tokens
- Fixes xunit warnings

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [ ] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
