### PR TITLE
Added retry to ORDS API calls in oracle-data-api

### DIFF
--- a/src/backend/oracle-data-api/pom.xml
+++ b/src/backend/oracle-data-api/pom.xml
@@ -22,9 +22,9 @@
 		<org.projectlombok.version>1.18.30</org.projectlombok.version>
 		<occam-package>ca.bc.gov.open.jag.tco.oracledataapi.ords.occam</occam-package>
 		<tco-package>ca.bc.gov.open.jag.tco.oracledataapi.ords.tco</tco-package>
-		
+
 		<!-- automatically run annotation processors within the incremental compilation -->
-  		<m2e.apt.activation>jdt_apt</m2e.apt.activation>
+		<m2e.apt.activation>jdt_apt</m2e.apt.activation>
 	</properties>
 
 	<dependencyManagement>
@@ -106,11 +106,11 @@
 			<artifactId>splunk-library-javalogging</artifactId>
 			<version>1.11.8</version>
 		</dependency>
-		
+
 		<dependency>
-		    <groupId>net.logstash.logback</groupId>
-		    <artifactId>logstash-logback-encoder</artifactId>
-		    <version>7.3</version>
+			<groupId>net.logstash.logback</groupId>
+			<artifactId>logstash-logback-encoder</artifactId>
+			<version>7.3</version>
 		</dependency>
 
 		<!-- Swagger UI -->
@@ -195,6 +195,27 @@
 			<groupId>com.google.code.findbugs</groupId>
 			<artifactId>jsr305</artifactId>
 			<version>3.0.2</version>
+		</dependency>
+
+		<!-- Provides configurable retry attempts for ORDS calls -->
+		<!-- This dependency is useful to easily add a @Retryable to any method, but this does not 
+		     work with AOP to add retry on every api call ... so we'll implement retry manually in AOP. 
+		<dependency>
+			<groupId>org.springframework.retry</groupId>
+			<artifactId>spring-retry</artifactId>
+		</dependency>
+		-->
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-aop</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-aop</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.aspectj</groupId>
+			<artifactId>aspectjweaver</artifactId>
 		</dependency>
 
 		<!-- Test dependencies -->

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/config/RetryAspect.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/config/RetryAspect.java
@@ -1,0 +1,70 @@
+package ca.bc.gov.open.jag.tco.oracledataapi.config;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Pointcut;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Aspect
+@Component
+//@EnableRetry
+public class RetryAspect {
+
+	private static Logger logger = LoggerFactory.getLogger(RetryAspect.class);
+
+	@Value("${ords.api.retry.count}")
+	private int maxAttempts;
+
+	@Value("${ords.api.retry.delay}")
+	private long retryDelay;
+
+	// This pointcut will match any public method on any class in the ords repository package (DisputeRepositoryImpl, JJDisputeRepositoryImpl, etc.)
+	// as well as the LookupValuesApi class that retrieves lookup values from ords.
+	@Pointcut("execution(public * ca.bc.gov.open.jag.tco.oracledataapi.repository.impl.ords.*.*(..)) || "
+			+ "execution(public * ca.bc.gov.open.jag.tco.oracledataapi.ords.occam.api.LookupValuesApi.*(..))")
+	public void retryOnOrdsApiMethods() {
+	}
+
+	//Unfortunately, @Retryable is not supported in AspectJ so this doesn't work
+	//@Retryable(maxAttemptsExpression = "${ords.api.retry.count}", backoff = @Backoff(delayExpression = "${ords.api.retry.delay}"))
+	@Around("retryOnOrdsApiMethods()")
+	public Object around(ProceedingJoinPoint pjp) throws Throwable {
+		for (int i = 0; i < maxAttempts; i++) {
+			try {
+				return pjp.proceed();
+			} 			
+			// Thrown by the Occam API, usually Policy Falsified error
+			catch (ca.bc.gov.open.jag.tco.oracledataapi.ords.occam.api.handler.ApiException e) {
+				handleException(pjp, i, e);
+			} 			
+			// Thrown by the TCO API, usually Policy Falsified error
+			catch (ca.bc.gov.open.jag.tco.oracledataapi.ords.tco.api.handler.ApiException e) {
+				handleException(pjp, i, e);
+			} 			
+			// javax.ws.rs.InternalServerErrorException is thrown when there is a database error (no point retrying these)
+			//catch (javax.ws.rs.InternalServerErrorException e) {
+			//	handleException(pjp, i, e);
+			//}
+		}
+		return null; // should never reach here
+	}
+
+	private void handleException(ProceedingJoinPoint pjp, int i, Exception e) throws Exception {
+		if (i < maxAttempts - 1) {
+			// delay before retrying
+			logger.debug("Attempt {} failed, retrying: {}", i + 1, pjp.getSignature().toShortString());
+			Thread.sleep(retryDelay);
+		}
+
+		else {
+			// re-throw the exception as this is the last attempt
+			logger.error("Attempt {} failed, calling: {}", maxAttempts, pjp.getSignature().toShortString(), e);
+			throw e;
+		}
+	}
+
+}

--- a/src/backend/oracle-data-api/src/main/resources/application.yml
+++ b/src/backend/oracle-data-api/src/main/resources/application.yml
@@ -95,8 +95,8 @@ ords:
     retry:
       # The maximum number of retry attempts to allow
       count: ${ORDS_API_RETRY_COUNT:3}
-      # The Duration of the fixed delays
-      delay: ${ORDS_API_RETRY_DELAY_SEC:5}
+      # The Duration of the fixed delays in milliseconds
+      delay: ${ORDS_API_RETRY_DELAY_SEC:5000}
     occam:
       url: ${ORDS_API_OCCAM_URL:localhost}
       # Basic auth username for calling ORDS OCCAM


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

This PR adds a global retry attempt mechanism to oracle-data-api using AOP (aspect-oriented programming).

Uses `ORDS_API_RETRY_COUNT` and `ORDS_API_RETRY_DELAY_SEC`, defaults to 3 attempts, 5 seconds apart.

Currently, the AOP Pointcut matches any public method on any class in the ords impl repository package (DisputeRepositoryImpl, JJDisputeRepositoryImpl, etc.) as well as the ords LookupValuesApi (when retrieving cached lookup values for Redis).

```
16:10:23.215 [http-nio-5010-exec-2] DEBUG ca.bc.gov.open.jag.tco.oracledataapi.config.RetryAspect: Attempt 1 failed, retrying: DisputeRepositoryImpl.findByStatusNot(..)
16:10:28.216 [http-nio-5010-exec-2] DEBUG ca.bc.gov.open.jag.tco.oracledataapi.config.RetryAspect: Attempt 2 failed, retrying: DisputeRepositoryImpl.findByStatusNot(..)
16:10:33.219 [http-nio-5010-exec-2] ERROR ca.bc.gov.open.jag.tco.oracledataapi.config.RetryAspect: Attempt 3 failed, calling: DisputeRepositoryImpl.findByStatusNot(..)
ca.bc.gov.open.jag.tco.oracledataapi.ords.occam.api.handler.ApiException: ERROR retrieving Disputes from ORDS
	at ca.bc.gov.open.jag.tco.oracledataapi.repository.impl.ords.DisputeRepositoryImpl.findByStatusNotAndCreatedTsAfterAndNoticeOfDisputeGuid(DisputeRepositoryImpl.java:82)
```

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
