### PR TITLE
TCVP-2694 Hide 'Unknown' from languages lookup

### DIFF
--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/mapper/LookupMapper.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/mapper/LookupMapper.java
@@ -6,9 +6,6 @@ import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.factory.Mappers;
 
-import ca.bc.gov.open.jag.tco.oracledataapi.model.Province;
-import ca.bc.gov.open.jag.tco.oracledataapi.ords.occam.api.model.Country;
-
 /**
  * Maps from ORDS lookup tables to OracleDataAPI
  */

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/service/impl/ords/LookupServiceImpl.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/service/impl/ords/LookupServiceImpl.java
@@ -1,6 +1,7 @@
 package ca.bc.gov.open.jag.tco.oracledataapi.service.impl.ords;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -29,11 +30,19 @@ public class LookupServiceImpl extends BaseLookupService {
 		List<ca.bc.gov.open.jag.tco.oracledataapi.ords.occam.api.model.Statute> statutes = lookupValuesApi.statutesList().getStatuteCodeValues();
 		return LookupMapper.INSTANCE.convertStatutes(statutes);
 	}
-
+	
 	@Override
 	public List<Language> getLanguages() throws ApiException {
-		List<ca.bc.gov.open.jag.tco.oracledataapi.ords.occam.api.model.Language> languages = lookupValuesApi.languagesList().getLanguageCodeValues();
-		return LookupMapper.INSTANCE.convertLanguages(languages);
+	  List<ca.bc.gov.open.jag.tco.oracledataapi.ords.occam.api.model.Language> languages = lookupValuesApi.languagesList().getLanguageCodeValues();
+	  
+	  List<Language> convertedLanguages = LookupMapper.INSTANCE.convertLanguages(languages);
+
+	  // TCVP-2694 Filter out the language 'Unknown' with code 'UNK'
+	  convertedLanguages = convertedLanguages.stream()
+	    .filter(language -> !language.getCode().equalsIgnoreCase("UNK"))
+	    .collect(Collectors.toList());
+
+	  return convertedLanguages;
 	}
 	
 	@Override

--- a/src/backend/oracle-data-api/src/test/java/ca/bc/gov/open/jag/tco/oracledataapi/service/LookupServiceTest.java
+++ b/src/backend/oracle-data-api/src/test/java/ca/bc/gov/open/jag/tco/oracledataapi/service/LookupServiceTest.java
@@ -1,6 +1,7 @@
 package ca.bc.gov.open.jag.tco.oracledataapi.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -35,6 +36,15 @@ public class LookupServiceTest extends BaseTestSuite {
 		assertThat(result.size() > 0);
 		assertThat("ALB".equals(result.get(0).getCode()));
 		assertThat("Albanian".equals(result.get(0).getDescription()));
+	}
+	
+	@Test
+	public void testGetLanguagesDoesNotContainUnknown() throws ApiException {
+		var result = service.getLanguages();
+
+		assertThat(result).isNotNull();
+		assertThat(result.size() > 0);
+		assertFalse(result.stream().anyMatch(language -> language.getCode().equals("UNK")));
 	}
 
 	@Test

--- a/src/backend/oracle-data-api/src/test/java/ca/bc/gov/open/jag/tco/oracledataapi/service/impl/csv/LookupServiceImpl.java
+++ b/src/backend/oracle-data-api/src/test/java/ca/bc/gov/open/jag/tco/oracledataapi/service/impl/csv/LookupServiceImpl.java
@@ -53,7 +53,9 @@ public class LookupServiceImpl extends BaseLookupService {
 				Language language = new Language();
 				language.setCode(row.length > 0 ? row[0] : null);
 				language.setDescription(row.length > 1 ? row[1] : null);
-				languages.add(language);
+				if (!"UNK".equalsIgnoreCase(language.getCode())) {
+					languages.add(language);
+				}
 			}
 		}
 		catch (Exception e) {


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- [TCVP-2694](https://justice.gov.bc.ca/jira/browse/TCVP-2694)
- Added functionality to filter out the language 'Unknown' with code 'UNK' from the languages list from both ORDS and CSV file before saving into Redis.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
