### PR TITLE
Adjust default logging levels

### DIFF
--- a/src/backend/TrafficCourts/Citizen.Service/appsettings.json
+++ b/src/backend/TrafficCourts/Citizen.Service/appsettings.json
@@ -11,7 +11,8 @@
     "MinimumLevel": {
       "Default": "Information",
       "Override": {
-        "Microsoft.AspNetCore": "Warning",
+        "Microsoft": "Warning",
+        "Microsoft.AspNetCore.DataProtection": "Error",
         "Polly": "Warning",
         "System": "Warning"
       }

--- a/src/backend/TrafficCourts/Staff.Service/appsettings.json
+++ b/src/backend/TrafficCourts/Staff.Service/appsettings.json
@@ -13,6 +13,7 @@
       "Override": {
         "MassTransit": "Warning",
         "Microsoft": "Warning",
+        "Microsoft.AspNetCore.DataProtection": "Error",
         "Polly": "Warning",
         "System": "Warning"
       }

--- a/src/backend/TrafficCourts/Workflow.Service/appsettings.json
+++ b/src/backend/TrafficCourts/Workflow.Service/appsettings.json
@@ -13,6 +13,7 @@
       "Override": {
         "MassTransit": "Warning",
         "Microsoft": "Warning",
+        "Microsoft.AspNetCore.DataProtection": "Error",
         "Polly": "Warning",
         "System": "Warning"
       }


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- Adjusts the default logging levels to avoid noise in the logs
- Prevents the warning ` No XML encryptor configured. Key {KeyId:B} may be persisted to storage in unencrypted form.` from `Microsoft.AspNetCore.DataProtection.KeyManagement.XmlKeyManager`. We are not CSRF or token generation in our applications. See [[No XML encryptor configured warning](https://github.com/dotnet/aspnetcore/issues/3309#top)](https://github.com/dotnet/aspnetcore/issues/3309#issuecomment-404246838)
