### PR TITLE
Bump PVC size to match manually changed size in dev, increase app db backup size to 2GB

### DIFF
--- a/gitops/charts/postgres/postgres-dev-values.yaml
+++ b/gitops/charts/postgres/postgres-dev-values.yaml
@@ -129,7 +129,7 @@ instances:
       - "ReadWriteOnce"
       resources:
         requests:
-          storage: 1Gi
+          storage: 5Gi
       storageClassName: "netapp-block-standard"
     resources:
       requests:
@@ -322,7 +322,7 @@ pgBackRestConfig:
         - "ReadWriteOnce"
         resources:
           requests:
-            storage: 1Gi
+            storage: 5Gi
         storageClassName: "netapp-file-backup"
   # this stuff is for the "pgbackrest" container (the only non-init container) in the "postgres-crunchy-repo-host" pod
   repoHost:

--- a/gitops/charts/postgres/postgres-test-application-values.yaml
+++ b/gitops/charts/postgres/postgres-test-application-values.yaml
@@ -319,7 +319,7 @@ pgBackRestConfig:
         - "ReadWriteOnce"
         resources:
           requests:
-            storage: 1Gi
+            storage: 2Gi
         storageClassName: "netapp-file-backup"
   # this stuff is for the "pgbackrest" container (the only non-init container) in the "postgres-crunchy-repo-host" pod
   repoHost:


### PR DESCRIPTION


# Description

This PR includes the following proposed change(s):

- fixes warning in dev where pvc size doesn't match the definition
![image](https://github.com/bcgov/jag-traffic-courts-online/assets/1844480/e265af7b-d6dc-4837-9d89-dc862bb7d6a4)
- increases the backup volume in test since the storage was at 80% of volume size

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [ ] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
