### PR TITLE
Updated the fake smtp server version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -464,10 +464,10 @@ services:
   #############################################################################################
   smtp-server:
     container_name: smtp-server
-    image: gessnerfl/fake-smtp-server
+    image: gessnerfl/fake-smtp-server:2.1.4
     environment:
       - "SERVER_PORT=8080"
-      - "SMTP_PORT=5025"
+      - "FAKESMTP_PORT=5025"
     ports:
       - "5125:8080"
       - "5025:5025"


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

Fixed docker-compose to lock down the version of the pulled fake smtp image from just using latest to a specific version). docker-compose should never pull latest as functionality could change in images over time. The version should be upgraded only during an intentional manual upgrade process.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [x] Yes
- [ ] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
