### PR TITLE
Improved startup of oracle-data-api

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -214,12 +214,6 @@ services:
       ORDS_API_RETRY_DELAY_SEC: ${ORDS_API_RETRY_DELAY_SEC:-5}
       SPRING_SLEUTH_ENABLED: ${SPRING_SLEUTH_ENABLED:-false}
       JAVA_OPTS: ${JAVA_OPTS:--Dlogging.level.ca.bc.gov.open.jag.tco.oracledataapi=DEBUG -Dlogging.level.org.hibernate.SQL=DEBUG}
-    healthcheck:
-      test: ["CMD-SHELL", "curl -f http://localhost:8080/actuator/health"]
-      interval: 5s
-      timeout: 5s
-      retries: 5
-
     depends_on:
       redis:
         condition: service_healthy

--- a/src/backend/oracle-data-api/Dockerfile
+++ b/src/backend/oracle-data-api/Dockerfile
@@ -47,6 +47,11 @@ WORKDIR /app
 EXPOSE 8080
 EXPOSE 8000
 
+# add curl for health check
+RUN apt-get update \
+  && apt-get install -y ca-certificates curl git --no-install-recommends \
+  && rm -rf /var/lib/apt/lists/*
+
 ADD https://repo1.maven.org/maven2/io/prometheus/jmx/jmx_prometheus_javaagent/${PROMETHEUS_AGENT_VERSION}/jmx_prometheus_javaagent-${PROMETHEUS_AGENT_VERSION}.jar /app/jmx_prometheus_javaagent.jar
 RUN printf "Generate jmx_prometheus_javaagent_config.yaml\n" & \
  echo "startDelaySeconds: 0 \n\
@@ -65,6 +70,9 @@ ADD https://github.com/open-telemetry/opentelemetry-java-instrumentation/release
 RUN chgrp 0 /app/opentelemetry-javaagent.jar          && chmod a+rw,o-rw opentelemetry-javaagent.jar
 
 ENV TZ=America/Vancouver
+
+# Configure healthcheck 
+HEALTHCHECK --interval=10s --timeout=3s --start-period=30s --retries=12 CMD curl --fail http://localhost:8080/actuator/health || exit 1
 
 COPY --from=build ./target/oracle-data-api.jar .
 COPY --from=build ./entrypoint.sh .

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/scheduled/StartupTasks.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/scheduled/StartupTasks.java
@@ -25,7 +25,7 @@ public class StartupTasks implements ApplicationListener<ApplicationReadyEvent> 
 	public void onApplicationEvent(ApplicationReadyEvent event) {
 		if (refreshAtStartup) {
 			logger.debug("Refreshing code tables at startup.");
-			lookupService.refresh();
+			new Thread(() -> lookupService.refresh()).start();
 		}
 	}
 


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

The healthcheck for oracle-data-api wasn't working. 
- Moved heathcheck to the Docker image instead of docker-compose
- Moved startup tasks to a background thread to speed up startup 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [x] Yes
- [ ] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
