### PR TITLE
TCVP-2748 Fix invalid drivers licence prov country combo

### DIFF
--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/service/DisputeService.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/service/DisputeService.java
@@ -210,7 +210,7 @@ public class DisputeService {
 	        disputeToUpdate.setAddressProvince(NA);
 	    }
 	    
-	    if (disputeToUpdate.getDriversLicenceIssuedProvinceSeqNo() == null && StringUtils.isBlank(disputeToUpdate.getDriversLicenceProvince())) {
+	    if (disputeToUpdate.getDriversLicenceIssuedCountryId() != null && disputeToUpdate.getDriversLicenceIssuedProvinceSeqNo() == null && StringUtils.isBlank(disputeToUpdate.getDriversLicenceProvince())) {
 	        disputeToUpdate.setDriversLicenceProvince(NA);
 	    }
 	}

--- a/src/backend/oracle-data-api/src/test/java/ca/bc/gov/open/jag/tco/oracledataapi/service/DisputeServiceTest.java
+++ b/src/backend/oracle-data-api/src/test/java/ca/bc/gov/open/jag/tco/oracledataapi/service/DisputeServiceTest.java
@@ -18,6 +18,7 @@ public class DisputeServiceTest extends BaseTestSuite {
         Dispute dispute = new Dispute();
 
         dispute.setAddressProvince(null);
+        dispute.setDriversLicenceIssuedCountryId(73);
         dispute.setDriversLicenceProvince(null);
 
         disputeService.replaceProvinceValuesWithNA(dispute);


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- [TCVP-2748](https://justice.gov.bc.ca/jira/browse/TCVP-2748)
- Fixed the logic that prevented dispute update from being saved with null driver's licence province/country combo.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
