### PR TITLE
Fix Multiple Officers and Accident Flags Styling

### DIFF
--- a/src/frontend/staff-portal/src/app/components/jj-dispute-info/jj-dispute/jj-dispute.component.html
+++ b/src/frontend/staff-portal/src/app/components/jj-dispute-info/jj-dispute/jj-dispute.component.html
@@ -61,10 +61,10 @@
               - {{ lastUpdatedJJDispute.occamDisputantName }} </b></h1>
         </span>
         <span style="float:right">
-          <span *ngIf="jjDisputeInfo.multipleOfficersYn===MultipleOfficers.Y"><button mat-rounded-button color="warn"
-              disabled="true">MUTLIPLE OFFICERS</button></span>
-          <span *ngIf="jjDisputeInfo.accidentYn===Accident.Y"><button mat-rounded-button color="primary"
-              disabled="true">ACCIDENT</button></span>
+          <span *ngIf="jjDisputeInfo.multipleOfficersYn===MultipleOfficers.Y"><button class="mo-btn"
+              disabled="true">{{ "label.multiple_officers_btn" | translate }}</button></span>
+          <span *ngIf="jjDisputeInfo.accidentYn===Accident.Y"><button class="accident-btn"
+              disabled="true">{{ "label.accident_btn" | translate }}</button></span>
           <span class="ticket-number">Ticket Number: {{ lastUpdatedJJDispute.ticketNumber }}</span>
         </span>
       </div> <br /><br />

--- a/src/frontend/staff-portal/src/app/components/jj-dispute-info/jj-dispute/jj-dispute.component.scss
+++ b/src/frontend/staff-portal/src/app/components/jj-dispute-info/jj-dispute/jj-dispute.component.scss
@@ -180,6 +180,20 @@ label {
   border-color: rgba(0, 0, 0, 0.12);
 }
 
+.mo-btn {
+  background: #5a9dff73;
+  border: 2px solid #0d6efd;
+  border-radius: 0.781rem;
+  margin-right: 1rem;
+}
+
+.accident-btn {
+  background: #dc354566;
+  border: 2px solid #dc3545;
+  border-radius: 0.781rem;
+  margin-right: 1rem;
+}
+
 // FIXME: ng-deep applies global styles, not component-specific styles. But these styles should be global anyway. Move to main scss.
 ::ng-deep {
   .heading-hr {

--- a/src/frontend/staff-portal/src/assets/i18n/en.json
+++ b/src/frontend/staff-portal/src/assets/i18n/en.json
@@ -142,6 +142,7 @@
   },
   "label": {
     "abatement": "Abatement",
+    "accident_btn": "ACCIDENT",
     "act_sect_desc": "Act/Sect/Desc",
     "amount_due": "Amount Due",
     "appearInCourt": "For this count I would like to",
@@ -187,6 +188,7 @@
     "legal_counsel_given_name_3": "Legal Counsel Given Name 3",
     "legal_counsel_surname": "Legal Counsel Surname",
     "mailing_address": "Mailing Address",
+    "multiple_officers_btn": "MULTIPLE OFFICERS",
     "name_of_law_firm": "Name of Law Firm",
     "offence_amount": "Offence Amount",
     "other": "Other",

--- a/src/frontend/staff-portal/src/assets/i18n/fr.json
+++ b/src/frontend/staff-portal/src/assets/i18n/fr.json
@@ -141,6 +141,7 @@
   },
   "label": {
     "abatement": "Abattement",
+    "accident_btn": "ACCIDENT",
     "act_sect_desc": "Acte/Secte/Desc",
     "amount_due": "Montant Dû",
     "appearInCourt": "Pour ce compte, j'aimerais",
@@ -186,6 +187,7 @@
     "legal_counsel_given_name_3": "Conseiller juridique Prénom 3",
     "legal_counsel_surname": "Nom du conseiller juridique",
     "mailing_address": "Adresse Postale",
+    "multiple_officers_btn": "PLUSIEURS OFFICIERS",
     "name_of_law_firm": "Nom du cabinet",
     "offence_amount": "Montant de l'Infraction",
     "other": "Autre",


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- [TCVP-2473](https://justice.gov.bc.ca/jira/browse/TCVP-2473)
- Fixed spelling and styling of 'multiple officers' and 'accident' flags that are displayed on DCF.

![mo-accident-flags-styling](https://github.com/bcgov/jag-traffic-courts-online/assets/98848668/ebc25b7a-bd7f-4003-a8fe-7061bd0d126e)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
