### PR TITLE
Delay processing of email verifications

### DIFF
--- a/src/backend/TrafficCourts/Workflow.Service/Sagas/TagProvider.cs
+++ b/src/backend/TrafficCourts/Workflow.Service/Sagas/TagProvider.cs
@@ -44,5 +44,4 @@ internal static partial class TagProvider
         collector.Add(nameof(context.Message.NoticeOfDisputeGuid), context.Message.NoticeOfDisputeGuid);
         collector.Add(nameof(context.Message.Reason), context.Message.Reason);
     }
-
 }

--- a/src/backend/TrafficCourts/Workflow.Service/Sagas/VerifyEmailAddressCleanupHostedService.cs
+++ b/src/backend/TrafficCourts/Workflow.Service/Sagas/VerifyEmailAddressCleanupHostedService.cs
@@ -24,6 +24,10 @@ public partial class VerifyEmailAddressCleanupHostedService : IHostedService
     {
         Starting();
 
+        // oracle data api can take a couple of minutes to startup, so delay this processing
+        // otherwise the consumer will get connection errors
+        await Task.Delay(TimeSpan.FromMinutes(5), cancellationToken);
+
         try
         {
             var messages = await _context


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- Removes an event from the Saga
- delays the processing of verified emails by 5 minutes to allow oracle data api to start

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change
