### PR TITLE
TCVP-1981 Made latestPlea editable

### DIFF
--- a/src/backend/oracle-data-api/src/test/java/ca/bc/gov/open/jag/tco/oracledataapi/util/RandomUtil.java
+++ b/src/backend/oracle-data-api/src/test/java/ca/bc/gov/open/jag/tco/oracledataapi/util/RandomUtil.java
@@ -26,6 +26,7 @@ import ca.bc.gov.open.jag.tco.oracledataapi.model.EmailHistory;
 import ca.bc.gov.open.jag.tco.oracledataapi.model.FileHistory;
 import ca.bc.gov.open.jag.tco.oracledataapi.model.JJDispute;
 import ca.bc.gov.open.jag.tco.oracledataapi.model.JJDisputeStatus;
+import ca.bc.gov.open.jag.tco.oracledataapi.model.JJDisputedCount;
 import ca.bc.gov.open.jag.tco.oracledataapi.model.Plea;
 import ca.bc.gov.open.jag.tco.oracledataapi.model.ViolationTicket;
 import ca.bc.gov.open.jag.tco.oracledataapi.model.ViolationTicketCount;
@@ -214,6 +215,16 @@ public class RandomUtil {
 		dispute.setViolationDate(randomDate(DateUtils.addDays(new Date(), -30), new Date())); // random date in the last 30 days
 		dispute.setAddressLine1("123 Boogie Woogie Avenue");
 		return dispute;
+	}
+	
+	public static JJDisputedCount createJJDisputedCount(long id) {
+		JJDisputedCount jjDisputedCount = new JJDisputedCount();
+		jjDisputedCount.setId(Long.valueOf(id));
+		jjDisputedCount.setCount(1);
+		jjDisputedCount.setAppearInCourt(randomYN());
+		jjDisputedCount.setRequestReduction(randomYN());
+		jjDisputedCount.setRequestTimeToPay(randomYN());
+		return jjDisputedCount;
 	}
 
 	public static EmailHistory createEmailHistory() {

--- a/src/frontend/staff-portal/src/app/components/jj-dispute-info/jj-count/jj-count.component.html
+++ b/src/frontend/staff-portal/src/app/components/jj-dispute-info/jj-count/jj-count.component.html
@@ -308,7 +308,7 @@
   </section>
 
   <!-- JJ Latest Change Plea -->
-  <section [formGroup]="form" *ngIf="jjDisputeInfo.hearingType === HearingType.CourtAppearance"
+  <section [formGroup]="form" *ngIf="jjDisputeInfo.hearingType === HearingType.CourtAppearance && !(isSSEditMode && jjDisputedCount)"
     style="padding: 0 0.2rem;">
     <br>
     <div class="row">
@@ -343,6 +343,26 @@
     <br>
     <hr style="margin: 0 0 0 0" />
   </section>
+  <br/>
+
+  <section *ngIf="jjDisputeInfo.hearingType === HearingType.CourtAppearance && (isSSEditMode && jjDisputedCount)">
+    <form [formGroup]="countForm">
+      <!-- Change Plea -->
+      <div class="row">
+        <label class="col-4">{{ "label.change_plea" | translate }}</label>
+        <div class="col-8">
+          <mat-form-field appearance="outline">
+            <mat-select formControlName="latestPlea">
+              <mat-option [value]=""></mat-option>
+              <mat-option [value]="LatestPlea.G">{{ "pleaType.guilty" | translate }}</mat-option>
+              <mat-option [value]="LatestPlea.N">{{ "pleaType.not_guilty" | translate }}</mat-option>
+            </mat-select>
+          </mat-form-field>
+        </div>
+      </div>
+    </form>
+  </section>
+
   <!-- JJ RoP for Court Appearance -->
   <section *ngIf="type !== 'ticket' && jjDisputeInfo.hearingType === HearingType.CourtAppearance && !isSSEditMode"
     style="padding: 0 0.2rem;">

--- a/src/frontend/staff-portal/src/app/components/jj-dispute-info/jj-count/jj-count.component.ts
+++ b/src/frontend/staff-portal/src/app/components/jj-dispute-info/jj-count/jj-count.component.ts
@@ -44,6 +44,7 @@ export class JJCountComponent implements OnInit, OnChanges {
     appearInCourt: [null],
     requestReduction: [null],
     requestTimeToPay: [null],
+    latestPlea: [null],
     lesserOrGreaterAmount: [null],
     includesSurcharge: [null],
     revisedDueDate: [null],

--- a/src/frontend/staff-portal/src/app/components/jj-dispute-info/jj-dispute/jj-dispute.component.ts
+++ b/src/frontend/staff-portal/src/app/components/jj-dispute-info/jj-dispute/jj-dispute.component.ts
@@ -421,6 +421,7 @@ export class JJDisputeComponent implements OnInit {
         jjDisputedCount.appearInCourt = updatedJJDisputedCount.appearInCourt;
         jjDisputedCount.requestReduction = updatedJJDisputedCount.requestReduction;
         jjDisputedCount.requestTimeToPay = updatedJJDisputedCount.requestTimeToPay;
+        jjDisputedCount.latestPlea = updatedJJDisputedCount.latestPlea;
         jjDisputedCount.lesserOrGreaterAmount = updatedJJDisputedCount.lesserOrGreaterAmount;
         jjDisputedCount.includesSurcharge = updatedJJDisputedCount.includesSurcharge;
         jjDisputedCount.revisedDueDate = updatedJJDisputedCount.revisedDueDate;

--- a/src/frontend/staff-portal/src/assets/i18n/en.json
+++ b/src/frontend/staff-portal/src/assets/i18n/en.json
@@ -145,6 +145,7 @@
     "amount_due": "Amount Due",
     "appearInCourt": "For this count I would like to",
     "back": "Back",
+    "change_plea": "Change Plea",
     "count_number": "Count #",
     "defence_witness": "Defence Witnesses",
     "desc_of_offence": "Description of Offence",

--- a/src/frontend/staff-portal/src/assets/i18n/fr.json
+++ b/src/frontend/staff-portal/src/assets/i18n/fr.json
@@ -144,6 +144,7 @@
     "amount_due": "Montant Dû",
     "appearInCourt": "Pour ce compte, j'aimerais",
     "back": "Reculer",
+    "change_plea": "Changement de Plaignant",
     "count_number": "Infraction #",
     "defence_witness": "Témoins à décharge",
     "desc_of_offence": "Description de l'Infraction",


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

TCVP-1981

Made JJDisputeCount.latestPlea an editable field for support-staff.
When updating this value, the corresponding latestPleaUpdatedTs is updated accordingly.

![image](https://github.com/bcgov/jag-traffic-courts-online/assets/55215368/6cadcd3a-a933-4cc7-a504-8f7a313befba)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
