### PR TITLE
TCVP-2782 Return file data for OCCAM disputes and update file upload request

### DIFF
--- a/src/backend/TrafficCourts/Common/Models/Dispute.cs
+++ b/src/backend/TrafficCourts/Common/Models/Dispute.cs
@@ -1,0 +1,14 @@
+﻿using TrafficCourts.Common.Models;
+
+namespace TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0;
+
+/// <summary>
+/// An extension of the Dispute object to include list of file metadata that contain ID (Unique identifiers for the files in COMS) and filename of the saved files for this Dispute.
+/// </summary>
+public partial class Dispute
+{
+    /// <summary>
+    /// List of file metadata that contain ID and Filename of all the uploaded documents related to this particular Dispute
+    /// </summary>
+    public List<FileMetadata>? FileData { get; set; }
+}

--- a/src/backend/TrafficCourts/Staff.Service/Controllers/DocumentController.cs
+++ b/src/backend/TrafficCourts/Staff.Service/Controllers/DocumentController.cs
@@ -51,9 +51,8 @@ public class DocumentController : StaffControllerBase
         [Required]
         IFormFile file,
         [FromHeader]
-        [Required]
         [Range(1, int.MaxValue)]
-        long disputeId,
+        long? disputeId,
         [FromHeader]
         [Required]
         string noticeOfDisputeId,


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- [TCVP-2782](https://justice.gov.bc.ca/jira/browse/TCVP-2782)
- These changes are required for front-end to provide document upload and view uploaded documents feature for OCCAM disputes. (TCVP-2598)
- Added functionality to return uploaded document data as part of get dispute request for occam disputes.
- Made the `disputeId` parameter optional for POST document request to allow uploading documents only associated to `noticeOfDisputeId`.
- Added error response handling for COMS on GET dispute request and XUnit test for that.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
