### PR TITLE
Add service account name

### DIFF
--- a/gitops/charts/rabbitmq-values.yaml
+++ b/gitops/charts/rabbitmq-values.yaml
@@ -884,7 +884,7 @@ serviceAccount:
   ## @param serviceAccount.name Name of the created serviceAccount
   ## If not set and create is true, a name is generated using the rabbitmq.fullname template
   ##
-  name: ""
+  name: "rabbitmq-discovery"
   ## @param serviceAccount.automountServiceAccountToken Auto-mount the service account token in the pod
   ##
   automountServiceAccountToken: true


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- In openshift, we need to hard code the service account as it needs to be created ahead of time with the correct permissions. Not everyone with access to our namespaces can create role bindings required by this service account

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [ ] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
