### PR TITLE
TCVP-2649 updated CSS styles on DCF staff-portal

### DIFF
--- a/src/frontend/staff-portal/src/app/components/jj-dispute-info/jj-count/jj-count.component.scss
+++ b/src/frontend/staff-portal/src/app/components/jj-dispute-info/jj-count/jj-count.component.scss
@@ -34,33 +34,6 @@ h3 {
   }
 }
 
-:host::ng-deep {
-  .mat-form-field-type-mat-select {
-    margin: 0px !important;
-    padding: 0px !important;
-    border: none !important;
-
-    .mat-form-field-wrapper {      
-      .mat-form-field-flex {
-        padding: 10px 0px 0px 10px;
-
-        .mat-form-field-outline {
-          background-color: #ffffff;
-        }
-
-        .mat-form-field-infix {
-          .mat-select-value {
-            line-height: normal;
-          }
-          .mat-select-arrow-wrapper {
-            transform: none;
-          }
-        }
-      }
-    }
-  }
-}
-
 .text {
   font-weight: 700;
   line-height: 1.5em;
@@ -248,6 +221,7 @@ p {
   }
 }
 
+// FIXME: ng-deep applies global styles, not component-specific styles. But these styles should be global anyway. Move to main scss.
 :host::ng-deep .mat-tooltip {
   /* your own custom styles here */ 
   /* e.g. */

--- a/src/frontend/staff-portal/src/app/components/jj-dispute-info/jj-dispute/jj-dispute.component.html
+++ b/src/frontend/staff-portal/src/app/components/jj-dispute-info/jj-dispute/jj-dispute.component.html
@@ -246,7 +246,7 @@
             <span class="section-grid-cell">
               <p class="section-grid-header">{{ "label.interpreter" | translate }}</p>
               <p class="section-grid-text" *ngIf="!isSSEditMode">{{ lastUpdatedJJDispute.interpreterLanguage }}</p>
-              <mat-form-field appearance="select-box-only" *ngIf="isSSEditMode">
+              <mat-form-field appearance="outline" *ngIf="isSSEditMode">
                 <mat-select formControlName="interpreterLanguageCd" placeholder="Language">
                   <mat-option [value]=""></mat-option>
                   <mat-option *ngFor="let lang of languages" [value]="lang.code">{{ lang.description }}</mat-option>
@@ -258,7 +258,7 @@
               <!--                
               <p class="section-grid-header">Disputant Attendance Type</p>
               <p class="section-grid-text" *ngIf="!isSSEditMode">{{ lastUpdatedJJDispute.disputantAttendanceType }}</p>
-              <mat-form-field appearance="select-box-only" *ngIf="isSSEditMode">
+              <mat-form-field appearance="outline" *ngIf="isSSEditMode">
                 <mat-select formControlName="disputantAttendanceType" placeholder="Attendance">
                   <mat-option [value]="AttendanceType.InPerson">{{ "attendanceType.in_person" | translate }}</mat-option>
                   <mat-option [value]="AttendanceType.MsteamsAudio">{{ "attendanceType.msteams_audio" | translate }}</mat-option>
@@ -306,7 +306,7 @@
               <p class="section-grid-header">APP (P/N/A)</p>
               <p class="section-grid-text">
                 <span *ngIf="isViewOnly && !isSSEditMode">{{ courtAppearanceForm?.value.appCd }}</span>
-                <mat-form-field appearance="select-box-only" *ngIf="!isViewOnly || isSSEditMode">
+                <mat-form-field appearance="outline" *ngIf="!isViewOnly || isSSEditMode">
                   <mat-select formControlName="appCd" (selectionChange)="onUpdateAPPCd()">
                     <mat-option [value]="RoPApp.P">{{ RoPApp.P }}</mat-option>
                     <mat-option [value]="RoPApp.N">{{ RoPApp.N }}</mat-option>
@@ -355,19 +355,21 @@
             <span class="section-grid-cell">
               <p class="section-grid-header">Def Att</p>
               <p class="section-grid-text">
-                <span *ngIf="isViewOnly">{{ courtAppearanceForm?.value.dattCd }}</span>
-                <mat-select *ngIf="!isViewOnly" formControlName="dattCd" style="background:#fffee6">
-                  <mat-option [value]="RoPDatt.A">{{ RoPDatt.A }}</mat-option>
-                  <mat-option [value]="RoPDatt.C">{{ RoPDatt.C }}</mat-option>
-                  <mat-option [value]="RoPDatt.N">{{ RoPDatt.N }}</mat-option>
-                </mat-select>
+                <span *ngIf="isViewOnly">{{ courtAppearanceForm?.value.dattCd }}</span>                
+                <mat-form-field appearance="outline" *ngIf="!isViewOnly">
+                    <mat-select formControlName="dattCd">
+                      <mat-option [value]="RoPDatt.A">{{ RoPDatt.A }}</mat-option>
+                      <mat-option [value]="RoPDatt.C">{{ RoPDatt.C }}</mat-option>
+                      <mat-option [value]="RoPDatt.N">{{ RoPDatt.N }}</mat-option>
+                    </mat-select>
+                </mat-form-field>
               </p>
             </span>
             <span class="section-grid-cell">
               <p class="section-grid-header">Crown</p>
               <p class="section-grid-text">
                 <span *ngIf="isViewOnly && !isSSEditMode">{{ courtAppearanceForm?.value.crown }}</span>
-                <mat-form-field appearance="select-box-only" *ngIf="!isViewOnly || isSSEditMode">
+                <mat-form-field appearance="outline" *ngIf="!isViewOnly || isSSEditMode">
                   <mat-select formControlName="crown">
                     <mat-option [value]="RoPCrown.P">{{ RoPCrown.P }}</mat-option>
                     <mat-option [value]="RoPCrown.N">{{ RoPCrown.N }}</mat-option>
@@ -378,10 +380,12 @@
             <span class="section-grid-cell">
               <p class="section-grid-header">Seized</p>
               <p class="section-grid-text">
-                <mat-select *ngIf="!isViewOnly" formControlName="jjSeized" style="background:#fffee6">
-                  <mat-option [value]="RoPSeized.Y">{{ RoPSeized.Y }}</mat-option>
-                  <mat-option [value]="RoPSeized.N">{{ RoPSeized.N }}</mat-option>
-                </mat-select>
+                <mat-form-field appearance="outline" *ngIf="!isViewOnly">
+                  <mat-select formControlName="jjSeized">
+                    <mat-option [value]="RoPSeized.Y">{{ RoPSeized.Y }}</mat-option>
+                    <mat-option [value]="RoPSeized.N">{{ RoPSeized.N }}</mat-option>
+                  </mat-select>
+                </mat-form-field>
                 <span *ngIf="isViewOnly">{{ courtAppearanceForm?.value.jjSeized }}</span>
               </p>
             </span>
@@ -485,14 +489,16 @@
             <button type="button" style="width:50px !important; border:none; background-color:white"
               (click)="onRemoveFile(doc.fileId, doc.fileName)"><mat-icon style="color:red">delete</mat-icon></button>
           </div>
-          <mat-form-field class="select-box-only">
-            <mat-label>File type for upload</mat-label>
-            <mat-select [(ngModel)]="fileTypeToUpload">
-              <mat-option value="Certified Extract">Certified Extract</mat-option>
-              <mat-option value="Adjournment">Adjournment</mat-option>
-              <mat-option value="Other">Other</mat-option>
-            </mat-select>
-          </mat-form-field>&nbsp;
+          <div>
+            <label>File type for upload:</label>
+            <mat-form-field appearance="outline" style="display: inline-flex;">
+              <mat-select [(ngModel)]="fileTypeToUpload">
+                <mat-option value="Certified Extract">Certified Extract</mat-option>
+                <mat-option value="Adjournment">Adjournment</mat-option>
+                <mat-option value="Other">Other</mat-option>
+              </mat-select>
+            </mat-form-field>
+          </div>
           <button class="large" mat-flat-button type="button" color="primary"
             onclick="document.getElementById('getFile').click()">
             <mat-icon>upload</mat-icon>&nbsp;Upload File
@@ -548,7 +554,7 @@
         <div *ngIf="type === 'ticket' && isViewOnly && lastUpdatedJJDispute.status === DisputeStatus.Confirmed"
           fxFlex="40" fxLayout="row">
           <div style="margin-right: 1rem;">
-            <mat-form-field class="select-box-only">
+            <mat-form-field appearance="outline">
               <mat-select [(ngModel)]="selectedJJ" placeholder="choose a JJ">
                 <mat-option [value]=""></mat-option>
                 <mat-option *ngFor="let jj of jjList" [value]="jj.idir"><i>{{ jj.jjDisplayName }}</i>

--- a/src/frontend/staff-portal/src/app/components/jj-dispute-info/jj-dispute/jj-dispute.component.scss
+++ b/src/frontend/staff-portal/src/app/components/jj-dispute-info/jj-dispute/jj-dispute.component.scss
@@ -47,6 +47,13 @@ p {
   line-height: 1.1;
 }
 
+label {
+  font-weight: 700;
+  font-size: 15px;
+  line-height: 24px;
+  font-family: BCSans, Noto Sans, Verdana, Arial, sans-serif;
+}
+
 .text {
   font-weight: 700;
   line-height: 1.5em;
@@ -154,7 +161,8 @@ p {
   }
 }
 
-:host::ng-deep {
+// FIXME: ng-deep applies global styles, not component-specific styles. But these styles should be global anyway. Move to main scss.
+::ng-deep {
   .heading-hr {
     width: 700% !important;
   }
@@ -196,13 +204,8 @@ p {
           padding: 0px 0px 7px 0px !important;
           line-height: 0px;
 
-          input, .mat-select {
+          input {
             line-height: 18px !important;
-          }
-
-          .mat-select {
-            border-top: none;
-            padding: 0px 0px 0px 0px !important;
           }
         }
       }
@@ -214,25 +217,32 @@ p {
       }
     }
   }
+}
 
