### PR TITLE
TCVP-2699 Bug fix for statute lookup on staff portal

### DIFF
--- a/src/frontend/staff-portal/src/app/services/violation-ticket.service.ts
+++ b/src/frontend/staff-portal/src/app/services/violation-ticket.service.ts
@@ -41,7 +41,7 @@ public ocrMessages: OCRMessageToDisplay[] = [];
 
   // act section(subsection)(paragraph)(subparagraph)
   public getLegalParagraphing(violationTicketCount: ViolationTicketCount): string {
-    if (!violationTicketCount) return "";
+    if (!violationTicketCount || !violationTicketCount.section) return "";
 
     let ticketDesc = violationTicketCount.actOrRegulationNameCode;
     if (!ticketDesc) {


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

TCVP-2699

On the staff portal, if there are < 3 counts, MVR would show up as the statute lookup and invalidate the form.  This bug fix addresses this.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
