### PR TITLE
TCVP-2636 Allow Saving Dispute Without Staff Comment

### DIFF
--- a/src/backend/TrafficCourts/Staff.Service/Controllers/DisputeController.cs
+++ b/src/backend/TrafficCourts/Staff.Service/Controllers/DisputeController.cs
@@ -146,9 +146,8 @@ public class DisputeController : StaffControllerBase<DisputeController>
     [KeycloakAuthorize(Resources.Dispute, Scopes.Update)]
     public async Task<IActionResult> UpdateDisputeAsync(long disputeId, 
         Dispute dispute,
-        [Required]
         [StringLength(500, ErrorMessage = "Staff comment cannot exceed 500 characters.")]
-        string staffComment, 
+        string? staffComment, 
         CancellationToken cancellationToken)
     {
         _logger.LogDebug("Updating the Dispute in oracle-data-api");

--- a/src/backend/TrafficCourts/Staff.Service/Services/DisputeService.cs
+++ b/src/backend/TrafficCourts/Staff.Service/Services/DisputeService.cs
@@ -152,7 +152,7 @@ public class DisputeService : IDisputeService
     }
 
 
-    public async Task<Dispute> UpdateDisputeAsync(long disputeId, ClaimsPrincipal user, string staffComment, Dispute dispute, CancellationToken cancellationToken)
+    public async Task<Dispute> UpdateDisputeAsync(long disputeId, ClaimsPrincipal user, string? staffComment, Dispute dispute, CancellationToken cancellationToken)
     {
         Dispute updatedDispute = await _oracleDataApi.UpdateDisputeAsync(disputeId, dispute, cancellationToken);
 
@@ -161,7 +161,7 @@ public class DisputeService : IDisputeService
             updatedDispute.NoticeOfDisputeGuid,
             FileHistoryAuditLogEntryType.FRMK, // VTC staff has added a file remark for saving or updating a dispute in Ticket Validation
             GetUserName(user),
-            staffComment);
+            staffComment!);
 
         await _bus.PublishWithLog(_logger, fileHistoryRecord, cancellationToken);
 

--- a/src/backend/TrafficCourts/Staff.Service/Services/IDisputeService.cs
+++ b/src/backend/TrafficCourts/Staff.Service/Services/IDisputeService.cs
@@ -36,7 +36,7 @@ public interface IDisputeService
     /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
     /// <returns>The modified Dispute record.</returns>
     /// <exception cref="ApiException">A server side error occurred.</exception>
-    Task<Dispute> UpdateDisputeAsync(long id, ClaimsPrincipal user, string staffComment, Dispute dispute, System.Threading.CancellationToken cancellationToken);
+    Task<Dispute> UpdateDisputeAsync(long id, ClaimsPrincipal user, string? staffComment, Dispute dispute, System.Threading.CancellationToken cancellationToken);
 
     /// <summary>Updates the status of a particular Dispute record to VALIDATED.</summary>
     /// <param name="id">Unique identifier of a Dispute record to validate.</param>


### PR DESCRIPTION
…g a dispute without staff comment

# Description

This PR includes the following proposed change(s):

- Made staff comment optional to allow saving/updating a dispute without staff comment temporarily.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