+// FIXME: ng-deep applies global styles, not component-specific styles. But these styles should be global anyway. Move to main scss.
+::ng-deep {
   .mat-form-field-type-mat-select {
-    margin: 4px 0px 0px 0px;
-    border: 1px solid rgb(224, 224, 224);
-    border-radius: 5px;
-    padding: 6px 0px 0px 10px;
+    margin: 0px !important;
+    padding: 0px !important;
+    border: none !important;
 
     .mat-form-field-wrapper {      
       .mat-form-field-flex {
+        padding: 0px 5px 0px 10px !important;
+
+        .mat-form-field-outline {
+          background-color: #ffffff;
+        }
+
         .mat-form-field-infix {
-          border: none !important;
           .mat-select-value {
             line-height: normal;
+          }
+          .mat-select-arrow-wrapper {
+            transform: none;
           }
         }
       }
     }
-  }
-  .mat-form-field-type-mat-select:hover {
-    border: 1px solid rgb(0, 0, 0);
   }
 }


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

TCVP-2649
Made all the select lists (drop-downs) look the same on the DCF tab on the staff-portal.
Bug fix: fixed the file upload select list ... it was really messed up.

![image](https://github.com/bcgov/jag-traffic-courts-online/assets/55215368/8696f32f-0f48-463b-b986-01dd342de3d3)

I found out that ::ng-deep styling is actually global, not component specific. Added FIXME comments so that some day when the huge tech dept on this project is addressed, someone will move such styles to the main globally styling sheet.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
