### PR TITLE
Add in memory cache of mock ticket and endpoint to add invoice

### DIFF
--- a/src/backend/TrafficCourts/Citizen.Service/Program.cs
+++ b/src/backend/TrafficCourts/Citizen.Service/Program.cs
@@ -1,4 +1,9 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Caching.Memory;
 using TrafficCourts.Citizen.Service;
+using TrafficCourts.Citizen.Service.Services.Tickets.Search.Common;
+using TrafficCourts.Citizen.Service.Services.Tickets.Search.Mock;
 using TrafficCourts.Common.Configuration;
 using TrafficCourts.Configuration.Validation;
 using TrafficCourts.Diagnostics;
@@ -9,6 +14,8 @@ Serilog.ILogger logger = builder.GetProgramLogger();
 builder.ConfigureApplication(logger); // this can throw ConfigurationErrorsException
 
 var app = builder.Build();
+
+AddMockInvoiceEndpoint(app);
 
 // Configure the HTTP request pipeline.
 var swagger = SwaggerConfiguration.Get(builder.Configuration);
@@ -45,4 +52,25 @@ catch (Exception exception)
 finally
 {
     Serilog.Log.CloseAndFlush();
+}
+
+
+void AddMockInvoiceEndpoint(WebApplication application)
+{
+    var type = builder.Configuration.GetSection($"TicketSearch:SearchType").Get<TicketSearchType>();
+    if (type == TicketSearchType.Mock)
+    {
+        application.MapPost("/api/invoice", [AllowAnonymous] (Invoice invoice, [FromServices] IMemoryCache cache) =>
+        {
+            if (string.IsNullOrEmpty(invoice?.InvoiceNumber))
+            {
+                return Results.BadRequest(new { error = "Invoice number missing" });
+            }
+
+            MockInvoiceCache invoiceCache = new(cache);
+            invoiceCache.Add(invoice);
+
+            return Results.Ok();
+        });
+    }
 }

--- a/src/backend/TrafficCourts/Citizen.Service/Services/Tickets/Search/Extensions.cs
+++ b/src/backend/TrafficCourts/Citizen.Service/Services/Tickets/Search/Extensions.cs
@@ -1,16 +1,13 @@
 ﻿using Microsoft.Extensions.Caching.Memory;
-using Microsoft.Extensions.Options;
 using Refit;
 using System.Configuration;
 using TrafficCourts.Citizen.Service.Services.Tickets.Search;
 using TrafficCourts.Citizen.Service.Services.Tickets.Search.Mock;
 using TrafficCourts.Citizen.Service.Services.Tickets.Search.Rsi;
 using TrafficCourts.Citizen.Service.Services.Tickets.Search.Rsi.Authentication;
-using TrafficCourts.Common.Authentication;
 using TrafficCourts.Configuration.Validation;
 using TrafficCourts.Core.Http;
 using TrafficCourts.Http;
-using static System.Collections.Specialized.BitVector32;
 
 namespace TrafficCourts.Citizen.Service
 {
@@ -71,6 +68,7 @@ namespace TrafficCourts.Citizen.Service
         {
             logger.Information("Using mock ticket search service");
             builder.Services.AddTransient<ITicketInvoiceSearchService, MockTicketSearchService>();
+            builder.Services.AddMemoryCache();
 
             // determine if configured to use a external file or embedded data
             var section = builder.Configuration.GetSection(Section);

--- a/src/backend/TrafficCourts/Citizen.Service/Services/Tickets/Search/Mock/MockInvoiceCache.cs
+++ b/src/backend/TrafficCourts/Citizen.Service/Services/Tickets/Search/Mock/MockInvoiceCache.cs
@@ -1,0 +1,41 @@
+﻿using Microsoft.Extensions.Caching.Memory;
+using TrafficCourts.Citizen.Service.Services.Tickets.Search.Common;
+
+namespace TrafficCourts.Citizen.Service.Services.Tickets.Search.Mock;
+
+public class MockInvoiceCache
+{
+    private const string cacheKey = "mock-rsi-invoices";
+    private readonly IMemoryCache _cache;
+    private readonly object SyncLock = new object();
+
+    public MockInvoiceCache(IMemoryCache cache)
+    {
+        _cache = cache ?? throw new ArgumentNullException(nameof(cache));
+    }
+
+    public void Add(Invoice invoice)
+    {
+        ArgumentNullException.ThrowIfNull(invoice);
+
+        lock(SyncLock)
+        {
+            List<Invoice> invoices = _cache.Get<List<Invoice>>(cacheKey) ?? [];
+
+            // remove any matching invoice by invoice number (ticket number + count)
+            invoices.RemoveAll(_ => _.InvoiceNumber == invoice.InvoiceNumber);
+            invoices.Add(invoice);
+
+            _cache.Set(cacheKey, invoices);
+        }
+    }
+
+    public List<Invoice> GetAll()
+    {
+        lock (SyncLock)
+        {
+            List<Invoice> invoices = _cache.Get<List<Invoice>>(cacheKey) ?? [];
+            return invoices;
+        }
+    }
+}

--- a/src/backend/TrafficCourts/Common/ClockExtensions.cs
+++ b/src/backend/TrafficCourts/Common/ClockExtensions.cs
@@ -24,4 +24,12 @@ public static class ClockExtensions
         DateTimeOffset pacificTime = now.InZone(_vancouver).ToDateTimeOffset();
         return pacificTime;
     }
+
+    public static DateTimeOffset GetCurrentPacificTime(this TimeProvider clock)
+    {
+        ArgumentNullException.ThrowIfNull(clock);
+        Instant now = Instant.FromDateTimeOffset(clock.GetUtcNow());
+        DateTimeOffset pacificTime = now.InZone(_vancouver).ToDateTimeOffset();
+        return pacificTime;
+    }
 }

--- a/src/backend/TrafficCourts/Test/TrafficCourts.Test.csproj
+++ b/src/backend/TrafficCourts/Test/TrafficCourts.Test.csproj
@@ -16,6 +16,7 @@
 		</PackageReference>
 		<PackageReference Include="MassTransit.TestFramework" Version="8.1.2" />
 		<PackageReference Include="MediatR" Version="12.2.0" />
+		<PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" Version="8.0.0" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
 		<PackageReference Include="Moq" Version="4.20.69" />
 		<PackageReference Include="NodaTime.Testing" Version="3.1.9" />


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- add in memory cache of ticket invoices
- add endpoint if search type is mock to add invoice

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [ ] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
