### PR TITLE
TCVP-2692 Update Models and Mapping to Save and Get Signatory Data

### DIFF
--- a/src/backend/TrafficCourts/Common/OpenAPIs/OracleDataAPI/v1_0/OracleDataApi.v1_0.json
+++ b/src/backend/TrafficCourts/Common/OpenAPIs/OracleDataAPI/v1_0/OracleDataApi.v1_0.json
@@ -1,1571 +1,3150 @@
 {
-    "openapi": "3.0.1",
-    "info": { "title": "Oracle Data Api", "version": "1.0.0" },
-    "servers": [{ "url": "http://localhost:5010", "description": "Generated server url" }],
-    "security": [{ "x-username": [] }],
-    "paths": {
-        "/api/v1.0/jj/dispute/{ticketNumber}": {
-            "put": {
-                "tags": ["jj-dispute-controller"],
-                "summary": "Updates the properties of a particular JJ Dispute record based on the given values.",
-                "operationId": "updateJJDispute",
-                "parameters": [
-                    { "name": "ticketNumber", "in": "path", "required": true, "schema": { "type": "string" } },
-                    { "name": "checkVTCAssigned", "in": "query", "required": true, "schema": { "type": "boolean" } }
-                ],
-                "requestBody": {
-                    "content": { "application/json": { "schema": { "$ref": "#/components/schemas/JJDispute" } } },
-                    "required": true
-                },
-                "responses": {
-                    "400": { "description": "Bad Request.", "content": { "*/*": { "schema": { "type": "object" } } } },
-                    "404": {
-                        "description": "JJDispute record not found. Update failed.",
-                        "content": { "*/*": { "schema": { "type": "object" } } }
-                    },
-                    "405": {
-                        "description": "An invalid JJ Dispute status is provided. Update failed.",
-                        "content": { "*/*": { "schema": { "type": "object" } } }
-                    },
-                    "500": { "description": "Internal Server Error", "content": { "*/*": { "schema": { "type": "object" } } } },
-                    "200": { "description": "Ok", "content": { "*/*": { "schema": { "$ref": "#/components/schemas/JJDispute" } } } }
-                }
-            }
-        },
-        "/api/v1.0/jj/dispute/{ticketNumber}/review": {
-            "put": {
-                "tags": ["jj-dispute-controller"],
-                "summary": "Updates the status of a particular JJDispute record to REVIEW.",
-                "operationId": "reviewJJDispute",
-                "parameters": [
-                    { "name": "ticketNumber", "in": "path", "required": true, "schema": { "type": "string" } },
-                    { "name": "checkVTCAssigned", "in": "query", "required": true, "schema": { "type": "boolean" } },
-                    { "name": "recalled", "in": "query", "required": true, "schema": { "type": "boolean" } }
-                ],
-                "requestBody": { "content": { "application/json": { "schema": { "maxLength": 256, "minLength": 0, "type": "string" } } } },
-                "responses": {
-                    "400": { "description": "Bad Request.", "content": { "*/*": { "schema": { "type": "object" } } } },
-                    "404": {
-                        "description": "JJDispute record not found. Update failed.",
-                        "content": { "*/*": { "schema": { "type": "object" } } }
-                    },
-                    "405": {
-                        "description": "A JJDispute status can only be set to REVIEW if status is CONFIRMED and the remark must be <= 256 characters OR if the status ACCEPTED, CONFIRMED or CONCLUDED and DCF's current hearing date = today's date. Update failed.",
-                        "content": { "*/*": { "schema": { "type": "object" } } }
-                    },
-                    "500": { "description": "Internal server error occured.", "content": { "*/*": { "schema": { "type": "object" } } } },
-                    "200": {
-                        "description": "Ok. Updated JJDispute record returned.",
-                        "content": { "*/*": { "schema": { "$ref": "#/components/schemas/JJDispute" } } }
-                    }
-                }
-            }
-        },
-        "/api/v1.0/jj/dispute/{ticketNumber}/requirecourthearing": {
-            "put": {
-                "tags": ["jj-dispute-controller"],
-                "summary": "Updates the status of a particular JJDispute record to REQUIRE_COURT_HEARING, type to COURT_APPEARANCE.",
-                "operationId": "requireCourtHearingJJDispute",
-                "parameters": [
-                    { "name": "ticketNumber", "in": "path", "required": true, "schema": { "type": "string" } },
-                    { "name": "remark", "in": "query", "required": false, "schema": { "maxLength": 256, "minLength": 0, "type": "string" } }
-                ],
-                "responses": {
-                    "400": { "description": "Bad Request.", "content": { "*/*": { "schema": { "type": "object" } } } },
-                    "404": {
-                        "description": "JJDispute record not found. Update failed.",
-                        "content": { "*/*": { "schema": { "type": "object" } } }
-                    },
-                    "405": {
-                        "description": "A JJDispute status can only be set to REQUIRE_COURT_HEARING iff status is one of the following: NEW, IN_PROGRESS, REVIEW, REQUIRE_COURT_HEARING and the remark must be <= 256 characters. Update failed.",
-                        "content": { "*/*": { "schema": { "type": "object" } } }
-                    },
-                    "500": { "description": "Internal server error occured.", "content": { "*/*": { "schema": { "type": "object" } } } },
-                    "200": {
-                        "description": "Ok. Updated JJDispute record returned.",
-                        "content": { "*/*": { "schema": { "$ref": "#/components/schemas/JJDispute" } } }
-                    }
-                }
-            }
-        },
-        "/api/v1.0/jj/dispute/{ticketNumber}/confirm": {
-            "put": {
-                "tags": ["jj-dispute-controller"],
-                "summary": "Updates the status of a particular JJDispute record to CONFIRMED.",
-                "operationId": "confirmJJDispute",
-                "parameters": [{ "name": "ticketNumber", "in": "path", "required": true, "schema": { "type": "string" } }],
-                "responses": {
-                    "400": { "description": "Bad Request.", "content": { "*/*": { "schema": { "type": "object" } } } },
-                    "404": {
-                        "description": "JJDispute record not found. Update failed.",
-                        "content": { "*/*": { "schema": { "type": "object" } } }
-                    },
-                    "405": {
-                        "description": "A JJDispute status can only be set to CONFIRMED iff status is one of the following: REVIEW, NEW, HEARING_SCHEDULED, IN_PROGRESS, CONFIRMED. Update failed.",
-                        "content": { "*/*": { "schema": { "type": "object" } } }
-                    },
-                    "500": { "description": "Internal server error occured.", "content": { "*/*": { "schema": { "type": "object" } } } },
-                    "200": {
-                        "description": "Ok. Updated JJDispute record returned.",
-                        "content": { "*/*": { "schema": { "$ref": "#/components/schemas/JJDispute" } } }
-                    }
-                }
-            }
-        },
-        "/api/v1.0/jj/dispute/{ticketNumber}/conclude": {
-            "put": {
-                "tags": ["jj-dispute-controller"],
-                "summary": "Updates the status of a particular JJDispute record to CONCLUDED.",
-                "operationId": "concludeJJDispute",
-                "parameters": [
-                    { "name": "ticketNumber", "in": "path", "required": true, "schema": { "type": "string" } },
-                    { "name": "checkVTCAssigned", "in": "query", "required": true, "schema": { "type": "boolean" } }
-                ],
-                "responses": {
-                    "400": { "description": "Bad Request.", "content": { "*/*": { "schema": { "type": "object" } } } },
-                    "404": {
-                        "description": "JJDispute record not found. Update failed.",
-                        "content": { "*/*": { "schema": { "type": "object" } } }
-                    },
-                    "405": { "description": "Method Not Allowed", "content": { "*/*": { "schema": { "type": "object" } } } },
-                    "500": { "description": "Internal server error occured.", "content": { "*/*": { "schema": { "type": "object" } } } },
-                    "200": {
-                        "description": "Ok. Updated JJDispute record returned.",
-                        "content": { "*/*": { "schema": { "$ref": "#/components/schemas/JJDispute" } } }
-                    }
-                }
-            }
-        },
-        "/api/v1.0/jj/dispute/{ticketNumber}/cascade": {
-            "put": {
-                "tags": ["jj-dispute-controller"],
-                "summary": "Updates the properties of a particular JJ Dispute record as well as cascading to underlying related Dispute data.",
-                "operationId": "updateJJDisputeCascade",
-                "parameters": [
-                    { "name": "ticketNumber", "in": "path", "required": true, "schema": { "type": "string" } },
-                    { "name": "checkVTCAssigned", "in": "query", "required": true, "schema": { "type": "boolean" } }
-                ],
-                "requestBody": {
-                    "content": { "application/json": { "schema": { "$ref": "#/components/schemas/JJDispute" } } },
-                    "required": true
-                },
-                "responses": {
-                    "400": { "description": "Bad Request.", "content": { "*/*": { "schema": { "type": "object" } } } },
-                    "404": {
-                        "description": "JJDispute record not found. Update failed.",
-                        "content": { "*/*": { "schema": { "type": "object" } } }
-                    },
-                    "405": {
-                        "description": "An invalid JJ Dispute status is provided. Update failed.",
-                        "content": { "*/*": { "schema": { "type": "object" } } }
-                    },
-                    "500": { "description": "Internal Server Error", "content": { "*/*": { "schema": { "type": "object" } } } },
-                    "200": { "description": "Ok", "content": { "*/*": { "schema": { "$ref": "#/components/schemas/JJDispute" } } } }
-                }
-            }
-        },
-        "/api/v1.0/jj/dispute/{ticketNumber}/cancel": {
-            "put": {
-                "tags": ["jj-dispute-controller"],
-                "summary": "Updates the status of a particular JJDispute record to CANCELLED.",
-                "operationId": "cancelJJDispute",
-                "parameters": [
-                    { "name": "ticketNumber", "in": "path", "required": true, "schema": { "type": "string" } },
-                    { "name": "checkVTCAssigned", "in": "query", "required": true, "schema": { "type": "boolean" } }
-                ],
-                "responses": {
-                    "400": { "description": "Bad Request.", "content": { "*/*": { "schema": { "type": "object" } } } },
-                    "404": {
-                        "description": "JJDispute record not found. Update failed.",
-                        "content": { "*/*": { "schema": { "type": "object" } } }
-                    },
-                    "405": { "description": "Method Not Allowed", "content": { "*/*": { "schema": { "type": "object" } } } },
-                    "500": { "description": "Internal server error occured.", "content": { "*/*": { "schema": { "type": "object" } } } },
-                    "200": {
-                        "description": "Ok. Updated JJDispute record returned.",
-                        "content": { "*/*": { "schema": { "$ref": "#/components/schemas/JJDispute" } } }
-                    }
-                }
-            }
-        },
-        "/api/v1.0/jj/dispute/{ticketNumber}/accept": {
-            "put": {
-                "tags": ["jj-dispute-controller"],
-                "summary": "Updates the status of a particular JJDispute record to ACCEPTED.",
-                "operationId": "acceptJJDispute",
-                "parameters": [
-                    { "name": "ticketNumber", "in": "path", "required": true, "schema": { "type": "string" } },
-                    { "name": "checkVTCAssigned", "in": "query", "required": true, "schema": { "type": "boolean" } },
-                    {
-                        "name": "partId",
-                        "in": "query",
-                        "description": "Adjudicator's participant ID",
-                        "required": false,
-                        "schema": { "type": "string" }
-                    }
-                ],
-                "responses": {
-                    "400": { "description": "Bad Request.", "content": { "*/*": { "schema": { "type": "object" } } } },
-                    "404": {
-                        "description": "JJDispute record not found. Update failed.",
-                        "content": { "*/*": { "schema": { "type": "object" } } }
-                    },
-                    "405": {
-                        "description": "A JJDispute status can only be set to ACCEPTED iff status is CONFIRMED. Update failed.",
-                        "content": { "*/*": { "schema": { "type": "object" } } }
-                    },
-                    "500": { "description": "Internal server error occured.", "content": { "*/*": { "schema": { "type": "object" } } } },
-                    "200": {
-                        "description": "Ok. Updated JJDispute record returned.",
-                        "content": { "*/*": { "schema": { "$ref": "#/components/schemas/JJDispute" } } }
-                    }
-                }
-            }
-        },
-        "/api/v1.0/jj/dispute/assign": {
-            "put": {
-                "tags": ["jj-dispute-controller"],
-                "summary": "Updates each JJ Dispute based on the passed in ticket numbers to assign them to a specific JJ or unassign them if JJ not specified.",
-                "operationId": "assignJJDisputesToJJ",
-                "parameters": [
-                    {
-                        "name": "ticketNumbers",
-                        "in": "query",
-                        "required": true,
-                        "schema": { "type": "array", "items": { "type": "string" } }
-                    },
-                    { "name": "jjUsername", "in": "query", "required": false, "schema": { "type": "string" } }
-                ],
-                "responses": {
-                    "400": { "description": "Bad Request.", "content": { "*/*": { "schema": { "type": "object" } } } },
-                    "404": {
-                        "description": "JJDispute record(s) not found. Update failed.",
-                        "content": { "*/*": { "schema": { "type": "object" } } }
-                    },
-                    "405": { "description": "Method Not Allowed", "content": { "*/*": { "schema": { "type": "object" } } } },
-                    "500": { "description": "Internal server error occured.", "content": { "*/*": { "schema": { "type": "object" } } } },
-                    "200": { "description": "Ok" }
-                }
-            }
-        },
-        "/api/v1.0/dispute/{id}": {
-            "put": {
-                "tags": ["dispute-controller"],
-                "summary": "Updates the properties of a particular Dispute record based on the given values.",
-                "operationId": "updateDispute",
-                "parameters": [{ "name": "id", "in": "path", "required": true, "schema": { "type": "integer", "format": "int64" } }],
-                "requestBody": {
-                    "content": { "application/json": { "schema": { "$ref": "#/components/schemas/Dispute" } } },
-                    "required": true
-                },
-                "responses": {
-                    "400": { "description": "Bad Request.", "content": { "*/*": { "schema": { "type": "object" } } } },
-                    "404": {
-                        "description": "Dispute record not found. Update failed.",
-                        "content": { "*/*": { "schema": { "type": "object" } } }
-                    },
-                    "405": { "description": "Method Not Allowed", "content": { "*/*": { "schema": { "type": "object" } } } },
-                    "500": { "description": "Internal Server Error", "content": { "*/*": { "schema": { "type": "object" } } } },
-                    "409": {
-                        "description": "The Dispute has already been assigned to a different user. Dispute cannot be modified until assigned time expires.",
-                        "content": { "*/*": { "schema": { "$ref": "#/components/schemas/Dispute" } } }
-                    },
-                    "200": { "description": "Ok", "content": { "*/*": { "schema": { "$ref": "#/components/schemas/Dispute" } } } }
-                }
-            },
-            "delete": {
-                "tags": ["dispute-controller"],
-                "summary": "Deletes a particular Dispute record.",
-                "operationId": "deleteDispute",
-                "parameters": [{ "name": "id", "in": "path", "required": true, "schema": { "type": "integer", "format": "int64" } }],
-                "responses": {
-                    "400": { "description": "Bad Request.", "content": { "*/*": { "schema": { "type": "object" } } } },
-                    "404": {
-                        "description": "Dispute record not found. Delete failed.",
-                        "content": { "*/*": { "schema": { "type": "object" } } }
-                    },
-                    "405": { "description": "Method Not Allowed", "content": { "*/*": { "schema": { "type": "object" } } } },
-                    "500": {
-                        "description": "Internal Server Error. Delete failed.",
-                        "content": { "*/*": { "schema": { "type": "object" } } }
-                    },
-                    "200": { "description": "Ok. Dispute record deleted." }
-                }
-            }
-        },
-        "/api/v1.0/dispute/{id}/validate": {
-            "put": {
-                "tags": ["dispute-controller"],
-                "summary": "Updates the status of a particular Dispute record to VALIDATED.",
-                "operationId": "validateDispute",
-                "parameters": [{ "name": "id", "in": "path", "required": true, "schema": { "type": "integer", "format": "int64" } }],
-                "responses": {
-                    "400": { "description": "Bad Request.", "content": { "*/*": { "schema": { "type": "object" } } } },
-                    "404": {
-                        "description": "Dispute record not found. Update failed.",
-                        "content": { "*/*": { "schema": { "type": "object" } } }
-                    },
-                    "405": {
-                        "description": "A Dispute status can only be set to VALIDATED iff status is NEW. Update failed.",
-                        "content": { "*/*": { "schema": { "type": "object" } } }
-                    },
-                    "500": { "description": "Internal Server Error", "content": { "*/*": { "schema": { "type": "object" } } } },
-                    "200": {
-                        "description": "Ok. Updated Dispute record returned.",
-                        "content": { "*/*": { "schema": { "$ref": "#/components/schemas/Dispute" } } }
-                    },
-                    "409": {
-                        "description": "The Dispute has already been assigned to a different user. Dispute cannot be modified until assigned time expires.",
-                        "content": { "*/*": { "schema": { "$ref": "#/components/schemas/Dispute" } } }
-                    }
-                }
-            }
-        },
-        "/api/v1.0/dispute/{id}/submit": {
-            "put": {
-                "tags": ["dispute-controller"],
-                "summary": "Updates the status of a particular Dispute record to PROCESSING.",
-                "operationId": "submitDispute",
-                "parameters": [{ "name": "id", "in": "path", "required": true, "schema": { "type": "integer", "format": "int64" } }],
-                "responses": {
-                    "400": { "description": "Bad Request.", "content": { "*/*": { "schema": { "type": "object" } } } },
-                    "404": {
-                        "description": "Dispute record not found. Update failed.",
-                        "content": { "*/*": { "schema": { "type": "object" } } }
-                    },
-                    "405": {
-                        "description": "A Dispute status can only be set to PROCESSING iff status is NEW or REJECTED. Update failed.",
-                        "content": { "*/*": { "schema": { "type": "object" } } }
-                    },
-                    "500": { "description": "Internal Server Error", "content": { "*/*": { "schema": { "type": "object" } } } },
-                    "200": {
-                        "description": "Ok. Updated Dispute record returned.",
-                        "content": { "*/*": { "schema": { "$ref": "#/components/schemas/Dispute" } } }
-                    },
-                    "409": {
-                        "description": "The Dispute has already been assigned to a different user. Dispute cannot be modified until assigned time expires.",
-                        "content": { "*/*": { "schema": { "$ref": "#/components/schemas/Dispute" } } }
-                    }
-                }
-            }
-        },
-        "/api/v1.0/dispute/{id}/reject": {
-            "put": {
-                "tags": ["dispute-controller"],
-                "summary": "Updates the status of a particular Dispute record to REJECTED.",
-                "operationId": "rejectDispute",
-                "parameters": [{ "name": "id", "in": "path", "required": true, "schema": { "type": "integer", "format": "int64" } }],
-                "requestBody": {
-                    "content": { "application/json": { "schema": { "maxLength": 256, "minLength": 1, "type": "string" } } },
-                    "required": true
-                },
-                "responses": {
-                    "400": { "description": "Bad Request.", "content": { "*/*": { "schema": { "type": "object" } } } },
-                    "404": {
-                        "description": "Dispute record not found. Update failed.",
-                        "content": { "*/*": { "schema": { "type": "object" } } }
-                    },
-                    "405": {
-                        "description": "A Dispute status can only be set to REJECTED iff status is NEW or VALIDATED and the rejected reason must be <= 256 characters. Update failed.",
-                        "content": { "*/*": { "schema": { "type": "object" } } }
-                    },
-                    "500": { "description": "Internal Server Error", "content": { "*/*": { "schema": { "type": "object" } } } },
-                    "200": {
-                        "description": "Ok. Updated Dispute record returned.",
-                        "content": { "*/*": { "schema": { "$ref": "#/components/schemas/Dispute" } } }
-                    },
-                    "409": {
-                        "description": "The Dispute has already been assigned to a different user. Dispute cannot be modified until assigned time expires.",
-                        "content": { "*/*": { "schema": { "$ref": "#/components/schemas/Dispute" } } }
-                    }
-                }
-            }
-        },
-        "/api/v1.0/dispute/{id}/email/verify": {
-            "put": {
-                "tags": ["dispute-controller"],
-                "summary": "Updates the emailVerification flag of a particular Dispute to true.",
-                "operationId": "verifyDisputeEmail",
-                "parameters": [
-                    {
-                        "name": "id",
-                        "in": "path",
-                        "description": "The id of the Dispute to update.",
-                        "required": true,
-                        "schema": { "type": "integer", "format": "int64" }
-                    }
-                ],
-                "responses": {
-                    "400": { "description": "Bad Request", "content": { "*/*": { "schema": { "type": "object" } } } },
-                    "404": {
-                        "description": "Dispute with specified id not found",
-                        "content": { "*/*": { "schema": { "type": "object" } } }
-                    },
-                    "405": { "description": "Method Not Allowed", "content": { "*/*": { "schema": { "type": "object" } } } },
-                    "500": { "description": "Internal server error occured.", "content": { "*/*": { "schema": { "type": "object" } } } },
-                    "200": { "description": "Ok. Email verified." }
-                }
-            }
-        },
-        "/api/v1.0/dispute/{id}/email/reset": {
-            "put": {
-                "tags": ["dispute-controller"],
-                "summary": "Updates the email address of a particular Dispute.",
-                "operationId": "resetDisputeEmail",
-                "parameters": [
-                    {
-                        "name": "id",
-                        "in": "path",
-                        "description": "The id of the Dispute to update.",
-                        "required": true,
-                        "schema": { "type": "integer", "format": "int64" }
-                    },
-                    {
-                        "name": "email",
-                        "in": "query",
-                        "description": "The new email address of the Disputant.",
-                        "required": false,
-                        "schema": { "maxLength": 100, "minLength": 1, "type": "string" }
-                    }
-                ],
-                "responses": {
-                    "400": {
-                        "description": "If the email address is > 100 characters",
-                        "content": { "*/*": { "schema": { "type": "object" } } }
-                    },
-                    "404": {
-                        "description": "Dispute with specified id not found",
-                        "content": { "*/*": { "schema": { "type": "object" } } }
-                    },
-                    "405": { "description": "Method Not Allowed", "content": { "*/*": { "schema": { "type": "object" } } } },
-                    "500": { "description": "Internal server error occured.", "content": { "*/*": { "schema": { "type": "object" } } } },
-                    "200": {
-                        "description": "Ok. Email reset.",
-                        "content": { "*/*": { "schema": { "$ref": "#/components/schemas/Dispute" } } }
-                    }
-                }
-            }
-        },
-        "/api/v1.0/dispute/{id}/cancel": {
-            "put": {
-                "tags": ["dispute-controller"],
-                "summary": "Updates the status of a particular Dispute record to CANCELLED.",
-                "operationId": "cancelDispute",
-                "parameters": [{ "name": "id", "in": "path", "required": true, "schema": { "type": "integer", "format": "int64" } }],
-                "requestBody": {
-                    "content": { "application/json": { "schema": { "maxLength": 256, "minLength": 1, "type": "string" } } },
-                    "required": true
-                },
-                "responses": {
-                    "400": { "description": "Bad Request.", "content": { "*/*": { "schema": { "type": "object" } } } },
-                    "404": {
-                        "description": "Dispute record not found. Update failed.",
-                        "content": { "*/*": { "schema": { "type": "object" } } }
-                    },
-                    "405": {
-                        "description": "A Dispute status can only be set to CANCELLED iff status is NEW, REJECTED or PROCESSING. Update failed.",
-                        "content": { "*/*": { "schema": { "type": "object" } } }
-                    },
-                    "500": { "description": "Internal Server Error", "content": { "*/*": { "schema": { "type": "object" } } } },
-                    "200": {
-                        "description": "Ok. Updated Dispute record returned.",
-                        "content": { "*/*": { "schema": { "$ref": "#/components/schemas/Dispute" } } }
-                    },
-                    "409": {
-                        "description": "The Dispute has already been assigned to a different user. Dispute cannot be modified until assigned time expires.",
-                        "content": { "*/*": { "schema": { "$ref": "#/components/schemas/Dispute" } } }
-                    }
-                }
-            }
-        },
-        "/api/v1.0/dispute/updateRequest/{id}": {
-            "put": {
-                "tags": ["dispute-controller"],
-                "summary": "An endpoint that updates the status of a DisputeUpdateRequest record.",
-                "operationId": "updateDisputeUpdateRequestStatus",
-                "parameters": [
-                    {
-                        "name": "id",
-                        "in": "path",
-                        "description": "The id of the DisputeUpdateRequest record to update.",
-                        "required": true,
-                        "schema": { "type": "integer", "format": "int64" }
-                    },
-                    {
-                        "name": "disputeUpdateRequestStatus",
-                        "in": "query",
-                        "description": "The status of the request record should be updated to.",
-                        "required": true,
-                        "schema": { "type": "string", "enum": ["UNKNOWN", "ACCEPTED", "PENDING", "REJECTED"] },
-                        "example": "ACCEPTED"
-                    }
-                ],
-                "responses": {
-                    "400": { "description": "Bad Request", "content": { "*/*": { "schema": { "type": "object" } } } },
-                    "404": {
-                        "description": "DisputeUpdateRequest could not be found.",
-                        "content": { "*/*": { "schema": { "type": "object" } } }
-                    },
-                    "405": { "description": "Method Not Allowed", "content": { "*/*": { "schema": { "type": "object" } } } },
-                    "500": {
-                        "description": "Internal Server Error. Save failed.",
-                        "content": { "*/*": { "schema": { "type": "object" } } }
-                    },
-                    "200": {
-                        "description": "Ok. DisputeUpdateRequest updated.",
-                        "content": { "*/*": { "schema": { "$ref": "#/components/schemas/DisputeUpdateRequest" } } }
-                    }
-                }
-            }
-        },
-        "/api/v1.0/fileHistory": {
-            "post": {
-                "tags": ["file-history-controller"],
-                "summary": "Inserts a file history record for the given ticket number.",
-                "operationId": "insertFileHistory",
-                "requestBody": {
-                    "content": { "application/json": { "schema": { "$ref": "#/components/schemas/FileHistory" } } },
-                    "required": true
-                },
-                "responses": {
-                    "400": { "description": "Bad Request.", "content": { "*/*": { "schema": { "type": "object" } } } },
-                    "404": {
-                        "description": "An invalid file history record provided. Insert failed.",
-                        "content": { "*/*": { "schema": { "type": "object" } } }
-                    },
-                    "405": { "description": "Method Not Allowed", "content": { "*/*": { "schema": { "type": "object" } } } },
-                    "500": { "description": "Internal Server Error", "content": { "*/*": { "schema": { "type": "object" } } } },
-                    "200": { "description": "Ok", "content": { "*/*": { "schema": { "type": "integer", "format": "int64" } } } }
-                }
-            }
-        },
-        "/api/v1.0/emailHistory": {
-            "post": {
-                "tags": ["email-history-controller"],
-                "summary": "Inserts an email history record for the given ticket number.",
-                "operationId": "insertEmailHistory",
-                "requestBody": {
-                    "content": { "application/json": { "schema": { "$ref": "#/components/schemas/EmailHistory" } } },
-                    "required": true
-                },
-                "responses": {
-                    "400": { "description": "Bad Request.", "content": { "*/*": { "schema": { "type": "object" } } } },
-                    "404": {
-                        "description": "An invalid email history record provided. Insert failed.",
-                        "content": { "*/*": { "schema": { "type": "object" } } }
-                    },
-                    "405": { "description": "Method Not Allowed", "content": { "*/*": { "schema": { "type": "object" } } } },
-                    "500": { "description": "Internal Server Error", "content": { "*/*": { "schema": { "type": "object" } } } },
-                    "200": { "description": "Ok", "content": { "*/*": { "schema": { "type": "integer", "format": "int64" } } } }
-                }
-            }
-        },
-        "/api/v1.0/dispute": {
-            "post": {
-                "tags": ["dispute-controller"],
-                "operationId": "saveDispute",
-                "requestBody": {
-                    "content": { "application/json": { "schema": { "$ref": "#/components/schemas/Dispute" } } },
-                    "required": true
-                },
-                "responses": {
-                    "400": { "description": "Bad Request", "content": { "*/*": { "schema": { "type": "object" } } } },
-                    "404": { "description": "Not Found", "content": { "*/*": { "schema": { "type": "object" } } } },
-                    "405": { "description": "Method Not Allowed", "content": { "*/*": { "schema": { "type": "object" } } } },
-                    "500": { "description": "Internal Server Error", "content": { "*/*": { "schema": { "type": "object" } } } },
-                    "200": { "description": "OK", "content": { "*/*": { "schema": { "type": "integer", "format": "int64" } } } }
-                }
-            }
-        },
-        "/api/v1.0/dispute/{guid}/updateRequest": {
-            "post": {
-                "tags": ["dispute-controller"],
-                "summary": "An endpoint that inserts a DisputeUpdateRequest into persistent storage.",
-                "operationId": "saveDisputeUpdateRequest",
-                "parameters": [
-                    {
-                        "name": "guid",
-                        "in": "path",
-                        "description": "The noticeOfDisputeGuid of the Dispute to associate with.",
-                        "required": true,
-                        "schema": { "type": "string" }
-                    }
-                ],
-                "requestBody": {
-                    "content": { "application/json": { "schema": { "$ref": "#/components/schemas/DisputeUpdateRequest" } } },
-                    "required": true
-                },
-                "responses": {
-                    "400": { "description": "Bad Request", "content": { "*/*": { "schema": { "type": "object" } } } },
-                    "404": { "description": "Dispute could not be found.", "content": { "*/*": { "schema": { "type": "object" } } } },
-                    "405": { "description": "Method Not Allowed", "content": { "*/*": { "schema": { "type": "object" } } } },
-                    "500": {
-                        "description": "Internal Server Error. Save failed.",
-                        "content": { "*/*": { "schema": { "type": "object" } } }
-                    },
-                    "200": {
-                        "description": "Ok. DisputeUpdateRequest record saved.",
-                        "content": { "*/*": { "schema": { "type": "integer", "format": "int64" } } }
-                    }
-                }
-            }
-        },
-        "/api/v1.0/jj/disputes": {
-            "get": {
-                "tags": ["jj-dispute-controller"],
-                "operationId": "getJJDisputes",
-                "parameters": [
-                    {
-                        "name": "jjAssignedTo",
-                        "in": "query",
-                        "description": "If specified, will retrieve the records which are assigned to the specified jj staff",
-                        "required": false,
-                        "schema": { "type": "string" }
-                    },
-                    {
-                        "name": "ticketNumber",
-                        "in": "query",
-                        "description": "If specified will filter by TicketNumber. (Format is XX00000000)",
-                        "required": false,
-                        "schema": { "pattern": "[A-Z]{2}\\d{8}", "type": "string" },
-                        "example": "AX12345678"
-                    }
-                ],
-                "responses": {
-                    "400": { "description": "Bad Request", "content": { "*/*": { "schema": { "type": "object" } } } },
-                    "404": { "description": "Not Found", "content": { "*/*": { "schema": { "type": "object" } } } },
-                    "405": { "description": "Method Not Allowed", "content": { "*/*": { "schema": { "type": "object" } } } },
-                    "500": { "description": "Internal Server Error", "content": { "*/*": { "schema": { "type": "object" } } } },
-                    "200": {
-                        "description": "OK",
-                        "content": { "*/*": { "schema": { "type": "array", "items": { "$ref": "#/components/schemas/JJDispute" } } } }
-                    }
-                }
-            }
-        },
-        "/api/v1.0/jj/dispute/{ticketNumber}/{assignVTC}": {
-            "get": {
-                "tags": ["jj-dispute-controller"],
-                "operationId": "getJJDispute",
-                "parameters": [
-                    {
-                        "name": "ticketNumber",
-                        "in": "path",
-                        "description": "The primary key of the jj dispute to retrieve",
-                        "required": true,
-                        "schema": { "type": "string" }
-                    },
-                    { "name": "assignVTC", "in": "path", "required": true, "schema": { "type": "boolean" } }
-                ],
-                "responses": {
-                    "400": { "description": "Bad Request", "content": { "*/*": { "schema": { "type": "object" } } } },
-                    "404": { "description": "Not Found", "content": { "*/*": { "schema": { "type": "object" } } } },
-                    "405": { "description": "Method Not Allowed", "content": { "*/*": { "schema": { "type": "object" } } } },
-                    "500": { "description": "Internal Server Error", "content": { "*/*": { "schema": { "type": "object" } } } },
-                    "200": { "description": "OK", "content": { "*/*": { "schema": { "$ref": "#/components/schemas/JJDispute" } } } }
-                }
-            }
-        },
-        "/api/v1.0/jj/dispute/ticketImage/{ticketNumber}/{documentType}": {
-            "get": {
-                "tags": ["jj-dispute-controller"],
-                "operationId": "getTicketImageData",
-                "parameters": [
-                    { "name": "ticketNumber", "in": "path", "required": true, "schema": { "type": "string" } },
-                    {
-                        "name": "documentType",
-                        "in": "path",
-                        "required": true,
-                        "schema": { "type": "string", "enum": ["UNKNOWN", "NOTICE_OF_DISPUTE", "TICKET_IMAGE"] }
-                    }
-                ],
-                "responses": {
-                    "400": { "description": "Bad Request", "content": { "*/*": { "schema": { "type": "object" } } } },
-                    "404": { "description": "Not Found", "content": { "*/*": { "schema": { "type": "object" } } } },
-                    "405": { "description": "Method Not Allowed", "content": { "*/*": { "schema": { "type": "object" } } } },
-                    "500": { "description": "Internal Server Error", "content": { "*/*": { "schema": { "type": "object" } } } },
-                    "200": {
-                        "description": "OK",
-                        "content": { "*/*": { "schema": { "$ref": "#/components/schemas/TicketImageDataJustinDocument" } } }
-                    }
-                }
-            }
-        },
-        "/api/v1.0/fileHistory/{ticketNumber}": {
-            "get": {
-                "tags": ["file-history-controller"],
-                "operationId": "getFileHistoryByTicketNumber",
-                "parameters": [
-                    {
-                        "name": "ticketNumber",
-                        "in": "path",
-                        "description": "Ticket number to retrieve related file history.",
-                        "required": true,
-                        "schema": { "type": "string" }
-                    }
-                ],
-                "responses": {
-                    "400": { "description": "Bad Request", "content": { "*/*": { "schema": { "type": "object" } } } },
-                    "404": { "description": "Not Found", "content": { "*/*": { "schema": { "type": "object" } } } },
-                    "405": { "description": "Method Not Allowed", "content": { "*/*": { "schema": { "type": "object" } } } },
-                    "500": { "description": "Internal Server Error", "content": { "*/*": { "schema": { "type": "object" } } } },
-                    "200": {
-                        "description": "OK",
-                        "content": { "*/*": { "schema": { "type": "array", "items": { "$ref": "#/components/schemas/FileHistory" } } } }
-                    }
-                }
-            }
-        },
-        "/api/v1.0/emailHistory/{ticketNumber}": {
-            "get": {
-                "tags": ["email-history-controller"],
-                "operationId": "getEmailHistoryByTicketNumber",
-                "parameters": [
-                    {
-                        "name": "ticketNumber",
-                        "in": "path",
-                        "description": "Ticket number to retrieve related emails.",
-                        "required": true,
-                        "schema": { "type": "string" }
-                    }
-                ],
-                "responses": {
-                    "400": { "description": "Bad Request", "content": { "*/*": { "schema": { "type": "object" } } } },
-                    "404": { "description": "Not Found", "content": { "*/*": { "schema": { "type": "object" } } } },
-                    "405": { "description": "Method Not Allowed", "content": { "*/*": { "schema": { "type": "object" } } } },
-                    "500": { "description": "Internal Server Error", "content": { "*/*": { "schema": { "type": "object" } } } },
-                    "200": {
-                        "description": "OK",
-                        "content": { "*/*": { "schema": { "type": "array", "items": { "$ref": "#/components/schemas/EmailHistory" } } } }
-                    }
-                }
-            }
-        },
-        "/api/v1.0/disputes": {
-            "get": {
-                "tags": ["dispute-controller"],
-                "summary": "Returns all dispute list details based on the specified optional parameters.",
-                "operationId": "getAllDisputes",
-                "parameters": [
-                    {
-                        "name": "newerThan",
-                        "in": "query",
-                        "description": "If specified, will retrieve records newer than this date (specified by yyyy-MM-dd)",
-                        "required": false,
-                        "schema": { "type": "string", "format": "date-time" },
-                        "example": "2022-03-15"
-                    },
-                    {
-                        "name": "excludeStatus",
-                        "in": "query",
-                        "description": "If specified, will retrieve records which do not have the specified status",
-                        "required": false,
-                        "schema": {
-                            "type": "string",
-                            "enum": ["UNKNOWN", "NEW", "VALIDATED", "PROCESSING", "REJECTED", "CANCELLED", "CONCLUDED"]
-                        },
-                        "example": "CANCELLED"
-                    }
-                ],
-                "responses": {
-                    "400": { "description": "Bad Request.", "content": { "*/*": { "schema": { "type": "object" } } } },
-                    "404": { "description": "Not Found", "content": { "*/*": { "schema": { "type": "object" } } } },
-                    "405": { "description": "Method Not Allowed", "content": { "*/*": { "schema": { "type": "object" } } } },
-                    "500": {
-                        "description": "Internal Server Error. Getting disputes failed.",
-                        "content": { "*/*": { "schema": { "type": "object" } } }
-                    },
-                    "200": {
-                        "description": "Ok. Disputes are returned.",
-                        "content": { "*/*": { "schema": { "type": "array", "items": { "$ref": "#/components/schemas/DisputeListItem" } } } }
-                    }
-                }
-            }
-        },
-        "/api/v1.0/disputes/unassign": {
-            "get": {
-                "tags": ["dispute-controller"],
-                "summary": "An endpoint hook to trigger the Unassign Dispute job.",
-                "description": "A Dispute can be assigned to a specific user that \"locks\" the record for others. This endpoing manually triggers the Unassign Dispute job that clears the assignment of all Disputes that were assigned for more than 1 hour.",
-                "operationId": "unassignDisputes",
-                "responses": {
-                    "400": { "description": "Bad Request", "content": { "*/*": { "schema": { "type": "object" } } } },
-                    "404": { "description": "Not Found", "content": { "*/*": { "schema": { "type": "object" } } } },
-                    "405": { "description": "Method Not Allowed", "content": { "*/*": { "schema": { "type": "object" } } } },
-                    "500": {
-                        "description": "Internal Server Error. Unassigned failed.",
-                        "content": { "*/*": { "schema": { "type": "object" } } }
-                    },
-                    "200": { "description": "Ok. Dispute record unassigned." }
-                }
-            }
-        },
-        "/api/v1.0/dispute/{id}/{isAssign}": {
-            "get": {
-                "tags": ["dispute-controller"],
-                "operationId": "getDispute",
-                "parameters": [
-                    { "name": "id", "in": "path", "required": true, "schema": { "type": "integer", "format": "int64" } },
-                    { "name": "isAssign", "in": "path", "required": true, "schema": { "type": "boolean" } }
-                ],
-                "responses": {
-                    "400": { "description": "Bad Request", "content": { "*/*": { "schema": { "type": "object" } } } },
-                    "404": { "description": "Not Found", "content": { "*/*": { "schema": { "type": "object" } } } },
-                    "405": { "description": "Method Not Allowed", "content": { "*/*": { "schema": { "type": "object" } } } },
-                    "500": { "description": "Internal Server Error", "content": { "*/*": { "schema": { "type": "object" } } } },
-                    "200": { "description": "OK", "content": { "*/*": { "schema": { "$ref": "#/components/schemas/Dispute" } } } }
-                }
-            }
-        },
-        "/api/v1.0/dispute/updateRequests": {
-            "get": {
-                "tags": ["dispute-controller"],
-                "summary": "An endpoint that retrieves all DisputeUpdateRequest optionally for a given Dispute, optionally filtered by DisputeUpdateRequestStatus.",
-                "operationId": "getDisputeUpdateRequests",
-                "parameters": [
-                    {
-                        "name": "id",
-                        "in": "query",
-                        "description": "If specified, filter request by the disputeId of the Dispute.",
-                        "required": false,
-                        "schema": { "type": "integer", "format": "int64" }
-                    },
-                    {
-                        "name": "status",
-                        "in": "query",
-                        "description": "If specified, filter request by DisputeUpdateRequestStatus",
-                        "required": false,
-                        "schema": { "type": "string", "enum": ["UNKNOWN", "ACCEPTED", "PENDING", "REJECTED"] },
-                        "example": "PENDING"
-                    }
-                ],
-                "responses": {
-                    "400": { "description": "Bad Request", "content": { "*/*": { "schema": { "type": "object" } } } },
-                    "404": { "description": "Not Found", "content": { "*/*": { "schema": { "type": "object" } } } },
-                    "405": { "description": "Method Not Allowed", "content": { "*/*": { "schema": { "type": "object" } } } },
-                    "500": {
-                        "description": "Internal Server Error. retrieve update requests failed.",
-                        "content": { "*/*": { "schema": { "type": "object" } } }
-                    },
-                    "200": {
-                        "description": "Ok. DisputeUpdateRequest record saved.",
-                        "content": {
-                            "*/*": { "schema": { "type": "array", "items": { "$ref": "#/components/schemas/DisputeUpdateRequest" } } }
-                        }
-                    }
-                }
-            }
-        },
-        "/api/v1.0/dispute/status": {
-            "get": {
-                "tags": ["dispute-controller"],
-                "summary": "Finds Dispute statuses by TicketNumber and IssuedTime or noticeOfDisputeGuid if specified.",
-                "operationId": "findDisputeStatuses",
-                "parameters": [
-                    {
-                        "name": "ticketNumber",
-                        "in": "query",
-                        "description": "The Dispute.ticketNumber to search for (of the format XX00000000)",
-                        "required": false,
-                        "schema": { "pattern": "^$|([A-Z]{2}\\d{8})", "type": "string" },
-                        "example": "AX12345678"
-                    },
-                    {
-                        "name": "issuedTime",
-                        "in": "query",
-                        "description": "The time portion of the Dispute.issuedTs field to search for (of the format HH:mm). Time is in UTC.",
-                        "required": false,
-                        "schema": { "type": "string" },
-                        "example": "14:53"
-                    },
-                    {
-                        "name": "noticeOfDisputeGuid",
-                        "in": "query",
-                        "description": "The noticeOfDisputeGuid of the Dispute to retreive.",
-                        "required": false,
-                        "schema": { "type": "string" }
-                    }
-                ],
-                "responses": {
-                    "400": { "description": "Bad Request, check parameters.", "content": { "*/*": { "schema": { "type": "object" } } } },
-                    "404": { "description": "Not Found", "content": { "*/*": { "schema": { "type": "object" } } } },
-                    "405": { "description": "Method Not Allowed", "content": { "*/*": { "schema": { "type": "object" } } } },
-                    "500": {
-                        "description": "Internal Server Error. Search failed.",
-                        "content": { "*/*": { "schema": { "type": "object" } } }
-                    },
-                    "200": {
-                        "description": "Ok.",
-                        "content": { "*/*": { "schema": { "type": "array", "items": { "$ref": "#/components/schemas/DisputeResult" } } } }
-                    }
-                }
-            }
-        },
-        "/api/v1.0/dispute/noticeOfDispute/{id}": {
-            "get": {
-                "tags": ["dispute-controller"],
-                "summary": "Retrieves Dispute by the noticeOfDisputeGuid (UUID).",
-                "operationId": "getDisputeByNoticeOfDisputeGuid",
-                "parameters": [
-                    {
-                        "name": "id",
-                        "in": "path",
-                        "description": "The noticeOfDisputeGuid of the Dispute to retreive.",
-                        "required": true,
-                        "schema": { "type": "string" }
-                    }
-                ],
-                "responses": {
-                    "400": { "description": "Bad Request", "content": { "*/*": { "schema": { "type": "object" } } } },
-                    "404": { "description": "Dispute could not be found.", "content": { "*/*": { "schema": { "type": "object" } } } },
-                    "405": { "description": "Method Not Allowed", "content": { "*/*": { "schema": { "type": "object" } } } },
-                    "500": { "description": "Internal server error occured.", "content": { "*/*": { "schema": { "type": "object" } } } },
-                    "200": {
-                        "description": "Ok. Dispute retrieved.",
-                        "content": { "*/*": { "schema": { "$ref": "#/components/schemas/Dispute" } } }
-                    }
-                }
-            }
-        },
-        "/api/v1.0/codetable/refresh": {
-            "get": {
-                "tags": ["dispute-controller"],
-                "summary": "An endpoint hook to trigger a redis rebuild of cached codetable data.",
-                "description": "The codetables in redis are cached copies of data pulled from Oracle to ensure TCO remains stable. This data is periodically refreshed, but can be forced by hitting this endpoint.",
-                "operationId": "codeTableRefresh",
-                "responses": {
-                    "400": { "description": "Bad Request", "content": { "*/*": { "schema": { "type": "object" } } } },
-                    "404": { "description": "Not Found", "content": { "*/*": { "schema": { "type": "object" } } } },
-                    "405": { "description": "Method Not Allowed", "content": { "*/*": { "schema": { "type": "object" } } } },
-                    "500": { "description": "Internal Server Error", "content": { "*/*": { "schema": { "type": "object" } } } },
-                    "200": { "description": "OK" }
-                }
-            }
-        },
-        "/api/v1.0/jj/dispute": {
-            "delete": {
-                "tags": ["jj-dispute-controller"],
-                "summary": "Deletes a particular JJDispute record.",
-                "operationId": "DeleteJJDispute",
-                "parameters": [
-                    {
-                        "name": "jjDisputeId",
-                        "in": "query",
-                        "description": "If specified, will delete the record of the specified jj dispute by this ID. JJ Dispute ID will take precedence if both ID and ticket number supplied",
-                        "required": false,
-                        "schema": { "type": "integer", "format": "int64" }
-                    },
-                    {
-                        "name": "ticketNumber",
-                        "in": "query",
-                        "description": "If specified, will delete the record of the specified jj dispute by this TicketNumber. (Format is XX00000000)",
-                        "required": false,
-                        "schema": { "pattern": "[A-Z]{2}\\d{8}", "type": "string" },
-                        "example": "AX12345678"
-                    }
-                ],
-                "responses": {
-                    "400": { "description": "Bad Request.", "content": { "*/*": { "schema": { "type": "object" } } } },
-                    "404": { "description": "Not Found", "content": { "*/*": { "schema": { "type": "object" } } } },
-                    "405": { "description": "Method Not Allowed", "content": { "*/*": { "schema": { "type": "object" } } } },
-                    "500": {
-                        "description": "Internal Server Error. Delete failed.",
-                        "content": { "*/*": { "schema": { "type": "object" } } }
-                    },
-                    "200": { "description": "Ok. JJ Dispute record deleted." }
-                }
-            }
-        }
-    },
-    "components": {
-        "schemas": {
-            "JJDispute": {
-                "type": "object",
-                "properties": {
-                    "createdBy": { "type": "string" },
-                    "createdTs": { "type": "string", "format": "date-time" },
-                    "modifiedBy": { "type": "string", "nullable": true },
-                    "modifiedTs": { "type": "string", "format": "date-time", "nullable": true },
-                    "id": { "type": "integer", "description": "ID", "format": "int64", "readOnly": true },
-                    "ticketNumber": { "type": "string" },
-                    "accidentYn": {
-                        "type": "string",
-                        "description": "Indicates whether the dispute is associated with an accident or not",
-                        "nullable": true,
-                        "enum": ["UNKNOWN", "Y", "N"]
-                    },
-                    "addressLine1": { "type": "string" },
-                    "addressLine2": { "type": "string", "nullable": true },
-                    "addressLine3": { "type": "string", "nullable": true },
-                    "addressCity": { "type": "string", "nullable": true },
-                    "addressProvince": { "type": "string", "nullable": true },
-                    "addressCountry": { "type": "string", "nullable": true },
-                    "addressPostalCode": { "type": "string", "nullable": true },
-                    "disputantBirthdate": { "type": "string", "format": "date-time", "nullable": true },
-                    "driversLicenceNumber": { "type": "string", "nullable": true },
-                    "drvLicIssuedProvSeqNo": { "type": "string", "nullable": true },
-                    "drvLicIssuedCtryId": { "type": "string", "nullable": true },
-                    "emailAddress": { "type": "string", "nullable": true },
-                    "status": {
-                        "type": "string",
-                        "enum": [
-                            "UNKNOWN",
-                            "NEW",
-                            "IN_PROGRESS",
-                            "DATA_UPDATE",
-                            "CONFIRMED",
-                            "REQUIRE_COURT_HEARING",
-                            "REQUIRE_MORE_INFO",
-                            "ACCEPTED",
-                            "REVIEW",
-                            "CONCLUDED",
-                            "CANCELLED",
-                            "HEARING_SCHEDULED"
-                        ]
-                    },
-                    "hearingType": { "type": "string", "nullable": true, "enum": ["UNKNOWN", "COURT_APPEARANCE", "WRITTEN_REASONS"] },
-                    "multipleOfficersYn": {
-                        "type": "string",
-                        "description": "Indicates whether the dispute is associated with multiple officers or not",
-                        "enum": ["UNKNOWN", "Y", "N"]
-                    },
-                    "noticeOfDisputeGuid": { "type": "string", "nullable": true },
-                    "noticeOfHearingYn": { "type": "string", "nullable": true, "enum": ["UNKNOWN", "Y", "N"] },
-                    "occamDisputantGiven1Nm": { "type": "string", "nullable": true },
-                    "occamDisputantGiven2Nm": { "type": "string", "nullable": true },
-                    "occamDisputantGiven3Nm": { "type": "string", "nullable": true },
-                    "occamDisputantSurnameNm": { "type": "string", "nullable": true },
-                    "occamDisputeId": { "type": "integer", "format": "int64" },
-                    "occamViolationTicketUpldId": { "type": "string", "nullable": true },
-                    "submittedTs": { "type": "string", "format": "date-time", "nullable": true },
-                    "issuedTs": { "type": "string", "format": "date-time", "nullable": true },
-                    "violationDate": { "type": "string", "format": "date-time", "nullable": true },
-                    "icbcReceivedDate": { "type": "string", "format": "date-time", "nullable": true },
-                    "enforcementOfficer": { "type": "string", "nullable": true },
-                    "electronicTicketYn": { "type": "string", "nullable": true, "enum": ["UNKNOWN", "Y", "N"] },
-                    "policeDetachment": { "type": "string", "nullable": true },
-                    "courthouseLocation": { "type": "string", "nullable": true },
-                    "offenceLocation": { "type": "string", "nullable": true },
-                    "jjAssignedTo": { "type": "string", "nullable": true },
-                    "jjDecisionDate": { "type": "string", "format": "date-time", "nullable": true },
-                    "vtcAssignedTo": { "type": "string", "nullable": true },
-                    "vtcAssignedTs": { "type": "string", "format": "date-time", "nullable": true },
-                    "fineReductionReason": { "type": "string", "nullable": true },
-                    "timeToPayReason": { "type": "string", "nullable": true },
-                    "contactLawFirmName": { "type": "string", "nullable": true },
-                    "contactGivenName1": { "type": "string", "nullable": true },
-                    "contactGivenName2": { "type": "string", "nullable": true },
-                    "contactGivenName3": { "type": "string", "nullable": true },
-                    "contactSurname": { "type": "string", "nullable": true },
-                    "contactType": { "type": "string", "nullable": true, "enum": ["UNKNOWN", "INDIVIDUAL", "LAWYER", "OTHER"] },
-                    "appearInCourt": { "type": "string", "enum": ["UNKNOWN", "Y", "N"] },
-                    "courtAgenId": { "type": "string", "nullable": true },
-                    "recalled": {
-                        "type": "boolean",
-                        "description": "Indicates whether the dispute is re-opened by a JJ and set to review from its previous accepted or concluded status or not.",
-                        "nullable": true
-                    },
-                    "lawFirmName": { "type": "string", "nullable": true },
-                    "lawyerSurname": { "type": "string", "nullable": true },
-                    "lawyerGivenName1": { "type": "string", "nullable": true },
-                    "lawyerGivenName2": { "type": "string", "nullable": true },
-                    "lawyerGivenName3": { "type": "string", "nullable": true },
-                    "justinRccId": { "type": "string", "nullable": true },
-                    "interpreterLanguageCd": { "type": "string", "nullable": true },
-                    "witnessNo": { "type": "integer", "format": "int32", "nullable": true },
-                    "disputantAttendanceType": {
-                        "type": "string",
-                        "nullable": true,
-                        "enum": [
-                            "UNKNOWN",
-                            "WRITTEN_REASONS",
-                            "VIDEO_CONFERENCE",
-                            "TELEPHONE_CONFERENCE",
-                            "MSTEAMS_AUDIO",
-                            "MSTEAMS_VIDEO",
-                            "IN_PERSON"
-                        ]
-                    },
-                    "remarks": { "type": "array", "items": { "$ref": "#/components/schemas/JJDisputeRemark" } },
-                    "jjDisputedCounts": { "type": "array", "items": { "$ref": "#/components/schemas/JJDisputedCount" } },
-                    "jjDisputeCourtAppearanceRoPs": {
-                        "type": "array",
-                        "items": { "$ref": "#/components/schemas/JJDisputeCourtAppearanceRoP" }
-                    }
-                }
-            },
-            "JJDisputeCourtAppearanceRoP": {
-                "type": "object",
-                "properties": {
-                    "justinAppearanceId": { "type": "string", "description": "Justin Appearance ID", "readOnly": true },
-                    "id": {
-                        "type": "integer",
-                        "description": "TCO Court Appearance ID",
-                        "format": "int64",
-                        "nullable": true,
-                        "readOnly": true
-                    },
-                    "appearanceTs": { "type": "string", "format": "date-time", "nullable": true },
-                    "room": { "type": "string", "nullable": true },
-                    "duration": { "type": "integer", "format": "int32", "nullable": true },
-                    "reason": { "type": "string", "nullable": true },
-                    "appCd": { "type": "string", "nullable": true, "enum": ["UNKNOWN", "A", "P", "N"] },
-                    "noAppTs": { "type": "string", "format": "date-time", "nullable": true },
-                    "clerkRecord": { "type": "string", "nullable": true },
-                    "defenceCounsel": { "type": "string", "nullable": true },
-                    "dattCd": { "type": "string", "nullable": true, "enum": ["UNKNOWN", "A", "C", "N"] },
-                    "crown": { "type": "string", "nullable": true, "enum": ["UNKNOWN", "P", "N"] },
-                    "jjSeized": { "type": "string", "nullable": true, "enum": ["UNKNOWN", "Y", "N"] },
-                    "adjudicator": { "type": "string", "nullable": true },
-                    "comments": { "maxLength": 4000, "minLength": 0, "type": "string", "nullable": true }
-                }
-            },
-            "JJDisputeRemark": {
-                "type": "object",
-                "properties": {
-                    "createdBy": { "type": "string" },
-                    "createdTs": { "type": "string", "format": "date-time" },
-                    "modifiedBy": { "type": "string", "nullable": true },
-                    "modifiedTs": { "type": "string", "format": "date-time", "nullable": true },
-                    "id": { "type": "integer", "description": "ID", "format": "int64", "readOnly": true },
-                    "userFullName": { "type": "string" },
-                    "note": { "maxLength": 4000, "minLength": 0, "type": "string" },
-                    "remarksMadeTs": { "type": "string", "format": "date-time" }
-                }
-            },
-            "JJDisputedCount": {
-                "type": "object",
-                "properties": {
-                    "createdBy": { "type": "string" },
-                    "createdTs": { "type": "string", "format": "date-time" },
-                    "modifiedBy": { "type": "string", "nullable": true },
-                    "modifiedTs": { "type": "string", "format": "date-time", "nullable": true },
-                    "id": { "type": "integer", "description": "ID", "format": "int64", "readOnly": true },
-                    "plea": {
-                        "type": "string",
-                        "description": "Represents the disputant's initial plea on count.",
-                        "enum": ["UNKNOWN", "G", "N"]
-                    },
-                    "count": { "maximum": 3, "minimum": 1, "type": "integer", "format": "int32" },
-                    "requestTimeToPay": { "type": "string", "enum": ["UNKNOWN", "Y", "N"] },
-                    "requestReduction": { "type": "string", "enum": ["UNKNOWN", "Y", "N"] },
-                    "appearInCourt": { "type": "string", "enum": ["UNKNOWN", "Y", "N"] },
-                    "description": { "type": "string", "nullable": true },
-                    "dueDate": { "type": "string", "format": "date-time", "nullable": true },
-                    "ticketedFineAmount": { "type": "number", "format": "float", "nullable": true },
-                    "lesserOrGreaterAmount": { "type": "number", "format": "float", "nullable": true },
-                    "includesSurcharge": { "type": "string", "nullable": true, "enum": ["UNKNOWN", "Y", "N"] },
-                    "revisedDueDate": { "type": "string", "format": "date-time", "nullable": true },
-                    "totalFineAmount": { "type": "number", "format": "float", "nullable": true },
-                    "violationDate": { "type": "string", "format": "date-time", "nullable": true },
-                    "comments": { "maxLength": 4000, "minLength": 0, "type": "string", "nullable": true },
-                    "latestPlea": {
-                        "type": "string",
-                        "description": "Represents the disputant's latest plea on count.",
-                        "nullable": true,
-                        "enum": ["UNKNOWN", "G", "N"]
-                    },
-                    "latestPleaUpdateTs": {
-                        "type": "string",
-                        "description": "The timestamp for when the last time disputant changed their plea.",
-                        "format": "date-time",
-                        "nullable": true
-                    },
-                    "jjDisputedCountRoP": { "$ref": "#/components/schemas/JJDisputedCountRoP" }
-                }
-            },
-            "JJDisputedCountRoP": {
-                "type": "object",
-                "properties": {
-                    "createdBy": { "type": "string" },
-                    "createdTs": { "type": "string", "format": "date-time" },
-                    "modifiedBy": { "type": "string", "nullable": true },
-                    "modifiedTs": { "type": "string", "format": "date-time", "nullable": true },
-                    "id": { "type": "integer", "description": "ID", "format": "int64", "readOnly": true },
-                    "finding": {
-                        "type": "string",
-                        "nullable": true,
-                        "enum": ["UNKNOWN", "GUILTY", "NOT_GUILTY", "CANCELLED", "PAID_PRIOR_TO_APPEARANCE", "GUILTY_LESSER"]
-                    },
-                    "lesserDescription": { "type": "string", "nullable": true },
-                    "ssProbationDuration": { "type": "string", "nullable": true },
-                    "ssProbationConditions": { "type": "string", "nullable": true },
-                    "jailDuration": { "type": "string", "nullable": true },
-                    "jailIntermittent": { "type": "string", "enum": ["UNKNOWN", "Y", "N"] },
-                    "probationDuration": { "type": "string", "nullable": true },
-                    "probationConditions": { "type": "string", "nullable": true },
-                    "drivingProhibition": { "type": "string", "nullable": true },
-                    "drivingProhibitionMVASection": { "type": "string", "nullable": true },
-                    "dismissed": { "type": "string", "enum": ["UNKNOWN", "Y", "N"] },
-                    "forWantOfProsecution": { "type": "string", "enum": ["UNKNOWN", "Y", "N"] },
-                    "withdrawn": { "type": "string", "enum": ["UNKNOWN", "Y", "N"] },
-                    "abatement": { "type": "string", "enum": ["UNKNOWN", "Y", "N"] },
-                    "stayOfProceedingsBy": { "type": "string", "nullable": true },
-                    "other": { "type": "string", "nullable": true }
-                },
-                "nullable": true
-            },
-            "Dispute": {
-                "type": "object",
-                "properties": {
-                    "createdBy": { "type": "string" },
-                    "createdTs": { "type": "string", "format": "date-time" },
-                    "modifiedBy": { "type": "string", "nullable": true },
-                    "modifiedTs": { "type": "string", "format": "date-time", "nullable": true },
-                    "disputeId": { "type": "integer", "description": "ID", "format": "int64", "readOnly": true },
-                    "noticeOfDisputeGuid": { "type": "string", "nullable": true },
-                    "ticketNumber": { "type": "string" },
-                    "issuedTs": { "type": "string", "format": "date-time", "nullable": true },
-                    "submittedTs": { "type": "string", "format": "date-time", "nullable": true },
-                    "disputantSurname": { "type": "string", "nullable": true },
-                    "disputantGivenName1": { "type": "string", "nullable": true },
-                    "disputantGivenName2": { "type": "string", "nullable": true },
-                    "disputantGivenName3": { "type": "string", "nullable": true },
-                    "disputantBirthdate": { "type": "string", "format": "date-time", "nullable": true },
-                    "driversLicenceNumber": { "maxLength": 30, "minLength": 0, "type": "string", "nullable": true },
-                    "disputantOrganization": { "type": "string", "nullable": true },
-                    "disputantClientId": { "type": "string", "nullable": true, "readOnly": true },
-                    "driversLicenceIssuedCountryId": { "type": "integer", "format": "int32", "nullable": true },
-                    "driversLicenceIssuedProvinceSeqNo": { "type": "integer", "format": "int32", "nullable": true },
-                    "driversLicenceProvince": { "maxLength": 30, "minLength": 0, "type": "string", "nullable": true },
-                    "status": {
-                        "type": "string",
-                        "enum": ["UNKNOWN", "NEW", "VALIDATED", "PROCESSING", "REJECTED", "CANCELLED", "CONCLUDED"]
-                    },
-                    "addressLine1": { "type": "string", "nullable": true },
-                    "addressLine2": { "type": "string", "nullable": true },
-                    "addressLine3": { "type": "string", "nullable": true },
-                    "addressCity": { "maxLength": 30, "minLength": 0, "type": "string", "nullable": true },
-                    "addressProvince": { "maxLength": 30, "minLength": 0, "type": "string", "nullable": true },
-                    "addressProvinceCountryId": { "type": "integer", "format": "int32", "nullable": true },
-                    "addressProvinceSeqNo": { "type": "integer", "format": "int32", "nullable": true },
-                    "addressCountryId": { "type": "integer", "format": "int32", "nullable": true },
-                    "postalCode": { "maxLength": 10, "minLength": 0, "type": "string", "nullable": true },
-                    "homePhoneNumber": { "type": "string", "nullable": true },
-                    "workPhoneNumber": { "type": "string", "nullable": true },
-                    "emailAddress": { "type": "string", "nullable": true },
-                    "emailAddressVerified": { "type": "boolean" },
-                    "filingDate": { "type": "string", "format": "date-time", "nullable": true },
-                    "representedByLawyer": { "type": "string", "nullable": true, "enum": ["UNKNOWN", "Y", "N"] },
-                    "lawFirmName": { "type": "string", "nullable": true },
-                    "lawyerSurname": { "type": "string", "nullable": true },
-                    "lawyerGivenName1": { "type": "string", "nullable": true },
-                    "lawyerGivenName2": { "type": "string", "nullable": true },
-                    "lawyerGivenName3": { "type": "string", "nullable": true },
-                    "lawyerAddress": { "maxLength": 300, "minLength": 0, "type": "string", "nullable": true },
-                    "lawyerPhoneNumber": { "type": "string", "nullable": true },
-                    "lawyerEmail": { "maxLength": 100, "minLength": 0, "type": "string", "nullable": true },
-                    "officerPin": { "type": "string", "nullable": true },
-                    "contactTypeCd": { "type": "string", "enum": ["UNKNOWN", "INDIVIDUAL", "LAWYER", "OTHER"] },
-                    "requestCourtAppearanceYn": { "type": "string", "nullable": true, "enum": ["UNKNOWN", "Y", "N"] },
-                    "contactLawFirmNm": { "type": "string", "nullable": true },
-                    "contactGiven1Nm": { "type": "string", "nullable": true },
-                    "contactGiven2Nm": { "type": "string", "nullable": true },
-                    "contactGiven3Nm": { "type": "string", "nullable": true },
-                    "contactSurnameNm": { "type": "string", "nullable": true },
-                    "appearanceDtm": { "type": "string", "format": "date-time", "nullable": true },
-                    "appearanceLessThan14DaysYn": { "type": "string", "nullable": true, "enum": ["UNKNOWN", "Y", "N"] },
-                    "detachmentLocation": { "type": "string", "nullable": true },
-                    "courtAgenId": { "type": "string", "nullable": true },
-                    "interpreterLanguageCd": { "maxLength": 3, "minLength": 0, "type": "string", "nullable": true },
-                    "interpreterRequired": { "type": "string", "nullable": true, "enum": ["UNKNOWN", "Y", "N"] },
-                    "witnessNo": { "type": "integer", "format": "int32", "nullable": true },
-                    "fineReductionReason": { "type": "string", "nullable": true },
-                    "timeToPayReason": { "type": "string", "nullable": true },
-                    "disputantComment": { "type": "string", "nullable": true },
-                    "rejectedReason": { "type": "string", "nullable": true },
-                    "userAssignedTo": { "type": "string", "nullable": true },
-                    "userAssignedTs": { "type": "string", "format": "date-time", "nullable": true },
-                    "disputantDetectedOcrIssues": { "type": "string", "nullable": true, "enum": ["UNKNOWN", "Y", "N"] },
-                    "disputantOcrIssues": { "type": "string", "nullable": true },
-                    "systemDetectedOcrIssues": { "type": "string", "enum": ["UNKNOWN", "Y", "N"] },
-                    "ocrTicketFilename": { "maxLength": 100, "minLength": 0, "type": "string", "nullable": true },
-                    "violationTicket": { "$ref": "#/components/schemas/ViolationTicket" },
-                    "disputeCounts": { "type": "array", "items": { "$ref": "#/components/schemas/DisputeCount" } }
-                }
-            },
-            "DisputeCount": {
-                "type": "object",
-                "properties": {
-                    "createdBy": { "type": "string" },
-                    "createdTs": { "type": "string", "format": "date-time" },
-                    "modifiedBy": { "type": "string", "nullable": true },
-                    "modifiedTs": { "type": "string", "format": "date-time", "nullable": true },
-                    "countNo": { "maximum": 3, "minimum": 1, "type": "integer", "format": "int32" },
-                    "pleaCode": { "type": "string", "enum": ["UNKNOWN", "G", "N"] },
-                    "requestTimeToPay": { "type": "string", "enum": ["UNKNOWN", "Y", "N"] },
-                    "requestReduction": { "type": "string", "enum": ["UNKNOWN", "Y", "N"] },
-                    "requestCourtAppearance": { "type": "string", "enum": ["UNKNOWN", "Y", "N"] }
-                }
-            },
-            "ViolationTicket": {
-                "type": "object",
-                "properties": {
-                    "createdBy": { "type": "string" },
-                    "createdTs": { "type": "string", "format": "date-time" },
-                    "modifiedBy": { "type": "string", "nullable": true },
-                    "modifiedTs": { "type": "string", "format": "date-time", "nullable": true },
-                    "violationTicketId": { "type": "integer", "description": "ID", "format": "int64", "readOnly": true },
-                    "ticketNumber": { "type": "string", "nullable": true },
-                    "disputantOrganizationName": { "type": "string", "nullable": true },
-                    "disputantSurname": { "type": "string", "nullable": true },
-                    "disputantGivenNames": { "type": "string", "nullable": true },
-                    "isYoungPerson": { "type": "string", "nullable": true, "enum": ["UNKNOWN", "Y", "N"] },
-                    "disputantDriversLicenceNumber": { "maxLength": 30, "minLength": 7, "type": "string", "nullable": true },
-                    "disputantClientNumber": { "type": "string", "nullable": true },
-                    "driversLicenceProvince": { "maxLength": 100, "minLength": 0, "type": "string", "nullable": true },
-                    "driversLicenceCountry": { "maxLength": 100, "minLength": 0, "type": "string" },
-                    "driversLicenceIssuedYear": { "type": "integer", "format": "int32", "nullable": true },
-                    "driversLicenceExpiryYear": { "type": "integer", "format": "int32", "nullable": true },
-                    "disputantBirthdate": { "type": "string", "format": "date-time", "nullable": true },
-                    "address": { "maxLength": 100, "minLength": 0, "type": "string", "nullable": true },
-                    "addressCity": { "type": "string", "nullable": true },
-                    "addressProvince": { "type": "string", "nullable": true },
-                    "addressPostalCode": { "type": "string", "nullable": true },
-                    "addressCountry": { "type": "string", "nullable": true },
-                    "officerPin": { "type": "string", "nullable": true },
-                    "detachmentLocation": { "type": "string", "nullable": true },
-                    "issuedTs": { "type": "string", "format": "date-time", "nullable": true },
-                    "issuedOnRoadOrHighway": { "type": "string", "nullable": true },
-                    "issuedAtOrNearCity": { "type": "string", "nullable": true },
-                    "isChangeOfAddress": { "type": "string", "nullable": true, "enum": ["UNKNOWN", "Y", "N"] },
-                    "isDriver": { "type": "string", "nullable": true, "enum": ["UNKNOWN", "Y", "N"] },
-                    "isOwner": { "type": "string", "nullable": true, "enum": ["UNKNOWN", "Y", "N"] },
-                    "courtLocation": { "type": "string", "nullable": true },
-                    "violationTicketCounts": { "type": "array", "items": { "$ref": "#/components/schemas/ViolationTicketCount" } }
-                },
-                "nullable": true
-            },
-            "ViolationTicketCount": {
-                "type": "object",
-                "properties": {
-                    "createdBy": { "type": "string" },
-                    "createdTs": { "type": "string", "format": "date-time" },
-                    "modifiedBy": { "type": "string", "nullable": true },
-                    "modifiedTs": { "type": "string", "format": "date-time", "nullable": true },
-                    "violationTicketCountId": { "type": "integer", "description": "ID", "format": "int64", "readOnly": true },
-                    "countNo": { "maximum": 3, "minimum": 1, "type": "integer", "format": "int32" },
-                    "description": { "type": "string", "nullable": true },
-                    "actOrRegulationNameCode": { "type": "string", "nullable": true },
-                    "isAct": { "type": "string", "nullable": true, "enum": ["UNKNOWN", "Y", "N"] },
-                    "isRegulation": { "type": "string", "nullable": true, "enum": ["UNKNOWN", "Y", "N"] },
-                    "section": { "maxLength": 10, "minLength": 0, "type": "string", "nullable": true, "readOnly": true },
-                    "subsection": { "maxLength": 4, "minLength": 0, "type": "string", "nullable": true, "readOnly": true },
-                    "paragraph": { "maxLength": 3, "minLength": 0, "type": "string", "nullable": true, "readOnly": true },
-                    "subparagraph": { "maxLength": 5, "minLength": 0, "type": "string", "nullable": true, "readOnly": true },
-                    "ticketedAmount": { "type": "number", "format": "float", "nullable": true }
-                }
-            },
-            "DisputeUpdateRequest": {
-                "required": ["status", "updateJson", "updateType"],
-                "type": "object",
-                "properties": {
-                    "createdBy": { "type": "string" },
-                    "createdTs": { "type": "string", "format": "date-time" },
-                    "modifiedBy": { "type": "string", "nullable": true },
-                    "modifiedTs": { "type": "string", "format": "date-time", "nullable": true },
-                    "disputeUpdateRequestId": { "type": "integer", "description": "ID", "format": "int64", "readOnly": true },
-                    "disputeId": { "type": "integer", "format": "int64" },
-                    "status": { "type": "string", "enum": ["UNKNOWN", "ACCEPTED", "PENDING", "REJECTED"] },
-                    "updateType": {
-                        "type": "string",
-                        "enum": [
-                            "UNKNOWN",
-                            "DISPUTANT_ADDRESS",
-                            "DISPUTANT_PHONE",
-                            "DISPUTANT_NAME",
-                            "COUNT",
-                            "DISPUTANT_EMAIL",
-                            "DISPUTANT_DOCUMENT",
-                            "COURT_OPTIONS"
-                        ]
-                    },
-                    "updateJson": { "maxLength": 1000, "minLength": 3, "type": "string" }
-                }
-            },
-            "FileHistory": {
-                "required": ["auditLogEntryType", "disputeId"],
-                "type": "object",
-                "properties": {
-                    "createdBy": { "type": "string" },
-                    "createdTs": { "type": "string", "format": "date-time" },
-                    "modifiedBy": { "type": "string", "nullable": true },
-                    "modifiedTs": { "type": "string", "format": "date-time", "nullable": true },
-                    "fileHistoryId": { "type": "integer", "description": "ID", "format": "int64", "readOnly": true },
-                    "disputeId": { "type": "integer", "format": "int64" },
-                    "auditLogEntryType": {
-                        "type": "string",
-                        "enum": [
-                            "UNKNOWN",
-                            "ARFL",
-                            "CAIN",
-                            "CAWT",
-                            "CCAN",
-                            "CCON",
-                            "CCWR",
-                            "CLEG",
-                            "CUEM",
-                            "CUEV",
-                            "CUIN",
-                            "CULG",
-                            "CUPD",
-                            "CUWR",
-                            "CUWT",
-                            "DURA",
-                            "DURR",
-                            "EMCA",
-                            "EMCF",
-                            "EMCR",
-                            "EMDC",
-                            "EMFD",
-                            "EMPR",
-                            "EMRJ",
-                            "EMRV",
-                            "EMST",
-                            "EMUP",
-                            "EMVF",
-                            "ESUR",
-                            "FDLD",
-                            "FDLS",
-                            "FUPD",
-                            "FUPS",
-                            "INIT",
-                            "JASG",
-                            "JCNF",
-                            "JDIV",
-                            "JPRG",
-                            "OCNT",
-                            "RCLD",
-                            "RECN",
-                            "SADM",
-                            "SCAN",
-                            "SPRC",
-                            "SREJ",
-                            "SUB",
-                            "SUPL",
-                            "SVAL",
-                            "URSR",
-                            "VREV",
-                            "VSUB"
-                        ]
-                    },
-                    "description": { "type": "string", "nullable": true },
-                    "actionByApplicationUser": { "type": "string", "nullable": true }
-                }
-            },
-            "EmailHistory": {
-                "type": "object",
-                "properties": {
-                    "createdBy": { "type": "string" },
-                    "createdTs": { "type": "string", "format": "date-time" },
-                    "modifiedBy": { "type": "string", "nullable": true },
-                    "modifiedTs": { "type": "string", "format": "date-time", "nullable": true },
-                    "emailHistoryId": { "type": "integer", "description": "ID", "format": "int64", "readOnly": true },
-                    "emailSentTs": { "type": "string", "format": "date-time" },
-                    "fromEmailAddress": { "maxLength": 100, "minLength": 0, "type": "string" },
-                    "toEmailAddress": { "maxLength": 4000, "minLength": 0, "type": "string" },
-                    "ccEmailAddress": { "maxLength": 4000, "minLength": 0, "type": "string", "nullable": true },
-                    "bccEmailAddress": { "maxLength": 4000, "minLength": 0, "type": "string", "nullable": true },
-                    "subject": { "maxLength": 1000, "minLength": 0, "type": "string" },
-                    "htmlContent": { "maxLength": 4000, "minLength": 0, "type": "string", "nullable": true },
-                    "plainTextContent": { "maxLength": 4000, "minLength": 0, "type": "string", "nullable": true },
-                    "successfullySent": { "type": "string", "enum": ["UNKNOWN", "Y", "N"] },
-                    "occamDisputeId": { "type": "integer", "format": "int64" }
-                }
-            },
-            "TicketImageDataJustinDocument": {
-                "type": "object",
-                "properties": {
-                    "reportType": { "type": "string", "nullable": true, "enum": ["UNKNOWN", "NOTICE_OF_DISPUTE", "TICKET_IMAGE"] },
-                    "reportFormat": { "type": "string", "nullable": true },
-                    "partId": { "type": "string", "nullable": true },
-                    "participantName": { "type": "string", "nullable": true },
-                    "index": { "type": "string", "nullable": true },
-                    "fileData": { "type": "string", "nullable": true }
-                }
-            },
-            "DisputeListItem": {
-                "type": "object",
-                "properties": {
-                    "disputeId": { "type": "integer", "description": "ID", "format": "int64", "readOnly": true },
-                    "ticketNumber": { "type": "string" },
-                    "submittedTs": { "type": "string", "format": "date-time", "nullable": true },
-                    "disputantSurname": { "type": "string", "nullable": true },
-                    "disputantGivenName1": { "type": "string", "nullable": true },
-                    "disputantGivenName2": { "type": "string", "nullable": true },
-                    "disputantGivenName3": { "type": "string", "nullable": true },
-                    "status": {
-                        "type": "string",
-                        "enum": ["UNKNOWN", "NEW", "VALIDATED", "PROCESSING", "REJECTED", "CANCELLED", "CONCLUDED"]
-                    },
-                    "emailAddress": { "type": "string", "nullable": true },
-                    "emailAddressVerified": { "type": "boolean" },
-                    "filingDate": { "type": "string", "format": "date-time", "nullable": true },
-                    "requestCourtAppearanceYn": { "type": "string", "nullable": true, "enum": ["UNKNOWN", "Y", "N"] },
-                    "userAssignedTo": { "type": "string", "nullable": true },
-                    "userAssignedTs": { "type": "string", "format": "date-time", "nullable": true },
-                    "disputantDetectedOcrIssues": { "type": "string", "nullable": true, "enum": ["UNKNOWN", "Y", "N"] },
-                    "systemDetectedOcrIssues": { "type": "string", "enum": ["UNKNOWN", "Y", "N"] },
-                    "violationDate": { "type": "string", "format": "date-time", "nullable": true },
-                    "jjDisputeStatus": {
-                        "type": "string",
-                        "nullable": true,
-                        "enum": [
-                            "UNKNOWN",
-                            "NEW",
-                            "IN_PROGRESS",
-                            "DATA_UPDATE",
-                            "CONFIRMED",
-                            "REQUIRE_COURT_HEARING",
-                            "REQUIRE_MORE_INFO",
-                            "ACCEPTED",
-                            "REVIEW",
-                            "CONCLUDED",
-                            "CANCELLED",
-                            "HEARING_SCHEDULED"
-                        ]
-                    },
-                    "jjAssignedTo": { "type": "string", "nullable": true },
-                    "jjDecisionDate": { "type": "string", "format": "date-time", "nullable": true },
-                    "courtAgenId": { "type": "string", "nullable": true }
-                }
-            },
-            "DisputeResult": {
-                "type": "object",
-                "properties": {
-                    "disputeId": { "type": "integer", "format": "int64" },
-                    "noticeOfDisputeGuid": { "type": "string" },
-                    "disputeStatus": {
-                        "type": "string",
-                        "enum": ["UNKNOWN", "NEW", "VALIDATED", "PROCESSING", "REJECTED", "CANCELLED", "CONCLUDED"]
-                    },
-                    "jjDisputeStatus": {
-                        "type": "string",
-                        "nullable": true,
-                        "enum": [
-                            "UNKNOWN",
-                            "NEW",
-                            "IN_PROGRESS",
-                            "DATA_UPDATE",
-                            "CONFIRMED",
-                            "REQUIRE_COURT_HEARING",
-                            "REQUIRE_MORE_INFO",
-                            "ACCEPTED",
-                            "REVIEW",
-                            "CONCLUDED",
-                            "CANCELLED",
-                            "HEARING_SCHEDULED"
-                        ]
-                    },
-                    "jjDisputeHearingType": {
-                        "type": "string",
-                        "nullable": true,
-                        "enum": ["UNKNOWN", "COURT_APPEARANCE", "WRITTEN_REASONS"]
-                    },
-                    "isEmailAddressVerified": { "type": "boolean" }
-                }
-            }
-        },
-        "securitySchemes": { "x-username": { "type": "apiKey", "name": "x-username", "in": "header" } }
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Oracle Data Api",
+    "version": "1.0.0"
+  },
+  "servers": [
+    {
+      "url": "http://localhost:8080",
+      "description": "Generated server url"
     }
+  ],
+  "security": [ { "x-username": [] } ],
+  "paths": {
+    "/api/v1.0/jj/dispute/{ticketNumber}": {
+      "put": {
+        "tags": [ "jj-dispute-controller" ],
+        "summary": "Updates the properties of a particular JJ Dispute record based on the given values.",
+        "operationId": "updateJJDispute",
+        "parameters": [
+          {
+            "name": "ticketNumber",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "checkVTCAssigned",
+            "in": "query",
+            "required": true,
+            "schema": { "type": "boolean" }
+          }
+        ],
+        "requestBody": {
+          "content": { "application/json": { "schema": { "$ref": "#/components/schemas/JJDispute" } } },
+          "required": true
+        },
+        "responses": {
+          "400": {
+            "description": "Bad Request.",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "405": {
+            "description": "An invalid JJ Dispute status is provided. Update failed.",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "404": {
+            "description": "JJDispute record not found. Update failed.",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "200": {
+            "description": "Ok",
+            "content": { "*/*": { "schema": { "$ref": "#/components/schemas/JJDispute" } } }
+          }
+        }
+      }
+    },
+    "/api/v1.0/jj/dispute/{ticketNumber}/review": {
+      "put": {
+        "tags": [ "jj-dispute-controller" ],
+        "summary": "Updates the status of a particular JJDispute record to REVIEW.",
+        "operationId": "reviewJJDispute",
+        "parameters": [
+          {
+            "name": "ticketNumber",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "checkVTCAssigned",
+            "in": "query",
+            "required": true,
+            "schema": { "type": "boolean" }
+          },
+          {
+            "name": "recalled",
+            "in": "query",
+            "required": true,
+            "schema": { "type": "boolean" }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "maxLength": 256,
+                "minLength": 0,
+                "type": "string"
+              }
+            }
+          }
+        },
+        "responses": {
+          "400": {
+            "description": "Bad Request.",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "405": {
+            "description": "A JJDispute status can only be set to REVIEW if status is CONFIRMED and the remark must be <= 256 characters OR if the status ACCEPTED, CONFIRMED or CONCLUDED and DCF's current hearing date = today's date. Update failed.",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "404": {
+            "description": "JJDispute record not found. Update failed.",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "500": {
+            "description": "Internal server error occured.",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "200": {
+            "description": "Ok. Updated JJDispute record returned.",
+            "content": { "*/*": { "schema": { "$ref": "#/components/schemas/JJDispute" } } }
+          }
+        }
+      }
+    },
+    "/api/v1.0/jj/dispute/{ticketNumber}/requirecourthearing": {
+      "put": {
+        "tags": [ "jj-dispute-controller" ],
+        "summary": "Updates the status of a particular JJDispute record to REQUIRE_COURT_HEARING, type to COURT_APPEARANCE.",
+        "operationId": "requireCourtHearingJJDispute",
+        "parameters": [
+          {
+            "name": "ticketNumber",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "remark",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "maxLength": 256,
+              "minLength": 0,
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "400": {
+            "description": "Bad Request.",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "405": {
+            "description": "A JJDispute status can only be set to REQUIRE_COURT_HEARING iff status is one of the following: NEW, IN_PROGRESS, REVIEW, REQUIRE_COURT_HEARING and the remark must be <= 256 characters. Update failed.",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "404": {
+            "description": "JJDispute record not found. Update failed.",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "500": {
+            "description": "Internal server error occured.",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "200": {
+            "description": "Ok. Updated JJDispute record returned.",
+            "content": { "*/*": { "schema": { "$ref": "#/components/schemas/JJDispute" } } }
+          }
+        }
+      }
+    },
+    "/api/v1.0/jj/dispute/{ticketNumber}/confirm": {
+      "put": {
+        "tags": [ "jj-dispute-controller" ],
+        "summary": "Updates the status of a particular JJDispute record to CONFIRMED.",
+        "operationId": "confirmJJDispute",
+        "parameters": [
+          {
+            "name": "ticketNumber",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "400": {
+            "description": "Bad Request.",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "405": {
+            "description": "A JJDispute status can only be set to CONFIRMED iff status is one of the following: REVIEW, NEW, HEARING_SCHEDULED, IN_PROGRESS, CONFIRMED. Update failed.",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "404": {
+            "description": "JJDispute record not found. Update failed.",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "500": {
+            "description": "Internal server error occured.",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "200": {
+            "description": "Ok. Updated JJDispute record returned.",
+            "content": { "*/*": { "schema": { "$ref": "#/components/schemas/JJDispute" } } }
+          }
+        }
+      }
+    },
+    "/api/v1.0/jj/dispute/{ticketNumber}/conclude": {
+      "put": {
+        "tags": [ "jj-dispute-controller" ],
+        "summary": "Updates the status of a particular JJDispute record to CONCLUDED.",
+        "operationId": "concludeJJDispute",
+        "parameters": [
+          {
+            "name": "ticketNumber",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "checkVTCAssigned",
+            "in": "query",
+            "required": true,
+            "schema": { "type": "boolean" }
+          }
+        ],
+        "responses": {
+          "400": {
+            "description": "Bad Request.",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "405": {
+            "description": "Method Not Allowed",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "404": {
+            "description": "JJDispute record not found. Update failed.",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "500": {
+            "description": "Internal server error occured.",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "200": {
+            "description": "Ok. Updated JJDispute record returned.",
+            "content": { "*/*": { "schema": { "$ref": "#/components/schemas/JJDispute" } } }
+          }
+        }
+      }
+    },
+    "/api/v1.0/jj/dispute/{ticketNumber}/cascade": {
+      "put": {
+        "tags": [ "jj-dispute-controller" ],
+        "summary": "Updates the properties of a particular JJ Dispute record as well as cascading to underlying related Dispute data.",
+        "operationId": "updateJJDisputeCascade",
+        "parameters": [
+          {
+            "name": "ticketNumber",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "checkVTCAssigned",
+            "in": "query",
+            "required": true,
+            "schema": { "type": "boolean" }
+          }
+        ],
+        "requestBody": {
+          "content": { "application/json": { "schema": { "$ref": "#/components/schemas/JJDispute" } } },
+          "required": true
+        },
+        "responses": {
+          "400": {
+            "description": "Bad Request.",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "405": {
+            "description": "An invalid JJ Dispute status is provided. Update failed.",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "404": {
+            "description": "JJDispute record not found. Update failed.",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "200": {
+            "description": "Ok",
+            "content": { "*/*": { "schema": { "$ref": "#/components/schemas/JJDispute" } } }
+          }
+        }
+      }
+    },
+    "/api/v1.0/jj/dispute/{ticketNumber}/cancel": {
+      "put": {
+        "tags": [ "jj-dispute-controller" ],
+        "summary": "Updates the status of a particular JJDispute record to CANCELLED.",
+        "operationId": "cancelJJDispute",
+        "parameters": [
+          {
+            "name": "ticketNumber",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "checkVTCAssigned",
+            "in": "query",
+            "required": true,
+            "schema": { "type": "boolean" }
+          }
+        ],
+        "responses": {
+          "400": {
+            "description": "Bad Request.",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "405": {
+            "description": "Method Not Allowed",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "404": {
+            "description": "JJDispute record not found. Update failed.",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "500": {
+            "description": "Internal server error occured.",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "200": {
+            "description": "Ok. Updated JJDispute record returned.",
+            "content": { "*/*": { "schema": { "$ref": "#/components/schemas/JJDispute" } } }
+          }
+        }
+      }
+    },
+    "/api/v1.0/jj/dispute/{ticketNumber}/accept": {
+      "put": {
+        "tags": [ "jj-dispute-controller" ],
+        "summary": "Updates the status of a particular JJDispute record to ACCEPTED.",
+        "operationId": "acceptJJDispute",
+        "parameters": [
+          {
+            "name": "ticketNumber",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "checkVTCAssigned",
+            "in": "query",
+            "required": true,
+            "schema": { "type": "boolean" }
+          },
+          {
+            "name": "partId",
+            "in": "query",
+            "description": "Adjudicator's participant ID",
+            "required": false,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "400": {
+            "description": "Bad Request.",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "405": {
+            "description": "A JJDispute status can only be set to ACCEPTED iff status is CONFIRMED. Update failed.",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "404": {
+            "description": "JJDispute record not found. Update failed.",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "500": {
+            "description": "Internal server error occured.",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "200": {
+            "description": "Ok. Updated JJDispute record returned.",
+            "content": { "*/*": { "schema": { "$ref": "#/components/schemas/JJDispute" } } }
+          }
+        }
+      }
+    },
+    "/api/v1.0/jj/dispute/assign": {
+      "put": {
+        "tags": [ "jj-dispute-controller" ],
+        "summary": "Updates each JJ Dispute based on the passed in ticket numbers to assign them to a specific JJ or unassign them if JJ not specified.",
+        "operationId": "assignJJDisputesToJJ",
+        "parameters": [
+          {
+            "name": "ticketNumbers",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "array",
+              "items": { "type": "string" }
+            }
+          },
+          {
+            "name": "jjUsername",
+            "in": "query",
+            "required": false,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "400": {
+            "description": "Bad Request.",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "405": {
+            "description": "Method Not Allowed",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "404": {
+            "description": "JJDispute record(s) not found. Update failed.",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "500": {
+            "description": "Internal server error occured.",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "200": { "description": "Ok" }
+        }
+      }
+    },
+    "/api/v1.0/dispute/{id}": {
+      "put": {
+        "tags": [ "dispute-controller" ],
+        "summary": "Updates the properties of a particular Dispute record based on the given values.",
+        "operationId": "updateDispute",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": { "application/json": { "schema": { "$ref": "#/components/schemas/Dispute" } } },
+          "required": true
+        },
+        "responses": {
+          "400": {
+            "description": "Bad Request.",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "405": {
+            "description": "Method Not Allowed",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "404": {
+            "description": "Dispute record not found. Update failed.",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "409": {
+            "description": "The Dispute has already been assigned to a different user. Dispute cannot be modified until assigned time expires.",
+            "content": { "*/*": { "schema": { "$ref": "#/components/schemas/Dispute" } } }
+          },
+          "200": {
+            "description": "Ok",
+            "content": { "*/*": { "schema": { "$ref": "#/components/schemas/Dispute" } } }
+          }
+        }
+      },
+      "delete": {
+        "tags": [ "dispute-controller" ],
+        "summary": "Deletes a particular Dispute record.",
+        "operationId": "deleteDispute",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "400": {
+            "description": "Bad Request.",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "405": {
+            "description": "Method Not Allowed",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "404": {
+            "description": "Dispute record not found. Delete failed.",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "500": {
+            "description": "Internal Server Error. Delete failed.",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "200": { "description": "Ok. Dispute record deleted." }
+        }
+      }
+    },
+    "/api/v1.0/dispute/{id}/validate": {
+      "put": {
+        "tags": [ "dispute-controller" ],
+        "summary": "Updates the status of a particular Dispute record to VALIDATED.",
+        "operationId": "validateDispute",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "400": {
+            "description": "Bad Request.",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "405": {
+            "description": "A Dispute status can only be set to VALIDATED iff status is NEW. Update failed.",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "404": {
+            "description": "Dispute record not found. Update failed.",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "200": {
+            "description": "Ok. Updated Dispute record returned.",
+            "content": { "*/*": { "schema": { "$ref": "#/components/schemas/Dispute" } } }
+          },
+          "409": {
+            "description": "The Dispute has already been assigned to a different user. Dispute cannot be modified until assigned time expires.",
+            "content": { "*/*": { "schema": { "$ref": "#/components/schemas/Dispute" } } }
+          }
+        }
+      }
+    },
+    "/api/v1.0/dispute/{id}/submit": {
+      "put": {
+        "tags": [ "dispute-controller" ],
+        "summary": "Updates the status of a particular Dispute record to PROCESSING.",
+        "operationId": "submitDispute",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "400": {
+            "description": "Bad Request.",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "405": {
+            "description": "A Dispute status can only be set to PROCESSING iff status is NEW or REJECTED. Update failed.",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "404": {
+            "description": "Dispute record not found. Update failed.",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "200": {
+            "description": "Ok. Updated Dispute record returned.",
+            "content": { "*/*": { "schema": { "$ref": "#/components/schemas/Dispute" } } }
+          },
+          "409": {
+            "description": "The Dispute has already been assigned to a different user. Dispute cannot be modified until assigned time expires.",
+            "content": { "*/*": { "schema": { "$ref": "#/components/schemas/Dispute" } } }
+          }
+        }
+      }
+    },
+    "/api/v1.0/dispute/{id}/reject": {
+      "put": {
+        "tags": [ "dispute-controller" ],
+        "summary": "Updates the status of a particular Dispute record to REJECTED.",
+        "operationId": "rejectDispute",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "maxLength": 256,
+                "minLength": 1,
+                "type": "string"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "400": {
+            "description": "Bad Request.",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "405": {
+            "description": "A Dispute status can only be set to REJECTED iff status is NEW or VALIDATED and the rejected reason must be <= 256 characters. Update failed.",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "404": {
+            "description": "Dispute record not found. Update failed.",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "200": {
+            "description": "Ok. Updated Dispute record returned.",
+            "content": { "*/*": { "schema": { "$ref": "#/components/schemas/Dispute" } } }
+          },
+          "409": {
+            "description": "The Dispute has already been assigned to a different user. Dispute cannot be modified until assigned time expires.",
+            "content": { "*/*": { "schema": { "$ref": "#/components/schemas/Dispute" } } }
+          }
+        }
+      }
+    },
+    "/api/v1.0/dispute/{id}/email/verify": {
+      "put": {
+        "tags": [ "dispute-controller" ],
+        "summary": "Updates the emailVerification flag of a particular Dispute to true.",
+        "operationId": "verifyDisputeEmail",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The id of the Dispute to update.",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "400": {
+            "description": "Bad Request",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "405": {
+            "description": "Method Not Allowed",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "404": {
+            "description": "Dispute with specified id not found",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "500": {
+            "description": "Internal server error occured.",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "200": { "description": "Ok. Email verified." }
+        }
+      }
+    },
+    "/api/v1.0/dispute/{id}/email/reset": {
+      "put": {
+        "tags": [ "dispute-controller" ],
+        "summary": "Updates the email address of a particular Dispute.",
+        "operationId": "resetDisputeEmail",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The id of the Dispute to update.",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          {
+            "name": "email",
+            "in": "query",
+            "description": "The new email address of the Disputant.",
+            "required": false,
+            "schema": {
+              "maxLength": 100,
+              "minLength": 1,
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "400": {
+            "description": "If the email address is > 100 characters",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "405": {
+            "description": "Method Not Allowed",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "404": {
+            "description": "Dispute with specified id not found",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "500": {
+            "description": "Internal server error occured.",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "200": {
+            "description": "Ok. Email reset.",
+            "content": { "*/*": { "schema": { "$ref": "#/components/schemas/Dispute" } } }
+          }
+        }
+      }
+    },
+    "/api/v1.0/dispute/{id}/cancel": {
+      "put": {
+        "tags": [ "dispute-controller" ],
+        "summary": "Updates the status of a particular Dispute record to CANCELLED.",
+        "operationId": "cancelDispute",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "maxLength": 256,
+                "minLength": 1,
+                "type": "string"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "400": {
+            "description": "Bad Request.",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "405": {
+            "description": "A Dispute status can only be set to CANCELLED iff status is NEW, REJECTED or PROCESSING. Update failed.",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "404": {
+            "description": "Dispute record not found. Update failed.",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "200": {
+            "description": "Ok. Updated Dispute record returned.",
+            "content": { "*/*": { "schema": { "$ref": "#/components/schemas/Dispute" } } }
+          },
+          "409": {
+            "description": "The Dispute has already been assigned to a different user. Dispute cannot be modified until assigned time expires.",
+            "content": { "*/*": { "schema": { "$ref": "#/components/schemas/Dispute" } } }
+          }
+        }
+      }
+    },
+    "/api/v1.0/dispute/updateRequest/{id}": {
+      "put": {
+        "tags": [ "dispute-controller" ],
+        "summary": "An endpoint that updates the status of a DisputeUpdateRequest record.",
+        "operationId": "updateDisputeUpdateRequestStatus",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The id of the DisputeUpdateRequest record to update.",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          {
+            "name": "disputeUpdateRequestStatus",
+            "in": "query",
+            "description": "The status of the request record should be updated to.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "enum": [ "UNKNOWN", "ACCEPTED", "PENDING", "REJECTED" ]
+            },
+            "example": "ACCEPTED"
+          }
+        ],
+        "responses": {
+          "400": {
+            "description": "Bad Request",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "405": {
+            "description": "Method Not Allowed",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "404": {
+            "description": "DisputeUpdateRequest could not be found.",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "500": {
+            "description": "Internal Server Error. Save failed.",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "200": {
+            "description": "Ok. DisputeUpdateRequest updated.",
+            "content": { "*/*": { "schema": { "$ref": "#/components/schemas/DisputeUpdateRequest" } } }
+          }
+        }
+      }
+    },
+    "/api/v1.0/fileHistory": {
+      "post": {
+        "tags": [ "file-history-controller" ],
+        "summary": "Inserts a file history record for the given ticket number.",
+        "operationId": "insertFileHistory",
+        "requestBody": {
+          "content": { "application/json": { "schema": { "$ref": "#/components/schemas/FileHistory" } } },
+          "required": true
+        },
+        "responses": {
+          "400": {
+            "description": "Bad Request.",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "405": {
+            "description": "Method Not Allowed",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "404": {
+            "description": "An invalid file history record provided. Insert failed.",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "200": {
+            "description": "Ok",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "integer",
+                  "format": "int64"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1.0/emailHistory": {
+      "post": {
+        "tags": [ "email-history-controller" ],
+        "summary": "Inserts an email history record for the given ticket number.",
+        "operationId": "insertEmailHistory",
+        "requestBody": {
+          "content": { "application/json": { "schema": { "$ref": "#/components/schemas/EmailHistory" } } },
+          "required": true
+        },
+        "responses": {
+          "400": {
+            "description": "Bad Request.",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "405": {
+            "description": "Method Not Allowed",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "404": {
+            "description": "An invalid email history record provided. Insert failed.",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "200": {
+            "description": "Ok",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "integer",
+                  "format": "int64"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1.0/dispute": {
+      "post": {
+        "tags": [ "dispute-controller" ],
+        "operationId": "saveDispute",
+        "requestBody": {
+          "content": { "application/json": { "schema": { "$ref": "#/components/schemas/Dispute" } } },
+          "required": true
+        },
+        "responses": {
+          "400": {
+            "description": "Bad Request",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "405": {
+            "description": "Method Not Allowed",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "integer",
+                  "format": "int64"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1.0/dispute/{guid}/updateRequest": {
+      "post": {
+        "tags": [ "dispute-controller" ],
+        "summary": "An endpoint that inserts a DisputeUpdateRequest into persistent storage.",
+        "operationId": "saveDisputeUpdateRequest",
+        "parameters": [
+          {
+            "name": "guid",
+            "in": "path",
+            "description": "The noticeOfDisputeGuid of the Dispute to associate with.",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "requestBody": {
+          "content": { "application/json": { "schema": { "$ref": "#/components/schemas/DisputeUpdateRequest" } } },
+          "required": true
+        },
+        "responses": {
+          "400": {
+            "description": "Bad Request",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "405": {
+            "description": "Method Not Allowed",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "404": {
+            "description": "Dispute could not be found.",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "500": {
+            "description": "Internal Server Error. Save failed.",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "200": {
+            "description": "Ok. DisputeUpdateRequest record saved.",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "integer",
+                  "format": "int64"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1.0/jj/disputes": {
+      "get": {
+        "tags": [ "jj-dispute-controller" ],
+        "operationId": "getJJDisputes",
+        "parameters": [
+          {
+            "name": "jjAssignedTo",
+            "in": "query",
+            "description": "If specified, will retrieve the records which are assigned to the specified jj staff",
+            "required": false,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "ticketNumber",
+            "in": "query",
+            "description": "If specified will filter by TicketNumber. (Format is XX00000000)",
+            "required": false,
+            "schema": {
+              "pattern": "[A-Z]{2}\\d{8}",
+              "type": "string"
+            },
+            "example": "AX12345678"
+          }
+        ],
+        "responses": {
+          "400": {
+            "description": "Bad Request",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "405": {
+            "description": "Method Not Allowed",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "array",
+                  "items": { "$ref": "#/components/schemas/JJDispute" }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1.0/jj/dispute/{ticketNumber}/{assignVTC}": {
+      "get": {
+        "tags": [ "jj-dispute-controller" ],
+        "operationId": "getJJDispute",
+        "parameters": [
+          {
+            "name": "ticketNumber",
+            "in": "path",
+            "description": "The primary key of the jj dispute to retrieve",
+            "required": true,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "assignVTC",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "boolean" }
+          }
+        ],
+        "responses": {
+          "400": {
+            "description": "Bad Request",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "405": {
+            "description": "Method Not Allowed",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "200": {
+            "description": "OK",
+            "content": { "*/*": { "schema": { "$ref": "#/components/schemas/JJDispute" } } }
+          }
+        }
+      }
+    },
+    "/api/v1.0/jj/dispute/ticketImage/{ticketNumber}/{documentType}": {
+      "get": {
+        "tags": [ "jj-dispute-controller" ],
+        "operationId": "getTicketImageData",
+        "parameters": [
+          {
+            "name": "ticketNumber",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "documentType",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "enum": [ "UNKNOWN", "NOTICE_OF_DISPUTE", "TICKET_IMAGE" ]
+            }
+          }
+        ],
+        "responses": {
+          "400": {
+            "description": "Bad Request",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "405": {
+            "description": "Method Not Allowed",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "200": {
+            "description": "OK",
+            "content": { "*/*": { "schema": { "$ref": "#/components/schemas/TicketImageDataJustinDocument" } } }
+          }
+        }
+      }
+    },
+    "/api/v1.0/fileHistory/{ticketNumber}": {
+      "get": {
+        "tags": [ "file-history-controller" ],
+        "operationId": "getFileHistoryByTicketNumber",
+        "parameters": [
+          {
+            "name": "ticketNumber",
+            "in": "path",
+            "description": "Ticket number to retrieve related file history.",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "400": {
+            "description": "Bad Request",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "405": {
+            "description": "Method Not Allowed",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "array",
+                  "items": { "$ref": "#/components/schemas/FileHistory" }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1.0/emailHistory/{ticketNumber}": {
+      "get": {
+        "tags": [ "email-history-controller" ],
+        "operationId": "getEmailHistoryByTicketNumber",
+        "parameters": [
+          {
+            "name": "ticketNumber",
+            "in": "path",
+            "description": "Ticket number to retrieve related emails.",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "400": {
+            "description": "Bad Request",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "405": {
+            "description": "Method Not Allowed",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "array",
+                  "items": { "$ref": "#/components/schemas/EmailHistory" }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1.0/disputes": {
+      "get": {
+        "tags": [ "dispute-controller" ],
+        "summary": "Returns all dispute list details based on the specified optional parameters.",
+        "operationId": "getAllDisputes",
+        "parameters": [
+          {
+            "name": "newerThan",
+            "in": "query",
+            "description": "If specified, will retrieve records newer than this date (specified by yyyy-MM-dd)",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "example": "2022-03-15"
+          },
+          {
+            "name": "excludeStatus",
+            "in": "query",
+            "description": "If specified, will retrieve records which do not have the specified status",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": [ "UNKNOWN", "NEW", "VALIDATED", "PROCESSING", "REJECTED", "CANCELLED", "CONCLUDED" ]
+            },
+            "example": "CANCELLED"
+          }
+        ],
+        "responses": {
+          "400": {
+            "description": "Bad Request.",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "405": {
+            "description": "Method Not Allowed",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "500": {
+            "description": "Internal Server Error. Getting disputes failed.",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "200": {
+            "description": "Ok. Disputes are returned.",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "array",
+                  "items": { "$ref": "#/components/schemas/DisputeListItem" }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1.0/disputes/unassign": {
+      "get": {
+        "tags": [ "dispute-controller" ],
+        "summary": "An endpoint hook to trigger the Unassign Dispute job.",
+        "description": "A Dispute can be assigned to a specific user that \"locks\" the record for others. This endpoing manually triggers the Unassign Dispute job that clears the assignment of all Disputes that were assigned for more than 1 hour.",
+        "operationId": "unassignDisputes",
+        "responses": {
+          "400": {
+            "description": "Bad Request",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "405": {
+            "description": "Method Not Allowed",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "500": {
+            "description": "Internal Server Error. Unassigned failed.",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "200": { "description": "Ok. Dispute record unassigned." }
+        }
+      }
+    },
+    "/api/v1.0/dispute/{id}/{isAssign}": {
+      "get": {
+        "tags": [ "dispute-controller" ],
+        "operationId": "getDispute",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          {
+            "name": "isAssign",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "boolean" }
+          }
+        ],
+        "responses": {
+          "400": {
+            "description": "Bad Request",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "405": {
+            "description": "Method Not Allowed",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "200": {
+            "description": "OK",
+            "content": { "*/*": { "schema": { "$ref": "#/components/schemas/Dispute" } } }
+          }
+        }
+      }
+    },
+    "/api/v1.0/dispute/updateRequests": {
+      "get": {
+        "tags": [ "dispute-controller" ],
+        "summary": "An endpoint that retrieves all DisputeUpdateRequest optionally for a given Dispute, optionally filtered by DisputeUpdateRequestStatus.",
+        "operationId": "getDisputeUpdateRequests",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "query",
+            "description": "If specified, filter request by the disputeId of the Dispute.",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          {
+            "name": "status",
+            "in": "query",
+            "description": "If specified, filter request by DisputeUpdateRequestStatus",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": [ "UNKNOWN", "ACCEPTED", "PENDING", "REJECTED" ]
+            },
+            "example": "PENDING"
+          }
+        ],
+        "responses": {
+          "400": {
+            "description": "Bad Request",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "405": {
+            "description": "Method Not Allowed",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "500": {
+            "description": "Internal Server Error. retrieve update requests failed.",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "200": {
+            "description": "Ok. DisputeUpdateRequest record saved.",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "array",
+                  "items": { "$ref": "#/components/schemas/DisputeUpdateRequest" }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1.0/dispute/status": {
+      "get": {
+        "tags": [ "dispute-controller" ],
+        "summary": "Finds Dispute statuses by TicketNumber and IssuedTime or noticeOfDisputeGuid if specified.",
+        "operationId": "findDisputeStatuses",
+        "parameters": [
+          {
+            "name": "ticketNumber",
+            "in": "query",
+            "description": "The Dispute.ticketNumber to search for (of the format XX00000000)",
+            "required": false,
+            "schema": {
+              "pattern": "^$|([A-Z]{2}\\d{8})",
+              "type": "string"
+            },
+            "example": "AX12345678"
+          },
+          {
+            "name": "issuedTime",
+            "in": "query",
+            "description": "The time portion of the Dispute.issuedTs field to search for (of the format HH:mm). Time is in UTC.",
+            "required": false,
+            "schema": { "type": "string" },
+            "example": "14:53"
+          },
+          {
+            "name": "noticeOfDisputeGuid",
+            "in": "query",
+            "description": "The noticeOfDisputeGuid of the Dispute to retreive.",
+            "required": false,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "400": {
+            "description": "Bad Request, check parameters.",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "405": {
+            "description": "Method Not Allowed",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "500": {
+            "description": "Internal Server Error. Search failed.",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "200": {
+            "description": "Ok.",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "array",
+                  "items": { "$ref": "#/components/schemas/DisputeResult" }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1.0/dispute/noticeOfDispute/{id}": {
+      "get": {
+        "tags": [ "dispute-controller" ],
+        "summary": "Retrieves Dispute by the noticeOfDisputeGuid (UUID).",
+        "operationId": "getDisputeByNoticeOfDisputeGuid",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The noticeOfDisputeGuid of the Dispute to retreive.",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "400": {
+            "description": "Bad Request",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "405": {
+            "description": "Method Not Allowed",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "404": {
+            "description": "Dispute could not be found.",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "500": {
+            "description": "Internal server error occured.",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "200": {
+            "description": "Ok. Dispute retrieved.",
+            "content": { "*/*": { "schema": { "$ref": "#/components/schemas/Dispute" } } }
+          }
+        }
+      }
+    },
+    "/api/v1.0/codetable/refresh": {
+      "get": {
+        "tags": [ "dispute-controller" ],
+        "summary": "An endpoint hook to trigger a redis rebuild of cached codetable data.",
+        "description": "The codetables in redis are cached copies of data pulled from Oracle to ensure TCO remains stable. This data is periodically refreshed, but can be forced by hitting this endpoint.",
+        "operationId": "codeTableRefresh",
+        "responses": {
+          "400": {
+            "description": "Bad Request",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "405": {
+            "description": "Method Not Allowed",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "200": { "description": "OK" }
+        }
+      }
+    },
+    "/api/v1.0/jj/dispute": {
+      "delete": {
+        "tags": [ "jj-dispute-controller" ],
+        "summary": "Deletes a particular JJDispute record.",
+        "operationId": "DeleteJJDispute",
+        "parameters": [
+          {
+            "name": "jjDisputeId",
+            "in": "query",
+            "description": "If specified, will delete the record of the specified jj dispute by this ID. JJ Dispute ID will take precedence if both ID and ticket number supplied",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          {
+            "name": "ticketNumber",
+            "in": "query",
+            "description": "If specified, will delete the record of the specified jj dispute by this TicketNumber. (Format is XX00000000)",
+            "required": false,
+            "schema": {
+              "pattern": "[A-Z]{2}\\d{8}",
+              "type": "string"
+            },
+            "example": "AX12345678"
+          }
+        ],
+        "responses": {
+          "400": {
+            "description": "Bad Request.",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "405": {
+            "description": "Method Not Allowed",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "500": {
+            "description": "Internal Server Error. Delete failed.",
+            "content": { "*/*": { "schema": { "type": "object" } } }
+          },
+          "200": { "description": "Ok. JJ Dispute record deleted." }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "JJDispute": {
+        "type": "object",
+        "properties": {
+          "createdBy": { "type": "string" },
+          "createdTs": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "modifiedBy": {
+            "type": "string",
+            "nullable": true
+          },
+          "modifiedTs": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "id": {
+            "type": "integer",
+            "description": "ID",
+            "format": "int64",
+            "readOnly": true
+          },
+          "ticketNumber": { "type": "string" },
+          "accidentYn": {
+            "type": "string",
+            "description": "Indicates whether the dispute is associated with an accident or not",
+            "nullable": true,
+            "enum": [ "UNKNOWN", "Y", "N" ]
+          },
+          "addressLine1": { "type": "string" },
+          "addressLine2": {
+            "type": "string",
+            "nullable": true
+          },
+          "addressLine3": {
+            "type": "string",
+            "nullable": true
+          },
+          "addressCity": {
+            "type": "string",
+            "nullable": true
+          },
+          "addressProvince": {
+            "type": "string",
+            "nullable": true
+          },
+          "addressCountry": {
+            "type": "string",
+            "nullable": true
+          },
+          "addressPostalCode": {
+            "type": "string",
+            "nullable": true
+          },
+          "disputantBirthdate": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "driversLicenceNumber": {
+            "type": "string",
+            "nullable": true
+          },
+          "drvLicIssuedProvSeqNo": {
+            "type": "string",
+            "nullable": true
+          },
+          "drvLicIssuedCtryId": {
+            "type": "string",
+            "nullable": true
+          },
+          "emailAddress": {
+            "type": "string",
+            "nullable": true
+          },
+          "status": {
+            "type": "string",
+            "enum": [ "UNKNOWN", "NEW", "IN_PROGRESS", "DATA_UPDATE", "CONFIRMED", "REQUIRE_COURT_HEARING", "REQUIRE_MORE_INFO", "ACCEPTED", "REVIEW", "CONCLUDED", "CANCELLED", "HEARING_SCHEDULED" ]
+          },
+          "hearingType": {
+            "type": "string",
+            "nullable": true,
+            "enum": [ "UNKNOWN", "COURT_APPEARANCE", "WRITTEN_REASONS" ]
+          },
+          "multipleOfficersYn": {
+            "type": "string",
+            "description": "Indicates whether the dispute is associated with multiple officers or not",
+            "enum": [ "UNKNOWN", "Y", "N" ]
+          },
+          "noticeOfDisputeGuid": {
+            "type": "string",
+            "nullable": true
+          },
+          "noticeOfHearingYn": {
+            "type": "string",
+            "nullable": true,
+            "enum": [ "UNKNOWN", "Y", "N" ]
+          },
+          "occamDisputantGiven1Nm": {
+            "type": "string",
+            "nullable": true
+          },
+          "occamDisputantGiven2Nm": {
+            "type": "string",
+            "nullable": true
+          },
+          "occamDisputantGiven3Nm": {
+            "type": "string",
+            "nullable": true
+          },
+          "occamDisputantSurnameNm": {
+            "type": "string",
+            "nullable": true
+          },
+          "occamDisputeId": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "occamViolationTicketUpldId": {
+            "type": "string",
+            "nullable": true
+          },
+          "submittedTs": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "issuedTs": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "violationDate": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "icbcReceivedDate": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "enforcementOfficer": {
+            "type": "string",
+            "nullable": true
+          },
+          "electronicTicketYn": {
+            "type": "string",
+            "nullable": true,
+            "enum": [ "UNKNOWN", "Y", "N" ]
+          },
+          "policeDetachment": {
+            "type": "string",
+            "nullable": true
+          },
+          "courthouseLocation": {
+            "type": "string",
+            "nullable": true
+          },
+          "offenceLocation": {
+            "type": "string",
+            "nullable": true
+          },
+          "jjAssignedTo": {
+            "type": "string",
+            "nullable": true
+          },
+          "jjDecisionDate": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "vtcAssignedTo": {
+            "type": "string",
+            "nullable": true
+          },
+          "vtcAssignedTs": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "fineReductionReason": {
+            "type": "string",
+            "nullable": true
+          },
+          "timeToPayReason": {
+            "type": "string",
+            "nullable": true
+          },
+          "contactLawFirmName": {
+            "type": "string",
+            "nullable": true
+          },
+          "contactGivenName1": {
+            "type": "string",
+            "nullable": true
+          },
+          "contactGivenName2": {
+            "type": "string",
+            "nullable": true
+          },
+          "contactGivenName3": {
+            "type": "string",
+            "nullable": true
+          },
+          "contactSurname": {
+            "type": "string",
+            "nullable": true
+          },
+          "contactType": {
+            "type": "string",
+            "nullable": true,
+            "enum": [ "UNKNOWN", "INDIVIDUAL", "LAWYER", "OTHER" ]
+          },
+          "appearInCourt": {
+            "type": "string",
+            "enum": [ "UNKNOWN", "Y", "N" ]
+          },
+          "courtAgenId": {
+            "type": "string",
+            "nullable": true
+          },
+          "recalled": {
+            "type": "boolean",
+            "description": "Indicates whether the dispute is re-opened by a JJ and set to review from its previous accepted or concluded status or not.",
+            "nullable": true
+          },
+          "lawFirmName": {
+            "type": "string",
+            "nullable": true
+          },
+          "lawyerSurname": {
+            "type": "string",
+            "nullable": true
+          },
+          "lawyerGivenName1": {
+            "type": "string",
+            "nullable": true
+          },
+          "lawyerGivenName2": {
+            "type": "string",
+            "nullable": true
+          },
+          "lawyerGivenName3": {
+            "type": "string",
+            "nullable": true
+          },
+          "justinRccId": {
+            "type": "string",
+            "nullable": true
+          },
+          "interpreterLanguageCd": {
+            "type": "string",
+            "nullable": true
+          },
+          "witnessNo": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "disputantAttendanceType": {
+            "type": "string",
+            "nullable": true,
+            "enum": [ "UNKNOWN", "WRITTEN_REASONS", "VIDEO_CONFERENCE", "TELEPHONE_CONFERENCE", "MSTEAMS_AUDIO", "MSTEAMS_VIDEO", "IN_PERSON" ]
+          },
+          "signatoryType": {
+            "maxLength": 1,
+            "type": "string",
+            "description": "Signatory Type. Can be either 'D' for Disputant or 'A' for Agent.",
+            "nullable": true,
+            "enum": [ "U", "D", "A" ]
+          },
+          "signatoryName": {
+            "maxLength": 100,
+            "type": "string",
+            "description": "Name of the person who signed the dispute.",
+            "nullable": true
+          },
+          "remarks": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/JJDisputeRemark" }
+          },
+          "jjDisputedCounts": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/JJDisputedCount" }
+          },
+          "jjDisputeCourtAppearanceRoPs": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/JJDisputeCourtAppearanceRoP" }
+          }
+        }
+      },
+      "JJDisputeCourtAppearanceRoP": {
+        "type": "object",
+        "properties": {
+          "justinAppearanceId": {
+            "type": "string",
+            "description": "Justin Appearance ID",
+            "readOnly": true
+          },
+          "id": {
+            "type": "integer",
+            "description": "TCO Court Appearance ID",
+            "format": "int64",
+            "nullable": true,
+            "readOnly": true
+          },
+          "appearanceTs": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "room": {
+            "type": "string",
+            "nullable": true
+          },
+          "duration": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "reason": {
+            "type": "string",
+            "nullable": true
+          },
+          "appCd": {
+            "type": "string",
+            "nullable": true,
+            "enum": [ "UNKNOWN", "A", "P", "N" ]
+          },
+          "noAppTs": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "clerkRecord": {
+            "type": "string",
+            "nullable": true
+          },
+          "defenceCounsel": {
+            "type": "string",
+            "nullable": true
+          },
+          "dattCd": {
+            "type": "string",
+            "nullable": true,
+            "enum": [ "UNKNOWN", "A", "C", "N" ]
+          },
+          "crown": {
+            "type": "string",
+            "nullable": true,
+            "enum": [ "UNKNOWN", "P", "N" ]
+          },
+          "jjSeized": {
+            "type": "string",
+            "nullable": true,
+            "enum": [ "UNKNOWN", "Y", "N" ]
+          },
+          "adjudicator": {
+            "type": "string",
+            "nullable": true
+          },
+          "comments": {
+            "maxLength": 4000,
+            "minLength": 0,
+            "type": "string",
+            "nullable": true
+          }
+        }
+      },
+      "JJDisputeRemark": {
+        "type": "object",
+        "properties": {
+          "createdBy": { "type": "string" },
+          "createdTs": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "modifiedBy": {
+            "type": "string",
+            "nullable": true
+          },
+          "modifiedTs": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "id": {
+            "type": "integer",
+            "description": "ID",
+            "format": "int64",
+            "readOnly": true
+          },
+          "userFullName": { "type": "string" },
+          "note": {
+            "maxLength": 4000,
+            "minLength": 0,
+            "type": "string"
+          },
+          "remarksMadeTs": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "JJDisputedCount": {
+        "type": "object",
+        "properties": {
+          "createdBy": { "type": "string" },
+          "createdTs": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "modifiedBy": {
+            "type": "string",
+            "nullable": true
+          },
+          "modifiedTs": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "id": {
+            "type": "integer",
+            "description": "ID",
+            "format": "int64",
+            "readOnly": true
+          },
+          "plea": {
+            "type": "string",
+            "description": "Represents the disputant's initial plea on count.",
+            "enum": [ "UNKNOWN", "G", "N" ]
+          },
+          "count": {
+            "maximum": 3,
+            "minimum": 1,
+            "type": "integer",
+            "format": "int32"
+          },
+          "requestTimeToPay": {
+            "type": "string",
+            "enum": [ "UNKNOWN", "Y", "N" ]
+          },
+          "requestReduction": {
+            "type": "string",
+            "enum": [ "UNKNOWN", "Y", "N" ]
+          },
+          "appearInCourt": {
+            "type": "string",
+            "enum": [ "UNKNOWN", "Y", "N" ]
+          },
+          "description": {
+            "type": "string",
+            "nullable": true
+          },
+          "dueDate": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "ticketedFineAmount": {
+            "type": "number",
+            "format": "float",
+            "nullable": true
+          },
+          "lesserOrGreaterAmount": {
+            "type": "number",
+            "format": "float",
+            "nullable": true
+          },
+          "includesSurcharge": {
+            "type": "string",
+            "nullable": true,
+            "enum": [ "UNKNOWN", "Y", "N" ]
+          },
+          "revisedDueDate": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "totalFineAmount": {
+            "type": "number",
+            "format": "float",
+            "nullable": true
+          },
+          "violationDate": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "comments": {
+            "maxLength": 4000,
+            "minLength": 0,
+            "type": "string",
+            "nullable": true
+          },
+          "latestPlea": {
+            "type": "string",
+            "description": "Represents the disputant's latest plea on count.",
+            "nullable": true,
+            "enum": [ "UNKNOWN", "G", "N" ]
+          },
+          "latestPleaUpdateTs": {
+            "type": "string",
+            "description": "The timestamp for when the last time disputant changed their plea.",
+            "format": "date-time",
+            "nullable": true
+          },
+          "jjDisputedCountRoP": { "$ref": "#/components/schemas/JJDisputedCountRoP" }
+        }
+      },
+      "JJDisputedCountRoP": {
+        "type": "object",
+        "properties": {
+          "createdBy": { "type": "string" },
+          "createdTs": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "modifiedBy": {
+            "type": "string",
+            "nullable": true
+          },
+          "modifiedTs": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "id": {
+            "type": "integer",
+            "description": "ID",
+            "format": "int64",
+            "readOnly": true
+          },
+          "finding": {
+            "type": "string",
+            "nullable": true,
+            "enum": [ "UNKNOWN", "GUILTY", "NOT_GUILTY", "CANCELLED", "PAID_PRIOR_TO_APPEARANCE", "GUILTY_LESSER" ]
+          },
+          "lesserDescription": {
+            "type": "string",
+            "nullable": true
+          },
+          "ssProbationDuration": {
+            "type": "string",
+            "nullable": true
+          },
+          "ssProbationConditions": {
+            "type": "string",
+            "nullable": true
+          },
+          "jailDuration": {
+            "type": "string",
+            "nullable": true
+          },
+          "jailIntermittent": {
+            "type": "string",
+            "enum": [ "UNKNOWN", "Y", "N" ]
+          },
+          "probationDuration": {
+            "type": "string",
+            "nullable": true
+          },
+          "probationConditions": {
+            "type": "string",
+            "nullable": true
+          },
+          "drivingProhibition": {
+            "type": "string",
+            "nullable": true
+          },
+          "drivingProhibitionMVASection": {
+            "type": "string",
+            "nullable": true
+          },
+          "dismissed": {
+            "type": "string",
+            "enum": [ "UNKNOWN", "Y", "N" ]
+          },
+          "forWantOfProsecution": {
+            "type": "string",
+            "enum": [ "UNKNOWN", "Y", "N" ]
+          },
+          "withdrawn": {
+            "type": "string",
+            "enum": [ "UNKNOWN", "Y", "N" ]
+          },
+          "abatement": {
+            "type": "string",
+            "enum": [ "UNKNOWN", "Y", "N" ]
+          },
+          "stayOfProceedingsBy": {
+            "type": "string",
+            "nullable": true
+          },
+          "other": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "nullable": true
+      },
+      "Dispute": {
+        "type": "object",
+        "properties": {
+          "createdBy": { "type": "string" },
+          "createdTs": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "modifiedBy": {
+            "type": "string",
+            "nullable": true
+          },
+          "modifiedTs": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "disputeId": {
+            "type": "integer",
+            "description": "ID",
+            "format": "int64",
+            "readOnly": true
+          },
+          "noticeOfDisputeGuid": {
+            "type": "string",
+            "nullable": true
+          },
+          "ticketNumber": { "type": "string" },
+          "issuedTs": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "submittedTs": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "disputantSurname": {
+            "type": "string",
+            "nullable": true
+          },
+          "disputantGivenName1": {
+            "type": "string",
+            "nullable": true
+          },
+          "disputantGivenName2": {
+            "type": "string",
+            "nullable": true
+          },
+          "disputantGivenName3": {
+            "type": "string",
+            "nullable": true
+          },
+          "disputantBirthdate": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "driversLicenceNumber": {
+            "maxLength": 30,
+            "minLength": 0,
+            "type": "string",
+            "nullable": true
+          },
+          "disputantOrganization": {
+            "type": "string",
+            "nullable": true
+          },
+          "disputantClientId": {
+            "type": "string",
+            "nullable": true,
+            "readOnly": true
+          },
+          "driversLicenceIssuedCountryId": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "driversLicenceIssuedProvinceSeqNo": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "driversLicenceProvince": {
+            "maxLength": 30,
+            "minLength": 0,
+            "type": "string",
+            "nullable": true
+          },
+          "status": {
+            "type": "string",
+            "enum": [ "UNKNOWN", "NEW", "VALIDATED", "PROCESSING", "REJECTED", "CANCELLED", "CONCLUDED" ]
+          },
+          "addressLine1": {
+            "type": "string",
+            "nullable": true
+          },
+          "addressLine2": {
+            "type": "string",
+            "nullable": true
+          },
+          "addressLine3": {
+            "type": "string",
+            "nullable": true
+          },
+          "addressCity": {
+            "maxLength": 30,
+            "minLength": 0,
+            "type": "string",
+            "nullable": true
+          },
+          "addressProvince": {
+            "maxLength": 30,
+            "minLength": 0,
+            "type": "string",
+            "nullable": true
+          },
+          "addressProvinceCountryId": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "addressProvinceSeqNo": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "addressCountryId": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "postalCode": {
+            "maxLength": 10,
+            "minLength": 0,
+            "type": "string",
+            "nullable": true
+          },
+          "homePhoneNumber": {
+            "type": "string",
+            "nullable": true
+          },
+          "workPhoneNumber": {
+            "type": "string",
+            "nullable": true
+          },
+          "emailAddress": {
+            "type": "string",
+            "nullable": true
+          },
+          "emailAddressVerified": { "type": "boolean" },
+          "filingDate": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "representedByLawyer": {
+            "type": "string",
+            "nullable": true,
+            "enum": [ "UNKNOWN", "Y", "N" ]
+          },
+          "lawFirmName": {
+            "type": "string",
+            "nullable": true
+          },
+          "lawyerSurname": {
+            "type": "string",
+            "nullable": true
+          },
+          "lawyerGivenName1": {
+            "type": "string",
+            "nullable": true
+          },
+          "lawyerGivenName2": {
+            "type": "string",
+            "nullable": true
+          },
+          "lawyerGivenName3": {
+            "type": "string",
+            "nullable": true
+          },
+          "lawyerAddress": {
+            "maxLength": 300,
+            "minLength": 0,
+            "type": "string",
+            "nullable": true
+          },
+          "lawyerPhoneNumber": {
+            "type": "string",
+            "nullable": true
+          },
+          "lawyerEmail": {
+            "maxLength": 100,
+            "minLength": 0,
+            "type": "string",
+            "nullable": true
+          },
+          "officerPin": {
+            "type": "string",
+            "nullable": true
+          },
+          "contactTypeCd": {
+            "type": "string",
+            "enum": [ "UNKNOWN", "INDIVIDUAL", "LAWYER", "OTHER" ]
+          },
+          "requestCourtAppearanceYn": {
+            "type": "string",
+            "nullable": true,
+            "enum": [ "UNKNOWN", "Y", "N" ]
+          },
+          "contactLawFirmNm": {
+            "type": "string",
+            "nullable": true
+          },
+          "contactGiven1Nm": {
+            "type": "string",
+            "nullable": true
+          },
+          "contactGiven2Nm": {
+            "type": "string",
+            "nullable": true
+          },
+          "contactGiven3Nm": {
+            "type": "string",
+            "nullable": true
+          },
+          "contactSurnameNm": {
+            "type": "string",
+            "nullable": true
+          },
+          "appearanceDtm": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "appearanceLessThan14DaysYn": {
+            "type": "string",
+            "nullable": true,
+            "enum": [ "UNKNOWN", "Y", "N" ]
+          },
+          "detachmentLocation": {
+            "type": "string",
+            "nullable": true
+          },
+          "courtAgenId": {
+            "type": "string",
+            "nullable": true
+          },
+          "interpreterLanguageCd": {
+            "maxLength": 3,
+            "minLength": 0,
+            "type": "string",
+            "nullable": true
+          },
+          "interpreterRequired": {
+            "type": "string",
+            "nullable": true,
+            "enum": [ "UNKNOWN", "Y", "N" ]
+          },
+          "witnessNo": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "fineReductionReason": {
+            "type": "string",
+            "nullable": true
+          },
+          "timeToPayReason": {
+            "type": "string",
+            "nullable": true
+          },
+          "disputantComment": {
+            "type": "string",
+            "nullable": true
+          },
+          "rejectedReason": {
+            "type": "string",
+            "nullable": true
+          },
+          "userAssignedTo": {
+            "type": "string",
+            "nullable": true
+          },
+          "userAssignedTs": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "disputantDetectedOcrIssues": {
+            "type": "string",
+            "nullable": true,
+            "enum": [ "UNKNOWN", "Y", "N" ]
+          },
+          "disputantOcrIssues": {
+            "type": "string",
+            "nullable": true
+          },
+          "systemDetectedOcrIssues": {
+            "type": "string",
+            "enum": [ "UNKNOWN", "Y", "N" ]
+          },
+          "ocrTicketFilename": {
+            "maxLength": 100,
+            "minLength": 0,
+            "type": "string",
+            "nullable": true
+          },
+          "signatoryType": {
+            "maxLength": 1,
+            "type": "string",
+            "description": "Signatory Type. Can be either 'D' for Disputant or 'A' for Agent.",
+            "nullable": true,
+            "enum": [ "U", "D", "A" ]
+          },
+          "signatoryName": {
+            "maxLength": 100,
+            "type": "string",
+            "description": "Name of the person who signed the dispute.",
+            "nullable": true
+          },
+          "violationTicket": { "$ref": "#/components/schemas/ViolationTicket" },
+          "disputeCounts": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/DisputeCount" }
+          }
+        }
+      },
+      "DisputeCount": {
+        "type": "object",
+        "properties": {
+          "createdBy": { "type": "string" },
+          "createdTs": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "modifiedBy": {
+            "type": "string",
+            "nullable": true
+          },
+          "modifiedTs": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "countNo": {
+            "maximum": 3,
+            "minimum": 1,
+            "type": "integer",
+            "format": "int32"
+          },
+          "pleaCode": {
+            "type": "string",
+            "enum": [ "UNKNOWN", "G", "N" ]
+          },
+          "requestTimeToPay": {
+            "type": "string",
+            "enum": [ "UNKNOWN", "Y", "N" ]
+          },
+          "requestReduction": {
+            "type": "string",
+            "enum": [ "UNKNOWN", "Y", "N" ]
+          },
+          "requestCourtAppearance": {
+            "type": "string",
+            "enum": [ "UNKNOWN", "Y", "N" ]
+          }
+        }
+      },
+      "ViolationTicket": {
+        "type": "object",
+        "properties": {
+          "createdBy": { "type": "string" },
+          "createdTs": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "modifiedBy": {
+            "type": "string",
+            "nullable": true
+          },
+          "modifiedTs": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "violationTicketId": {
+            "type": "integer",
+            "description": "ID",
+            "format": "int64",
+            "readOnly": true
+          },
+          "ticketNumber": {
+            "type": "string",
+            "nullable": true
+          },
+          "disputantOrganizationName": {
+            "type": "string",
+            "nullable": true
+          },
+          "disputantSurname": {
+            "type": "string",
+            "nullable": true
+          },
+          "disputantGivenNames": {
+            "type": "string",
+            "nullable": true
+          },
+          "isYoungPerson": {
+            "type": "string",
+            "nullable": true,
+            "enum": [ "UNKNOWN", "Y", "N" ]
+          },
+          "disputantDriversLicenceNumber": {
+            "maxLength": 30,
+            "minLength": 7,
+            "type": "string",
+            "nullable": true
+          },
+          "disputantClientNumber": {
+            "type": "string",
+            "nullable": true
+          },
+          "driversLicenceProvince": {
+            "maxLength": 100,
+            "minLength": 0,
+            "type": "string",
+            "nullable": true
+          },
+          "driversLicenceCountry": {
+            "maxLength": 100,
+            "minLength": 0,
+            "type": "string"
+          },
+          "driversLicenceIssuedYear": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "driversLicenceExpiryYear": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "disputantBirthdate": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "address": {
+            "maxLength": 100,
+            "minLength": 0,
+            "type": "string",
+            "nullable": true
+          },
+          "addressCity": {
+            "type": "string",
+            "nullable": true
+          },
+          "addressProvince": {
+            "type": "string",
+            "nullable": true
+          },
+          "addressPostalCode": {
+            "type": "string",
+            "nullable": true
+          },
+          "addressCountry": {
+            "type": "string",
+            "nullable": true
+          },
+          "officerPin": {
+            "type": "string",
+            "nullable": true
+          },
+          "detachmentLocation": {
+            "type": "string",
+            "nullable": true
+          },
+          "issuedTs": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "issuedOnRoadOrHighway": {
+            "type": "string",
+            "nullable": true
+          },
+          "issuedAtOrNearCity": {
+            "type": "string",
+            "nullable": true
+          },
+          "isChangeOfAddress": {
+            "type": "string",
+            "nullable": true,
+            "enum": [ "UNKNOWN", "Y", "N" ]
+          },
+          "isDriver": {
+            "type": "string",
+            "nullable": true,
+            "enum": [ "UNKNOWN", "Y", "N" ]
+          },
+          "isOwner": {
+            "type": "string",
+            "nullable": true,
+            "enum": [ "UNKNOWN", "Y", "N" ]
+          },
+          "courtLocation": {
+            "type": "string",
+            "nullable": true
+          },
+          "violationTicketCounts": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/ViolationTicketCount" }
+          }
+        },
+        "nullable": true
+      },
+      "ViolationTicketCount": {
+        "type": "object",
+        "properties": {
+          "createdBy": { "type": "string" },
+          "createdTs": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "modifiedBy": {
+            "type": "string",
+            "nullable": true
+          },
+          "modifiedTs": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "violationTicketCountId": {
+            "type": "integer",
+            "description": "ID",
+            "format": "int64",
+            "readOnly": true
+          },
+          "countNo": {
+            "maximum": 3,
+            "minimum": 1,
+            "type": "integer",
+            "format": "int32"
+          },
+          "description": {
+            "type": "string",
+            "nullable": true
+          },
+          "actOrRegulationNameCode": {
+            "type": "string",
+            "nullable": true
+          },
+          "isAct": {
+            "type": "string",
+            "nullable": true,
+            "enum": [ "UNKNOWN", "Y", "N" ]
+          },
+          "isRegulation": {
+            "type": "string",
+            "nullable": true,
+            "enum": [ "UNKNOWN", "Y", "N" ]
+          },
+          "section": {
+            "maxLength": 10,
+            "minLength": 0,
+            "type": "string",
+            "nullable": true,
+            "readOnly": true
+          },
+          "subsection": {
+            "maxLength": 4,
+            "minLength": 0,
+            "type": "string",
+            "nullable": true,
+            "readOnly": true
+          },
+          "paragraph": {
+            "maxLength": 3,
+            "minLength": 0,
+            "type": "string",
+            "nullable": true,
+            "readOnly": true
+          },
+          "subparagraph": {
+            "maxLength": 5,
+            "minLength": 0,
+            "type": "string",
+            "nullable": true,
+            "readOnly": true
+          },
+          "ticketedAmount": {
+            "type": "number",
+            "format": "float",
+            "nullable": true
+          }
+        }
+      },
+      "DisputeUpdateRequest": {
+        "required": [ "status", "updateJson", "updateType" ],
+        "type": "object",
+        "properties": {
+          "createdBy": { "type": "string" },
+          "createdTs": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "modifiedBy": {
+            "type": "string",
+            "nullable": true
+          },
+          "modifiedTs": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "disputeUpdateRequestId": {
+            "type": "integer",
+            "description": "ID",
+            "format": "int64",
+            "readOnly": true
+          },
+          "disputeId": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "status": {
+            "type": "string",
+            "enum": [ "UNKNOWN", "ACCEPTED", "PENDING", "REJECTED" ]
+          },
+          "updateType": {
+            "type": "string",
+            "enum": [ "UNKNOWN", "DISPUTANT_ADDRESS", "DISPUTANT_PHONE", "DISPUTANT_NAME", "COUNT", "DISPUTANT_EMAIL", "DISPUTANT_DOCUMENT", "COURT_OPTIONS" ]
+          },
+          "updateJson": {
+            "maxLength": 1000,
+            "minLength": 3,
+            "type": "string"
+          }
+        }
+      },
+      "FileHistory": {
+        "required": [ "auditLogEntryType", "disputeId" ],
+        "type": "object",
+        "properties": {
+          "createdBy": { "type": "string" },
+          "createdTs": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "modifiedBy": {
+            "type": "string",
+            "nullable": true
+          },
+          "modifiedTs": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "fileHistoryId": {
+            "type": "integer",
+            "description": "ID",
+            "format": "int64",
+            "readOnly": true
+          },
+          "disputeId": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "auditLogEntryType": {
+            "type": "string",
+            "enum": [ "UNKNOWN", "ARFL", "CAIN", "CAWT", "CCAN", "CCON", "CCWR", "CLEG", "CUEM", "CUEV", "CUIN", "CULG", "CUPD", "CUWR", "CUWT", "DURA", "DURR", "EMCA", "EMCF", "EMCR", "EMDC", "EMFD", "EMPR", "EMRJ", "EMRV", "EMST", "EMUP", "EMVF", "ESUR", "FDLD", "FDLS", "FUPD", "FUPS", "INIT", "JASG", "JCNF", "JDIV", "JPRG", "OCNT", "RCLD", "RECN", "SADM", "SCAN", "SPRC", "SREJ", "SUB", "SUPL", "SVAL", "URSR", "VREV", "VSUB" ]
+          },
+          "description": {
+            "type": "string",
+            "nullable": true
+          },
+          "actionByApplicationUser": {
+            "type": "string",
+            "nullable": true
+          }
+        }
+      },
+      "EmailHistory": {
+        "type": "object",
+        "properties": {
+          "createdBy": { "type": "string" },
+          "createdTs": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "modifiedBy": {
+            "type": "string",
+            "nullable": true
+          },
+          "modifiedTs": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "emailHistoryId": {
+            "type": "integer",
+            "description": "ID",
+            "format": "int64",
+            "readOnly": true
+          },
+          "emailSentTs": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "fromEmailAddress": {
+            "maxLength": 100,
+            "minLength": 0,
+            "type": "string"
+          },
+          "toEmailAddress": {
+            "maxLength": 4000,
+            "minLength": 0,
+            "type": "string"
+          },
+          "ccEmailAddress": {
+            "maxLength": 4000,
+            "minLength": 0,
+            "type": "string",
+            "nullable": true
+          },
+          "bccEmailAddress": {
+            "maxLength": 4000,
+            "minLength": 0,
+            "type": "string",
+            "nullable": true
+          },
+          "subject": {
+            "maxLength": 1000,
+            "minLength": 0,
+            "type": "string"
+          },
+          "htmlContent": {
+            "maxLength": 4000,
+            "minLength": 0,
+            "type": "string",
+            "nullable": true
+          },
+          "plainTextContent": {
+            "maxLength": 4000,
+            "minLength": 0,
+            "type": "string",
+            "nullable": true
+          },
+          "successfullySent": {
+            "type": "string",
+            "enum": [ "UNKNOWN", "Y", "N" ]
+          },
+          "occamDisputeId": {
+            "type": "integer",
+            "format": "int64"
+          }
+        }
+      },
+      "TicketImageDataJustinDocument": {
+        "type": "object",
+        "properties": {
+          "reportType": {
+            "type": "string",
+            "nullable": true,
+            "enum": [ "UNKNOWN", "NOTICE_OF_DISPUTE", "TICKET_IMAGE" ]
+          },
+          "reportFormat": {
+            "type": "string",
+            "nullable": true
+          },
+          "partId": {
+            "type": "string",
+            "nullable": true
+          },
+          "participantName": {
+            "type": "string",
+            "nullable": true
+          },
+          "index": {
+            "type": "string",
+            "nullable": true
+          },
+          "fileData": {
+            "type": "string",
+            "nullable": true
+          }
+        }
+      },
+      "DisputeListItem": {
+        "type": "object",
+        "properties": {
+          "disputeId": {
+            "type": "integer",
+            "description": "ID",
+            "format": "int64",
+            "readOnly": true
+          },
+          "ticketNumber": { "type": "string" },
+          "submittedTs": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "disputantSurname": {
+            "type": "string",
+            "nullable": true
+          },
+          "disputantGivenName1": {
+            "type": "string",
+            "nullable": true
+          },
+          "disputantGivenName2": {
+            "type": "string",
+            "nullable": true
+          },
+          "disputantGivenName3": {
+            "type": "string",
+            "nullable": true
+          },
+          "status": {
+            "type": "string",
+            "enum": [ "UNKNOWN", "NEW", "VALIDATED", "PROCESSING", "REJECTED", "CANCELLED", "CONCLUDED" ]
+          },
+          "emailAddress": {
+            "type": "string",
+            "nullable": true
+          },
+          "emailAddressVerified": { "type": "boolean" },
+          "filingDate": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "requestCourtAppearanceYn": {
+            "type": "string",
+            "nullable": true,
+            "enum": [ "UNKNOWN", "Y", "N" ]
+          },
+          "userAssignedTo": {
+            "type": "string",
+            "nullable": true
+          },
+          "userAssignedTs": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "disputantDetectedOcrIssues": {
+            "type": "string",
+            "nullable": true,
+            "enum": [ "UNKNOWN", "Y", "N" ]
+          },
+          "systemDetectedOcrIssues": {
+            "type": "string",
+            "enum": [ "UNKNOWN", "Y", "N" ]
+          },
+          "violationDate": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "jjDisputeStatus": {
+            "type": "string",
+            "nullable": true,
+            "enum": [ "UNKNOWN", "NEW", "IN_PROGRESS", "DATA_UPDATE", "CONFIRMED", "REQUIRE_COURT_HEARING", "REQUIRE_MORE_INFO", "ACCEPTED", "REVIEW", "CONCLUDED", "CANCELLED", "HEARING_SCHEDULED" ]
+          },
+          "jjAssignedTo": {
+            "type": "string",
+            "nullable": true
+          },
+          "jjDecisionDate": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "courtAgenId": {
+            "type": "string",
+            "nullable": true
+          }
+        }
+      },
+      "DisputeResult": {
+        "type": "object",
+        "properties": {
+          "disputeId": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "noticeOfDisputeGuid": { "type": "string" },
+          "disputeStatus": {
+            "type": "string",
+            "enum": [ "UNKNOWN", "NEW", "VALIDATED", "PROCESSING", "REJECTED", "CANCELLED", "CONCLUDED" ]
+          },
+          "jjDisputeStatus": {
+            "type": "string",
+            "nullable": true,
+            "enum": [ "UNKNOWN", "NEW", "IN_PROGRESS", "DATA_UPDATE", "CONFIRMED", "REQUIRE_COURT_HEARING", "REQUIRE_MORE_INFO", "ACCEPTED", "REVIEW", "CONCLUDED", "CANCELLED", "HEARING_SCHEDULED" ]
+          },
+          "jjDisputeHearingType": {
+            "type": "string",
+            "nullable": true,
+            "enum": [ "UNKNOWN", "COURT_APPEARANCE", "WRITTEN_REASONS" ]
+          },
+          "isEmailAddressVerified": { "type": "boolean" }
+        }
+      }
+    },
+    "securitySchemes": {
+      "x-username": {
+        "type": "apiKey",
+        "name": "x-username",
+        "in": "header"
+      }
+    }
+  }
 }

--- a/src/backend/TrafficCourts/Common/OpenAPIs/OracleDataAPI/v1_0/OracleDataApiClient.g.cs
+++ b/src/backend/TrafficCourts/Common/OpenAPIs/OracleDataAPI/v1_0/OracleDataApiClient.g.cs
@@ -673,16 +673,6 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                             throw new ApiException<FileResponse>("Bad Request.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
-                        if (status_ == 404)
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            throw new ApiException<FileResponse>("JJDispute record not found. Update failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
-                        }
-                        else
                         if (status_ == 405)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
@@ -691,6 +681,16 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             throw new ApiException<FileResponse>("An invalid JJ Dispute status is provided. Update failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 404)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<FileResponse>("JJDispute record not found. Update failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 500)
@@ -816,16 +816,6 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                             throw new ApiException<FileResponse>("Bad Request.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
-                        if (status_ == 404)
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            throw new ApiException<FileResponse>("JJDispute record not found. Update failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
-                        }
-                        else
                         if (status_ == 405)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
@@ -834,6 +824,16 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             throw new ApiException<FileResponse>("A JJDispute status can only be set to REVIEW if status is CONFIRMED and the remark must be <= 256 characters OR if the status ACCEPTED, CONFIRMED or CONCLUDED and DCF\'s current hearing date = today\'s date. Update failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 404)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<FileResponse>("JJDispute record not found. Update failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 500)
@@ -952,16 +952,6 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                             throw new ApiException<FileResponse>("Bad Request.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
-                        if (status_ == 404)
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            throw new ApiException<FileResponse>("JJDispute record not found. Update failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
-                        }
-                        else
                         if (status_ == 405)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
@@ -970,6 +960,16 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             throw new ApiException<FileResponse>("A JJDispute status can only be set to REQUIRE_COURT_HEARING iff status is one of the following: NEW, IN_PROGRESS, REVIEW, REQUIRE_COURT_HEARING and the remark must be <= 256 characters. Update failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 404)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<FileResponse>("JJDispute record not found. Update failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 500)
@@ -1082,16 +1082,6 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                             throw new ApiException<FileResponse>("Bad Request.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
-                        if (status_ == 404)
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            throw new ApiException<FileResponse>("JJDispute record not found. Update failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
-                        }
-                        else
                         if (status_ == 405)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
@@ -1100,6 +1090,16 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             throw new ApiException<FileResponse>("A JJDispute status can only be set to CONFIRMED iff status is one of the following: REVIEW, NEW, HEARING_SCHEDULED, IN_PROGRESS, CONFIRMED. Update failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 404)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<FileResponse>("JJDispute record not found. Update failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 500)
@@ -1218,16 +1218,6 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                             throw new ApiException<FileResponse>("Bad Request.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
-                        if (status_ == 404)
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            throw new ApiException<FileResponse>("JJDispute record not found. Update failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
-                        }
-                        else
                         if (status_ == 405)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
@@ -1236,6 +1226,16 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             throw new ApiException<FileResponse>("Method Not Allowed", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 404)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<FileResponse>("JJDispute record not found. Update failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 500)
@@ -1360,16 +1360,6 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                             throw new ApiException<FileResponse>("Bad Request.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
-                        if (status_ == 404)
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            throw new ApiException<FileResponse>("JJDispute record not found. Update failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
-                        }
-                        else
                         if (status_ == 405)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
@@ -1378,6 +1368,16 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             throw new ApiException<FileResponse>("An invalid JJ Dispute status is provided. Update failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 404)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<FileResponse>("JJDispute record not found. Update failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 500)
@@ -1496,16 +1496,6 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                             throw new ApiException<FileResponse>("Bad Request.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
-                        if (status_ == 404)
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            throw new ApiException<FileResponse>("JJDispute record not found. Update failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
-                        }
-                        else
                         if (status_ == 405)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
@@ -1514,6 +1504,16 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             throw new ApiException<FileResponse>("Method Not Allowed", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 404)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<FileResponse>("JJDispute record not found. Update failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 500)
@@ -1638,16 +1638,6 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                             throw new ApiException<FileResponse>("Bad Request.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
-                        if (status_ == 404)
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            throw new ApiException<FileResponse>("JJDispute record not found. Update failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
-                        }
-                        else
                         if (status_ == 405)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
@@ -1656,6 +1646,16 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             throw new ApiException<FileResponse>("A JJDispute status can only be set to ACCEPTED iff status is CONFIRMED. Update failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 404)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<FileResponse>("JJDispute record not found. Update failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 500)
@@ -1772,16 +1772,6 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                             throw new ApiException<FileResponse>("Bad Request.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
-                        if (status_ == 404)
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            throw new ApiException<FileResponse>("JJDispute record(s) not found. Update failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
-                        }
-                        else
                         if (status_ == 405)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
@@ -1790,6 +1780,16 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             throw new ApiException<FileResponse>("Method Not Allowed", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 404)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<FileResponse>("JJDispute record(s) not found. Update failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 500)
@@ -1902,16 +1902,6 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                             throw new ApiException<FileResponse>("Bad Request.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
-                        if (status_ == 404)
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            throw new ApiException<FileResponse>("Dispute record not found. Update failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
-                        }
-                        else
                         if (status_ == 405)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
@@ -1920,6 +1910,16 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             throw new ApiException<FileResponse>("Method Not Allowed", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 404)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<FileResponse>("Dispute record not found. Update failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 500)
@@ -2039,16 +2039,6 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                             throw new ApiException<FileResponse>("Bad Request.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
-                        if (status_ == 404)
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            throw new ApiException<FileResponse>("Dispute record not found. Delete failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
-                        }
-                        else
                         if (status_ == 405)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
@@ -2057,6 +2047,16 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             throw new ApiException<FileResponse>("Method Not Allowed", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 404)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<FileResponse>("Dispute record not found. Delete failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 500)
@@ -2164,16 +2164,6 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                             throw new ApiException<FileResponse>("Bad Request.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
-                        if (status_ == 404)
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            throw new ApiException<FileResponse>("Dispute record not found. Update failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
-                        }
-                        else
                         if (status_ == 405)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
@@ -2182,6 +2172,16 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             throw new ApiException<FileResponse>("A Dispute status can only be set to VALIDATED iff status is NEW. Update failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 404)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<FileResponse>("Dispute record not found. Update failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 500)
@@ -2304,16 +2304,6 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                             throw new ApiException<FileResponse>("Bad Request.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
-                        if (status_ == 404)
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            throw new ApiException<FileResponse>("Dispute record not found. Update failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
-                        }
-                        else
                         if (status_ == 405)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
@@ -2322,6 +2312,16 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             throw new ApiException<FileResponse>("A Dispute status can only be set to PROCESSING iff status is NEW or REJECTED. Update failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 404)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<FileResponse>("Dispute record not found. Update failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 500)
@@ -2450,16 +2450,6 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                             throw new ApiException<FileResponse>("Bad Request.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
-                        if (status_ == 404)
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            throw new ApiException<FileResponse>("Dispute record not found. Update failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
-                        }
-                        else
                         if (status_ == 405)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
@@ -2468,6 +2458,16 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             throw new ApiException<FileResponse>("A Dispute status can only be set to REJECTED iff status is NEW or VALIDATED and the rejected reason must be <= 256 characters. Update failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 404)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<FileResponse>("Dispute record not found. Update failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 500)
@@ -2591,16 +2591,6 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                             throw new ApiException<FileResponse>("Bad Request", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
-                        if (status_ == 404)
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            throw new ApiException<FileResponse>("Dispute with specified id not found", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
-                        }
-                        else
                         if (status_ == 405)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
@@ -2609,6 +2599,16 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             throw new ApiException<FileResponse>("Method Not Allowed", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 404)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<FileResponse>("Dispute with specified id not found", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 500)
@@ -2726,16 +2726,6 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                             throw new ApiException<FileResponse>("If the email address is > 100 characters", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
-                        if (status_ == 404)
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            throw new ApiException<FileResponse>("Dispute with specified id not found", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
-                        }
-                        else
                         if (status_ == 405)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
@@ -2744,6 +2734,16 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             throw new ApiException<FileResponse>("Method Not Allowed", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 404)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<FileResponse>("Dispute with specified id not found", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 500)
@@ -2862,16 +2862,6 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                             throw new ApiException<FileResponse>("Bad Request.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
-                        if (status_ == 404)
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            throw new ApiException<FileResponse>("Dispute record not found. Update failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
-                        }
-                        else
                         if (status_ == 405)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
@@ -2880,6 +2870,16 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             throw new ApiException<FileResponse>("A Dispute status can only be set to CANCELLED iff status is NEW, REJECTED or PROCESSING. Update failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 404)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<FileResponse>("Dispute record not found. Update failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 500)
@@ -3011,16 +3011,6 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                             throw new ApiException<FileResponse>("Bad Request", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
-                        if (status_ == 404)
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            throw new ApiException<FileResponse>("DisputeUpdateRequest could not be found.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
-                        }
-                        else
                         if (status_ == 405)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
@@ -3029,6 +3019,16 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             throw new ApiException<FileResponse>("Method Not Allowed", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 404)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<FileResponse>("DisputeUpdateRequest could not be found.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 500)
@@ -3142,16 +3142,6 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                             throw new ApiException<FileResponse>("Bad Request.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
-                        if (status_ == 404)
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            throw new ApiException<FileResponse>("An invalid file history record provided. Insert failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
-                        }
-                        else
                         if (status_ == 405)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
@@ -3160,6 +3150,16 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             throw new ApiException<FileResponse>("Method Not Allowed", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 404)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<FileResponse>("An invalid file history record provided. Insert failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 500)
@@ -3273,16 +3273,6 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                             throw new ApiException<FileResponse>("Bad Request.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
-                        if (status_ == 404)
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            throw new ApiException<FileResponse>("An invalid email history record provided. Insert failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
-                        }
-                        else
                         if (status_ == 405)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
@@ -3291,6 +3281,16 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             throw new ApiException<FileResponse>("Method Not Allowed", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 404)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<FileResponse>("An invalid email history record provided. Insert failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 500)
@@ -3398,16 +3398,6 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                             throw new ApiException<FileResponse>("Bad Request", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
-                        if (status_ == 404)
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            throw new ApiException<FileResponse>("Not Found", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
-                        }
-                        else
                         if (status_ == 405)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
@@ -3416,6 +3406,16 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             throw new ApiException<FileResponse>("Method Not Allowed", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 404)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<FileResponse>("Not Found", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 500)
@@ -3536,16 +3536,6 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                             throw new ApiException<FileResponse>("Bad Request", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
-                        if (status_ == 404)
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            throw new ApiException<FileResponse>("Dispute could not be found.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
-                        }
-                        else
                         if (status_ == 405)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
@@ -3554,6 +3544,16 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             throw new ApiException<FileResponse>("Method Not Allowed", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 404)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<FileResponse>("Dispute could not be found.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 500)
@@ -3668,16 +3668,6 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                             throw new ApiException<FileResponse>("Bad Request", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
-                        if (status_ == 404)
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            throw new ApiException<FileResponse>("Not Found", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
-                        }
-                        else
                         if (status_ == 405)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
@@ -3686,6 +3676,16 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             throw new ApiException<FileResponse>("Method Not Allowed", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 404)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<FileResponse>("Not Found", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 500)
@@ -3797,16 +3797,6 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                             throw new ApiException<FileResponse>("Bad Request", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
-                        if (status_ == 404)
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            throw new ApiException<FileResponse>("Not Found", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
-                        }
-                        else
                         if (status_ == 405)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
@@ -3815,6 +3805,16 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             throw new ApiException<FileResponse>("Method Not Allowed", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 404)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<FileResponse>("Not Found", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 500)
@@ -3924,16 +3924,6 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                             throw new ApiException<FileResponse>("Bad Request", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
-                        if (status_ == 404)
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            throw new ApiException<FileResponse>("Not Found", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
-                        }
-                        else
                         if (status_ == 405)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
@@ -3942,6 +3932,16 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             throw new ApiException<FileResponse>("Method Not Allowed", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 404)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<FileResponse>("Not Found", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 500)
@@ -4048,16 +4048,6 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                             throw new ApiException<FileResponse>("Bad Request", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
-                        if (status_ == 404)
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            throw new ApiException<FileResponse>("Not Found", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
-                        }
-                        else
                         if (status_ == 405)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
@@ -4066,6 +4056,16 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             throw new ApiException<FileResponse>("Method Not Allowed", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 404)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<FileResponse>("Not Found", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 500)
@@ -4172,16 +4172,6 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                             throw new ApiException<FileResponse>("Bad Request", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
-                        if (status_ == 404)
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            throw new ApiException<FileResponse>("Not Found", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
-                        }
-                        else
                         if (status_ == 405)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
@@ -4190,6 +4180,16 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             throw new ApiException<FileResponse>("Method Not Allowed", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 404)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<FileResponse>("Not Found", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 500)
@@ -4310,16 +4310,6 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                             throw new ApiException<FileResponse>("Bad Request.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
-                        if (status_ == 404)
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            throw new ApiException<FileResponse>("Not Found", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
-                        }
-                        else
                         if (status_ == 405)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
@@ -4328,6 +4318,16 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             throw new ApiException<FileResponse>("Method Not Allowed", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 404)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<FileResponse>("Not Found", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 500)
@@ -4439,16 +4439,6 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                             throw new ApiException<FileResponse>("Bad Request", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
-                        if (status_ == 404)
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            throw new ApiException<FileResponse>("Not Found", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
-                        }
-                        else
                         if (status_ == 405)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
@@ -4457,6 +4447,16 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             throw new ApiException<FileResponse>("Method Not Allowed", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 404)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<FileResponse>("Not Found", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 500)
@@ -4561,16 +4561,6 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                             throw new ApiException<FileResponse>("Bad Request", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
-                        if (status_ == 404)
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            throw new ApiException<FileResponse>("Not Found", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
-                        }
-                        else
                         if (status_ == 405)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
@@ -4579,6 +4569,16 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             throw new ApiException<FileResponse>("Method Not Allowed", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 404)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<FileResponse>("Not Found", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 500)
@@ -4699,16 +4699,6 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                             throw new ApiException<FileResponse>("Bad Request", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
-                        if (status_ == 404)
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            throw new ApiException<FileResponse>("Not Found", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
-                        }
-                        else
                         if (status_ == 405)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
@@ -4717,6 +4707,16 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             throw new ApiException<FileResponse>("Method Not Allowed", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 404)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<FileResponse>("Not Found", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 500)
@@ -4843,16 +4843,6 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                             throw new ApiException<FileResponse>("Bad Request, check parameters.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
-                        if (status_ == 404)
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            throw new ApiException<FileResponse>("Not Found", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
-                        }
-                        else
                         if (status_ == 405)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
@@ -4861,6 +4851,16 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             throw new ApiException<FileResponse>("Method Not Allowed", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 404)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<FileResponse>("Not Found", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 500)
@@ -4973,16 +4973,6 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                             throw new ApiException<FileResponse>("Bad Request", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
-                        if (status_ == 404)
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            throw new ApiException<FileResponse>("Dispute could not be found.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
-                        }
-                        else
                         if (status_ == 405)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
@@ -4991,6 +4981,16 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             throw new ApiException<FileResponse>("Method Not Allowed", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 404)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<FileResponse>("Dispute could not be found.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 500)
@@ -5102,16 +5102,6 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                             throw new ApiException<FileResponse>("Bad Request", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
-                        if (status_ == 404)
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            throw new ApiException<FileResponse>("Not Found", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
-                        }
-                        else
                         if (status_ == 405)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
@@ -5120,6 +5110,16 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             throw new ApiException<FileResponse>("Method Not Allowed", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 404)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<FileResponse>("Not Found", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 500)
@@ -5234,16 +5234,6 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                             throw new ApiException<FileResponse>("Bad Request.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
-                        if (status_ == 404)
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            throw new ApiException<FileResponse>("Not Found", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
-                        }
-                        else
                         if (status_ == 405)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
@@ -5252,6 +5242,16 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             throw new ApiException<FileResponse>("Method Not Allowed", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 404)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<FileResponse>("Not Found", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 500)
@@ -5612,6 +5612,21 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
         [Newtonsoft.Json.JsonProperty("disputantAttendanceType", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
         public JJDisputeDisputantAttendanceType? DisputantAttendanceType { get; set; }
+
+        /// <summary>
+        /// Signatory Type. Can be either 'D' for Disputant or 'A' for Agent.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("signatoryType", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [System.ComponentModel.DataAnnotations.StringLength(1)]
+        [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
+        public JJDisputeSignatoryType? SignatoryType { get; set; }
+
+        /// <summary>
+        /// Name of the person who signed the dispute.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("signatoryName", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [System.ComponentModel.DataAnnotations.StringLength(100)]
+        public string SignatoryName { get; set; }
 
         [Newtonsoft.Json.JsonProperty("remarks", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public System.Collections.Generic.ICollection<JJDisputeRemark> Remarks { get; set; }
@@ -6160,6 +6175,21 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
         [Newtonsoft.Json.JsonProperty("ocrTicketFilename", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         [System.ComponentModel.DataAnnotations.StringLength(100)]
         public string OcrTicketFilename { get; set; }
+
+        /// <summary>
+        /// Signatory Type. Can be either 'D' for Disputant or 'A' for Agent.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("signatoryType", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [System.ComponentModel.DataAnnotations.StringLength(1)]
+        [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
+        public DisputeSignatoryType? SignatoryType { get; set; }
+
+        /// <summary>
+        /// Name of the person who signed the dispute.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("signatoryName", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [System.ComponentModel.DataAnnotations.StringLength(100)]
+        public string SignatoryName { get; set; }
 
         [Newtonsoft.Json.JsonProperty("violationTicket", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public ViolationTicket ViolationTicket { get; set; }
@@ -6989,6 +7019,21 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
     }
 
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "14.0.0.0 (NJsonSchema v11.0.0.0 (Newtonsoft.Json v13.0.0.0))")]
+    public enum JJDisputeSignatoryType
+    {
+
+        [System.Runtime.Serialization.EnumMember(Value = @"U")]
+        U = 0,
+
+        [System.Runtime.Serialization.EnumMember(Value = @"D")]
+        D = 1,
+
+        [System.Runtime.Serialization.EnumMember(Value = @"A")]
+        A = 2,
+
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "14.0.0.0 (NJsonSchema v11.0.0.0 (Newtonsoft.Json v13.0.0.0))")]
     public enum JJDisputeCourtAppearanceRoPAppCd
     {
 
@@ -7375,6 +7420,21 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
 
         [System.Runtime.Serialization.EnumMember(Value = @"N")]
         N = 2,
+
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "14.0.0.0 (NJsonSchema v11.0.0.0 (Newtonsoft.Json v13.0.0.0))")]
+    public enum DisputeSignatoryType
+    {
+
+        [System.Runtime.Serialization.EnumMember(Value = @"U")]
+        U = 0,
+
+        [System.Runtime.Serialization.EnumMember(Value = @"D")]
+        D = 1,
+
+        [System.Runtime.Serialization.EnumMember(Value = @"A")]
+        A = 2,
 
     }
 

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/mapper/DisputeMapper.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/mapper/DisputeMapper.java
@@ -96,6 +96,8 @@ public abstract class DisputeMapper extends BaseMapper {
 	@Mapping(source = "dispute.disputantOcrIssuesTxt", target = "disputantOcrIssues")
 	@Mapping(source = "dispute.systemDetectOcrIssuesYn", target = "systemDetectedOcrIssues")
 	@Mapping(source = "dispute.ocrTicketJsonFilenameTxt", target = "ocrTicketFilename")
+	@Mapping(source = "dispute.signatoryTypeCd", target = "signatoryType")
+	@Mapping(source = "dispute.signatoryNameTxt", target = "signatoryName")
 	// Map violation ticket data from ORDS to Oracle Data API violation ticket model
 	@Mapping(source = "entUserId", target = "violationTicket.createdBy")
 	@Mapping(source = "entDtm", target = "violationTicket.createdTs")

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/mapper/JJDisputeMapper.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/mapper/JJDisputeMapper.java
@@ -68,6 +68,8 @@ public abstract class JJDisputeMapper extends BaseMapper {
 	@Mapping(source = "occamDisputeId", target = "occamDisputeId")
 	@Mapping(source = "occamViolationTicketUpldId", target = "occamViolationTicketUpldId")
 	@Mapping(source = "offenceLocationTxt", target = "offenceLocation")
+	@Mapping(source = "signatoryNameTxt", target = "signatoryName")
+	@Mapping(source = "signatoryTypeCd", target = "signatoryType")
 	@Mapping(source = "submittedDt", target = "submittedTs")
 	@Mapping(source = "ticketNumberTxt", target = "ticketNumber")
 	@Mapping(source = "timeToPayReasonTxt", target = "timeToPayReason")
@@ -134,6 +136,8 @@ public abstract class JJDisputeMapper extends BaseMapper {
 	@Mapping(source = "appearInCourt", target = "requestCourtAppearanceYn")
 	@Mapping(source = "remarks", target = "disputeRemarks")
 	@Mapping(source = "status", target = "disputeStatusTypeCd", qualifiedByName="mapShortNamedEnum")
+	@Mapping(target = "signatoryNameTxt", ignore = true) // ignore back reference mapping
+	@Mapping(target = "signatoryTypeCd", ignore = true) // ignore back reference mapping
 	@Mapping(source = "submittedTs", target = "submittedDt")
 	@Mapping(source = "ticketNumber", target = "ticketNumberTxt")
 	@Mapping(source = "timeToPayReason", target = "timeToPayReasonTxt")

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/mapper/ViolationTicketMapper.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/mapper/ViolationTicketMapper.java
@@ -96,6 +96,8 @@ public interface ViolationTicketMapper {
 	@Mapping(target = "dispute.disputantOcrIssuesTxt", source = "disputantOcrIssues")
 	@Mapping(target = "dispute.systemDetectOcrIssuesYn", source = "systemDetectedOcrIssues")
 	@Mapping(target = "dispute.ocrTicketJsonFilenameTxt", source = "ocrTicketFilename")
+	@Mapping(target = "dispute.signatoryTypeCd", source = "signatoryType")
+	@Mapping(target = "dispute.signatoryNameTxt", source = "signatoryName")
 	// If these IDs are passed as null, then the actual string value of the field such as (drvLicIssuedIntlProvTxt) will be saved based on the logic in the database
 	@Mapping(target = "dispute.drvLicIssuedCtryId", source = "driversLicenceIssuedCountryId")
 	@Mapping(target = "dispute.drvLicIssuedProvSeqNo", source = "driversLicenceIssuedProvinceSeqNo")

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/model/Dispute.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/model/Dispute.java
@@ -500,6 +500,18 @@ public class Dispute extends Auditable<String> {
 	@Schema(maxLength = 100, nullable = true)
 	private String ocrTicketFilename;
 	
+	/**
+	 * Signatory Type. Can be either 'D' for Disputant or 'A' for Agent.
+	 */
+	@Schema(description = "Signatory Type. Can be either 'D' for Disputant or 'A' for Agent.", maxLength = 1, nullable = true)
+	private SignatoryType signatoryType;
+	
+	/**
+	 * Name of the person who signed the dispute.
+	 */
+	@Schema(description = "Name of the person who signed the dispute.", maxLength = 100, nullable = true)
+	private String signatoryName;
+	
 	@JsonManagedReference
 	@OneToOne(fetch = FetchType.LAZY, optional = true, cascade = CascadeType.ALL, orphanRemoval = true, mappedBy = "dispute")
 	@Schema(nullable = true)

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/model/JJDispute.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/model/JJDispute.java
@@ -401,6 +401,18 @@ public class JJDispute extends Auditable<String> {
 	@Schema(nullable = true)
 	@Enumerated(EnumType.STRING)
 	private JJDisputeAttendanceType disputantAttendanceType;
+	
+	/**
+	 * Signatory Type. Can be either 'D' for Disputant or 'A' for Agent.
+	 */
+	@Schema(description = "Signatory Type. Can be either 'D' for Disputant or 'A' for Agent.", maxLength = 1, nullable = true)
+	private SignatoryType signatoryType;
+	
+	/**
+	 * Name of the person who signed the dispute.
+	 */
+	@Schema(description = "Name of the person who signed the dispute.", maxLength = 100, nullable = true)
+	private String signatoryName;
 
 	/**
 	 * All the remarks for this jj dispute that are for internal use of JJs.

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/model/SignatoryType.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/model/SignatoryType.java
@@ -1,0 +1,8 @@
+package ca.bc.gov.open.jag.tco.oracledataapi.model;
+
+public enum SignatoryType {
+
+	U, // Unknown type (undefined). Must be index 0.
+	D, // Disputant
+	A; // Agent
+}

--- a/src/backend/oracle-data-api/src/main/resources/occm-openapi-spec.yaml
+++ b/src/backend/oracle-data-api/src/main/resources/occm-openapi-spec.yaml
@@ -1050,6 +1050,12 @@ components:
         representedByLawyerYn:
           type: string
           format: nullable
+        signatoryNameTxt:
+          type: string
+          format: nullable
+        signatoryTypeCd:
+          type: string
+          format: nullable
         submittedDt:
           type: string
           format: date-time

--- a/src/backend/oracle-data-api/src/main/resources/tco-openapi-spec.yaml
+++ b/src/backend/oracle-data-api/src/main/resources/tco-openapi-spec.yaml
@@ -525,6 +525,12 @@ components:
         offenceLocationTxt:
           type: string
           format: nullable
+        signatoryNameTxt:
+          type: string
+          format: nullable
+        signatoryTypeCd:
+          type: string
+          format: nullable
         submittedDt:
           type: string
           format: date-time

--- a/src/backend/oracle-data-api/src/test/java/ca/bc/gov/open/jag/tco/oracledataapi/util/RandomUtil.java
+++ b/src/backend/oracle-data-api/src/test/java/ca/bc/gov/open/jag/tco/oracledataapi/util/RandomUtil.java
@@ -28,6 +28,7 @@ import ca.bc.gov.open.jag.tco.oracledataapi.model.JJDispute;
 import ca.bc.gov.open.jag.tco.oracledataapi.model.JJDisputeStatus;
 import ca.bc.gov.open.jag.tco.oracledataapi.model.JJDisputedCount;
 import ca.bc.gov.open.jag.tco.oracledataapi.model.Plea;
+import ca.bc.gov.open.jag.tco.oracledataapi.model.SignatoryType;
 import ca.bc.gov.open.jag.tco.oracledataapi.model.ViolationTicket;
 import ca.bc.gov.open.jag.tco.oracledataapi.model.ViolationTicketCount;
 import ca.bc.gov.open.jag.tco.oracledataapi.model.YesNo;
@@ -422,7 +423,8 @@ public class RandomUtil {
 		dispute.setViolationTicket(createViolationTicket(dispute));
 		dispute.setWitnessNo(Integer.valueOf(randomNumeric(3)));
 		dispute.setWorkPhoneNumber(randomNumeric(20));
-
+		dispute.setSignatoryType(SignatoryType.D);
+		dispute.setSignatoryName(randomAlphabetic(100));
 		// 36 character field
 		assertTrue(dispute.getNoticeOfDisputeGuid().length() == 36);
 


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- TCVP-2692 and TCVP-2693
Based on the database changes and recent ORDS updates:
- Added signatory type enum and signatory name fields to the Dispute model in order to be saved as part of Dispute submission and retrieved as part of Dispute data.
- Updated occm-openapi-spec.yaml and mappers for ORDS endpoint requests.
- Added signatory type and name fields to JJDispute model and updated mappers and tco-openapi-spec in order to retrieve signatory fields as part of DCF data.
- Regenerated Oracle Data API OpenAPI Spec for .net APIs.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
