### PR TITLE
TCVP-2829 Fix drivers licence check digit logic in ARC service

### DIFF
--- a/src/backend/TrafficCourts/Test/Arc.Dispute.Service/Models/DriversLicenceTest.cs
+++ b/src/backend/TrafficCourts/Test/Arc.Dispute.Service/Models/DriversLicenceTest.cs
@@ -11,6 +11,7 @@ namespace TrafficCourts.Test.Arc.Dispute.Service.Models
         [InlineData("01111111", "011111112")]
         [InlineData("1234567", "012345678")]
         [InlineData("01234567", "012345678")]
+        [InlineData("1690028", "016900280")]
         public void WithCheckDigit(string input, string expected)
         {
             string actual = DriversLicence.WithCheckDigit(input);

--- a/src/backend/TrafficCourts/TrafficCourts.Arc.Dispute.Service/Models/DriversLicence.cs
+++ b/src/backend/TrafficCourts/TrafficCourts.Arc.Dispute.Service/Models/DriversLicence.cs
@@ -23,7 +23,8 @@
                 sum += (driversLicence[i] - '0') * _digitWeights[i];
             }
 
-            char checkDigit = Convert.ToChar((sum % 11) + '0');
+            // Calculate the check digit by taking the last digit of the modulus. (TCVP-2829)
+            char checkDigit = Convert.ToChar((sum % 11) % 10 + '0');
 
             return driversLicence + checkDigit;
         }


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- [TCVP-2829](https://justice.gov.bc.ca/jira/browse/TCVP-2829)
- Fixed a bug that causes ':' character added at end of DL/Client Number in ARC File by calculating the check digit by taking the last digit of the modulus.
- The bug was caused by the modulo operation sum % 11 can return a value = 10. When the value is 10, adding '0' (which has the ASCII value 48) results in 58, which corresponds to the ASCII character `:`. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
