### PR TITLE
TCVP-2831 Improved OCR post-processing

### DIFF
--- a/src/backend/TrafficCourts/Citizen.Service/Validators/FormRecognizerValidator.cs
+++ b/src/backend/TrafficCourts/Citizen.Service/Validators/FormRecognizerValidator.cs
@@ -158,14 +158,22 @@ public class FormRecognizerValidator : IFormRecognizerValidator
         // if DL province not populated and DL number starts with two chars take first two chars from DL number
         if (violationTicket.Fields.ContainsKey(OcrViolationTicket.DriverLicenceNumber) && violationTicket.Fields.ContainsKey(OcrViolationTicket.DriverLicenceProvince))
         {
-            if (!violationTicket.Fields[OcrViolationTicket.DriverLicenceProvince].IsPopulated()) // blank DL province
+            string dlNumber = "";
+
+            if (violationTicket.Fields[OcrViolationTicket.DriverLicenceProvince].IsPopulated() 
+                && !violationTicket.Fields[OcrViolationTicket.DriverLicenceNumber].IsPopulated()) // blank DL number
             {
-                string dlNumber = violationTicket.Fields[OcrViolationTicket.DriverLicenceNumber].Value ?? "";
-                if (Regex.IsMatch(dlNumber, @"^[a-zA-Z][a-zA-Z]")) // DL number starts with two chars
-                {
-                    violationTicket.Fields[OcrViolationTicket.DriverLicenceNumber].Value = dlNumber.Substring(2, dlNumber.Length - 2).Trim();
-                    violationTicket.Fields[OcrViolationTicket.DriverLicenceProvince].Value = dlNumber.Substring(0, 2); // extract first two chars for province code
-                }
+                dlNumber = violationTicket.Fields[OcrViolationTicket.DriverLicenceProvince].Value ?? "";
+            }
+            else if (!violationTicket.Fields[OcrViolationTicket.DriverLicenceProvince].IsPopulated() // blank DL province
+                && violationTicket.Fields[OcrViolationTicket.DriverLicenceNumber].IsPopulated())
+            {
+                dlNumber = violationTicket.Fields[OcrViolationTicket.DriverLicenceNumber].Value ?? "";
+            }
+            if (Regex.IsMatch(dlNumber, @"^[a-zA-Z]{2}\s*\d+")) // DL number starts with two chars followed by digits
+            {
+                violationTicket.Fields[OcrViolationTicket.DriverLicenceNumber].Value = dlNumber.Substring(2, dlNumber.Length - 2).Trim();
+                violationTicket.Fields[OcrViolationTicket.DriverLicenceProvince].Value = dlNumber.Substring(0, 2); // extract first two chars for province code
             }
         }
 

--- a/src/backend/TrafficCourts/Test/Citizen.Service/Validators/FormRecognizerValidatorTest.cs
+++ b/src/backend/TrafficCourts/Test/Citizen.Service/Validators/FormRecognizerValidatorTest.cs
@@ -100,4 +100,45 @@ public class FormRecognizerValidatorTest
         // Then
         Assert.Equal(Field._unselected, violationTicket.Fields[OcrViolationTicket.OffenceIsMVAR].Value);
     }
+
+    [Fact]
+    public async void TestSanitize_DLNumberFromProvince()
+    {
+        // Given
+        var _statuteLookupService = new Mock<IStatuteLookupService>();
+        var _logger = new Mock<ILogger<FormRecognizerValidator>>();
+        FormRecognizerValidator formRecognizerValidator = new(_statuteLookupService.Object, _logger.Object);
+
+        OcrViolationTicket violationTicket = new();
+        violationTicket.Fields.Add(OcrViolationTicket.DriverLicenceNumber, new Field(""));
+        violationTicket.Fields.Add(OcrViolationTicket.DriverLicenceProvince, new Field("BC 1234567"));
+
+        // When
+        await formRecognizerValidator.SanitizeAsync(violationTicket);
+
+        // Then
+        Assert.Equal("BC", violationTicket.Fields[OcrViolationTicket.DriverLicenceProvince].Value);
+        Assert.Equal("1234567", violationTicket.Fields[OcrViolationTicket.DriverLicenceNumber].Value);
+    }
+
+    [Fact]
+    public async void TestSanitize_ProvinceFromDLNumber()
+    {
+        // Given
+        var _statuteLookupService = new Mock<IStatuteLookupService>();
+        var _logger = new Mock<ILogger<FormRecognizerValidator>>();
+        FormRecognizerValidator formRecognizerValidator = new(_statuteLookupService.Object, _logger.Object);
+
+        OcrViolationTicket violationTicket = new();
+        violationTicket.Fields.Add(OcrViolationTicket.DriverLicenceNumber, new Field("BC1234567"));
+        violationTicket.Fields.Add(OcrViolationTicket.DriverLicenceProvince, new Field(""));
+
+        // When
+        await formRecognizerValidator.SanitizeAsync(violationTicket);
+
+        // Then
+        Assert.Equal("BC", violationTicket.Fields[OcrViolationTicket.DriverLicenceProvince].Value);
+        Assert.Equal("1234567", violationTicket.Fields[OcrViolationTicket.DriverLicenceNumber].Value);
+    }
+
 }


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

OCR needs a lot of help post processing. It can happen that the two adjacent fields DL Province and DL Licence are merged together into one of the fields. This post-processing task helps to split the fields apart before validation rules are applied.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
