### PR TITLE
TCVP-2706 Force MVA/R selection to Count Statute Act lookup

### DIFF
--- a/src/backend/TrafficCourts/Common/Models/OcrViolationTicket.cs
+++ b/src/backend/TrafficCourts/Common/Models/OcrViolationTicket.cs
@@ -149,6 +149,10 @@ public class Field
     private static readonly string _dateRegex = @"^\s*(\d{2}|\d{4})\D*(\d{1,2})\D*(\d{1,2})\s*$";
     private static readonly string _timeRegex = @"^\s*(\d{1,2})\s*:?\s*(\d{1,2})\s*$";
     private static readonly string _currencyRegex = @"^\$?(\d{1,3}(\,\d{3})*|(\d+))(\.\d{2})?$";
+    public static readonly string _mva = "MVA";
+    public static readonly string _mvar = "MVAR";
+    public static readonly string _selected = "selected";
+    public static readonly string _unselected = "unselected";
 
     public Field() { }
 

--- a/src/backend/TrafficCourts/Test/Citizen.Service/Validators/FormRecognizerValidatorTest.cs
+++ b/src/backend/TrafficCourts/Test/Citizen.Service/Validators/FormRecognizerValidatorTest.cs
@@ -1,0 +1,99 @@
+using Moq;
+using TrafficCourts.Citizen.Service.Validators;
+using TrafficCourts.Common.Features.Lookups;
+using TrafficCourts.Common.Models;
+using TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0;
+using Xunit;
+
+namespace TrafficCourts.Test.Citizen.Service.Validators;
+
+public class FormRecognizerValidatorTest
+{
+    [Fact]
+    public void TestSanitize_MVAStatuteExists()
+    {
+        // isMVA should be overwritten to _selected if the section text references a valid MVA Statute
+
+        // Given
+        Statute statute = new Statute("19590", "MVA", "100", "1", "a", "", "MVA 100(1)(a)", "Fail to stop/police pursuit", "Fail to stop/police pursuit");
+        var _statuteLookupService = new Mock<IStatuteLookupService>();
+        _statuteLookupService.Setup(x => x.GetBySectionAsync("100(1)(a)")).ReturnsAsync(statute);
+        FormRecognizerValidator formRecognizerValidator = new FormRecognizerValidator(_statuteLookupService.Object);
+
+        OcrViolationTicket violationTicket = new ();
+        violationTicket.Fields.Add(OcrViolationTicket.OffenceIsMVA, new Field("unknown"));
+        violationTicket.Fields.Add(OcrViolationTicket.Count1Section, new Field("100(1)(a)"));
+
+        // When
+        formRecognizerValidator.Sanitize(violationTicket);
+
+        // Then
+        Assert.Equal(Field._selected, violationTicket.Fields[OcrViolationTicket.OffenceIsMVA].Value);
+    }
+
+    [Fact]
+    public void TestSanitize_MVAStatuteDoesntExist()
+    {
+        // isMVA should be overwritten to _unselected if the section text is blank or does not reference a valid MVA Statute.
+
+        // Given
+        Statute statute = new Statute("19590", "MVA", "100", "1", "a", "", "MVA 100(1)(a)", "Fail to stop/police pursuit", "Fail to stop/police pursuit");
+        var _statuteLookupService = new Mock<IStatuteLookupService>();
+        _statuteLookupService.Setup(x => x.GetBySectionAsync("100(1)(a)")).ReturnsAsync(statute);
+        FormRecognizerValidator formRecognizerValidator = new FormRecognizerValidator(_statuteLookupService.Object);
+
+        OcrViolationTicket violationTicket = new ();
+        violationTicket.Fields.Add(OcrViolationTicket.OffenceIsMVA, new Field("unknown"));
+        violationTicket.Fields.Add(OcrViolationTicket.Count1Section, new Field("777"));
+
+        // When
+        formRecognizerValidator.Sanitize(violationTicket);
+
+        // Then
+        Assert.Equal(Field._unselected, violationTicket.Fields[OcrViolationTicket.OffenceIsMVA].Value);
+    }
+    
+    [Fact]
+    public void TestSanitize_MVARStatuteExists()
+    {
+        // isMVAR should be overwritten to _selected if the section text references a valid MVA Statute
+
+        // Given
+        Statute statute = new Statute("19590", "MVAR", "100", "1", "a", "", "MVAR 100(1)(a)", "Fail to stop/police pursuit", "Fail to stop/police pursuit");
+        var _statuteLookupService = new Mock<IStatuteLookupService>();
+        _statuteLookupService.Setup(x => x.GetBySectionAsync("100(1)(a)")).ReturnsAsync(statute);
+        FormRecognizerValidator formRecognizerValidator = new FormRecognizerValidator(_statuteLookupService.Object);
+
+        OcrViolationTicket violationTicket = new ();
+        violationTicket.Fields.Add(OcrViolationTicket.OffenceIsMVAR, new Field("unknown"));
+        violationTicket.Fields.Add(OcrViolationTicket.Count1Section, new Field("100(1)(a)"));
+
+        // When
+        formRecognizerValidator.Sanitize(violationTicket);
+
+        // Then
+        Assert.Equal(Field._selected, violationTicket.Fields[OcrViolationTicket.OffenceIsMVAR].Value);
+    }
+
+    [Fact]
+    public void TestSanitize_MVARStatuteDoesntExist()
+    {
+        // isMVA should be overwritten to _unselected if the section text is blank or does not reference a valid MVA Statute.
+
+        // Given
+        Statute statute = new Statute("19590", "MVAR", "100", "1", "a", "", "MVAR 100(1)(a)", "Fail to stop/police pursuit", "Fail to stop/police pursuit");
+        var _statuteLookupService = new Mock<IStatuteLookupService>();
+        _statuteLookupService.Setup(x => x.GetBySectionAsync("100(1)(a)")).ReturnsAsync(statute);
+        FormRecognizerValidator formRecognizerValidator = new FormRecognizerValidator(_statuteLookupService.Object);
+
+        OcrViolationTicket violationTicket = new ();
+        violationTicket.Fields.Add(OcrViolationTicket.OffenceIsMVAR, new Field("unknown"));
+        violationTicket.Fields.Add(OcrViolationTicket.Count1Section, new Field("777"));
+
+        // When
+        formRecognizerValidator.Sanitize(violationTicket);
+
+        // Then
+        Assert.Equal(Field._unselected, violationTicket.Fields[OcrViolationTicket.OffenceIsMVAR].Value);
+    }
+}

