### PR TITLE
TCVP-2702 passed isEmailVerified through to Update Dispute form

### DIFF
--- a/src/backend/TrafficCourts/Common/OpenAPIs/OracleDataAPI/v1_0/OracleDataApi.v1_0.json
+++ b/src/backend/TrafficCourts/Common/OpenAPIs/OracleDataAPI/v1_0/OracleDataApi.v1_0.json
@@ -10,11 +10,17 @@
       "description": "Generated server url"
     }
   ],
-  "security": [ { "x-username": [] } ],
+  "security": [
+    {
+      "x-username": []
+    }
+  ],
   "paths": {
     "/api/v1.0/jj/dispute/{ticketNumber}": {
       "put": {
-        "tags": [ "jj-dispute-controller" ],
+        "tags": [
+          "jj-dispute-controller"
+        ],
         "summary": "Updates the properties of a particular JJ Dispute record based on the given values.",
         "operationId": "updateJJDispute",
         "parameters": [
@@ -22,46 +28,88 @@
             "name": "ticketNumber",
             "in": "path",
             "required": true,
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "checkVTCAssigned",
             "in": "query",
             "required": true,
-            "schema": { "type": "boolean" }
+            "schema": {
+              "type": "boolean"
+            }
           }
         ],
         "requestBody": {
-          "content": { "application/json": { "schema": { "$ref": "#/components/schemas/JJDispute" } } },
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/JJDispute"
+              }
+            }
+          },
           "required": true
         },
         "responses": {
           "400": {
             "description": "Bad Request.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "405": {
-            "description": "An invalid JJ Dispute status is provided. Update failed.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
           },
           "404": {
             "description": "JJDispute record not found. Update failed.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
           },
           "500": {
             "description": "Internal Server Error",
-            "content": { "*/*": { "schema": { "type": "object" } } }
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "An invalid JJ Dispute status is provided. Update failed.",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
           },
           "200": {
             "description": "Ok",
-            "content": { "*/*": { "schema": { "$ref": "#/components/schemas/JJDispute" } } }
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/JJDispute"
+                }
+              }
+            }
           }
         }
       }
     },
     "/api/v1.0/jj/dispute/{ticketNumber}/review": {
       "put": {
-        "tags": [ "jj-dispute-controller" ],
+        "tags": [
+          "jj-dispute-controller"
+        ],
         "summary": "Updates the status of a particular JJDispute record to REVIEW.",
         "operationId": "reviewJJDispute",
         "parameters": [
@@ -69,19 +117,25 @@
             "name": "ticketNumber",
             "in": "path",
             "required": true,
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "checkVTCAssigned",
             "in": "query",
             "required": true,
-            "schema": { "type": "boolean" }
+            "schema": {
+              "type": "boolean"
+            }
           },
           {
             "name": "recalled",
             "in": "query",
             "required": true,
-            "schema": { "type": "boolean" }
+            "schema": {
+              "type": "boolean"
+            }
           }
         ],
         "requestBody": {
@@ -98,30 +152,62 @@
         "responses": {
           "400": {
             "description": "Bad Request.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "405": {
-            "description": "A JJDispute status can only be set to REVIEW if status is CONFIRMED and the remark must be <= 256 characters OR if the status ACCEPTED, CONFIRMED or CONCLUDED and DCF's current hearing date = today's date. Update failed.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
           },
           "404": {
             "description": "JJDispute record not found. Update failed.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
           },
           "500": {
             "description": "Internal server error occured.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "A JJDispute status can only be set to REVIEW if status is CONFIRMED and the remark must be <= 256 characters OR if the status ACCEPTED, CONFIRMED or CONCLUDED and DCF's current hearing date = today's date. Update failed.",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
           },
           "200": {
             "description": "Ok. Updated JJDispute record returned.",
-            "content": { "*/*": { "schema": { "$ref": "#/components/schemas/JJDispute" } } }
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/JJDispute"
+                }
+              }
+            }
           }
         }
       }
     },
     "/api/v1.0/jj/dispute/{ticketNumber}/requirecourthearing": {
       "put": {
-        "tags": [ "jj-dispute-controller" ],
+        "tags": [
+          "jj-dispute-controller"
+        ],
         "summary": "Updates the status of a particular JJDispute record to REQUIRE_COURT_HEARING, type to COURT_APPEARANCE.",
         "operationId": "requireCourtHearingJJDispute",
         "parameters": [
@@ -129,7 +215,9 @@
             "name": "ticketNumber",
             "in": "path",
             "required": true,
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "remark",
@@ -145,30 +233,62 @@
         "responses": {
           "400": {
             "description": "Bad Request.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "405": {
-            "description": "A JJDispute status can only be set to REQUIRE_COURT_HEARING iff status is one of the following: NEW, IN_PROGRESS, REVIEW, REQUIRE_COURT_HEARING and the remark must be <= 256 characters. Update failed.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
           },
           "404": {
             "description": "JJDispute record not found. Update failed.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
           },
           "500": {
             "description": "Internal server error occured.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "A JJDispute status can only be set to REQUIRE_COURT_HEARING iff status is one of the following: NEW, IN_PROGRESS, REVIEW, REQUIRE_COURT_HEARING and the remark must be <= 256 characters. Update failed.",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
           },
           "200": {
             "description": "Ok. Updated JJDispute record returned.",
-            "content": { "*/*": { "schema": { "$ref": "#/components/schemas/JJDispute" } } }
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/JJDispute"
+                }
+              }
+            }
           }
         }
       }
     },
     "/api/v1.0/jj/dispute/{ticketNumber}/confirm": {
       "put": {
-        "tags": [ "jj-dispute-controller" ],
+        "tags": [
+          "jj-dispute-controller"
+        ],
         "summary": "Updates the status of a particular JJDispute record to CONFIRMED.",
         "operationId": "confirmJJDispute",
         "parameters": [
@@ -176,36 +296,70 @@
             "name": "ticketNumber",
             "in": "path",
             "required": true,
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
           "400": {
             "description": "Bad Request.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "405": {
-            "description": "A JJDispute status can only be set to CONFIRMED iff status is one of the following: REVIEW, NEW, HEARING_SCHEDULED, IN_PROGRESS, CONFIRMED. Update failed.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
           },
           "404": {
             "description": "JJDispute record not found. Update failed.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
           },
           "500": {
             "description": "Internal server error occured.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "A JJDispute status can only be set to CONFIRMED iff status is one of the following: REVIEW, NEW, HEARING_SCHEDULED, IN_PROGRESS, CONFIRMED. Update failed.",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
           },
           "200": {
             "description": "Ok. Updated JJDispute record returned.",
-            "content": { "*/*": { "schema": { "$ref": "#/components/schemas/JJDispute" } } }
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/JJDispute"
+                }
+              }
+            }
           }
         }
       }
     },
     "/api/v1.0/jj/dispute/{ticketNumber}/conclude": {
       "put": {
-        "tags": [ "jj-dispute-controller" ],
+        "tags": [
+          "jj-dispute-controller"
+        ],
         "summary": "Updates the status of a particular JJDispute record to CONCLUDED.",
         "operationId": "concludeJJDispute",
         "parameters": [
@@ -213,42 +367,78 @@
             "name": "ticketNumber",
             "in": "path",
             "required": true,
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "checkVTCAssigned",
             "in": "query",
             "required": true,
-            "schema": { "type": "boolean" }
+            "schema": {
+              "type": "boolean"
+            }
           }
         ],
         "responses": {
           "400": {
             "description": "Bad Request.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "405": {
-            "description": "Method Not Allowed",
-            "content": { "*/*": { "schema": { "type": "object" } } }
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
           },
           "404": {
             "description": "JJDispute record not found. Update failed.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
           },
           "500": {
             "description": "Internal server error occured.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method Not Allowed",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
           },
           "200": {
             "description": "Ok. Updated JJDispute record returned.",
-            "content": { "*/*": { "schema": { "$ref": "#/components/schemas/JJDispute" } } }
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/JJDispute"
+                }
+              }
+            }
           }
         }
       }
     },
     "/api/v1.0/jj/dispute/{ticketNumber}/cascade": {
       "put": {
-        "tags": [ "jj-dispute-controller" ],
+        "tags": [
+          "jj-dispute-controller"
+        ],
         "summary": "Updates the properties of a particular JJ Dispute record as well as cascading to underlying related Dispute data.",
         "operationId": "updateJJDisputeCascade",
         "parameters": [
@@ -256,46 +446,88 @@
             "name": "ticketNumber",
             "in": "path",
             "required": true,
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "checkVTCAssigned",
             "in": "query",
             "required": true,
-            "schema": { "type": "boolean" }
+            "schema": {
+              "type": "boolean"
+            }
           }
         ],
         "requestBody": {
-          "content": { "application/json": { "schema": { "$ref": "#/components/schemas/JJDispute" } } },
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/JJDispute"
+              }
+            }
+          },
           "required": true
         },
         "responses": {
           "400": {
             "description": "Bad Request.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "405": {
-            "description": "An invalid JJ Dispute status is provided. Update failed.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
           },
           "404": {
             "description": "JJDispute record not found. Update failed.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
           },
           "500": {
             "description": "Internal Server Error",
-            "content": { "*/*": { "schema": { "type": "object" } } }
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "An invalid JJ Dispute status is provided. Update failed.",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
           },
           "200": {
             "description": "Ok",
-            "content": { "*/*": { "schema": { "$ref": "#/components/schemas/JJDispute" } } }
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/JJDispute"
+                }
+              }
+            }
           }
         }
       }
     },
     "/api/v1.0/jj/dispute/{ticketNumber}/cancel": {
       "put": {
-        "tags": [ "jj-dispute-controller" ],
+        "tags": [
+          "jj-dispute-controller"
+        ],
         "summary": "Updates the status of a particular JJDispute record to CANCELLED.",
         "operationId": "cancelJJDispute",
         "parameters": [
@@ -303,42 +535,78 @@
             "name": "ticketNumber",
             "in": "path",
             "required": true,
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "checkVTCAssigned",
             "in": "query",
             "required": true,
-            "schema": { "type": "boolean" }
+            "schema": {
+              "type": "boolean"
+            }
           }
         ],
         "responses": {
           "400": {
             "description": "Bad Request.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "405": {
-            "description": "Method Not Allowed",
-            "content": { "*/*": { "schema": { "type": "object" } } }
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
           },
           "404": {
             "description": "JJDispute record not found. Update failed.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
           },
           "500": {
             "description": "Internal server error occured.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method Not Allowed",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
           },
           "200": {
             "description": "Ok. Updated JJDispute record returned.",
-            "content": { "*/*": { "schema": { "$ref": "#/components/schemas/JJDispute" } } }
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/JJDispute"
+                }
+              }
+            }
           }
         }
       }
     },
     "/api/v1.0/jj/dispute/{ticketNumber}/accept": {
       "put": {
-        "tags": [ "jj-dispute-controller" ],
+        "tags": [
+          "jj-dispute-controller"
+        ],
         "summary": "Updates the status of a particular JJDispute record to ACCEPTED.",
         "operationId": "acceptJJDispute",
         "parameters": [
@@ -346,49 +614,87 @@
             "name": "ticketNumber",
             "in": "path",
             "required": true,
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "checkVTCAssigned",
             "in": "query",
             "required": true,
-            "schema": { "type": "boolean" }
+            "schema": {
+              "type": "boolean"
+            }
           },
           {
             "name": "partId",
             "in": "query",
             "description": "Adjudicator's participant ID",
             "required": false,
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
           "400": {
             "description": "Bad Request.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "405": {
-            "description": "A JJDispute status can only be set to ACCEPTED iff status is CONFIRMED. Update failed.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
           },
           "404": {
             "description": "JJDispute record not found. Update failed.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
           },
           "500": {
             "description": "Internal server error occured.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "A JJDispute status can only be set to ACCEPTED iff status is CONFIRMED. Update failed.",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
           },
           "200": {
             "description": "Ok. Updated JJDispute record returned.",
-            "content": { "*/*": { "schema": { "$ref": "#/components/schemas/JJDispute" } } }
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/JJDispute"
+                }
+              }
+            }
           }
         }
       }
     },
     "/api/v1.0/jj/dispute/assign": {
       "put": {
-        "tags": [ "jj-dispute-controller" ],
+        "tags": [
+          "jj-dispute-controller"
+        ],
         "summary": "Updates each JJ Dispute based on the passed in ticket numbers to assign them to a specific JJ or unassign them if JJ not specified.",
         "operationId": "assignJJDisputesToJJ",
         "parameters": [
@@ -398,40 +704,72 @@
             "required": true,
             "schema": {
               "type": "array",
-              "items": { "type": "string" }
+              "items": {
+                "type": "string"
+              }
             }
           },
           {
             "name": "jjUsername",
             "in": "query",
             "required": false,
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
           "400": {
             "description": "Bad Request.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "405": {
-            "description": "Method Not Allowed",
-            "content": { "*/*": { "schema": { "type": "object" } } }
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
           },
           "404": {
             "description": "JJDispute record(s) not found. Update failed.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
           },
           "500": {
             "description": "Internal server error occured.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
           },
-          "200": { "description": "Ok" }
+          "405": {
+            "description": "Method Not Allowed",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "200": {
+            "description": "Ok"
+          }
         }
       }
     },
     "/api/v1.0/dispute/{id}": {
       "put": {
-        "tags": [ "dispute-controller" ],
+        "tags": [
+          "dispute-controller"
+        ],
         "summary": "Updates the properties of a particular Dispute record based on the given values.",
         "operationId": "updateDispute",
         "parameters": [
@@ -446,38 +784,82 @@
           }
         ],
         "requestBody": {
-          "content": { "application/json": { "schema": { "$ref": "#/components/schemas/Dispute" } } },
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Dispute"
+              }
+            }
+          },
           "required": true
         },
         "responses": {
           "400": {
             "description": "Bad Request.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "405": {
-            "description": "Method Not Allowed",
-            "content": { "*/*": { "schema": { "type": "object" } } }
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
           },
           "404": {
             "description": "Dispute record not found. Update failed.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
           },
           "500": {
             "description": "Internal Server Error",
-            "content": { "*/*": { "schema": { "type": "object" } } }
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method Not Allowed",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
           },
           "409": {
             "description": "The Dispute has already been assigned to a different user. Dispute cannot be modified until assigned time expires.",
-            "content": { "*/*": { "schema": { "$ref": "#/components/schemas/Dispute" } } }
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/Dispute"
+                }
+              }
+            }
           },
           "200": {
             "description": "Ok",
-            "content": { "*/*": { "schema": { "$ref": "#/components/schemas/Dispute" } } }
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/Dispute"
+                }
+              }
+            }
           }
         }
       },
       "delete": {
-        "tags": [ "dispute-controller" ],
+        "tags": [
+          "dispute-controller"
+        ],
         "summary": "Deletes a particular Dispute record.",
         "operationId": "deleteDispute",
         "parameters": [
@@ -494,27 +876,55 @@
         "responses": {
           "400": {
             "description": "Bad Request.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "405": {
-            "description": "Method Not Allowed",
-            "content": { "*/*": { "schema": { "type": "object" } } }
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
           },
           "404": {
             "description": "Dispute record not found. Delete failed.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
           },
           "500": {
             "description": "Internal Server Error. Delete failed.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
           },
-          "200": { "description": "Ok. Dispute record deleted." }
+          "405": {
+            "description": "Method Not Allowed",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "200": {
+            "description": "Ok. Dispute record deleted."
+          }
         }
       }
     },
     "/api/v1.0/dispute/{id}/validate": {
       "put": {
-        "tags": [ "dispute-controller" ],
+        "tags": [
+          "dispute-controller"
+        ],
         "summary": "Updates the status of a particular Dispute record to VALIDATED.",
         "operationId": "validateDispute",
         "parameters": [
@@ -531,34 +941,72 @@
         "responses": {
           "400": {
             "description": "Bad Request.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "405": {
-            "description": "A Dispute status can only be set to VALIDATED iff status is NEW. Update failed.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
           },
           "404": {
             "description": "Dispute record not found. Update failed.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
           },
           "500": {
             "description": "Internal Server Error",
-            "content": { "*/*": { "schema": { "type": "object" } } }
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "A Dispute status can only be set to VALIDATED iff status is NEW. Update failed.",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
           },
           "200": {
             "description": "Ok. Updated Dispute record returned.",
-            "content": { "*/*": { "schema": { "$ref": "#/components/schemas/Dispute" } } }
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/Dispute"
+                }
+              }
+            }
           },
           "409": {
             "description": "The Dispute has already been assigned to a different user. Dispute cannot be modified until assigned time expires.",
-            "content": { "*/*": { "schema": { "$ref": "#/components/schemas/Dispute" } } }
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/Dispute"
+                }
+              }
+            }
           }
         }
       }
     },
     "/api/v1.0/dispute/{id}/submit": {
       "put": {
-        "tags": [ "dispute-controller" ],
+        "tags": [
+          "dispute-controller"
+        ],
         "summary": "Updates the status of a particular Dispute record to PROCESSING.",
         "operationId": "submitDispute",
         "parameters": [
@@ -575,34 +1023,72 @@
         "responses": {
           "400": {
             "description": "Bad Request.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "405": {
-            "description": "A Dispute status can only be set to PROCESSING iff status is NEW or REJECTED. Update failed.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
           },
           "404": {
             "description": "Dispute record not found. Update failed.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
           },
           "500": {
             "description": "Internal Server Error",
-            "content": { "*/*": { "schema": { "type": "object" } } }
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "A Dispute status can only be set to PROCESSING iff status is NEW or REJECTED. Update failed.",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
           },
           "200": {
             "description": "Ok. Updated Dispute record returned.",
-            "content": { "*/*": { "schema": { "$ref": "#/components/schemas/Dispute" } } }
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/Dispute"
+                }
+              }
+            }
           },
           "409": {
             "description": "The Dispute has already been assigned to a different user. Dispute cannot be modified until assigned time expires.",
-            "content": { "*/*": { "schema": { "$ref": "#/components/schemas/Dispute" } } }
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/Dispute"
+                }
+              }
+            }
           }
         }
       }
     },
     "/api/v1.0/dispute/{id}/reject": {
       "put": {
-        "tags": [ "dispute-controller" ],
+        "tags": [
+          "dispute-controller"
+        ],
         "summary": "Updates the status of a particular Dispute record to REJECTED.",
         "operationId": "rejectDispute",
         "parameters": [
@@ -631,34 +1117,72 @@
         "responses": {
           "400": {
             "description": "Bad Request.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "405": {
-            "description": "A Dispute status can only be set to REJECTED iff status is NEW or VALIDATED and the rejected reason must be <= 256 characters. Update failed.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
           },
           "404": {
             "description": "Dispute record not found. Update failed.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
           },
           "500": {
             "description": "Internal Server Error",
-            "content": { "*/*": { "schema": { "type": "object" } } }
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "A Dispute status can only be set to REJECTED iff status is NEW or VALIDATED and the rejected reason must be <= 256 characters. Update failed.",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
           },
           "200": {
             "description": "Ok. Updated Dispute record returned.",
-            "content": { "*/*": { "schema": { "$ref": "#/components/schemas/Dispute" } } }
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/Dispute"
+                }
+              }
+            }
           },
           "409": {
             "description": "The Dispute has already been assigned to a different user. Dispute cannot be modified until assigned time expires.",
-            "content": { "*/*": { "schema": { "$ref": "#/components/schemas/Dispute" } } }
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/Dispute"
+                }
+              }
+            }
           }
         }
       }
     },
     "/api/v1.0/dispute/{id}/email/verify": {
       "put": {
-        "tags": [ "dispute-controller" ],
+        "tags": [
+          "dispute-controller"
+        ],
         "summary": "Updates the emailVerification flag of a particular Dispute to true.",
         "operationId": "verifyDisputeEmail",
         "parameters": [
@@ -676,27 +1200,55 @@
         "responses": {
           "400": {
             "description": "Bad Request",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "405": {
-            "description": "Method Not Allowed",
-            "content": { "*/*": { "schema": { "type": "object" } } }
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
           },
           "404": {
             "description": "Dispute with specified id not found",
-            "content": { "*/*": { "schema": { "type": "object" } } }
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
           },
           "500": {
             "description": "Internal server error occured.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
           },
-          "200": { "description": "Ok. Email verified." }
+          "405": {
+            "description": "Method Not Allowed",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "200": {
+            "description": "Ok. Email verified."
+          }
         }
       }
     },
     "/api/v1.0/dispute/{id}/email/reset": {
       "put": {
-        "tags": [ "dispute-controller" ],
+        "tags": [
+          "dispute-controller"
+        ],
         "summary": "Updates the email address of a particular Dispute.",
         "operationId": "resetDisputeEmail",
         "parameters": [
@@ -725,30 +1277,62 @@
         "responses": {
           "400": {
             "description": "If the email address is > 100 characters",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "405": {
-            "description": "Method Not Allowed",
-            "content": { "*/*": { "schema": { "type": "object" } } }
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
           },
           "404": {
             "description": "Dispute with specified id not found",
-            "content": { "*/*": { "schema": { "type": "object" } } }
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
           },
           "500": {
             "description": "Internal server error occured.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method Not Allowed",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
           },
           "200": {
             "description": "Ok. Email reset.",
-            "content": { "*/*": { "schema": { "$ref": "#/components/schemas/Dispute" } } }
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/Dispute"
+                }
+              }
+            }
           }
         }
       }
     },
     "/api/v1.0/dispute/{id}/cancel": {
       "put": {
-        "tags": [ "dispute-controller" ],
+        "tags": [
+          "dispute-controller"
+        ],
         "summary": "Updates the status of a particular Dispute record to CANCELLED.",
         "operationId": "cancelDispute",
         "parameters": [
@@ -777,34 +1361,72 @@
         "responses": {
           "400": {
             "description": "Bad Request.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "405": {
-            "description": "A Dispute status can only be set to CANCELLED iff status is NEW, REJECTED or PROCESSING. Update failed.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
           },
           "404": {
             "description": "Dispute record not found. Update failed.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
           },
           "500": {
             "description": "Internal Server Error",
-            "content": { "*/*": { "schema": { "type": "object" } } }
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "A Dispute status can only be set to CANCELLED iff status is NEW, REJECTED or PROCESSING. Update failed.",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
           },
           "200": {
             "description": "Ok. Updated Dispute record returned.",
-            "content": { "*/*": { "schema": { "$ref": "#/components/schemas/Dispute" } } }
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/Dispute"
+                }
+              }
+            }
           },
           "409": {
             "description": "The Dispute has already been assigned to a different user. Dispute cannot be modified until assigned time expires.",
-            "content": { "*/*": { "schema": { "$ref": "#/components/schemas/Dispute" } } }
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/Dispute"
+                }
+              }
+            }
           }
         }
       }
     },
     "/api/v1.0/dispute/updateRequest/{id}": {
       "put": {
-        "tags": [ "dispute-controller" ],
+        "tags": [
+          "dispute-controller"
+        ],
         "summary": "An endpoint that updates the status of a DisputeUpdateRequest record.",
         "operationId": "updateDisputeUpdateRequestStatus",
         "parameters": [
@@ -825,7 +1447,12 @@
             "required": true,
             "schema": {
               "type": "string",
-              "enum": [ "UNKNOWN", "ACCEPTED", "PENDING", "REJECTED" ]
+              "enum": [
+                "UNKNOWN",
+                "ACCEPTED",
+                "PENDING",
+                "REJECTED"
+              ]
             },
             "example": "ACCEPTED"
           }
@@ -833,52 +1460,114 @@
         "responses": {
           "400": {
             "description": "Bad Request",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "405": {
-            "description": "Method Not Allowed",
-            "content": { "*/*": { "schema": { "type": "object" } } }
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
           },
           "404": {
             "description": "DisputeUpdateRequest could not be found.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
           },
           "500": {
             "description": "Internal Server Error. Save failed.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method Not Allowed",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
           },
           "200": {
             "description": "Ok. DisputeUpdateRequest updated.",
-            "content": { "*/*": { "schema": { "$ref": "#/components/schemas/DisputeUpdateRequest" } } }
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/DisputeUpdateRequest"
+                }
+              }
+            }
           }
         }
       }
     },
     "/api/v1.0/fileHistory": {
       "post": {
-        "tags": [ "file-history-controller" ],
+        "tags": [
+          "file-history-controller"
+        ],
         "summary": "Inserts a file history record for the given ticket number.",
         "operationId": "insertFileHistory",
         "requestBody": {
-          "content": { "application/json": { "schema": { "$ref": "#/components/schemas/FileHistory" } } },
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FileHistory"
+              }
+            }
+          },
           "required": true
         },
         "responses": {
           "400": {
             "description": "Bad Request.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "405": {
-            "description": "Method Not Allowed",
-            "content": { "*/*": { "schema": { "type": "object" } } }
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
           },
           "404": {
             "description": "An invalid file history record provided. Insert failed.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
           },
           "500": {
             "description": "Internal Server Error",
-            "content": { "*/*": { "schema": { "type": "object" } } }
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method Not Allowed",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
           },
           "200": {
             "description": "Ok",
@@ -896,29 +1585,61 @@
     },
     "/api/v1.0/emailHistory": {
       "post": {
-        "tags": [ "email-history-controller" ],
+        "tags": [
+          "email-history-controller"
+        ],
         "summary": "Inserts an email history record for the given ticket number.",
         "operationId": "insertEmailHistory",
         "requestBody": {
-          "content": { "application/json": { "schema": { "$ref": "#/components/schemas/EmailHistory" } } },
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EmailHistory"
+              }
+            }
+          },
           "required": true
         },
         "responses": {
           "400": {
             "description": "Bad Request.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "405": {
-            "description": "Method Not Allowed",
-            "content": { "*/*": { "schema": { "type": "object" } } }
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
           },
           "404": {
             "description": "An invalid email history record provided. Insert failed.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
           },
           "500": {
             "description": "Internal Server Error",
-            "content": { "*/*": { "schema": { "type": "object" } } }
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method Not Allowed",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
           },
           "200": {
             "description": "Ok",
@@ -936,28 +1657,60 @@
     },
     "/api/v1.0/dispute": {
       "post": {
-        "tags": [ "dispute-controller" ],
+        "tags": [
+          "dispute-controller"
+        ],
         "operationId": "saveDispute",
         "requestBody": {
-          "content": { "application/json": { "schema": { "$ref": "#/components/schemas/Dispute" } } },
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Dispute"
+              }
+            }
+          },
           "required": true
         },
         "responses": {
           "400": {
             "description": "Bad Request",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "405": {
-            "description": "Method Not Allowed",
-            "content": { "*/*": { "schema": { "type": "object" } } }
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
           },
           "404": {
             "description": "Not Found",
-            "content": { "*/*": { "schema": { "type": "object" } } }
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
           },
           "500": {
             "description": "Internal Server Error",
-            "content": { "*/*": { "schema": { "type": "object" } } }
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method Not Allowed",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
           },
           "200": {
             "description": "OK",
@@ -975,7 +1728,9 @@
     },
     "/api/v1.0/dispute/{guid}/updateRequest": {
       "post": {
-        "tags": [ "dispute-controller" ],
+        "tags": [
+          "dispute-controller"
+        ],
         "summary": "An endpoint that inserts a DisputeUpdateRequest into persistent storage.",
         "operationId": "saveDisputeUpdateRequest",
         "parameters": [
@@ -984,29 +1739,61 @@
             "in": "path",
             "description": "The noticeOfDisputeGuid of the Dispute to associate with.",
             "required": true,
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "requestBody": {
-          "content": { "application/json": { "schema": { "$ref": "#/components/schemas/DisputeUpdateRequest" } } },
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DisputeUpdateRequest"
+              }
+            }
+          },
           "required": true
         },
         "responses": {
           "400": {
             "description": "Bad Request",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "405": {
-            "description": "Method Not Allowed",
-            "content": { "*/*": { "schema": { "type": "object" } } }
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
           },
           "404": {
             "description": "Dispute could not be found.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
           },
           "500": {
             "description": "Internal Server Error. Save failed.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method Not Allowed",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
           },
           "200": {
             "description": "Ok. DisputeUpdateRequest record saved.",
@@ -1024,7 +1811,9 @@
     },
     "/api/v1.0/jj/disputes": {
       "get": {
-        "tags": [ "jj-dispute-controller" ],
+        "tags": [
+          "jj-dispute-controller"
+        ],
         "operationId": "getJJDisputes",
         "parameters": [
           {
@@ -1032,7 +1821,9 @@
             "in": "query",
             "description": "If specified, will retrieve the records which are assigned to the specified jj staff",
             "required": false,
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "ticketNumber",
@@ -1049,19 +1840,43 @@
         "responses": {
           "400": {
             "description": "Bad Request",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "405": {
-            "description": "Method Not Allowed",
-            "content": { "*/*": { "schema": { "type": "object" } } }
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
           },
           "404": {
             "description": "Not Found",
-            "content": { "*/*": { "schema": { "type": "object" } } }
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
           },
           "500": {
             "description": "Internal Server Error",
-            "content": { "*/*": { "schema": { "type": "object" } } }
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method Not Allowed",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
           },
           "200": {
             "description": "OK",
@@ -1069,7 +1884,9 @@
               "*/*": {
                 "schema": {
                   "type": "array",
-                  "items": { "$ref": "#/components/schemas/JJDispute" }
+                  "items": {
+                    "$ref": "#/components/schemas/JJDispute"
+                  }
                 }
               }
             }
@@ -1079,7 +1896,9 @@
     },
     "/api/v1.0/jj/dispute/{ticketNumber}/{assignVTC}": {
       "get": {
-        "tags": [ "jj-dispute-controller" ],
+        "tags": [
+          "jj-dispute-controller"
+        ],
         "operationId": "getJJDispute",
         "parameters": [
           {
@@ -1087,49 +1906,87 @@
             "in": "path",
             "description": "The primary key of the jj dispute to retrieve",
             "required": true,
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "assignVTC",
             "in": "path",
             "required": true,
-            "schema": { "type": "boolean" }
+            "schema": {
+              "type": "boolean"
+            }
           }
         ],
         "responses": {
           "400": {
             "description": "Bad Request",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "405": {
-            "description": "Method Not Allowed",
-            "content": { "*/*": { "schema": { "type": "object" } } }
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
           },
           "404": {
             "description": "Not Found",
-            "content": { "*/*": { "schema": { "type": "object" } } }
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
           },
           "500": {
             "description": "Internal Server Error",
-            "content": { "*/*": { "schema": { "type": "object" } } }
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method Not Allowed",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
           },
           "200": {
             "description": "OK",
-            "content": { "*/*": { "schema": { "$ref": "#/components/schemas/JJDispute" } } }
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/JJDispute"
+                }
+              }
+            }
           }
         }
       }
     },
     "/api/v1.0/jj/dispute/ticketImage/{ticketNumber}/{documentType}": {
       "get": {
-        "tags": [ "jj-dispute-controller" ],
+        "tags": [
+          "jj-dispute-controller"
+        ],
         "operationId": "getTicketImageData",
         "parameters": [
           {
             "name": "ticketNumber",
             "in": "path",
             "required": true,
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "documentType",
@@ -1137,37 +1994,73 @@
             "required": true,
             "schema": {
               "type": "string",
-              "enum": [ "UNKNOWN", "NOTICE_OF_DISPUTE", "TICKET_IMAGE" ]
+              "enum": [
+                "UNKNOWN",
+                "NOTICE_OF_DISPUTE",
+                "TICKET_IMAGE"
+              ]
             }
           }
         ],
         "responses": {
           "400": {
             "description": "Bad Request",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "405": {
-            "description": "Method Not Allowed",
-            "content": { "*/*": { "schema": { "type": "object" } } }
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
           },
           "404": {
             "description": "Not Found",
-            "content": { "*/*": { "schema": { "type": "object" } } }
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
           },
           "500": {
             "description": "Internal Server Error",
-            "content": { "*/*": { "schema": { "type": "object" } } }
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method Not Allowed",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
           },
           "200": {
             "description": "OK",
-            "content": { "*/*": { "schema": { "$ref": "#/components/schemas/TicketImageDataJustinDocument" } } }
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/TicketImageDataJustinDocument"
+                }
+              }
+            }
           }
         }
       }
     },
     "/api/v1.0/fileHistory/{ticketNumber}": {
       "get": {
-        "tags": [ "file-history-controller" ],
+        "tags": [
+          "file-history-controller"
+        ],
         "operationId": "getFileHistoryByTicketNumber",
         "parameters": [
           {
@@ -1175,25 +2068,51 @@
             "in": "path",
             "description": "Ticket number to retrieve related file history.",
             "required": true,
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
           "400": {
             "description": "Bad Request",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "405": {
-            "description": "Method Not Allowed",
-            "content": { "*/*": { "schema": { "type": "object" } } }
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
           },
           "404": {
             "description": "Not Found",
-            "content": { "*/*": { "schema": { "type": "object" } } }
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
           },
           "500": {
             "description": "Internal Server Error",
-            "content": { "*/*": { "schema": { "type": "object" } } }
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method Not Allowed",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
           },
           "200": {
             "description": "OK",
@@ -1201,7 +2120,9 @@
               "*/*": {
                 "schema": {
                   "type": "array",
-                  "items": { "$ref": "#/components/schemas/FileHistory" }
+                  "items": {
+                    "$ref": "#/components/schemas/FileHistory"
+                  }
                 }
               }
             }
@@ -1211,7 +2132,9 @@
     },
     "/api/v1.0/emailHistory/{ticketNumber}": {
       "get": {
-        "tags": [ "email-history-controller" ],
+        "tags": [
+          "email-history-controller"
+        ],
         "operationId": "getEmailHistoryByTicketNumber",
         "parameters": [
           {
@@ -1219,25 +2142,51 @@
             "in": "path",
             "description": "Ticket number to retrieve related emails.",
             "required": true,
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
           "400": {
             "description": "Bad Request",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "405": {
-            "description": "Method Not Allowed",
-            "content": { "*/*": { "schema": { "type": "object" } } }
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
           },
           "404": {
             "description": "Not Found",
-            "content": { "*/*": { "schema": { "type": "object" } } }
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
           },
           "500": {
             "description": "Internal Server Error",
-            "content": { "*/*": { "schema": { "type": "object" } } }
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method Not Allowed",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
           },
           "200": {
             "description": "OK",
@@ -1245,7 +2194,9 @@
               "*/*": {
                 "schema": {
                   "type": "array",
-                  "items": { "$ref": "#/components/schemas/EmailHistory" }
+                  "items": {
+                    "$ref": "#/components/schemas/EmailHistory"
+                  }
                 }
               }
             }
@@ -1255,7 +2206,9 @@
     },
     "/api/v1.0/disputes": {
       "get": {
-        "tags": [ "dispute-controller" ],
+        "tags": [
+          "dispute-controller"
+        ],
         "summary": "Returns all dispute list details based on the specified optional parameters.",
         "operationId": "getAllDisputes",
         "parameters": [
@@ -1277,7 +2230,15 @@
             "required": false,
             "schema": {
               "type": "string",
-              "enum": [ "UNKNOWN", "NEW", "VALIDATED", "PROCESSING", "REJECTED", "CANCELLED", "CONCLUDED" ]
+              "enum": [
+                "UNKNOWN",
+                "NEW",
+                "VALIDATED",
+                "PROCESSING",
+                "REJECTED",
+                "CANCELLED",
+                "CONCLUDED"
+              ]
             },
             "example": "CANCELLED"
           }
@@ -1285,19 +2246,43 @@
         "responses": {
           "400": {
             "description": "Bad Request.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "405": {
-            "description": "Method Not Allowed",
-            "content": { "*/*": { "schema": { "type": "object" } } }
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
           },
           "404": {
             "description": "Not Found",
-            "content": { "*/*": { "schema": { "type": "object" } } }
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
           },
           "500": {
             "description": "Internal Server Error. Getting disputes failed.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method Not Allowed",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
           },
           "200": {
             "description": "Ok. Disputes are returned.",
@@ -1305,7 +2290,9 @@
               "*/*": {
                 "schema": {
                   "type": "array",
-                  "items": { "$ref": "#/components/schemas/DisputeListItem" }
+                  "items": {
+                    "$ref": "#/components/schemas/DisputeListItem"
+                  }
                 }
               }
             }
@@ -1315,34 +2302,64 @@
     },
     "/api/v1.0/disputes/unassign": {
       "get": {
-        "tags": [ "dispute-controller" ],
+        "tags": [
+          "dispute-controller"
+        ],
         "summary": "An endpoint hook to trigger the Unassign Dispute job.",
         "description": "A Dispute can be assigned to a specific user that \"locks\" the record for others. This endpoing manually triggers the Unassign Dispute job that clears the assignment of all Disputes that were assigned for more than 1 hour.",
         "operationId": "unassignDisputes",
         "responses": {
           "400": {
             "description": "Bad Request",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "405": {
-            "description": "Method Not Allowed",
-            "content": { "*/*": { "schema": { "type": "object" } } }
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
           },
           "404": {
             "description": "Not Found",
-            "content": { "*/*": { "schema": { "type": "object" } } }
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
           },
           "500": {
             "description": "Internal Server Error. Unassigned failed.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
           },
-          "200": { "description": "Ok. Dispute record unassigned." }
+          "405": {
+            "description": "Method Not Allowed",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "200": {
+            "description": "Ok. Dispute record unassigned."
+          }
         }
       }
     },
     "/api/v1.0/dispute/{id}/{isAssign}": {
       "get": {
-        "tags": [ "dispute-controller" ],
+        "tags": [
+          "dispute-controller"
+        ],
         "operationId": "getDispute",
         "parameters": [
           {
@@ -1358,36 +2375,70 @@
             "name": "isAssign",
             "in": "path",
             "required": true,
-            "schema": { "type": "boolean" }
+            "schema": {
+              "type": "boolean"
+            }
           }
         ],
         "responses": {
           "400": {
             "description": "Bad Request",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "405": {
-            "description": "Method Not Allowed",
-            "content": { "*/*": { "schema": { "type": "object" } } }
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
           },
           "404": {
             "description": "Not Found",
-            "content": { "*/*": { "schema": { "type": "object" } } }
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
           },
           "500": {
             "description": "Internal Server Error",
-            "content": { "*/*": { "schema": { "type": "object" } } }
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method Not Allowed",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
           },
           "200": {
             "description": "OK",
-            "content": { "*/*": { "schema": { "$ref": "#/components/schemas/Dispute" } } }
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/Dispute"
+                }
+              }
+            }
           }
         }
       }
     },
     "/api/v1.0/dispute/updateRequests": {
       "get": {
-        "tags": [ "dispute-controller" ],
+        "tags": [
+          "dispute-controller"
+        ],
         "summary": "An endpoint that retrieves all DisputeUpdateRequest optionally for a given Dispute, optionally filtered by DisputeUpdateRequestStatus.",
         "operationId": "getDisputeUpdateRequests",
         "parameters": [
@@ -1408,7 +2459,12 @@
             "required": false,
             "schema": {
               "type": "string",
-              "enum": [ "UNKNOWN", "ACCEPTED", "PENDING", "REJECTED" ]
+              "enum": [
+                "UNKNOWN",
+                "ACCEPTED",
+                "PENDING",
+                "REJECTED"
+              ]
             },
             "example": "PENDING"
           }
@@ -1416,19 +2472,43 @@
         "responses": {
           "400": {
             "description": "Bad Request",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "405": {
-            "description": "Method Not Allowed",
-            "content": { "*/*": { "schema": { "type": "object" } } }
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
           },
           "404": {
             "description": "Not Found",
-            "content": { "*/*": { "schema": { "type": "object" } } }
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
           },
           "500": {
             "description": "Internal Server Error. retrieve update requests failed.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method Not Allowed",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
           },
           "200": {
             "description": "Ok. DisputeUpdateRequest record saved.",
@@ -1436,7 +2516,9 @@
               "*/*": {
                 "schema": {
                   "type": "array",
-                  "items": { "$ref": "#/components/schemas/DisputeUpdateRequest" }
+                  "items": {
+                    "$ref": "#/components/schemas/DisputeUpdateRequest"
+                  }
                 }
               }
             }
@@ -1446,7 +2528,9 @@
     },
     "/api/v1.0/dispute/status": {
       "get": {
-        "tags": [ "dispute-controller" ],
+        "tags": [
+          "dispute-controller"
+        ],
         "summary": "Finds Dispute statuses by TicketNumber and IssuedTime or noticeOfDisputeGuid if specified.",
         "operationId": "findDisputeStatuses",
         "parameters": [
@@ -1466,7 +2550,9 @@
             "in": "query",
             "description": "The time portion of the Dispute.issuedTs field to search for (of the format HH:mm). Time is in UTC.",
             "required": false,
-            "schema": { "type": "string" },
+            "schema": {
+              "type": "string"
+            },
             "example": "14:53"
           },
           {
@@ -1474,25 +2560,51 @@
             "in": "query",
             "description": "The noticeOfDisputeGuid of the Dispute to retreive.",
             "required": false,
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
           "400": {
             "description": "Bad Request, check parameters.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "405": {
-            "description": "Method Not Allowed",
-            "content": { "*/*": { "schema": { "type": "object" } } }
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
           },
           "404": {
             "description": "Not Found",
-            "content": { "*/*": { "schema": { "type": "object" } } }
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
           },
           "500": {
             "description": "Internal Server Error. Search failed.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method Not Allowed",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
           },
           "200": {
             "description": "Ok.",
@@ -1500,7 +2612,9 @@
               "*/*": {
                 "schema": {
                   "type": "array",
-                  "items": { "$ref": "#/components/schemas/DisputeResult" }
+                  "items": {
+                    "$ref": "#/components/schemas/DisputeResult"
+                  }
                 }
               }
             }
@@ -1510,7 +2624,9 @@
     },
     "/api/v1.0/dispute/noticeOfDispute/{id}": {
       "get": {
-        "tags": [ "dispute-controller" ],
+        "tags": [
+          "dispute-controller"
+        ],
         "summary": "Retrieves Dispute by the noticeOfDisputeGuid (UUID).",
         "operationId": "getDisputeByNoticeOfDisputeGuid",
         "parameters": [
@@ -1519,63 +2635,125 @@
             "in": "path",
             "description": "The noticeOfDisputeGuid of the Dispute to retreive.",
             "required": true,
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
           "400": {
             "description": "Bad Request",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "405": {
-            "description": "Method Not Allowed",
-            "content": { "*/*": { "schema": { "type": "object" } } }
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
           },
           "404": {
             "description": "Dispute could not be found.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
           },
           "500": {
             "description": "Internal server error occured.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method Not Allowed",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
           },
           "200": {
             "description": "Ok. Dispute retrieved.",
-            "content": { "*/*": { "schema": { "$ref": "#/components/schemas/Dispute" } } }
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/Dispute"
+                }
+              }
+            }
           }
         }
       }
     },
     "/api/v1.0/codetable/refresh": {
       "get": {
-        "tags": [ "dispute-controller" ],
+        "tags": [
+          "dispute-controller"
+        ],
         "summary": "An endpoint hook to trigger a redis rebuild of cached codetable data.",
         "description": "The codetables in redis are cached copies of data pulled from Oracle to ensure TCO remains stable. This data is periodically refreshed, but can be forced by hitting this endpoint.",
         "operationId": "codeTableRefresh",
         "responses": {
           "400": {
             "description": "Bad Request",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "405": {
-            "description": "Method Not Allowed",
-            "content": { "*/*": { "schema": { "type": "object" } } }
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
           },
           "404": {
             "description": "Not Found",
-            "content": { "*/*": { "schema": { "type": "object" } } }
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
           },
           "500": {
             "description": "Internal Server Error",
-            "content": { "*/*": { "schema": { "type": "object" } } }
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
           },
-          "200": { "description": "OK" }
+          "405": {
+            "description": "Method Not Allowed",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "200": {
+            "description": "OK"
+          }
         }
       }
     },
     "/api/v1.0/jj/dispute": {
       "delete": {
-        "tags": [ "jj-dispute-controller" ],
+        "tags": [
+          "jj-dispute-controller"
+        ],
         "summary": "Deletes a particular JJDispute record.",
         "operationId": "DeleteJJDispute",
         "parameters": [
@@ -1604,21 +2782,47 @@
         "responses": {
           "400": {
             "description": "Bad Request.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
-          },
-          "405": {
-            "description": "Method Not Allowed",
-            "content": { "*/*": { "schema": { "type": "object" } } }
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
           },
           "404": {
             "description": "Not Found",
-            "content": { "*/*": { "schema": { "type": "object" } } }
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
           },
           "500": {
             "description": "Internal Server Error. Delete failed.",
-            "content": { "*/*": { "schema": { "type": "object" } } }
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
           },
-          "200": { "description": "Ok. JJ Dispute record deleted." }
+          "405": {
+            "description": "Method Not Allowed",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "200": {
+            "description": "Ok. JJ Dispute record deleted."
+          }
         }
       }
     }
@@ -1628,7 +2832,9 @@
       "JJDispute": {
         "type": "object",
         "properties": {
-          "createdBy": { "type": "string" },
+          "createdBy": {
+            "type": "string"
+          },
           "createdTs": {
             "type": "string",
             "format": "date-time"
@@ -1648,14 +2854,22 @@
             "format": "int64",
             "readOnly": true
           },
-          "ticketNumber": { "type": "string" },
+          "ticketNumber": {
+            "type": "string"
+          },
           "accidentYn": {
             "type": "string",
             "description": "Indicates whether the dispute is associated with an accident or not",
             "nullable": true,
-            "enum": [ "UNKNOWN", "Y", "N" ]
+            "enum": [
+              "UNKNOWN",
+              "Y",
+              "N"
+            ]
           },
-          "addressLine1": { "type": "string" },
+          "addressLine1": {
+            "type": "string"
+          },
           "addressLine2": {
             "type": "string",
             "nullable": true
@@ -1703,17 +2917,38 @@
           },
           "status": {
             "type": "string",
-            "enum": [ "UNKNOWN", "NEW", "IN_PROGRESS", "DATA_UPDATE", "CONFIRMED", "REQUIRE_COURT_HEARING", "REQUIRE_MORE_INFO", "ACCEPTED", "REVIEW", "CONCLUDED", "CANCELLED", "HEARING_SCHEDULED" ]
+            "enum": [
+              "UNKNOWN",
+              "NEW",
+              "IN_PROGRESS",
+              "DATA_UPDATE",
+              "CONFIRMED",
+              "REQUIRE_COURT_HEARING",
+              "REQUIRE_MORE_INFO",
+              "ACCEPTED",
+              "REVIEW",
+              "CONCLUDED",
+              "CANCELLED",
+              "HEARING_SCHEDULED"
+            ]
           },
           "hearingType": {
             "type": "string",
             "nullable": true,
-            "enum": [ "UNKNOWN", "COURT_APPEARANCE", "WRITTEN_REASONS" ]
+            "enum": [
+              "UNKNOWN",
+              "COURT_APPEARANCE",
+              "WRITTEN_REASONS"
+            ]
           },
           "multipleOfficersYn": {
             "type": "string",
             "description": "Indicates whether the dispute is associated with multiple officers or not",
-            "enum": [ "UNKNOWN", "Y", "N" ]
+            "enum": [
+              "UNKNOWN",
+              "Y",
+              "N"
+            ]
           },
           "noticeOfDisputeGuid": {
             "type": "string",
@@ -1722,7 +2957,11 @@
           "noticeOfHearingYn": {
             "type": "string",
             "nullable": true,
-            "enum": [ "UNKNOWN", "Y", "N" ]
+            "enum": [
+              "UNKNOWN",
+              "Y",
+              "N"
+            ]
           },
           "occamDisputantGiven1Nm": {
             "type": "string",
@@ -1775,7 +3014,11 @@
           "electronicTicketYn": {
             "type": "string",
             "nullable": true,
-            "enum": [ "UNKNOWN", "Y", "N" ]
+            "enum": [
+              "UNKNOWN",
+              "Y",
+              "N"
+            ]
           },
           "policeDetachment": {
             "type": "string",
@@ -1838,11 +3081,20 @@
           "contactType": {
             "type": "string",
             "nullable": true,
-            "enum": [ "UNKNOWN", "INDIVIDUAL", "LAWYER", "OTHER" ]
+            "enum": [
+              "UNKNOWN",
+              "INDIVIDUAL",
+              "LAWYER",
+              "OTHER"
+            ]
           },
           "appearInCourt": {
             "type": "string",
-            "enum": [ "UNKNOWN", "Y", "N" ]
+            "enum": [
+              "UNKNOWN",
+              "Y",
+              "N"
+            ]
           },
           "courtAgenId": {
             "type": "string",
@@ -1889,13 +3141,25 @@
           "disputantAttendanceType": {
             "type": "string",
             "nullable": true,
-            "enum": [ "UNKNOWN", "WRITTEN_REASONS", "VIDEO_CONFERENCE", "TELEPHONE_CONFERENCE", "MSTEAMS_AUDIO", "MSTEAMS_VIDEO", "IN_PERSON" ]
+            "enum": [
+              "UNKNOWN",
+              "WRITTEN_REASONS",
+              "VIDEO_CONFERENCE",
+              "TELEPHONE_CONFERENCE",
+              "MSTEAMS_AUDIO",
+              "MSTEAMS_VIDEO",
+              "IN_PERSON"
+            ]
           },
           "signatoryType": {
             "type": "string",
             "description": "Signatory Type. Can be either 'D' for Disputant or 'A' for Agent.",
             "nullable": true,
-            "enum": [ "U", "D", "A" ]
+            "enum": [
+              "U",
+              "D",
+              "A"
+            ]
           },
           "signatoryName": {
             "maxLength": 100,
@@ -1905,15 +3169,21 @@
           },
           "remarks": {
             "type": "array",
-            "items": { "$ref": "#/components/schemas/JJDisputeRemark" }
+            "items": {
+              "$ref": "#/components/schemas/JJDisputeRemark"
+            }
           },
           "jjDisputedCounts": {
             "type": "array",
-            "items": { "$ref": "#/components/schemas/JJDisputedCount" }
+            "items": {
+              "$ref": "#/components/schemas/JJDisputedCount"
+            }
           },
           "jjDisputeCourtAppearanceRoPs": {
             "type": "array",
-            "items": { "$ref": "#/components/schemas/JJDisputeCourtAppearanceRoP" }
+            "items": {
+              "$ref": "#/components/schemas/JJDisputeCourtAppearanceRoP"
+            }
           }
         }
       },
@@ -1953,7 +3223,12 @@
           "appCd": {
             "type": "string",
             "nullable": true,
-            "enum": [ "UNKNOWN", "A", "P", "N" ]
+            "enum": [
+              "UNKNOWN",
+              "A",
+              "P",
+              "N"
+            ]
           },
           "noAppTs": {
             "type": "string",
@@ -1971,17 +3246,30 @@
           "dattCd": {
             "type": "string",
             "nullable": true,
-            "enum": [ "UNKNOWN", "A", "C", "N" ]
+            "enum": [
+              "UNKNOWN",
+              "A",
+              "C",
+              "N"
+            ]
           },
           "crown": {
             "type": "string",
             "nullable": true,
-            "enum": [ "UNKNOWN", "P", "N" ]
+            "enum": [
+              "UNKNOWN",
+              "P",
+              "N"
+            ]
           },
           "jjSeized": {
             "type": "string",
             "nullable": true,
-            "enum": [ "UNKNOWN", "Y", "N" ]
+            "enum": [
+              "UNKNOWN",
+              "Y",
+              "N"
+            ]
           },
           "adjudicator": {
             "type": "string",
@@ -1998,7 +3286,9 @@
       "JJDisputeRemark": {
         "type": "object",
         "properties": {
-          "createdBy": { "type": "string" },
+          "createdBy": {
+            "type": "string"
+          },
           "createdTs": {
             "type": "string",
             "format": "date-time"
@@ -2018,7 +3308,9 @@
             "format": "int64",
             "readOnly": true
           },
-          "userFullName": { "type": "string" },
+          "userFullName": {
+            "type": "string"
+          },
           "note": {
             "maxLength": 4000,
             "minLength": 0,
@@ -2033,7 +3325,9 @@
       "JJDisputedCount": {
         "type": "object",
         "properties": {
-          "createdBy": { "type": "string" },
+          "createdBy": {
+            "type": "string"
+          },
           "createdTs": {
             "type": "string",
             "format": "date-time"
@@ -2056,7 +3350,11 @@
           "plea": {
             "type": "string",
             "description": "Represents the disputant's initial plea on count.",
-            "enum": [ "UNKNOWN", "G", "N" ]
+            "enum": [
+              "UNKNOWN",
+              "G",
+              "N"
+            ]
           },
           "count": {
             "maximum": 3,
@@ -2066,15 +3364,27 @@
           },
           "requestTimeToPay": {
             "type": "string",
-            "enum": [ "UNKNOWN", "Y", "N" ]
+            "enum": [
+              "UNKNOWN",
+              "Y",
+              "N"
+            ]
           },
           "requestReduction": {
             "type": "string",
-            "enum": [ "UNKNOWN", "Y", "N" ]
+            "enum": [
+              "UNKNOWN",
+              "Y",
+              "N"
+            ]
           },
           "appearInCourt": {
             "type": "string",
-            "enum": [ "UNKNOWN", "Y", "N" ]
+            "enum": [
+              "UNKNOWN",
+              "Y",
+              "N"
+            ]
           },
           "description": {
             "type": "string",
@@ -2098,7 +3408,11 @@
           "includesSurcharge": {
             "type": "string",
             "nullable": true,
-            "enum": [ "UNKNOWN", "Y", "N" ]
+            "enum": [
+              "UNKNOWN",
+              "Y",
+              "N"
+            ]
           },
           "revisedDueDate": {
             "type": "string",
@@ -2125,7 +3439,11 @@
             "type": "string",
             "description": "Represents the disputant's latest plea on count.",
             "nullable": true,
-            "enum": [ "UNKNOWN", "G", "N" ]
+            "enum": [
+              "UNKNOWN",
+              "G",
+              "N"
+            ]
           },
           "latestPleaUpdateTs": {
             "type": "string",
@@ -2133,13 +3451,17 @@
             "format": "date-time",
             "nullable": true
           },
-          "jjDisputedCountRoP": { "$ref": "#/components/schemas/JJDisputedCountRoP" }
+          "jjDisputedCountRoP": {
+            "$ref": "#/components/schemas/JJDisputedCountRoP"
+          }
         }
       },
       "JJDisputedCountRoP": {
         "type": "object",
         "properties": {
-          "createdBy": { "type": "string" },
+          "createdBy": {
+            "type": "string"
+          },
           "createdTs": {
             "type": "string",
             "format": "date-time"
@@ -2162,7 +3484,14 @@
           "finding": {
             "type": "string",
             "nullable": true,
-            "enum": [ "UNKNOWN", "GUILTY", "NOT_GUILTY", "CANCELLED", "PAID_PRIOR_TO_APPEARANCE", "GUILTY_LESSER" ]
+            "enum": [
+              "UNKNOWN",
+              "GUILTY",
+              "NOT_GUILTY",
+              "CANCELLED",
+              "PAID_PRIOR_TO_APPEARANCE",
+              "GUILTY_LESSER"
+            ]
           },
           "lesserDescription": {
             "type": "string",
@@ -2182,7 +3511,11 @@
           },
           "jailIntermittent": {
             "type": "string",
-            "enum": [ "UNKNOWN", "Y", "N" ]
+            "enum": [
+              "UNKNOWN",
+              "Y",
+              "N"
+            ]
           },
           "probationDuration": {
             "type": "string",
@@ -2202,19 +3535,35 @@
           },
           "dismissed": {
             "type": "string",
-            "enum": [ "UNKNOWN", "Y", "N" ]
+            "enum": [
+              "UNKNOWN",
+              "Y",
+              "N"
+            ]
           },
           "forWantOfProsecution": {
             "type": "string",
-            "enum": [ "UNKNOWN", "Y", "N" ]
+            "enum": [
+              "UNKNOWN",
+              "Y",
+              "N"
+            ]
           },
           "withdrawn": {
             "type": "string",
-            "enum": [ "UNKNOWN", "Y", "N" ]
+            "enum": [
+              "UNKNOWN",
+              "Y",
+              "N"
+            ]
           },
           "abatement": {
             "type": "string",
-            "enum": [ "UNKNOWN", "Y", "N" ]
+            "enum": [
+              "UNKNOWN",
+              "Y",
+              "N"
+            ]
           },
           "stayOfProceedingsBy": {
             "type": "string",
@@ -2230,7 +3579,9 @@
       "Dispute": {
         "type": "object",
         "properties": {
-          "createdBy": { "type": "string" },
+          "createdBy": {
+            "type": "string"
+          },
           "createdTs": {
             "type": "string",
             "format": "date-time"
@@ -2254,7 +3605,9 @@
             "type": "string",
             "nullable": true
           },
-          "ticketNumber": { "type": "string" },
+          "ticketNumber": {
+            "type": "string"
+          },
           "issuedTs": {
             "type": "string",
             "format": "date-time",
@@ -2319,7 +3672,15 @@
           },
           "status": {
             "type": "string",
-            "enum": [ "UNKNOWN", "NEW", "VALIDATED", "PROCESSING", "REJECTED", "CANCELLED", "CONCLUDED" ]
+            "enum": [
+              "UNKNOWN",
+              "NEW",
+              "VALIDATED",
+              "PROCESSING",
+              "REJECTED",
+              "CANCELLED",
+              "CONCLUDED"
+            ]
           },
           "addressLine1": {
             "type": "string",
@@ -2378,7 +3739,9 @@
             "type": "string",
             "nullable": true
           },
-          "emailAddressVerified": { "type": "boolean" },
+          "emailAddressVerified": {
+            "type": "boolean"
+          },
           "filingDate": {
             "type": "string",
             "format": "date-time",
@@ -2387,7 +3750,11 @@
           "representedByLawyer": {
             "type": "string",
             "nullable": true,
-            "enum": [ "UNKNOWN", "Y", "N" ]
+            "enum": [
+              "UNKNOWN",
+              "Y",
+              "N"
+            ]
           },
           "lawFirmName": {
             "type": "string",
@@ -2431,12 +3798,21 @@
           },
           "contactTypeCd": {
             "type": "string",
-            "enum": [ "UNKNOWN", "INDIVIDUAL", "LAWYER", "OTHER" ]
+            "enum": [
+              "UNKNOWN",
+              "INDIVIDUAL",
+              "LAWYER",
+              "OTHER"
+            ]
           },
           "requestCourtAppearanceYn": {
             "type": "string",
             "nullable": true,
-            "enum": [ "UNKNOWN", "Y", "N" ]
+            "enum": [
+              "UNKNOWN",
+              "Y",
+              "N"
+            ]
           },
           "contactLawFirmNm": {
             "type": "string",
@@ -2466,7 +3842,11 @@
           "appearanceLessThan14DaysYn": {
             "type": "string",
             "nullable": true,
-            "enum": [ "UNKNOWN", "Y", "N" ]
+            "enum": [
+              "UNKNOWN",
+              "Y",
+              "N"
+            ]
           },
           "detachmentLocation": {
             "type": "string",
@@ -2485,7 +3865,11 @@
           "interpreterRequired": {
             "type": "string",
             "nullable": true,
-            "enum": [ "UNKNOWN", "Y", "N" ]
+            "enum": [
+              "UNKNOWN",
+              "Y",
+              "N"
+            ]
           },
           "witnessNo": {
             "type": "integer",
@@ -2520,7 +3904,11 @@
           "disputantDetectedOcrIssues": {
             "type": "string",
             "nullable": true,
-            "enum": [ "UNKNOWN", "Y", "N" ]
+            "enum": [
+              "UNKNOWN",
+              "Y",
+              "N"
+            ]
           },
           "disputantOcrIssues": {
             "type": "string",
@@ -2528,7 +3916,11 @@
           },
           "systemDetectedOcrIssues": {
             "type": "string",
-            "enum": [ "UNKNOWN", "Y", "N" ]
+            "enum": [
+              "UNKNOWN",
+              "Y",
+              "N"
+            ]
           },
           "ocrTicketFilename": {
             "maxLength": 100,
@@ -2540,7 +3932,11 @@
             "type": "string",
             "description": "Signatory Type. Can be either 'D' for Disputant or 'A' for Agent.",
             "nullable": true,
-            "enum": [ "U", "D", "A" ]
+            "enum": [
+              "U",
+              "D",
+              "A"
+            ]
           },
           "signatoryName": {
             "maxLength": 100,
@@ -2548,17 +3944,23 @@
             "description": "Name of the person who signed the dispute.",
             "nullable": true
           },
-          "violationTicket": { "$ref": "#/components/schemas/ViolationTicket" },
+          "violationTicket": {
+            "$ref": "#/components/schemas/ViolationTicket"
+          },
           "disputeCounts": {
             "type": "array",
-            "items": { "$ref": "#/components/schemas/DisputeCount" }
+            "items": {
+              "$ref": "#/components/schemas/DisputeCount"
+            }
           }
         }
       },
       "DisputeCount": {
         "type": "object",
         "properties": {
-          "createdBy": { "type": "string" },
+          "createdBy": {
+            "type": "string"
+          },
           "createdTs": {
             "type": "string",
             "format": "date-time"
@@ -2580,26 +3982,44 @@
           },
           "pleaCode": {
             "type": "string",
-            "enum": [ "UNKNOWN", "G", "N" ]
+            "enum": [
+              "UNKNOWN",
+              "G",
+              "N"
+            ]
           },
           "requestTimeToPay": {
             "type": "string",
-            "enum": [ "UNKNOWN", "Y", "N" ]
+            "enum": [
+              "UNKNOWN",
+              "Y",
+              "N"
+            ]
           },
           "requestReduction": {
             "type": "string",
-            "enum": [ "UNKNOWN", "Y", "N" ]
+            "enum": [
+              "UNKNOWN",
+              "Y",
+              "N"
+            ]
           },
           "requestCourtAppearance": {
             "type": "string",
-            "enum": [ "UNKNOWN", "Y", "N" ]
+            "enum": [
+              "UNKNOWN",
+              "Y",
+              "N"
+            ]
           }
         }
       },
       "ViolationTicket": {
         "type": "object",
         "properties": {
-          "createdBy": { "type": "string" },
+          "createdBy": {
+            "type": "string"
+          },
           "createdTs": {
             "type": "string",
             "format": "date-time"
@@ -2638,7 +4058,11 @@
           "isYoungPerson": {
             "type": "string",
             "nullable": true,
-            "enum": [ "UNKNOWN", "Y", "N" ]
+            "enum": [
+              "UNKNOWN",
+              "Y",
+              "N"
+            ]
           },
           "disputantDriversLicenceNumber": {
             "maxLength": 30,
@@ -2722,17 +4146,29 @@
           "isChangeOfAddress": {
             "type": "string",
             "nullable": true,
-            "enum": [ "UNKNOWN", "Y", "N" ]
+            "enum": [
+              "UNKNOWN",
+              "Y",
+              "N"
+            ]
           },
           "isDriver": {
             "type": "string",
             "nullable": true,
-            "enum": [ "UNKNOWN", "Y", "N" ]
+            "enum": [
+              "UNKNOWN",
+              "Y",
+              "N"
+            ]
           },
           "isOwner": {
             "type": "string",
             "nullable": true,
-            "enum": [ "UNKNOWN", "Y", "N" ]
+            "enum": [
+              "UNKNOWN",
+              "Y",
+              "N"
+            ]
           },
           "courtLocation": {
             "type": "string",
@@ -2740,7 +4176,9 @@
           },
           "violationTicketCounts": {
             "type": "array",
-            "items": { "$ref": "#/components/schemas/ViolationTicketCount" }
+            "items": {
+              "$ref": "#/components/schemas/ViolationTicketCount"
+            }
           }
         },
         "nullable": true
@@ -2748,7 +4186,9 @@
       "ViolationTicketCount": {
         "type": "object",
         "properties": {
-          "createdBy": { "type": "string" },
+          "createdBy": {
+            "type": "string"
+          },
           "createdTs": {
             "type": "string",
             "format": "date-time"
@@ -2785,12 +4225,20 @@
           "isAct": {
             "type": "string",
             "nullable": true,
-            "enum": [ "UNKNOWN", "Y", "N" ]
+            "enum": [
+              "UNKNOWN",
+              "Y",
+              "N"
+            ]
           },
           "isRegulation": {
             "type": "string",
             "nullable": true,
-            "enum": [ "UNKNOWN", "Y", "N" ]
+            "enum": [
+              "UNKNOWN",
+              "Y",
+              "N"
+            ]
           },
           "section": {
             "maxLength": 10,
@@ -2828,10 +4276,16 @@
         }
       },
       "DisputeUpdateRequest": {
-        "required": [ "status", "updateJson", "updateType" ],
+        "required": [
+          "status",
+          "updateJson",
+          "updateType"
+        ],
         "type": "object",
         "properties": {
-          "createdBy": { "type": "string" },
+          "createdBy": {
+            "type": "string"
+          },
           "createdTs": {
             "type": "string",
             "format": "date-time"
@@ -2857,11 +4311,25 @@
           },
           "status": {
             "type": "string",
-            "enum": [ "UNKNOWN", "ACCEPTED", "PENDING", "REJECTED" ]
+            "enum": [
+              "UNKNOWN",
+              "ACCEPTED",
+              "PENDING",
+              "REJECTED"
+            ]
           },
           "updateType": {
             "type": "string",
-            "enum": [ "UNKNOWN", "DISPUTANT_ADDRESS", "DISPUTANT_PHONE", "DISPUTANT_NAME", "COUNT", "DISPUTANT_EMAIL", "DISPUTANT_DOCUMENT", "COURT_OPTIONS" ]
+            "enum": [
+              "UNKNOWN",
+              "DISPUTANT_ADDRESS",
+              "DISPUTANT_PHONE",
+              "DISPUTANT_NAME",
+              "COUNT",
+              "DISPUTANT_EMAIL",
+              "DISPUTANT_DOCUMENT",
+              "COURT_OPTIONS"
+            ]
           },
           "updateJson": {
             "maxLength": 1000,
@@ -2871,10 +4339,15 @@
         }
       },
       "FileHistory": {
-        "required": [ "auditLogEntryType", "disputeId" ],
+        "required": [
+          "auditLogEntryType",
+          "disputeId"
+        ],
         "type": "object",
         "properties": {
-          "createdBy": { "type": "string" },
+          "createdBy": {
+            "type": "string"
+          },
           "createdTs": {
             "type": "string",
             "format": "date-time"
@@ -2900,7 +4373,60 @@
           },
           "auditLogEntryType": {
             "type": "string",
-            "enum": [ "UNKNOWN", "ARFL", "CAIN", "CAWT", "CCAN", "CCON", "CCWR", "CLEG", "CUEM", "CUEV", "CUIN", "CULG", "CUPD", "CUWR", "CUWT", "DURA", "DURR", "EMCA", "EMCF", "EMCR", "EMDC", "EMFD", "EMPR", "EMRJ", "EMRV", "EMST", "EMUP", "EMVF", "ESUR", "FDLD", "FDLS", "FUPD", "FUPS", "FRMK", "INIT", "JASG", "JCNF", "JDIV", "JPRG", "OCNT", "RCLD", "RECN", "SADM", "SCAN", "SPRC", "SREJ", "SUB", "SUPL", "SVAL", "URSR", "VREV", "VSUB" ]
+            "enum": [
+              "UNKNOWN",
+              "ARFL",
+              "CAIN",
+              "CAWT",
+              "CCAN",
+              "CCON",
+              "CCWR",
+              "CLEG",
+              "CUEM",
+              "CUEV",
+              "CUIN",
+              "CULG",
+              "CUPD",
+              "CUWR",
+              "CUWT",
+              "DURA",
+              "DURR",
+              "EMCA",
+              "EMCF",
+              "EMCR",
+              "EMDC",
+              "EMFD",
+              "EMPR",
+              "EMRJ",
+              "EMRV",
+              "EMST",
+              "EMUP",
+              "EMVF",
+              "ESUR",
+              "FDLD",
+              "FDLS",
+              "FUPD",
+              "FUPS",
+              "FRMK",
+              "INIT",
+              "JASG",
+              "JCNF",
+              "JDIV",
+              "JPRG",
+              "OCNT",
+              "RCLD",
+              "RECN",
+              "SADM",
+              "SCAN",
+              "SPRC",
+              "SREJ",
+              "SUB",
+              "SUPL",
+              "SVAL",
+              "URSR",
+              "VREV",
+              "VSUB"
+            ]
           },
           "description": {
             "type": "string",
@@ -2920,7 +4446,9 @@
       "EmailHistory": {
         "type": "object",
         "properties": {
-          "createdBy": { "type": "string" },
+          "createdBy": {
+            "type": "string"
+          },
           "createdTs": {
             "type": "string",
             "format": "date-time"
@@ -2985,7 +4513,11 @@
           },
           "successfullySent": {
             "type": "string",
-            "enum": [ "UNKNOWN", "Y", "N" ]
+            "enum": [
+              "UNKNOWN",
+              "Y",
+              "N"
+            ]
           },
           "occamDisputeId": {
             "type": "integer",
@@ -2999,7 +4531,11 @@
           "reportType": {
             "type": "string",
             "nullable": true,
-            "enum": [ "UNKNOWN", "NOTICE_OF_DISPUTE", "TICKET_IMAGE" ]
+            "enum": [
+              "UNKNOWN",
+              "NOTICE_OF_DISPUTE",
+              "TICKET_IMAGE"
+            ]
           },
           "reportFormat": {
             "type": "string",
@@ -3032,7 +4568,9 @@
             "format": "int64",
             "readOnly": true
           },
-          "ticketNumber": { "type": "string" },
+          "ticketNumber": {
+            "type": "string"
+          },
           "submittedTs": {
             "type": "string",
             "format": "date-time",
@@ -3056,13 +4594,23 @@
           },
           "status": {
             "type": "string",
-            "enum": [ "UNKNOWN", "NEW", "VALIDATED", "PROCESSING", "REJECTED", "CANCELLED", "CONCLUDED" ]
+            "enum": [
+              "UNKNOWN",
+              "NEW",
+              "VALIDATED",
+              "PROCESSING",
+              "REJECTED",
+              "CANCELLED",
+              "CONCLUDED"
+            ]
           },
           "emailAddress": {
             "type": "string",
             "nullable": true
           },
-          "emailAddressVerified": { "type": "boolean" },
+          "emailAddressVerified": {
+            "type": "boolean"
+          },
           "filingDate": {
             "type": "string",
             "format": "date-time",
@@ -3071,7 +4619,11 @@
           "requestCourtAppearanceYn": {
             "type": "string",
             "nullable": true,
-            "enum": [ "UNKNOWN", "Y", "N" ]
+            "enum": [
+              "UNKNOWN",
+              "Y",
+              "N"
+            ]
           },
           "userAssignedTo": {
             "type": "string",
@@ -3085,11 +4637,19 @@
           "disputantDetectedOcrIssues": {
             "type": "string",
             "nullable": true,
-            "enum": [ "UNKNOWN", "Y", "N" ]
+            "enum": [
+              "UNKNOWN",
+              "Y",
+              "N"
+            ]
           },
           "systemDetectedOcrIssues": {
             "type": "string",
-            "enum": [ "UNKNOWN", "Y", "N" ]
+            "enum": [
+              "UNKNOWN",
+              "Y",
+              "N"
+            ]
           },
           "violationDate": {
             "type": "string",
@@ -3099,7 +4659,20 @@
           "jjDisputeStatus": {
             "type": "string",
             "nullable": true,
-            "enum": [ "UNKNOWN", "NEW", "IN_PROGRESS", "DATA_UPDATE", "CONFIRMED", "REQUIRE_COURT_HEARING", "REQUIRE_MORE_INFO", "ACCEPTED", "REVIEW", "CONCLUDED", "CANCELLED", "HEARING_SCHEDULED" ]
+            "enum": [
+              "UNKNOWN",
+              "NEW",
+              "IN_PROGRESS",
+              "DATA_UPDATE",
+              "CONFIRMED",
+              "REQUIRE_COURT_HEARING",
+              "REQUIRE_MORE_INFO",
+              "ACCEPTED",
+              "REVIEW",
+              "CONCLUDED",
+              "CANCELLED",
+              "HEARING_SCHEDULED"
+            ]
           },
           "jjAssignedTo": {
             "type": "string",
@@ -3123,22 +4696,53 @@
             "type": "integer",
             "format": "int64"
           },
-          "noticeOfDisputeGuid": { "type": "string" },
+          "noticeOfDisputeGuid": {
+            "type": "string"
+          },
           "disputeStatus": {
             "type": "string",
-            "enum": [ "UNKNOWN", "NEW", "VALIDATED", "PROCESSING", "REJECTED", "CANCELLED", "CONCLUDED" ]
+            "enum": [
+              "UNKNOWN",
+              "NEW",
+              "VALIDATED",
+              "PROCESSING",
+              "REJECTED",
+              "CANCELLED",
+              "CONCLUDED"
+            ]
           },
           "jjDisputeStatus": {
             "type": "string",
             "nullable": true,
-            "enum": [ "UNKNOWN", "NEW", "IN_PROGRESS", "DATA_UPDATE", "CONFIRMED", "REQUIRE_COURT_HEARING", "REQUIRE_MORE_INFO", "ACCEPTED", "REVIEW", "CONCLUDED", "CANCELLED", "HEARING_SCHEDULED" ]
+            "enum": [
+              "UNKNOWN",
+              "NEW",
+              "IN_PROGRESS",
+              "DATA_UPDATE",
+              "CONFIRMED",
+              "REQUIRE_COURT_HEARING",
+              "REQUIRE_MORE_INFO",
+              "ACCEPTED",
+              "REVIEW",
+              "CONCLUDED",
+              "CANCELLED",
+              "HEARING_SCHEDULED"
+            ]
           },
           "jjDisputeHearingType": {
             "type": "string",
             "nullable": true,
-            "enum": [ "UNKNOWN", "COURT_APPEARANCE", "WRITTEN_REASONS" ]
+            "enum": [
+              "UNKNOWN",
+              "COURT_APPEARANCE",
+              "WRITTEN_REASONS"
+            ]
           },
-          "isEmailAddressVerified": { "type": "boolean" }
+          "isEmailAddressVerified": {
+            "type": "boolean",
+            "description": "Null if there is no email address, true if the email address has been successfully verified, false otherwise.",
+            "nullable": true
+          }
         }
       }
     },

--- a/src/backend/TrafficCourts/Common/OpenAPIs/OracleDataAPI/v1_0/OracleDataApiClient.g.cs
+++ b/src/backend/TrafficCourts/Common/OpenAPIs/OracleDataAPI/v1_0/OracleDataApiClient.g.cs
@@ -673,16 +673,6 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                             throw new ApiException<FileResponse>("Bad Request.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
-                        if (status_ == 405)
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            throw new ApiException<FileResponse>("An invalid JJ Dispute status is provided. Update failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
-                        }
-                        else
                         if (status_ == 404)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
@@ -701,6 +691,16 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             throw new ApiException<FileResponse>("Internal Server Error", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 405)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<FileResponse>("An invalid JJ Dispute status is provided. Update failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 200)
@@ -816,16 +816,6 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                             throw new ApiException<FileResponse>("Bad Request.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
-                        if (status_ == 405)
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            throw new ApiException<FileResponse>("A JJDispute status can only be set to REVIEW if status is CONFIRMED and the remark must be <= 256 characters OR if the status ACCEPTED, CONFIRMED or CONCLUDED and DCF\'s current hearing date = today\'s date. Update failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
-                        }
-                        else
                         if (status_ == 404)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
@@ -844,6 +834,16 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             throw new ApiException<FileResponse>("Internal server error occured.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 405)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<FileResponse>("A JJDispute status can only be set to REVIEW if status is CONFIRMED and the remark must be <= 256 characters OR if the status ACCEPTED, CONFIRMED or CONCLUDED and DCF\'s current hearing date = today\'s date. Update failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 200)
@@ -952,16 +952,6 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                             throw new ApiException<FileResponse>("Bad Request.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
-                        if (status_ == 405)
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            throw new ApiException<FileResponse>("A JJDispute status can only be set to REQUIRE_COURT_HEARING iff status is one of the following: NEW, IN_PROGRESS, REVIEW, REQUIRE_COURT_HEARING and the remark must be <= 256 characters. Update failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
-                        }
-                        else
                         if (status_ == 404)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
@@ -980,6 +970,16 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             throw new ApiException<FileResponse>("Internal server error occured.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 405)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<FileResponse>("A JJDispute status can only be set to REQUIRE_COURT_HEARING iff status is one of the following: NEW, IN_PROGRESS, REVIEW, REQUIRE_COURT_HEARING and the remark must be <= 256 characters. Update failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 200)
@@ -1082,16 +1082,6 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                             throw new ApiException<FileResponse>("Bad Request.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
-                        if (status_ == 405)
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            throw new ApiException<FileResponse>("A JJDispute status can only be set to CONFIRMED iff status is one of the following: REVIEW, NEW, HEARING_SCHEDULED, IN_PROGRESS, CONFIRMED. Update failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
-                        }
-                        else
                         if (status_ == 404)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
@@ -1110,6 +1100,16 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             throw new ApiException<FileResponse>("Internal server error occured.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 405)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<FileResponse>("A JJDispute status can only be set to CONFIRMED iff status is one of the following: REVIEW, NEW, HEARING_SCHEDULED, IN_PROGRESS, CONFIRMED. Update failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 200)
@@ -1218,16 +1218,6 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                             throw new ApiException<FileResponse>("Bad Request.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
-                        if (status_ == 405)
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            throw new ApiException<FileResponse>("Method Not Allowed", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
-                        }
-                        else
                         if (status_ == 404)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
@@ -1246,6 +1236,16 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             throw new ApiException<FileResponse>("Internal server error occured.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 405)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<FileResponse>("Method Not Allowed", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 200)
@@ -1360,16 +1360,6 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                             throw new ApiException<FileResponse>("Bad Request.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
-                        if (status_ == 405)
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            throw new ApiException<FileResponse>("An invalid JJ Dispute status is provided. Update failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
-                        }
-                        else
                         if (status_ == 404)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
@@ -1388,6 +1378,16 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             throw new ApiException<FileResponse>("Internal Server Error", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 405)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<FileResponse>("An invalid JJ Dispute status is provided. Update failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 200)
@@ -1496,16 +1496,6 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                             throw new ApiException<FileResponse>("Bad Request.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
-                        if (status_ == 405)
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            throw new ApiException<FileResponse>("Method Not Allowed", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
-                        }
-                        else
                         if (status_ == 404)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
@@ -1524,6 +1514,16 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             throw new ApiException<FileResponse>("Internal server error occured.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 405)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<FileResponse>("Method Not Allowed", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 200)
@@ -1638,16 +1638,6 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                             throw new ApiException<FileResponse>("Bad Request.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
-                        if (status_ == 405)
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            throw new ApiException<FileResponse>("A JJDispute status can only be set to ACCEPTED iff status is CONFIRMED. Update failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
-                        }
-                        else
                         if (status_ == 404)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
@@ -1666,6 +1656,16 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             throw new ApiException<FileResponse>("Internal server error occured.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 405)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<FileResponse>("A JJDispute status can only be set to ACCEPTED iff status is CONFIRMED. Update failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 200)
@@ -1772,16 +1772,6 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                             throw new ApiException<FileResponse>("Bad Request.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
-                        if (status_ == 405)
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            throw new ApiException<FileResponse>("Method Not Allowed", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
-                        }
-                        else
                         if (status_ == 404)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
@@ -1800,6 +1790,16 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             throw new ApiException<FileResponse>("Internal server error occured.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 405)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<FileResponse>("Method Not Allowed", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 200)
@@ -1902,16 +1902,6 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                             throw new ApiException<FileResponse>("Bad Request.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
-                        if (status_ == 405)
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            throw new ApiException<FileResponse>("Method Not Allowed", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
-                        }
-                        else
                         if (status_ == 404)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
@@ -1930,6 +1920,16 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             throw new ApiException<FileResponse>("Internal Server Error", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 405)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<FileResponse>("Method Not Allowed", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 409)
@@ -2039,16 +2039,6 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                             throw new ApiException<FileResponse>("Bad Request.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
-                        if (status_ == 405)
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            throw new ApiException<FileResponse>("Method Not Allowed", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
-                        }
-                        else
                         if (status_ == 404)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
@@ -2067,6 +2057,16 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             throw new ApiException<FileResponse>("Internal Server Error. Delete failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 405)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<FileResponse>("Method Not Allowed", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 200)
@@ -2164,16 +2164,6 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                             throw new ApiException<FileResponse>("Bad Request.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
-                        if (status_ == 405)
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            throw new ApiException<FileResponse>("A Dispute status can only be set to VALIDATED iff status is NEW. Update failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
-                        }
-                        else
                         if (status_ == 404)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
@@ -2192,6 +2182,16 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             throw new ApiException<FileResponse>("Internal Server Error", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 405)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<FileResponse>("A Dispute status can only be set to VALIDATED iff status is NEW. Update failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 200)
@@ -2304,16 +2304,6 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                             throw new ApiException<FileResponse>("Bad Request.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
-                        if (status_ == 405)
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            throw new ApiException<FileResponse>("A Dispute status can only be set to PROCESSING iff status is NEW or REJECTED. Update failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
-                        }
-                        else
                         if (status_ == 404)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
@@ -2332,6 +2322,16 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             throw new ApiException<FileResponse>("Internal Server Error", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 405)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<FileResponse>("A Dispute status can only be set to PROCESSING iff status is NEW or REJECTED. Update failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 200)
@@ -2450,16 +2450,6 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                             throw new ApiException<FileResponse>("Bad Request.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
-                        if (status_ == 405)
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            throw new ApiException<FileResponse>("A Dispute status can only be set to REJECTED iff status is NEW or VALIDATED and the rejected reason must be <= 256 characters. Update failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
-                        }
-                        else
                         if (status_ == 404)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
@@ -2478,6 +2468,16 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             throw new ApiException<FileResponse>("Internal Server Error", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 405)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<FileResponse>("A Dispute status can only be set to REJECTED iff status is NEW or VALIDATED and the rejected reason must be <= 256 characters. Update failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 200)
@@ -2591,16 +2591,6 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                             throw new ApiException<FileResponse>("Bad Request", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
-                        if (status_ == 405)
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            throw new ApiException<FileResponse>("Method Not Allowed", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
-                        }
-                        else
                         if (status_ == 404)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
@@ -2619,6 +2609,16 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             throw new ApiException<FileResponse>("Internal server error occured.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 405)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<FileResponse>("Method Not Allowed", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 200)
@@ -2726,16 +2726,6 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                             throw new ApiException<FileResponse>("If the email address is > 100 characters", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
-                        if (status_ == 405)
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            throw new ApiException<FileResponse>("Method Not Allowed", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
-                        }
-                        else
                         if (status_ == 404)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
@@ -2754,6 +2744,16 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             throw new ApiException<FileResponse>("Internal server error occured.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 405)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<FileResponse>("Method Not Allowed", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 200)
@@ -2862,16 +2862,6 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                             throw new ApiException<FileResponse>("Bad Request.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
-                        if (status_ == 405)
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            throw new ApiException<FileResponse>("A Dispute status can only be set to CANCELLED iff status is NEW, REJECTED or PROCESSING. Update failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
-                        }
-                        else
                         if (status_ == 404)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
@@ -2890,6 +2880,16 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             throw new ApiException<FileResponse>("Internal Server Error", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 405)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<FileResponse>("A Dispute status can only be set to CANCELLED iff status is NEW, REJECTED or PROCESSING. Update failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 200)
@@ -3011,16 +3011,6 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                             throw new ApiException<FileResponse>("Bad Request", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
-                        if (status_ == 405)
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            throw new ApiException<FileResponse>("Method Not Allowed", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
-                        }
-                        else
                         if (status_ == 404)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
@@ -3039,6 +3029,16 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             throw new ApiException<FileResponse>("Internal Server Error. Save failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 405)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<FileResponse>("Method Not Allowed", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 200)
@@ -3142,16 +3142,6 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                             throw new ApiException<FileResponse>("Bad Request.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
-                        if (status_ == 405)
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            throw new ApiException<FileResponse>("Method Not Allowed", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
-                        }
-                        else
                         if (status_ == 404)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
@@ -3170,6 +3160,16 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             throw new ApiException<FileResponse>("Internal Server Error", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 405)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<FileResponse>("Method Not Allowed", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 200)
@@ -3273,16 +3273,6 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                             throw new ApiException<FileResponse>("Bad Request.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
-                        if (status_ == 405)
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            throw new ApiException<FileResponse>("Method Not Allowed", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
-                        }
-                        else
                         if (status_ == 404)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
@@ -3301,6 +3291,16 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             throw new ApiException<FileResponse>("Internal Server Error", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 405)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<FileResponse>("Method Not Allowed", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 200)
@@ -3398,16 +3398,6 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                             throw new ApiException<FileResponse>("Bad Request", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
-                        if (status_ == 405)
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            throw new ApiException<FileResponse>("Method Not Allowed", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
-                        }
-                        else
                         if (status_ == 404)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
@@ -3426,6 +3416,16 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             throw new ApiException<FileResponse>("Internal Server Error", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 405)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<FileResponse>("Method Not Allowed", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 200)
@@ -3536,16 +3536,6 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                             throw new ApiException<FileResponse>("Bad Request", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
-                        if (status_ == 405)
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            throw new ApiException<FileResponse>("Method Not Allowed", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
-                        }
-                        else
                         if (status_ == 404)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
@@ -3564,6 +3554,16 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             throw new ApiException<FileResponse>("Internal Server Error. Save failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 405)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<FileResponse>("Method Not Allowed", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 200)
@@ -3668,16 +3668,6 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                             throw new ApiException<FileResponse>("Bad Request", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
-                        if (status_ == 405)
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            throw new ApiException<FileResponse>("Method Not Allowed", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
-                        }
-                        else
                         if (status_ == 404)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
@@ -3696,6 +3686,16 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             throw new ApiException<FileResponse>("Internal Server Error", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 405)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<FileResponse>("Method Not Allowed", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 200)
@@ -3797,16 +3797,6 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                             throw new ApiException<FileResponse>("Bad Request", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
-                        if (status_ == 405)
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            throw new ApiException<FileResponse>("Method Not Allowed", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
-                        }
-                        else
                         if (status_ == 404)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
@@ -3825,6 +3815,16 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             throw new ApiException<FileResponse>("Internal Server Error", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 405)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<FileResponse>("Method Not Allowed", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 200)
@@ -3924,16 +3924,6 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                             throw new ApiException<FileResponse>("Bad Request", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
-                        if (status_ == 405)
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            throw new ApiException<FileResponse>("Method Not Allowed", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
-                        }
-                        else
                         if (status_ == 404)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
@@ -3952,6 +3942,16 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             throw new ApiException<FileResponse>("Internal Server Error", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 405)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<FileResponse>("Method Not Allowed", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 200)
@@ -4048,16 +4048,6 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                             throw new ApiException<FileResponse>("Bad Request", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
-                        if (status_ == 405)
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            throw new ApiException<FileResponse>("Method Not Allowed", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
-                        }
-                        else
                         if (status_ == 404)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
@@ -4076,6 +4066,16 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             throw new ApiException<FileResponse>("Internal Server Error", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 405)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<FileResponse>("Method Not Allowed", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 200)
@@ -4172,16 +4172,6 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                             throw new ApiException<FileResponse>("Bad Request", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
-                        if (status_ == 405)
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            throw new ApiException<FileResponse>("Method Not Allowed", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
-                        }
-                        else
                         if (status_ == 404)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
@@ -4200,6 +4190,16 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             throw new ApiException<FileResponse>("Internal Server Error", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 405)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<FileResponse>("Method Not Allowed", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 200)
@@ -4310,16 +4310,6 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                             throw new ApiException<FileResponse>("Bad Request.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
-                        if (status_ == 405)
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            throw new ApiException<FileResponse>("Method Not Allowed", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
-                        }
-                        else
                         if (status_ == 404)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
@@ -4338,6 +4328,16 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             throw new ApiException<FileResponse>("Internal Server Error. Getting disputes failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 405)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<FileResponse>("Method Not Allowed", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 200)
@@ -4439,16 +4439,6 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                             throw new ApiException<FileResponse>("Bad Request", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
-                        if (status_ == 405)
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            throw new ApiException<FileResponse>("Method Not Allowed", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
-                        }
-                        else
                         if (status_ == 404)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
@@ -4467,6 +4457,16 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             throw new ApiException<FileResponse>("Internal Server Error. Unassigned failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 405)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<FileResponse>("Method Not Allowed", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 200)
@@ -4561,16 +4561,6 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                             throw new ApiException<FileResponse>("Bad Request", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
-                        if (status_ == 405)
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            throw new ApiException<FileResponse>("Method Not Allowed", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
-                        }
-                        else
                         if (status_ == 404)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
@@ -4589,6 +4579,16 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             throw new ApiException<FileResponse>("Internal Server Error", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 405)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<FileResponse>("Method Not Allowed", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 200)
@@ -4699,16 +4699,6 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                             throw new ApiException<FileResponse>("Bad Request", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
-                        if (status_ == 405)
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            throw new ApiException<FileResponse>("Method Not Allowed", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
-                        }
-                        else
                         if (status_ == 404)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
@@ -4727,6 +4717,16 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             throw new ApiException<FileResponse>("Internal Server Error. retrieve update requests failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 405)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<FileResponse>("Method Not Allowed", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 200)
@@ -4843,16 +4843,6 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                             throw new ApiException<FileResponse>("Bad Request, check parameters.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
-                        if (status_ == 405)
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            throw new ApiException<FileResponse>("Method Not Allowed", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
-                        }
-                        else
                         if (status_ == 404)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
@@ -4871,6 +4861,16 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             throw new ApiException<FileResponse>("Internal Server Error. Search failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 405)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<FileResponse>("Method Not Allowed", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 200)
@@ -4973,16 +4973,6 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                             throw new ApiException<FileResponse>("Bad Request", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
-                        if (status_ == 405)
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            throw new ApiException<FileResponse>("Method Not Allowed", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
-                        }
-                        else
                         if (status_ == 404)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
@@ -5001,6 +4991,16 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             throw new ApiException<FileResponse>("Internal server error occured.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 405)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<FileResponse>("Method Not Allowed", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 200)
@@ -5102,16 +5102,6 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                             throw new ApiException<FileResponse>("Bad Request", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
-                        if (status_ == 405)
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            throw new ApiException<FileResponse>("Method Not Allowed", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
-                        }
-                        else
                         if (status_ == 404)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
@@ -5130,6 +5120,16 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             throw new ApiException<FileResponse>("Internal Server Error", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 405)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<FileResponse>("Method Not Allowed", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 200)
@@ -5234,16 +5234,6 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                             throw new ApiException<FileResponse>("Bad Request.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
-                        if (status_ == 405)
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
-                            if (objectResponse_.Object == null)
-                            {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
-                            }
-                            throw new ApiException<FileResponse>("Method Not Allowed", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
-                        }
-                        else
                         if (status_ == 404)
                         {
                             var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
@@ -5262,6 +5252,16 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
                             throw new ApiException<FileResponse>("Internal Server Error. Delete failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ == 405)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<FileResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<FileResponse>("Method Not Allowed", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 200)
@@ -6753,8 +6753,11 @@ namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0
         [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
         public DisputeResultJjDisputeHearingType? JjDisputeHearingType { get; set; }
 
-        [Newtonsoft.Json.JsonProperty("isEmailAddressVerified", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public bool IsEmailAddressVerified { get; set; }
+        /// <summary>
+        /// Null if there is no email address, true if the email address has been successfully verified, false otherwise.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("isEmailAddressVerified", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public bool? IsEmailAddressVerified { get; set; }
 
         private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
 

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/controller/v1_0/DisputeController.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/controller/v1_0/DisputeController.java
@@ -3,7 +3,6 @@ package ca.bc.gov.open.jag.tco.oracledataapi.controller.v1_0;
 import java.security.Principal;
 import java.util.Date;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotBlank;
@@ -29,7 +28,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import ca.bc.gov.open.jag.tco.oracledataapi.mapper.DisputeMapper;
 import ca.bc.gov.open.jag.tco.oracledataapi.model.Dispute;
 import ca.bc.gov.open.jag.tco.oracledataapi.model.DisputeListItem;
 import ca.bc.gov.open.jag.tco.oracledataapi.model.DisputeResult;

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/model/DisputeResult.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/model/DisputeResult.java
@@ -24,14 +24,15 @@ public class DisputeResult {
 	@Schema(nullable = true)
 	private JJDisputeHearingType jjDisputeHearingType;
 
-	private Boolean isEmailAddressVerified = Boolean.FALSE;
+	@Schema(nullable = true, description = "Null if there is no email address, true if the email address has been successfully verified, false otherwise.")
+	private Boolean isEmailAddressVerified;
 
 	/**
 	 * 
 	 * @param disputeId
 	 * @param noticeOfDisputeGuid
 	 * @param disputeStatus
-	 * @param isEmailAddressVerified TRUE if there is no email address or if the email address has been successfully verified, FALSE otherwise.
+	 * @param isEmailAddressVerified <code>NULL</code> if there is no email address, <code>TRUE</code> if the email address has been successfully verified, <code>FALSE</code> otherwise.
 	 */
 	public DisputeResult(Long disputeId, String noticeOfDisputeGuid, DisputeStatus disputeStatus, Boolean isEmailAddressVerified) {
 		this.disputeId = disputeId;

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/repository/impl/ords/DisputeRepositoryImpl.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/repository/impl/ords/DisputeRepositoryImpl.java
@@ -107,7 +107,7 @@ public class DisputeRepositoryImpl implements DisputeRepository {
 						dispute.getDisputeId(),
 						dispute.getNoticeOfDisputeGuid(),
 						dispute.getStatus(),
-						StringUtils.isBlank(dispute.getEmailAddress()) ? Boolean.TRUE : dispute.getEmailAddressVerified()))
+						StringUtils.isBlank(dispute.getEmailAddress()) ? null : dispute.getEmailAddressVerified()))
 				.collect(Collectors.toList());
 
 		return disputeResults;
@@ -125,7 +125,7 @@ public class DisputeRepositoryImpl implements DisputeRepository {
 						dispute.getDisputeId(),
 						dispute.getNoticeOfDisputeGuid(),
 						dispute.getStatus(),
-						StringUtils.isBlank(dispute.getEmailAddress()) ? Boolean.TRUE : dispute.getEmailAddressVerified()))
+						StringUtils.isBlank(dispute.getEmailAddress()) ? null : dispute.getEmailAddressVerified()))
 				.collect(Collectors.toList());
 
 		return disputeResults;

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/service/DisputeService.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/service/DisputeService.java
@@ -373,7 +373,7 @@ public class DisputeService {
 						dispute.getDisputeId(),
 						dispute.getNoticeOfDisputeGuid(),
 						dispute.getStatus(),
-						StringUtils.isBlank(dispute.getEmailAddress()) ? Boolean.TRUE : dispute.getEmailAddressVerified()));
+						StringUtils.isBlank(dispute.getEmailAddress()) ? null : dispute.getEmailAddressVerified()));
 				ticketNumber = dispute.getTicketNumber();
 				issuedTime = dispute.getIssuedTs();
 			}

--- a/src/frontend/citizen-portal/src/app/components/disputant-form/disputant-form.component.ts
+++ b/src/frontend/citizen-portal/src/app/components/disputant-form/disputant-form.component.ts
@@ -20,6 +20,7 @@ export class DisputantFormComponent implements OnInit, AfterViewInit {
   @Input() isMobile: boolean;
   @Input() mode: DisputeFormMode;
   @Input() form: NoticeOfDisputeFormGroup | DisputantContactInformationFormGroup;
+  @Input() preferEmail: boolean;
   @ViewChild(AddressAutocompleteComponent) private addressAutocomplete: AddressAutocompleteComponent;
 
   DisputeFormMode = DisputeFormMode;
@@ -96,7 +97,7 @@ export class DisputantFormComponent implements OnInit, AfterViewInit {
       this.driversLicenceProvinceFormControl.setValue(this.bc);
     }
 
-    if (!form.value.email_address && (this.mode === this.DisputeFormMode.UPDATE || this.mode === this.DisputeFormMode.UPDATEDISPUTANT)) {
+    if (!this.preferEmail) {
       this.form.controls.email_address.disable();
       this.optOut = true;
     }

--- a/src/frontend/citizen-portal/src/app/components/update-dispute-contact/update-dispute-contact.component.html
+++ b/src/frontend/citizen-portal/src/app/components/update-dispute-contact/update-dispute-contact.component.html
@@ -12,7 +12,7 @@ Your current contact information on file is not being displayed to protect your 
     <app-resolution-header></app-resolution-header>
   </section>
 
-  <app-disputant-form *ngIf="form" [form]="form" [mode]="mode"></app-disputant-form>
+  <app-disputant-form *ngIf="form" [form]="form" [mode]="mode" [preferEmail]="preferEmail"></app-disputant-form>
 
   <div fxLayout="row" class="my-4 d-print-none">
     <button fxFlex="25" mat-stroked-button color="primary" class="large" (click)="back()">

--- a/src/frontend/citizen-portal/src/app/components/update-dispute-contact/update-dispute-contact.component.ts
+++ b/src/frontend/citizen-portal/src/app/components/update-dispute-contact/update-dispute-contact.component.ts
@@ -1,4 +1,5 @@
 import { ChangeDetectionStrategy, Component, OnInit } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
 import { Store } from '@ngrx/store';
 import { DisputeFormMode } from '@shared/enums/dispute-form-mode';
 import { DisputeService } from 'app/services/dispute.service';
@@ -17,14 +18,18 @@ export class UpdateDisputeContactComponent implements OnInit {
   form: DisputantContactInformationFormGroup;
 
   private state: DisputeStore.State;
+  public preferEmail: boolean = true;
 
   constructor(
     private disputeService: DisputeService,
     private store: Store,
+    private route: ActivatedRoute
   ) {
   }
 
   ngOnInit(): void {
+    this.preferEmail = this.route.snapshot.queryParamMap.get('preferEmail') === 'true' ? true : false;
+    
     this.disputeService.checkStoredDispute().subscribe(found => {
       if (found) {
         this.form = this.disputeService.getDisputantForm();

--- a/src/frontend/citizen-portal/src/app/components/update-dispute-landing/update-dispute-landing.component.html
+++ b/src/frontend/citizen-portal/src/app/components/update-dispute-landing/update-dispute-landing.component.html
@@ -23,7 +23,7 @@
       <div fxFlex="32">
         <div class="option">
           <button type="button" mat-flat-button color="primary" class="large" (click)="goToUpdateDispute()" 
-              [disabled]="!isEmailVerified" title="{{ isEmailVerified ? '' : 'Email address not yet verified' }}">
+              [disabled]="isEmailVerified === false" title="{{ isEmailVerified ? '' : 'Email address not yet verified' }}">
             <h2><b>Change Dispute</b></h2>
           </button>
           <div>Change your contact information, plea or court options, or upload additional supporting documents to

--- a/src/frontend/citizen-portal/src/app/components/update-dispute-landing/update-dispute-landing.component.ts
+++ b/src/frontend/citizen-portal/src/app/components/update-dispute-landing/update-dispute-landing.component.ts
@@ -18,7 +18,7 @@ export class UpdateDisputeLandingComponent implements OnInit {
   private nonEditableStatus = [JJDisputeStatus.Cancelled, JJDisputeStatus.Concluded, DisputeStatus.Concluded, DisputeStatus.Cancelled, DisputeStatus.Rejected];
   public isEditable: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(false);
   public bcServicesCardInfoLink: string;
-  public isEmailVerified: boolean = false;
+  public isEmailVerified: boolean | null = null;
 
   constructor(
     private appConfigService: AppConfigService,
@@ -42,8 +42,8 @@ export class UpdateDisputeLandingComponent implements OnInit {
             else if (dispute.hearing_type === JJDisputeHearingType.WrittenReasons && dispute.jjdispute_status) this.isEditable.next(false); // written reasons and has a jj workbench status
             else this.isEditable.next(true); // otherwise allow editing
 
-            this.isEmailVerified = dispute?.is_email_verified ? true : false;
-            if (!this.isEmailVerified) {
+            this.isEmailVerified = dispute?.is_email_verified === null ? null : dispute?.is_email_verified;
+            if (this.isEmailVerified === false) {
               this.disputeService.openDisputantEmailNotVerifiedDialog();
             }
           }
@@ -61,6 +61,6 @@ export class UpdateDisputeLandingComponent implements OnInit {
   }
 
   goToUpdateDisputeContact(): void {
-    this.disputeService.goToUpdateDisputeContact(this.state.params);
+    this.disputeService.goToUpdateDisputeContact(this.state.params, this.isEmailVerified !== null);
   }
 }

--- a/src/frontend/citizen-portal/src/app/services/dispute.service.ts
+++ b/src/frontend/citizen-portal/src/app/services/dispute.service.ts
@@ -165,9 +165,9 @@ export class DisputeService {
     });
   }
 
-  goToUpdateDisputeContact(params: QueryParamsForSearch): void {
+  goToUpdateDisputeContact(params: QueryParamsForSearch, preferEmail: boolean): void {
     this.router.navigate([AppRoutes.disputePath(AppRoutes.UPDATE_DISPUTE_CONTACT)], {
-      queryParams: params,
+      queryParams: { ...params, preferEmail: preferEmail },
     })
   }
 


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

TCVP-2702
Change of requirements - On the Update Dispute Request screen, the opting out should be based on whether the user had previously opted out of email or not.
- modified DisputeResult.isEmailAddressVerified to be a tri-state variable (null for opted out, true for verified, false for not verfied)
- updated openapi client in .NET
- passed isEmailAddressVerified through to Update Dispute screen and defaulted the opted out based on that.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change
- [x] Change request

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
