### PR TITLE
Hard code ARC organization to POL

### DIFF
--- a/src/backend/TrafficCourts/Messaging/MessageContracts/DisputeApproved.cs
+++ b/src/backend/TrafficCourts/Messaging/MessageContracts/DisputeApproved.cs
@@ -2,9 +2,6 @@
 {
     public class DisputeApproved
     {
-        [Obsolete($"Use {nameof(GivenName1)}, {nameof(GivenName2)},  {nameof(GivenName3)} and {nameof(Surname)}")]
-        public string? CitizenName { get; set; }
-
         public string? Surname { get; set; }
         public string? GivenName1 { get; set; }
         public string? GivenName2 { get; set; }

--- a/src/backend/TrafficCourts/Staff.Service/Mappers/Mapper.cs
+++ b/src/backend/TrafficCourts/Staff.Service/Mappers/Mapper.cs
@@ -24,8 +24,10 @@ public class Mapper
         target.GivenName3 = dispute.DisputantGivenName3;
         target.TicketIssuanceDate = dispute.IssuedTs?.DateTime;
         target.TicketFileNumber = dispute.TicketNumber;
-        target.IssuingOrganization = dispute.ViolationTicket.DetachmentLocation;
-        target.IssuingLocation = dispute.ViolationTicket.CourtLocation;
+
+        // TCVP-2793 - issuing organziation should always be police (POL) and issuing location is the detachment location
+        target.IssuingOrganization = "POL";
+        target.IssuingLocation = dispute.ViolationTicket.DetachmentLocation;
 
         // If DL Province is out of province, do not send drivers licence
         if (dispute.DriversLicenceNumber is not null && dispute.DriversLicenceIssuedProvinceSeqNo == 1 && dispute.DriversLicenceIssuedCountryId == 1)
@@ -36,15 +38,13 @@ public class Mapper
         target.ViolationTicketCounts = Map(dispute.ViolationTicket.ViolationTicketCounts);
 
         // TODO: Lookup address province seq no and country id and set addressprovince to abbreviation code
-        if (dispute.AddressProvinceSeqNo != null) target.Province = dispute.AddressProvince;
+        if (dispute.AddressProvinceSeqNo is not null) target.Province = dispute.AddressProvince;
         // only need two character code (province may be more than two chars if not USA or Canada)
         else if (dispute.AddressProvince is not null && dispute.AddressProvince.Length > 2) target.Province = dispute.AddressProvince.Substring(0, 2);
         else dispute.AddressProvince = null;
 
         target.StreetAddress = FormatStreetAddress(dispute);
         target.City = dispute.AddressCity;
-        target.City = dispute.AddressCity;
-
         target.PostalCode = dispute.PostalCode;
         target.Email = dispute.EmailAddress;
 


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- Hard codes the organization to POL when sending to ARC. See TCVP-2793 for justification.
- Removes obsolete field in a message contract. It has been obsolete for a long time.

There may be another change coming related to the organization location, but I have not been able to confirm it is an issue.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [ ] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
