### PR TITLE
TCVP-2686 Fixed DisputeResult on CitizenPortal screen

### DIFF
--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/model/Dispute.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/model/Dispute.java
@@ -252,7 +252,6 @@ public class Dispute extends Auditable<String> {
 
 	/**
 	 * Indicates whether the disputant's email address is verified or not.
-	 * This should always be in UTC date (ISO 8601) format
 	 */
 	@Column
 	private Boolean emailAddressVerified = Boolean.FALSE;

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/model/DisputeListItem.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/model/DisputeListItem.java
@@ -89,7 +89,6 @@ public class DisputeListItem {
 
 	/**
 	 * Indicates whether the disputant's email address is verified or not.
-	 * This should always be in UTC date (ISO 8601) format
 	 */
 	@Column
 	private Boolean emailAddressVerified = Boolean.FALSE;

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/model/DisputeResult.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/model/DisputeResult.java
@@ -26,6 +26,13 @@ public class DisputeResult {
 
 	private Boolean isEmailAddressVerified = Boolean.FALSE;
 
+	/**
+	 * 
+	 * @param disputeId
+	 * @param noticeOfDisputeGuid
+	 * @param disputeStatus
+	 * @param isEmailAddressVerified TRUE if there is no email address or if the email address has been successfully verified, FALSE otherwise.
+	 */
 	public DisputeResult(Long disputeId, String noticeOfDisputeGuid, DisputeStatus disputeStatus, Boolean isEmailAddressVerified) {
 		this.disputeId = disputeId;
 		this.noticeOfDisputeGuid = noticeOfDisputeGuid;

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/repository/impl/ords/DisputeRepositoryImpl.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/repository/impl/ords/DisputeRepositoryImpl.java
@@ -36,6 +36,7 @@ import ca.bc.gov.open.jag.tco.oracledataapi.ords.occam.api.model.ViolationTicket
 import ca.bc.gov.open.jag.tco.oracledataapi.repository.DisputeRepository;
 import ca.bc.gov.open.jag.tco.oracledataapi.util.DateUtil;
 import net.logstash.logback.argument.StructuredArguments;
+import net.logstash.logback.util.StringUtils;
 
 @ConditionalOnProperty(name = "repository.dispute", havingValue = "ords", matchIfMissing = true)
 @Qualifier("disputeRepository")
@@ -106,7 +107,7 @@ public class DisputeRepositoryImpl implements DisputeRepository {
 						dispute.getDisputeId(),
 						dispute.getNoticeOfDisputeGuid(),
 						dispute.getStatus(),
-						dispute.getEmailAddressVerified()))
+						StringUtils.isBlank(dispute.getEmailAddress()) ? Boolean.TRUE : dispute.getEmailAddressVerified()))
 				.collect(Collectors.toList());
 
 		return disputeResults;
@@ -124,7 +125,7 @@ public class DisputeRepositoryImpl implements DisputeRepository {
 						dispute.getDisputeId(),
 						dispute.getNoticeOfDisputeGuid(),
 						dispute.getStatus(),
-						dispute.getEmailAddressVerified()))
+						StringUtils.isBlank(dispute.getEmailAddress()) ? Boolean.TRUE : dispute.getEmailAddressVerified()))
 				.collect(Collectors.toList());
 
 		return disputeResults;

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/service/DisputeService.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/service/DisputeService.java
@@ -373,7 +373,7 @@ public class DisputeService {
 						dispute.getDisputeId(),
 						dispute.getNoticeOfDisputeGuid(),
 						dispute.getStatus(),
-						dispute.getEmailAddressVerified()));
+						StringUtils.isBlank(dispute.getEmailAddress()) ? Boolean.TRUE : dispute.getEmailAddressVerified()));
 				ticketNumber = dispute.getTicketNumber();
 				issuedTime = dispute.getIssuedTs();
 			}


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

TCVP-2686

On the Citizen Portal, the Change Dispute button was disabled if the citizen hasn't yet verified their email address. However, the button should not be disabled if the user opted out of email altogether.

This fix is an easy change on the oracle-data-api to pass TRUE _if there is no email address or_ if the email address has been successfully verified, FALSE otherwise.

![image](https://github.com/bcgov/jag-traffic-courts-online/assets/55215368/88481cdd-49a9-475b-97c1-72085fe0a519)


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
