### PR TITLE
TCVP-2832 OCR cleanup counts post-processing rules

### DIFF
--- a/src/backend/TrafficCourts/Citizen.Service/Validators/FormRecognizerValidator.cs
+++ b/src/backend/TrafficCourts/Citizen.Service/Validators/FormRecognizerValidator.cs
@@ -92,7 +92,7 @@ public class FormRecognizerValidator : IFormRecognizerValidator
         }
 
         // For each count do the the three sanitization
-        void SanitizeCount(string sectionKey, string actRegsKey, string descKey)
+        void SanitizeCount(string sectionKey, string actRegsKey, string descKey, string ticketAmount)
         {
             SplitSectionActRegs(sectionKey, actRegsKey);
             ReplaceMUWithMV(actRegsKey);
@@ -114,6 +114,15 @@ public class FormRecognizerValidator : IFormRecognizerValidator
 
                 violationTicket.Fields[sectionKey].Value = newValue;
             }
+
+            // If the description is populated but the section and ticketAmount fields are blank, clear out the description as it was probably misread from the vertical text on the ticket image.
+            if (violationTicket.Fields.ContainsKey(descKey) && violationTicket.Fields[descKey].IsPopulated() 
+                && violationTicket.Fields.ContainsKey(sectionKey) && !violationTicket.Fields[sectionKey].IsPopulated()
+                && violationTicket.Fields.ContainsKey(ticketAmount) && !violationTicket.Fields[ticketAmount].IsPopulated())
+            {
+                violationTicket.Fields[descKey].Value = null;
+            }
+
         }
         
         void SanitizeWhiteSpace(string sectionKey)
@@ -127,9 +136,9 @@ public class FormRecognizerValidator : IFormRecognizerValidator
 
         SanitizeWhiteSpace(OcrViolationTicket.ViolationTicketTitle);
 
-        SanitizeCount(OcrViolationTicket.Count1Section, OcrViolationTicket.Count1ActRegs, OcrViolationTicket.Count1Description);
-        SanitizeCount(OcrViolationTicket.Count2Section, OcrViolationTicket.Count2ActRegs, OcrViolationTicket.Count2Description);
-        SanitizeCount(OcrViolationTicket.Count3Section, OcrViolationTicket.Count3ActRegs, OcrViolationTicket.Count3Description);
+        SanitizeCount(OcrViolationTicket.Count1Section, OcrViolationTicket.Count1ActRegs, OcrViolationTicket.Count1Description, OcrViolationTicket.Count1TicketAmount);
+        SanitizeCount(OcrViolationTicket.Count2Section, OcrViolationTicket.Count2ActRegs, OcrViolationTicket.Count2Description, OcrViolationTicket.Count2TicketAmount);
+        SanitizeCount(OcrViolationTicket.Count3Section, OcrViolationTicket.Count3ActRegs, OcrViolationTicket.Count3Description, OcrViolationTicket.Count3TicketAmount);
 
         // Pre-process ticket number if scan reads an A Oh as A Zero replace the Zero with an O in the second position
         // replace A1 with AI

--- a/src/backend/TrafficCourts/Test/Citizen.Service/Validators/FormRecognizerValidatorTest.cs
+++ b/src/backend/TrafficCourts/Test/Citizen.Service/Validators/FormRecognizerValidatorTest.cs
@@ -141,4 +141,39 @@ public class FormRecognizerValidatorTest
         Assert.Equal("1234567", violationTicket.Fields[OcrViolationTicket.DriverLicenceNumber].Value);
     }
 
+    [Fact]
+    public async void TestSanitize_EmptySectionAndTicketAmountForAllCounts()
+    {
+        // Given
+        var _statuteLookupService = new Mock<IStatuteLookupService>();
+        var _logger = new Mock<ILogger<FormRecognizerValidator>>();
+        FormRecognizerValidator formRecognizerValidator = new(_statuteLookupService.Object, _logger.Object);
+
+        OcrViolationTicket violationTicket = new();
+
+        violationTicket.Fields.Add(OcrViolationTicket.Count1Description, new Field("description1"));
+        violationTicket.Fields.Add(OcrViolationTicket.Count1ActRegs, new Field(""));
+        violationTicket.Fields.Add(OcrViolationTicket.Count1Section, new Field(""));
+        violationTicket.Fields.Add(OcrViolationTicket.Count1TicketAmount, new Field(""));
+
+        violationTicket.Fields.Add(OcrViolationTicket.Count2Description, new Field("description2"));
+        violationTicket.Fields.Add(OcrViolationTicket.Count2ActRegs, new Field(""));
+        violationTicket.Fields.Add(OcrViolationTicket.Count2Section, new Field(""));
+        violationTicket.Fields.Add(OcrViolationTicket.Count2TicketAmount, new Field(""));
+
+        violationTicket.Fields.Add(OcrViolationTicket.Count3Description, new Field("description3"));
+        violationTicket.Fields.Add(OcrViolationTicket.Count3ActRegs, new Field(""));
+        violationTicket.Fields.Add(OcrViolationTicket.Count3Section, new Field(""));
+        violationTicket.Fields.Add(OcrViolationTicket.Count3TicketAmount, new Field(""));
+
+        // When
+        await formRecognizerValidator.SanitizeAsync(violationTicket);
+
+        // Then
+        Assert.True(string.IsNullOrEmpty(violationTicket.Fields[OcrViolationTicket.Count1Description].Value));
+        Assert.True(string.IsNullOrEmpty(violationTicket.Fields[OcrViolationTicket.Count2Description].Value));
+        Assert.True(string.IsNullOrEmpty(violationTicket.Fields[OcrViolationTicket.Count3Description].Value));
+    }
+
+
 }


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

It often happens that the OCR will merge fields or pull in adjacent text. These post-processing rules help clean up the OCR results before being passed to the OCR validator. In this case, the description fields sometimes has the vertical Count 1,2,3 text on the ticket image when the description itselft was blank.

The following rules where implemented:
- If Count 1 description has text, but Count 1 section and amount fields are blank, clear out the count 1 description.
- If Count 2 description has text, but Count 2 section and amount fields are blank, clear out the count 2 description.
- If Count 3 description has text, but Count 3 section and amount fields are blank, clear out the count 3 description.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
