### PR TITLE
TCVP-2748 Replace empty province values with N/A

### DIFF
--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/service/DisputeService.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/service/DisputeService.java
@@ -205,7 +205,7 @@ public class DisputeService {
 		return updatedDispute;
 	}
 	
-	private void replaceProvinceValuesWithNA(Dispute disputeToUpdate) {
+	protected void replaceProvinceValuesWithNA(Dispute disputeToUpdate) {
 	    if (disputeToUpdate.getAddressProvinceCountryId() == null && disputeToUpdate.getAddressProvinceSeqNo() == null && StringUtils.isBlank(disputeToUpdate.getAddressProvince())) {
 	        disputeToUpdate.setAddressProvince(NA);
 	    }
@@ -215,7 +215,7 @@ public class DisputeService {
 	    }
 	}
 	
-	private void replaceNAValuesWithEmpty(Dispute disputeToUpdate) {
+	protected void replaceNAValuesWithEmpty(Dispute disputeToUpdate) {
 	    if (NA.equals(disputeToUpdate.getAddressProvince())) {
 	        disputeToUpdate.setAddressProvince("");
 	    }

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/service/DisputeService.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/service/DisputeService.java
@@ -49,6 +49,8 @@ public class DisputeService {
 
 	@Autowired
 	private DisputeUpdateRequestRepository disputeUpdateRequestRepository;
+	
+	private static final String NA = "N/A";
 
 	/**
 	 * Retrieves all {@link DisputeListItem} records
@@ -83,7 +85,12 @@ public class DisputeService {
 	 * @return
 	 */
 	public Dispute getDisputeById(Long id) {
-		return disputeRepository.findById(id).orElseThrow();
+		Dispute dispute = disputeRepository.findById(id).orElseThrow();
+		
+		// TCVP-2748 - Replace NA values with empty strings
+		replaceNAValuesWithEmpty(dispute);
+		
+		return dispute;
 	}
 
 	/**
@@ -143,6 +150,10 @@ public class DisputeService {
 		}
 
 		BeanUtils.copyProperties(dispute, disputeToUpdate, "createdBy", "createdTs", "disputeId", "disputeCounts", "violationTicket");
+		
+		// TCVP-2748 Replace null province values with NA if specific province IDs are null since db check constraints expect values if IDs are null for provinces
+		replaceProvinceValuesWithNA(disputeToUpdate);
+		
 		// Copy all new dispute counts data to be saved from the request to disputeCountsToUpdate ignoring the disputeCountId, creation audit fields
 		if (dispute.getDisputeCounts() != null && disputeCountsToUpdate != null) {
 			if (dispute.getDisputeCounts().size() == disputeCountsToUpdate.size()) {
@@ -192,6 +203,26 @@ public class DisputeService {
 		Dispute updatedDispute = disputeRepository.update(disputeToUpdate);
 
 		return updatedDispute;
+	}
+	
+	private void replaceProvinceValuesWithNA(Dispute disputeToUpdate) {
+	    if (disputeToUpdate.getAddressProvinceCountryId() == null && disputeToUpdate.getAddressProvinceSeqNo() == null && StringUtils.isBlank(disputeToUpdate.getAddressProvince())) {
+	        disputeToUpdate.setAddressProvince(NA);
+	    }
+	    
+	    if (disputeToUpdate.getDriversLicenceIssuedProvinceSeqNo() == null && StringUtils.isBlank(disputeToUpdate.getDriversLicenceProvince())) {
+	        disputeToUpdate.setDriversLicenceProvince(NA);
+	    }
+	}
+	
+	private void replaceNAValuesWithEmpty(Dispute disputeToUpdate) {
+	    if (NA.equals(disputeToUpdate.getAddressProvince())) {
+	        disputeToUpdate.setAddressProvince("");
+	    }
+	    
+	    if (NA.equals(disputeToUpdate.getDriversLicenceProvince())) {
+	        disputeToUpdate.setDriversLicenceProvince("");
+	    }
 	}
 
 	/**
@@ -356,7 +387,12 @@ public class DisputeService {
 		if (findByNoticeOfDisputeGuid.size() > 1) {
 			logger.warn("Unexpected number of disputes returned. More than 1 dispute have been returned based on the provided noticeOfDisputeGuid: {}", StructuredArguments.value("noticeOfDisputeGuid", noticeOfDisputeGuid));
 		}
-		return findByNoticeOfDisputeGuid.get(0);
+		
+		Dispute dispute = findByNoticeOfDisputeGuid.get(0);
+		// TCVP-2748 - Replace NA values with empty strings
+		replaceNAValuesWithEmpty(dispute);
+		
+		return dispute;
 	}
 
 	/**

--- a/src/backend/oracle-data-api/src/test/java/ca/bc/gov/open/jag/tco/oracledataapi/service/DisputeServiceTest.java
+++ b/src/backend/oracle-data-api/src/test/java/ca/bc/gov/open/jag/tco/oracledataapi/service/DisputeServiceTest.java
@@ -3,15 +3,18 @@ package ca.bc.gov.open.jag.tco.oracledataapi.service;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 
 import ca.bc.gov.open.jag.tco.oracledataapi.BaseTestSuite;
 import ca.bc.gov.open.jag.tco.oracledataapi.model.Dispute;
 
 public class DisputeServiceTest extends BaseTestSuite {
+	
+	@Autowired
+	private DisputeService disputeService;
 
     @Test
     public void testReplaceProvinceValuesWithNA() {
-        DisputeService disputeService = new DisputeService();
         Dispute dispute = new Dispute();
 
         dispute.setAddressProvince(null);
@@ -25,7 +28,6 @@ public class DisputeServiceTest extends BaseTestSuite {
 
     @Test
     public void testReplaceNAValuesWithEmpty() {
-        DisputeService disputeService = new DisputeService();
         Dispute dispute = new Dispute();
 
         dispute.setAddressProvince("N/A");

--- a/src/backend/oracle-data-api/src/test/java/ca/bc/gov/open/jag/tco/oracledataapi/service/DisputeServiceTest.java
+++ b/src/backend/oracle-data-api/src/test/java/ca/bc/gov/open/jag/tco/oracledataapi/service/DisputeServiceTest.java
@@ -1,0 +1,39 @@
+package ca.bc.gov.open.jag.tco.oracledataapi.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+import ca.bc.gov.open.jag.tco.oracledataapi.BaseTestSuite;
+import ca.bc.gov.open.jag.tco.oracledataapi.model.Dispute;
+
+public class DisputeServiceTest extends BaseTestSuite {
+
+    @Test
+    public void testReplaceProvinceValuesWithNA() {
+        DisputeService disputeService = new DisputeService();
+        Dispute dispute = new Dispute();
+
+        dispute.setAddressProvince(null);
+        dispute.setDriversLicenceProvince(null);
+
+        disputeService.replaceProvinceValuesWithNA(dispute);
+
+        assertEquals("N/A", dispute.getAddressProvince());
+        assertEquals("N/A", dispute.getDriversLicenceProvince());
+    }
+
+    @Test
+    public void testReplaceNAValuesWithEmpty() {
+        DisputeService disputeService = new DisputeService();
+        Dispute dispute = new Dispute();
+
+        dispute.setAddressProvince("N/A");
+        dispute.setDriversLicenceProvince("N/A");
+
+        disputeService.replaceNAValuesWithEmpty(dispute);
+
+        assertEquals("", dispute.getAddressProvince());
+        assertEquals("", dispute.getDriversLicenceProvince());
+    }
+}


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- [TCVP-2748](https://justice.gov.bc.ca/jira/browse/TCVP-2748)
- Added functionality to replace null province values with NA if specific province IDs are null since db check constraints expect string values if IDs are null for provinces.
- Added JUnit tests for replace NA helper methods.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Ran the apps locally and tried updating a ticket with empty province values and confirmed that the values are saved successfully.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
