### PR TITLE
Updated API to be more robust with FR versions

### DIFF
--- a/src/backend/TrafficCourts/Citizen.Service/Services/Impl/FormRecognizerService_2022_08_31.cs
+++ b/src/backend/TrafficCourts/Citizen.Service/Services/Impl/FormRecognizerService_2022_08_31.cs
@@ -132,13 +132,16 @@ public class FormRecognizerService_2022_08_31 : IFormRecognizerService
         {
             AnalyzedDocument document = result.Documents[0];
             violationTicket.GlobalConfidence = document.Confidence;
-            if (OcrViolationTicket.ViolationTicketVersion1_0 == document.DocumentType)
+            if (document.DocumentType is not null 
+                && (OcrViolationTicket.ViolationTicketVersion1_beta == document.DocumentType
+                 || document.DocumentType.StartsWith(OcrViolationTicket.ViolationTicketVersion1_x)))
             {
                 violationTicket.TicketVersion = ViolationTicketVersion.VT1;
                 fieldLabels = IFormRecognizerService.FieldLabels_VT1;
             }
-            else if (OcrViolationTicket.ViolationTicketVersion2_0 == document.DocumentType
-                  || OcrViolationTicket.ViolationTicketVersion2_1 == document.DocumentType)
+            else if (document.DocumentType is not null 
+                && (OcrViolationTicket.ViolationTicketVersion2_beta == document.DocumentType
+                 || document.DocumentType.StartsWith(OcrViolationTicket.ViolationTicketVersion2_x)))
             {
                 violationTicket.TicketVersion = ViolationTicketVersion.VT2;
                 fieldLabels = IFormRecognizerService.FieldLabels_VT2;

--- a/src/backend/TrafficCourts/Citizen.Service/Services/Impl/FormRecognizerService_2_1.cs
+++ b/src/backend/TrafficCourts/Citizen.Service/Services/Impl/FormRecognizerService_2_1.cs
@@ -107,15 +107,16 @@ public class FormRecognizerService_2_1 : IFormRecognizerService
         {
             violationTicket.GlobalConfidence = result[0].FormTypeConfidence ?? 0f;
             Dictionary<string, string> fieldLabels = new();
-            if (OcrViolationTicket.ViolationTicketVersion1_0_beta == result[0].FormType
-             || OcrViolationTicket.ViolationTicketVersion1_0 == result[0].FormType)
+            if (result[0].FormType is not null 
+                && (OcrViolationTicket.ViolationTicketVersion1_beta == result[0].FormType
+                 || result[0].FormType.StartsWith(OcrViolationTicket.ViolationTicketVersion1_x)))
             {
                 violationTicket.TicketVersion = ViolationTicketVersion.VT1;
                 fieldLabels = IFormRecognizerService.FieldLabels_VT1;
             }
-            else if (OcrViolationTicket.ViolationTicketVersion2_0_beta == result[0].FormType
-                  || OcrViolationTicket.ViolationTicketVersion2_0 == result[0].FormType
-                  || OcrViolationTicket.ViolationTicketVersion2_1 == result[0].FormType)
+            else if (result[0].FormType is not null 
+                && (OcrViolationTicket.ViolationTicketVersion2_beta == result[0].FormType
+                 || result[0].FormType.StartsWith(OcrViolationTicket.ViolationTicketVersion2_x)))
             {
                 violationTicket.TicketVersion = ViolationTicketVersion.VT2;
                 fieldLabels = IFormRecognizerService.FieldLabels_VT2;

--- a/src/backend/TrafficCourts/Common/Models/OcrViolationTicket.cs
+++ b/src/backend/TrafficCourts/Common/Models/OcrViolationTicket.cs
@@ -27,19 +27,14 @@ public class OcrViolationTicket
     /// <summary>
     /// A Violation Ticket form that was in circulation around 2022.04
     /// </summary>
-    public static readonly string ViolationTicketVersion1_0 = "ViolationTicket:ViolationTicket_v1.0";
-    public static readonly string ViolationTicketVersion1_0_beta = "Violation Ticket:Violation Ticket 2022.04";
+    public static readonly string ViolationTicketVersion1_x = "ViolationTicket:ViolationTicket_v1";
+    public static readonly string ViolationTicketVersion1_beta = "Violation Ticket:Violation Ticket 2022.04";
     
     /// <summary>
     /// A new Violation Ticket form that was in introduced in 2023.09
     /// </summary>
-    public static readonly string ViolationTicketVersion2_0 = "ViolationTicket:ViolationTicket_v2.0";
-    public static readonly string ViolationTicketVersion2_0_beta = "Violation Ticket:Violation Ticket 2023.09";
-
-    /// <summary>
-    /// A new Violation Ticket form that was in introduced in 2023.09, but trained with generated and real ticket images
-    /// </summary>
-    public static readonly string ViolationTicketVersion2_1 = "ViolationTicket:ViolationTicket_v2.1";
+    public static readonly string ViolationTicketVersion2_x = "ViolationTicket:ViolationTicket_v2";
+    public static readonly string ViolationTicketVersion2_beta = "Violation Ticket:Violation Ticket 2023.09";
 
     public static readonly string ViolationTicketTitle = "violationTicketTitle";
     public static readonly string ViolationTicketNumber = "ticket_number";


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

TCVP-2739 Small tweak to make the citizen-api a little more robust to better handle future Form Recognizer versions. This change will allow us to not have to make an application change every time we rollout a new model. 

Used StartsWith() instead of exact string comparison to find the version of the ViolationTicket (VT1 or VT2)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