--- a/src/backend/TrafficCourts/Test/Citizen.Service/Validators/Rules/CountActRegMustBeMVATest.cs
+++ b/src/backend/TrafficCourts/Test/Citizen.Service/Validators/Rules/CountActRegMustBeMVATest.cs
@@ -1,6 +1,8 @@
-﻿using System.Threading.Tasks;
+﻿using Moq;
+using System.Threading.Tasks;
 using TrafficCourts.Citizen.Service.Validators;
 using TrafficCourts.Citizen.Service.Validators.Rules;
+using TrafficCourts.Common.Features.Lookups;
 using TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0;
 using Xunit;
 
@@ -50,9 +52,11 @@ public class CountActRegMustBeMVATest
         violationTicket.Fields.Add(OcrViolationTicket.Count1ActRegs, actRegField);
         violationTicket.Fields.Add(OcrViolationTicket.Count1Section, sectionField);
         CountActRegMustBeMVA rule = new(actRegField, 1);
+        var _statuteLookupService = new Mock<IStatuteLookupService>();
+        FormRecognizerValidator formRecognizerValidator = new FormRecognizerValidator(_statuteLookupService.Object);
 
         // When
-        FormRecognizerValidator.Sanitize(violationTicket);
+        formRecognizerValidator.Sanitize(violationTicket);
         await rule.RunAsync();
 
         // Then.

--- a/src/backend/TrafficCourts/Test/Citizen.Service/Validators/Rules/DateOfServiceLT30RuleTest.cs
+++ b/src/backend/TrafficCourts/Test/Citizen.Service/Validators/Rules/DateOfServiceLT30RuleTest.cs
@@ -1,7 +1,9 @@
+using Moq;
 using System;
 using System.Threading.Tasks;
 using TrafficCourts.Citizen.Service.Validators;
 using TrafficCourts.Citizen.Service.Validators.Rules;
+using TrafficCourts.Common.Features.Lookups;
 using TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0;
 using Xunit;
 
@@ -59,9 +61,11 @@ public class DateOfServiceLT30RuleTest
         violationTicket.TicketVersion = ViolationTicketVersion.VT2;
         violationTicket.Fields.Add(OcrViolationTicket.ViolationDate, new Field(violationDateStr));
         violationTicket.Fields.Add(OcrViolationTicket.DateOfService, new Field(dateOfServiceStr));
-        
+        var _statuteLookupService = new Mock<IStatuteLookupService>();
+        FormRecognizerValidator formRecognizerValidator = new FormRecognizerValidator(_statuteLookupService.Object);
+
         // When
-        FormRecognizerValidator.Sanitize(violationTicket);
+        formRecognizerValidator.Sanitize(violationTicket);
 
         // Then
         Assert.Equal(violationTicket.Fields[OcrViolationTicket.ViolationDate].GetDate()?.ToString("yyyy-MM-dd"), expectedVDStr);


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

TCVP-2706
It appears that Form Recognizer (v2.1) does a poor job at recognizing checkboxes.
Instead of the detected values, use the counts to lookup statutes and if they are valid, replace MVA/MVAR Did Commit checkbox selections with identified Statute act codes.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change
- [x] Hacky workaround

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Added new XUnit tests

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
