### PR TITLE
TCVP-2712 hide update dispute options for specific court dispute types

### DIFF
--- a/src/frontend/citizen-portal/src/app/components/update-dispute-landing/update-dispute-landing.component.ts
+++ b/src/frontend/citizen-portal/src/app/components/update-dispute-landing/update-dispute-landing.component.ts
@@ -16,6 +16,7 @@ import { BehaviorSubject } from 'rxjs';
 export class UpdateDisputeLandingComponent implements OnInit {
   private state: DisputeStore.State;
   private nonEditableStatus = [JJDisputeStatus.Cancelled, JJDisputeStatus.Concluded, DisputeStatus.Concluded, DisputeStatus.Cancelled, DisputeStatus.Rejected];
+  private completedJJStatuses = [JJDisputeStatus.Accepted, JJDisputeStatus.Concluded];
   public isEditable: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(false);
   public bcServicesCardInfoLink: string;
   public isEmailVerified: boolean | null = null;
@@ -40,6 +41,8 @@ export class UpdateDisputeLandingComponent implements OnInit {
             else if (this.nonEditableStatus.includes(dispute.dispute_status)) this.isEditable.next(false); // OCCAM dispute done
             else if (this.nonEditableStatus.includes(dispute.jjdispute_status)) this.isEditable.next(false); // JJ Dispute over
             else if (dispute.hearing_type === JJDisputeHearingType.WrittenReasons && dispute.jjdispute_status) this.isEditable.next(false); // written reasons and has a jj workbench status
+            // TCVP-2712 Do not show Change Address or Change Dispute for Completed Hearing Disputes
+            else if (this.completedJJStatuses.includes(dispute.jjdispute_status)) this.isEditable.next(false); // Has a completed JJDisputeStatus
             else this.isEditable.next(true); // otherwise allow editing
 
             this.isEmailVerified = dispute?.is_email_verified === null ? null : dispute?.is_email_verified;


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

TCVP-2712 This PR is a change request to hide the Change Contact and Change Dispute widgets on the citizen portal update requests screen if the Dispute is a hearing dispute and has a status of Accepted or Concluded.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
