### PR TITLE
TCVP-2639 Fixed permissions on jj workbench

### DIFF
--- a/src/frontend/staff-portal/src/app/components/jj-workbench/jj-workbench-dashboard/jj-workbench-dashboard.component.html
+++ b/src/frontend/staff-portal/src/app/components/jj-workbench/jj-workbench-dashboard/jj-workbench-dashboard.component.html
@@ -1,28 +1,28 @@
 <app-page *ngIf="!showDispute">
   <mat-tab-group class="dashTabs" mat-align-tabs="start" [selectedIndex]="tabSelected.value"
     (selectedIndexChange)="tabSelected.setValue($event)">
-    <mat-tab *ngIf="jjAdminRole">
+    <mat-tab *ngIf="hasAssignmentsPermission">
       <ng-template mat-tab-label>
         <h2>WR Assignments</h2>
       </ng-template>
       <br />
       <app-jj-dispute-wr-assignments (jjDisputeInfo)="changeJJDispute($event)"></app-jj-dispute-wr-assignments>
     </mat-tab>
-    <mat-tab>
+    <mat-tab *ngIf="hasWRInboxPermission">
       <ng-template mat-tab-label>
         <h2>WR Inbox</h2>
       </ng-template>
       <br />
       <app-jj-dispute-wr-inbox (jjDisputeInfo)="changeJJDispute($event)"></app-jj-dispute-wr-inbox>
     </mat-tab>
-    <mat-tab>
+    <mat-tab *ngIf="hasHearingInboxPermission">
       <ng-template mat-tab-label>
         <h2>Hearing Inbox</h2>
       </ng-template>
       <br />
       <app-jj-dispute-hearing-inbox (jjDisputeInfo)="changeJJDispute($event)"></app-jj-dispute-hearing-inbox>
     </mat-tab>
-    <mat-tab #DCF>
+    <mat-tab #DCF *ngIf="hasDCFPermission">
       <ng-template mat-tab-label>
         <h2>DCF</h2>
       </ng-template>

--- a/src/frontend/staff-portal/src/app/components/jj-workbench/jj-workbench-dashboard/jj-workbench-dashboard.component.ts
+++ b/src/frontend/staff-portal/src/app/components/jj-workbench/jj-workbench-dashboard/jj-workbench-dashboard.component.ts
@@ -8,6 +8,7 @@ import { AppState } from 'app/store';
 import { Store } from '@ngrx/store';
 import * as JJDisputeStore from "app/store/jj-dispute";
 import { BusyService } from '@core/services/busy.service';
+import { UserGroup } from '@shared/enums/user-group.enum';
 
 @Component({
   selector: 'app-jj-workbench-dashboard',
@@ -22,9 +23,13 @@ export class JjWorkbenchDashboardComponent implements OnInit {
   showDispute: boolean = false;
   tabSelected = new FormControl(0);
   jjPage: string = "WR Assignments";
-  jjAdminRole: boolean = false;
   jjDisputeInfo: JJDispute;
   isInfoEditable: boolean = false;
+
+  hasAssignmentsPermission: boolean = false;
+  hasWRInboxPermission: boolean = false;
+  hasHearingInboxPermission: boolean = false;
+  hasDCFPermission: boolean = false;
 
   constructor(
     private authService: AuthService,
@@ -38,7 +43,12 @@ export class JjWorkbenchDashboardComponent implements OnInit {
     this.busyService.busy$.subscribe(i => this.busy = i);
     this.authService.userProfile$.subscribe(userProfile => {
       if (userProfile) {
-        this.jjAdminRole = this.authService.checkRole("admin-judicial-justice");
+        
+        // TCVP-1981 - only show tabs to users with permissions
+        this.hasAssignmentsPermission = this.authService.checkRoles([UserGroup.ADMIN_JUDICIAL_JUSTICE, UserGroup.SUPPORT_STAFF]);
+        this.hasWRInboxPermission = this.authService.checkRoles([UserGroup.ADMIN_JUDICIAL_JUSTICE, UserGroup.JUDICIAL_JUSTICE, UserGroup.SUPPORT_STAFF]);
+        this.hasHearingInboxPermission = this.authService.checkRoles([UserGroup.ADMIN_JUDICIAL_JUSTICE, UserGroup.JUDICIAL_JUSTICE, UserGroup.SUPPORT_STAFF]);
+        this.hasDCFPermission = this.authService.checkRoles([UserGroup.ADMIN_JUDICIAL_JUSTICE, UserGroup.JUDICIAL_JUSTICE, UserGroup.SUPPORT_STAFF]);
       }
     })
     this.data$ = this.store.select(state => state.jjDispute.data).pipe(filter(i => !!i));

--- a/src/frontend/staff-portal/src/app/services/auth.service.ts
+++ b/src/frontend/staff-portal/src/app/services/auth.service.ts
@@ -189,6 +189,16 @@ export class AuthService {
   checkRole(role: string): boolean {
     return this.keycloak.isUserInRole(role, this.site);
   }
+  
+  /**
+   * Check if the user has any of the specified roles.
+   *
+   * @param {string[]} roles - An array of roles to check.
+   * @return {boolean} - true if the user has any of the specified roles, false otherwise.
+   */
+  checkRoles(roles: string[]): boolean {
+    return roles.some(role => this.keycloak.isUserInRole(role, this.site));
+  }
 
   getUsersInGroup(group: string): Observable<Array<UserRepresentation>> {
     return this.keycloakAPI.apiKeycloakGroupNameUsersGet(group)

--- a/src/frontend/staff-portal/src/app/shared/enums/user-group.enum.ts
+++ b/src/frontend/staff-portal/src/app/shared/enums/user-group.enum.ts
@@ -1,4 +1,7 @@
 export enum UserGroup {
   JUDICIAL_JUSTICE = 'judicial-justice',
+  ADMIN_JUDICIAL_JUSTICE = 'admin-judicial-justice',
   VTC_STAFF = 'vtc-staff',
+  SUPPORT_STAFF = 'support-staff'
 }
+ 


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

TCVP-2639

Fixed the jj workbench permissions by only showing each individual tab if the user has permissions to view that tab - based on the permissions specified on the project wiki.

i.e. To view the Assignments tab, a user must have either: **admin-judicial-justice** or **support-staff** roles.

At the moment, if the user doesn't have permissions to any of the tabs, the screen is just blank. Colm is working to create a UI mockup in such a scenario to indicate something to the user they don't have permissions to see the screen.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Logged in with a user with only **vtc-staff** and confirmed they cannot see any of the tabs.
Logged in with a user with **admin-judicial-justice** and confirmed they can see all of the tabs.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
