### PR TITLE
TCVP-2817 Save signatory fields on update request

### DIFF
--- a/src/backend/TrafficCourts/Messaging/MessageContracts/DisputeUpdateRequest.cs
+++ b/src/backend/TrafficCourts/Messaging/MessageContracts/DisputeUpdateRequest.cs
@@ -1,4 +1,5 @@
-﻿using TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0;
+﻿using System.Text.Json.Serialization;
+using TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0;
 
 namespace TrafficCourts.Messaging.MessageContracts;
 
@@ -102,8 +103,18 @@ public class DisputeUpdateRequest : DisputeUpdateContactRequest
     /// <summary>
     /// Request Court Appearance
     /// </summary>
-    public DisputeRequestCourtAppearanceYn RequestCourtAppearance { get; set; }    
-    
+    public DisputeRequestCourtAppearanceYn RequestCourtAppearance { get; set; }
+
+    /// <summary>
+    /// Name of the person who signed the dispute.
+    /// </summary>
+    public string? SignatoryName { get; set; }
+
+    /// <summary>
+    /// Signatory Type. Can be either 'D' for Disputant or 'A' for Agent.
+    /// </summary>
+    public DisputeSignatoryType? SignatoryType { get; set; }
+
     /// <summary>
     /// Dispute Counts
     /// </summary>

--- a/src/backend/TrafficCourts/Workflow.Service/Consumers/DisputeUpdateRequestAcceptedConsumer.cs
+++ b/src/backend/TrafficCourts/Workflow.Service/Consumers/DisputeUpdateRequestAcceptedConsumer.cs
@@ -1,5 +1,6 @@
 ﻿using MassTransit;
 using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 using TrafficCourts.Common.Features.Mail.Templates;
 using TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0;
 using TrafficCourts.Messaging.MessageContracts;
@@ -52,6 +53,13 @@ public class DisputeUpdateRequestAcceptedConsumer : IConsumer<DisputeUpdateReque
 
                 // Get the current Dispute by id
                 Dispute dispute = await _oracleDataApiService.GetDisputeByIdAsync(updateRequest.DisputeId, false, context.CancellationToken);
+
+                // Update signatory fields regardless of update type
+                if (dispute.SignatoryName != patch.SignatoryName || dispute.SignatoryType != patch.SignatoryType)
+                {
+                    dispute.SignatoryName = patch.SignatoryName;
+                    dispute.SignatoryType = patch.SignatoryType;
+                }
 
                 switch (updateRequest.UpdateType)
                 {
@@ -284,6 +292,10 @@ public class UpdateRequest
     public string? FineReductionReason { get; set; }
 
     public string? TimeToPayReason { get; set; }
+
+    public string? SignatoryName { get; set; }
+
+    public DisputeSignatoryType? SignatoryType { get; set; }
 
     public System.Collections.Generic.ICollection<UpdateDisputeCountRequest>? DisputeCounts { get; set; }
 


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- TCVP-2817
- Updated disputeUpdateRequest message and dispute accepted consumer to save changes to the signatory fields made by disputant. 
- Note: These changes requires ORDS packages to be updated as well so the release to DEV and TEST should be coordinated with ORDS updates and deployments as well.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
