### PR TITLE
TCVP-2834 add configuration item to enable quorum queues

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,16 @@
+# Set the default behavior, in case people don't have core.autocrlf set.
+#* text=auto
+
+# Declare files that will always have CRLF line endings on checkout.
+*.sln text eol=crlf
+*.cs text eol=crlf
+
+# Declare files that will always have LF line endings on checkout.
 *.sh      text eol=lf
+
+
+# Denote all files that are truly binary and should not be modified.
+*.jpg binary
+*.png binary
+
+*.pdf binary

--- a/src/backend/TrafficCourts/Messaging/Configuration/RabbitMqHostOptions.cs
+++ b/src/backend/TrafficCourts/Messaging/Configuration/RabbitMqHostOptions.cs
@@ -48,6 +48,15 @@ public class RabbitMqHostOptions : IValidatable
 
     public RetryOptions Retry { get; set; } = new RetryOptions();
 
+    /// <summary>
+    /// Should queues be declared as quorum queues
+    /// <see cref="https://www.rabbitmq.com/docs/quorum-queues"/>
+    /// </summary>
+    /// <remarks>
+    /// In production this will be need to be true and must be set before any queue is created.
+    /// </remarks>
+    public bool UseQuorumQueues { get; set; } = false;
+
     public void Validate()
     {
         if (string.IsNullOrEmpty(Host)) throw new SettingsValidationException(Section, nameof(Host), "is required");

--- a/src/backend/TrafficCourts/Messaging/Configuration/RetryOptions.cs
+++ b/src/backend/TrafficCourts/Messaging/Configuration/RetryOptions.cs
@@ -8,12 +8,12 @@ public class RetryOptions
     public int Times { get; set; } = 5;
 
     /// <summary>
-    /// The interval between each retry attempt
+    /// The interval between each retry attempt in minutes
     /// </summary>
     public int Interval { get; set; } = 2;
 
     /// <summary>
     /// Limits the number of concurrent messages consumed on the receive endpoint, regardless of message type.
     /// </summary>
-    public int ConcurrencyLimit { get; set; } = 2;
+    public int? ConcurrencyLimit { get; set; }
 }


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- adds a `UseQuorumQueues` configuration property that defaults to false.
- if `UseQuorumQueues` is true, MassTransit is configured to set the queues to be quorum queues required for clustered configuration.
- Queues must be declared as quorum queues when created

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

I cleared my rabbitmq storage in docker, restarted the workflow service and rabbitmq and observed the queues being created as quorum queues.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
