### PR TITLE
TCVP-2792 Exclude unapproved citizen documents on jj workbench

### DIFF
--- a/src/backend/TrafficCourts/Citizen.Service/Services/Impl/CitizenDocumentService.cs
+++ b/src/backend/TrafficCourts/Citizen.Service/Services/Impl/CitizenDocumentService.cs
@@ -47,7 +47,7 @@ public class CitizenDocumentService : ICitizenDocumentService
         FileSearchResult file = searchResults[0];
 
         DocumentProperties properties = new(file.Metadata, file.Tags);
-        
+
         // Citizen Portal should only have access to Citizen documents
         if (properties.DocumentSource is not null && properties.DocumentSource is not DocumentSource.Citizen) {
             // Should never happen since this file is not even available in the UI for selection to delete.
@@ -139,7 +139,7 @@ public class CitizenDocumentService : ICitizenDocumentService
         _logger.LogDebug("Saving file through COMS");
 
         properties.DocumentSource = DocumentSource.Citizen;
-        properties.StaffReviewStatus = "pending";
+        properties.StaffReviewStatus = DisputeUpdateRequestStatus.PENDING.ToString();
 
         var metadata = properties.ToMetadata();
         var tags = properties.ToTags();

--- a/src/backend/TrafficCourts/Staff.Service/Services/JJDisputeService.cs
+++ b/src/backend/TrafficCourts/Staff.Service/Services/JJDisputeService.cs
@@ -62,6 +62,11 @@ public partial class JJDisputeService : IJJDisputeService
 
         dispute.FileData = disputeFiles;
 
+        // TCVP-2792 Filter files and exclude citizen-uploaded documents whose status is not ACCEPTED if assignVTC=false (requests coming from the jj workbench have this set to false, staff workbench has it set to true)
+        if (!assignVTC && dispute.FileData is not null) {
+            dispute.FileData = dispute.FileData.Where(x => x.DocumentSource != DocumentSource.Citizen || x.DocumentStatus == DisputeUpdateRequestStatus.ACCEPTED.ToString()).ToList();
+        }
+
         // Populate the statute description of each count of the JJDispute
         foreach (var count in dispute.JjDisputedCounts)
         {

--- a/src/backend/TrafficCourts/Staff.Service/Services/StaffDocumentService.cs
+++ b/src/backend/TrafficCourts/Staff.Service/Services/StaffDocumentService.cs
@@ -102,6 +102,7 @@ public class StaffDocumentService : IStaffDocumentService
                 FileName = properties.DocumentName,
                 DocumentType = properties.DocumentType,
                 DocumentSource = properties.DocumentSource,
+                DocumentStatus = properties.StaffReviewStatus,
                 NoticeOfDisputeGuid = properties.NoticeOfDisputeId?.ToString("d"),
                 VirusScanStatus = properties.VirusScanStatus,
                 DisputeId = properties.TcoDisputeId


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

TCVP-2792 
JJs should not be able to see uploaded citizen document if staff haven't reviewed and approved them first.
- set the initial status of uploaded citizen document to PENDING
- added filter to StaffDocumentService to filter documents to only staff-uploaded or citizen documents that have been approved.

Note: there is a bug in COMS where if a staff that approves a citizen document, COMS is not updated.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [ ] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
