### PR TITLE
TCVP-2720 Fix Inconsistent Appearance Time

### DIFF
--- a/src/frontend/staff-portal/src/app/components/jj-workbench/jj-dispute-hearing-inbox/jj-dispute-hearing-inbox.component.html
+++ b/src/frontend/staff-portal/src/app/components/jj-workbench/jj-dispute-hearing-inbox/jj-dispute-hearing-inbox.component.html
@@ -81,7 +81,7 @@
         DATE / TIME
       </th>
       <td mat-cell *matCellDef="let element">
-        <span>{{ element.mostRecentCourtAppearance?.appearanceTs | date: "MM/dd/YYYY HH:mm" }}</span>
+        <span>{{ element.mostRecentCourtAppearance?.appearanceTs | date: "MM/dd/YYYY HH:mm" : "UTC" }}</span>
       </td>
     </ng-container>
 


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- [TCVP-2720](https://justice.gov.bc.ca/jira/browse/TCVP-2720)
- Fixed the inconsistent time between list and detail view of hearing disputes for appearance date/time by not adjusting the date/time displayed on list view to browser's time since it should be displayed as it is from the response.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
