### PR TITLE
Avoid failing to send email if there is an error with Oracle Data API

### DIFF
--- a/src/backend/TrafficCourts/Workflow.Service/Consumers/SendEmailToDisputantConsumer.cs
+++ b/src/backend/TrafficCourts/Workflow.Service/Consumers/SendEmailToDisputantConsumer.cs
@@ -9,85 +9,202 @@ namespace TrafficCourts.Workflow.Service.Consumers;
 /// <summary>
 /// Sends a email message to a disputant.
 /// </summary>
-public class SendEmailToDisputantConsumer : IConsumer<SendDisputantEmail>
+public partial class SendEmailToDisputantConsumer : IConsumer<SendDisputantEmail>
 {
     private readonly IEmailSenderService _emailSenderService;
     private readonly TimeProvider _clock;
-    private readonly ILogger<SendEmailToDisputantConsumer> _logger;
     private readonly IOracleDataApiService _oracleDataApiService;
+    private readonly ILogger<SendEmailToDisputantConsumer> _logger;
 
-    public SendEmailToDisputantConsumer(IEmailSenderService emailSenderService, TimeProvider clock, ILogger<SendEmailToDisputantConsumer> logger, IOracleDataApiService oracleDataApiService)
+    public SendEmailToDisputantConsumer(
+        IEmailSenderService emailSenderService, 
+        TimeProvider clock, 
+        IOracleDataApiService oracleDataApiService, 
+        ILogger<SendEmailToDisputantConsumer> logger)
     {
         _emailSenderService = emailSenderService ?? throw new ArgumentNullException(nameof(emailSenderService));
         _clock = clock ?? throw new ArgumentNullException(nameof(clock));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
-        _oracleDataApiService = oracleDataApiService;
+        _oracleDataApiService = oracleDataApiService ?? throw new ArgumentNullException(nameof(oracleDataApiService));
     }
 
     public async Task Consume(ConsumeContext<SendDisputantEmail> context)
     {
+        CancellationToken cancellationToken = context.CancellationToken;
+
         using var scope = _logger.BeginConsumeScope(context, message => message.NoticeOfDisputeGuid );
-        _logger.LogDebug("Calling email sender service");
+
+        Dispute? dispute = null;
+        bool triedToGetDispute = false; // keep track if we tried to call GetDisputeAsync
+        bool emailSent = false;
 
         try
         {
-            // search for dispute log warning if not found
-            Dispute? dispute = await _oracleDataApiService.GetDisputeByNoticeOfDisputeGuidAsync(context.Message.NoticeOfDisputeGuid, context.CancellationToken);
-            if (dispute is null) 
-            {
-                // avoid logging PII, do not log the message
-                _logger.LogWarning("Sending email without existing dispute"); 
-            }
+            // There is extra logic here to avoid calling into the Oracle Data API 
+            // until absolutely nessassary. If the Oracle Data API is having a problem
+            // we want to still send the email if possible. For example when submitting
+            // your dispute, the email verification email should go out even if the 
+            // Oracle Data API is having problems. Submitting notice of dispute will 
+            // have the email address specified unless opted out. No "SendEmailToDisputantConsumer"
+            // message would be populated in this situation.
 
             EmailMessage emailMessage = context.Message.Message;
 
-            // try to fill in to if missing
-            if (string.IsNullOrEmpty(emailMessage.To) && dispute is not null && dispute.EmailAddress is not null && dispute.EmailAddressVerified == true)
-                emailMessage.To = dispute.EmailAddress;
+            if (string.IsNullOrEmpty(emailMessage.To))
+            {
+                LogEmailToAddressMissing(); // really should always have a target email
 
-            var result = string.IsNullOrEmpty(emailMessage.To) 
-                ? SendEmailResult.Filtered 
-                : await _emailSenderService.SendEmailAsync(emailMessage, context.CancellationToken);
+                dispute = await GetDisputeAsync(context.Message.NoticeOfDisputeGuid, cancellationToken);
+                if (dispute is null)
+                {
+                    LogEmailSentWithNoDispute();
+                }
+                else if (dispute.EmailAddress is not null && dispute.EmailAddressVerified)
+                {
+                    emailMessage.To = dispute.EmailAddress;
+                }
+
+                triedToGetDispute = true;
+            }
+
+            var result = await SendEmailAsync(emailMessage, cancellationToken);
 
             var now = _clock.GetUtcNow();
 
             // Do not log outgoing email if no dispute found since requires dispute id
-            if (result == SendEmailResult.Success && dispute is not null)
+            if (result == SendEmailResult.Success)
             {
-                _logger.LogDebug("Sending email was successful");
+                emailSent = true;
+                LogEmailSent();
 
-                var message = new DisputantEmailSent
+                if (!triedToGetDispute)
                 {
-                    Message = emailMessage,
-                    SentAt = now,
-                    OccamDisputeId = dispute.DisputeId
-                };
+                    dispute = await GetDisputeAsync(context.Message.NoticeOfDisputeGuid, cancellationToken);
+                    triedToGetDispute = true;
+                }
 
-                await context.PublishWithLog(_logger, message, context.CancellationToken);
+                if (dispute is not null)
+                {
+                    // publish that an email was sent to the target dispute id, if the dispute 
+                    // does not yet exist, no history can be added
+                    var message = new DisputantEmailSent
+                    {
+                        Message = emailMessage,
+                        SentAt = now,
+                        OccamDisputeId = dispute.DisputeId
+                    };
+
+                    await context.PublishWithLog(_logger, message, cancellationToken);
+                }
             }
             // Do not log outgoing email if no dispute found since requires dispute id
-            else if (result == SendEmailResult.Filtered && dispute is not null)
+            else if (result == SendEmailResult.Filtered)
             {
-                _logger.LogDebug("Sending email was filtered");
+                LogEmailFiltered();
 
-                var message = new DisputantEmailFiltered
+                if (!triedToGetDispute)
                 {
-                    Message = emailMessage,
-                    FilteredAt = now,
-                    OccamDisputeId = dispute.DisputeId
-                };
+                    dispute = await GetDisputeAsync(context.Message.NoticeOfDisputeGuid, cancellationToken);
+                    triedToGetDispute = true;
+                }
 
-                await context.PublishWithLog(_logger, message, context.CancellationToken);
+                if (dispute is not null)
+                {
+                    // publish that an email was filtered to the target dispute id, if the dispute 
+                    // does not yet exist, no history can be added
+                    var message = new DisputantEmailFiltered
+                    {
+                        Message = emailMessage,
+                        FilteredAt = now,
+                        OccamDisputeId = dispute.DisputeId
+                    };
+
+                    await context.PublishWithLog(_logger, message, context.CancellationToken);
+                }
             }
         }
