### PR TITLE
Made OCR a little more robust

### DIFF
--- a/src/backend/TrafficCourts/Citizen.Service/Services/Impl/FormRecognizerService_2_1.cs
+++ b/src/backend/TrafficCourts/Citizen.Service/Services/Impl/FormRecognizerService_2_1.cs
@@ -101,7 +101,14 @@ public class FormRecognizerService_2_1 : IFormRecognizerService
                     if (field.Type is not null && field.Type.Equals("SelectionMark"))
                     {
                         // Special case, SelectionMarks. These, it would seem, never populate the ValueData.Text property - always null. We need to extract the value of the field via other means.
-                        field.Value = Enum.GetName(extractedField.Value.AsSelectionMarkState())?.ToLower();
+                        try {
+                            field.Value = Enum.GetName(extractedField.Value.AsSelectionMarkState())?.ToLower();
+                        }
+                        catch (Exception)
+                        {
+                            // Could not parse as a SelectionMarkState. When the confidence is so low, there is no valueSelectionMark attribute, so assume "unselected".
+                            field.Value = "unselected";
+                        }
                     }
                     else 
                     {


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

In an OCR scan, selectionMarks are special fields whose valueSelectionMark attribute must be either "selected" or "unselected". However, in very rare scenarios, the confidence value can be so low that there is no valueSelectionMark attribute, which causes an NPE.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