-        catch (ArgumentNullException ex) // log it and move on
+        catch (ArgumentNullException exception) // log it and move on
         {
             // why does ArgumentNullException get thrown??
-            _logger.LogError(ex, "Failed to send email");
+            LogSendEmailFailed(exception);
         }
-        catch (InvalidEmailMessageException ex) // log it and move on
+        catch (InvalidEmailMessageException exception) // log it and move on
         {
-            _logger.LogError(ex, "Failed to send email, invalid email message");
+            LogInvalidEmailMessage(exception);
+        }
+        catch (Exception exception)
+        {
+            if (emailSent)
+            {
+                LogConsumeMessageFailedAfterEmailSent(exception);
+            }
+            else
+            {
+                LogConsumeMessageFailedWithoutEmailBeingSent(exception);
+                throw;
+            }
         }
     }
+
+    private async Task<Dispute?> GetDisputeAsync(Guid noticeOfDisputeId, CancellationToken cancellationToken)
+    {
+        try
+        {
+            Dispute? dispute = await _oracleDataApiService.GetDisputeByNoticeOfDisputeGuidAsync(noticeOfDisputeId, cancellationToken);
+            return dispute;
+        }
+        catch (ApiException ex)
+        {
+            LogFailedToGetDisputeByNoticeOfDisputeGuid(ex);
+            return null;
+        }
+    }
+
+    private async Task<SendEmailResult> SendEmailAsync(EmailMessage message, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrEmpty(message.To))
+        {
+            return SendEmailResult.Filtered;
+        }
+
+        LogCallingEmailSenderService();
+        var result = await _emailSenderService.SendEmailAsync(message, cancellationToken);
+        return result;
+    }
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Error occurred getting dispute by Notice NoticeOfDisputeId")]
+    private partial void LogFailedToGetDisputeByNoticeOfDisputeGuid(ApiException exception);
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "Error occurred consuming message without email was sent, message will be requeued")]
+    private partial void LogConsumeMessageFailedWithoutEmailBeingSent(Exception exception);
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "Error occurred consuming message after email was sent, message will not be requeued")]
+    private partial void LogConsumeMessageFailedAfterEmailSent(Exception exception);
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "Calling email sender service")]
+    private partial void LogCallingEmailSenderService();
+
+    [LoggerMessage(Level = LogLevel.Error, Message = "Failed to send email")]
+    private partial void LogSendEmailFailed(Exception ex);
+
+    [LoggerMessage(Level = LogLevel.Error, Message = "Could not send email, invalid email message")]
+    private partial void LogInvalidEmailMessage(Exception ex);
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "Sending email was filtered")]
+    private partial void LogEmailFiltered();
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "Sending email was successful")]
+    private partial void LogEmailSent();
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Sending email without existing dispute")]
+    private partial void LogEmailSentWithNoDispute();
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "No To email address specified on email message")]
+    private partial void LogEmailToAddressMissing();
+
+
+
+
+
+
 }


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- Avoid calling Oracle Data API before sending email
- Handle errors better
- Adjust logging

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [ ] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
