### PR TITLE
Update Oracle Data Api mapping

### DIFF
--- a/src/backend/TrafficCourts/TrafficCourts.OracleDataApi.Test/EnumMappingTests.cs
+++ b/src/backend/TrafficCourts/TrafficCourts.OracleDataApi.Test/EnumMappingTests.cs
@@ -1,0 +1,940 @@
+﻿using Xunit.Abstractions;
+using Oracle = TrafficCourts.OracleDataApi.Client.V1;
+
+namespace TrafficCourts.OracleDataApi.Test;
+
+public class EnumMappingTests : DomainModelMappingTest
+{
+    public EnumMappingTests(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [Fact]
+    public void EnumMapping()
+    {
+        #region DisputeAppearanceLessThan14DaysYn
+        // Oracle => Domain
+        Assert.Equal(Domain.Models.DisputeAppearanceLessThan14DaysYn.UNKNOWN, _sut.Map<Domain.Models.DisputeAppearanceLessThan14DaysYn>(Oracle.DisputeAppearanceLessThan14DaysYn.UNKNOWN));
+        Assert.Equal(Domain.Models.DisputeAppearanceLessThan14DaysYn.Y, _sut.Map<Domain.Models.DisputeAppearanceLessThan14DaysYn>(Oracle.DisputeAppearanceLessThan14DaysYn.Y));
+        Assert.Equal(Domain.Models.DisputeAppearanceLessThan14DaysYn.N, _sut.Map<Domain.Models.DisputeAppearanceLessThan14DaysYn>(Oracle.DisputeAppearanceLessThan14DaysYn.N));
+        // Domain => Oracle
+        Assert.Equal(Oracle.DisputeAppearanceLessThan14DaysYn.UNKNOWN, _sut.Map<Oracle.DisputeAppearanceLessThan14DaysYn>(Domain.Models.DisputeAppearanceLessThan14DaysYn.UNKNOWN));
+        Assert.Equal(Oracle.DisputeAppearanceLessThan14DaysYn.Y, _sut.Map<Oracle.DisputeAppearanceLessThan14DaysYn>(Domain.Models.DisputeAppearanceLessThan14DaysYn.Y));
+        Assert.Equal(Oracle.DisputeAppearanceLessThan14DaysYn.N, _sut.Map<Oracle.DisputeAppearanceLessThan14DaysYn>(Domain.Models.DisputeAppearanceLessThan14DaysYn.N));
+        #endregion DisputeAppearanceLessThan14DaysYn
+
+        #region DisputeContactTypeCd
+        // Oracle => Domain
+        Assert.Equal(Domain.Models.DisputeContactTypeCd.UNKNOWN, _sut.Map<Domain.Models.DisputeContactTypeCd>(Oracle.DisputeContactTypeCd.UNKNOWN));
+        Assert.Equal(Domain.Models.DisputeContactTypeCd.INDIVIDUAL, _sut.Map<Domain.Models.DisputeContactTypeCd>(Oracle.DisputeContactTypeCd.INDIVIDUAL));
+        Assert.Equal(Domain.Models.DisputeContactTypeCd.LAWYER, _sut.Map<Domain.Models.DisputeContactTypeCd>(Oracle.DisputeContactTypeCd.LAWYER));
+        Assert.Equal(Domain.Models.DisputeContactTypeCd.OTHER, _sut.Map<Domain.Models.DisputeContactTypeCd>(Oracle.DisputeContactTypeCd.OTHER));
+        // Domain => Oracle
+        Assert.Equal(Oracle.DisputeContactTypeCd.UNKNOWN, _sut.Map<Oracle.DisputeContactTypeCd>(Domain.Models.DisputeContactTypeCd.UNKNOWN));
+        Assert.Equal(Oracle.DisputeContactTypeCd.INDIVIDUAL, _sut.Map<Oracle.DisputeContactTypeCd>(Domain.Models.DisputeContactTypeCd.INDIVIDUAL));
+        Assert.Equal(Oracle.DisputeContactTypeCd.LAWYER, _sut.Map<Oracle.DisputeContactTypeCd>(Domain.Models.DisputeContactTypeCd.LAWYER));
+        Assert.Equal(Oracle.DisputeContactTypeCd.OTHER, _sut.Map<Oracle.DisputeContactTypeCd>(Domain.Models.DisputeContactTypeCd.OTHER));
+        #endregion DisputeContactTypeCd
+
+        #region DisputeCountPleaCode
+        // Oracle => Domain
+        Assert.Equal(Domain.Models.DisputeCountPleaCode.UNKNOWN, _sut.Map<Domain.Models.DisputeCountPleaCode>(Oracle.DisputeCountPleaCode.UNKNOWN));
+        Assert.Equal(Domain.Models.DisputeCountPleaCode.G, _sut.Map<Domain.Models.DisputeCountPleaCode>(Oracle.DisputeCountPleaCode.G));
+        Assert.Equal(Domain.Models.DisputeCountPleaCode.N, _sut.Map<Domain.Models.DisputeCountPleaCode>(Oracle.DisputeCountPleaCode.N));
+        // Domain => Oracle
+        Assert.Equal(Oracle.DisputeCountPleaCode.UNKNOWN, _sut.Map<Oracle.DisputeCountPleaCode>(Domain.Models.DisputeCountPleaCode.UNKNOWN));
+        Assert.Equal(Oracle.DisputeCountPleaCode.G, _sut.Map<Oracle.DisputeCountPleaCode>(Domain.Models.DisputeCountPleaCode.G));
+        Assert.Equal(Oracle.DisputeCountPleaCode.N, _sut.Map<Oracle.DisputeCountPleaCode>(Domain.Models.DisputeCountPleaCode.N));
+        #endregion DisputeCountPleaCode
+
+        #region DisputeCountRequestCourtAppearance
+        // Oracle => Domain
+        Assert.Equal(Domain.Models.DisputeCountRequestCourtAppearance.UNKNOWN, _sut.Map<Domain.Models.DisputeCountRequestCourtAppearance>(Oracle.DisputeCountRequestCourtAppearance.UNKNOWN));
+        Assert.Equal(Domain.Models.DisputeCountRequestCourtAppearance.Y, _sut.Map<Domain.Models.DisputeCountRequestCourtAppearance>(Oracle.DisputeCountRequestCourtAppearance.Y));
+        Assert.Equal(Domain.Models.DisputeCountRequestCourtAppearance.N, _sut.Map<Domain.Models.DisputeCountRequestCourtAppearance>(Oracle.DisputeCountRequestCourtAppearance.N));
+        // Domain => Oracle
+        Assert.Equal(Oracle.DisputeCountRequestCourtAppearance.UNKNOWN, _sut.Map<Oracle.DisputeCountRequestCourtAppearance>(Domain.Models.DisputeCountRequestCourtAppearance.UNKNOWN));
+        Assert.Equal(Oracle.DisputeCountRequestCourtAppearance.Y, _sut.Map<Oracle.DisputeCountRequestCourtAppearance>(Domain.Models.DisputeCountRequestCourtAppearance.Y));
+        Assert.Equal(Oracle.DisputeCountRequestCourtAppearance.N, _sut.Map<Oracle.DisputeCountRequestCourtAppearance>(Domain.Models.DisputeCountRequestCourtAppearance.N));
+        #endregion DisputeCountRequestCourtAppearance
+
+        #region DisputeCountRequestReduction
+        // Oracle => Domain
+        Assert.Equal(Domain.Models.DisputeCountRequestReduction.UNKNOWN, _sut.Map<Domain.Models.DisputeCountRequestReduction>(Oracle.DisputeCountRequestReduction.UNKNOWN));
+        Assert.Equal(Domain.Models.DisputeCountRequestReduction.Y, _sut.Map<Domain.Models.DisputeCountRequestReduction>(Oracle.DisputeCountRequestReduction.Y));
+        Assert.Equal(Domain.Models.DisputeCountRequestReduction.N, _sut.Map<Domain.Models.DisputeCountRequestReduction>(Oracle.DisputeCountRequestReduction.N));
+        // Domain => Oracle
+        Assert.Equal(Oracle.DisputeCountRequestReduction.UNKNOWN, _sut.Map<Oracle.DisputeCountRequestReduction>(Domain.Models.DisputeCountRequestReduction.UNKNOWN));
+        Assert.Equal(Oracle.DisputeCountRequestReduction.Y, _sut.Map<Oracle.DisputeCountRequestReduction>(Domain.Models.DisputeCountRequestReduction.Y));
+        Assert.Equal(Oracle.DisputeCountRequestReduction.N, _sut.Map<Oracle.DisputeCountRequestReduction>(Domain.Models.DisputeCountRequestReduction.N));
+        #endregion DisputeCountRequestReduction
+
+        #region DisputeCountRequestTimeToPay
+        // Oracle => Domain
+        Assert.Equal(Domain.Models.DisputeCountRequestTimeToPay.UNKNOWN, _sut.Map<Domain.Models.DisputeCountRequestTimeToPay>(Oracle.DisputeCountRequestTimeToPay.UNKNOWN));
+        Assert.Equal(Domain.Models.DisputeCountRequestTimeToPay.Y, _sut.Map<Domain.Models.DisputeCountRequestTimeToPay>(Oracle.DisputeCountRequestTimeToPay.Y));
+        Assert.Equal(Domain.Models.DisputeCountRequestTimeToPay.N, _sut.Map<Domain.Models.DisputeCountRequestTimeToPay>(Oracle.DisputeCountRequestTimeToPay.N));
+        // Domain => Oracle
+        Assert.Equal(Oracle.DisputeCountRequestTimeToPay.UNKNOWN, _sut.Map<Oracle.DisputeCountRequestTimeToPay>(Domain.Models.DisputeCountRequestTimeToPay.UNKNOWN));
+        Assert.Equal(Oracle.DisputeCountRequestTimeToPay.Y, _sut.Map<Oracle.DisputeCountRequestTimeToPay>(Domain.Models.DisputeCountRequestTimeToPay.Y));
+        Assert.Equal(Oracle.DisputeCountRequestTimeToPay.N, _sut.Map<Oracle.DisputeCountRequestTimeToPay>(Domain.Models.DisputeCountRequestTimeToPay.N));
+        #endregion DisputeCountRequestTimeToPay
+
+        #region DisputeDisputantDetectedOcrIssues
+        // Oracle => Domain
+        Assert.Equal(Domain.Models.DisputeDisputantDetectedOcrIssues.UNKNOWN, _sut.Map<Domain.Models.DisputeDisputantDetectedOcrIssues>(Oracle.DisputeDisputantDetectedOcrIssues.UNKNOWN));
+        Assert.Equal(Domain.Models.DisputeDisputantDetectedOcrIssues.Y, _sut.Map<Domain.Models.DisputeDisputantDetectedOcrIssues>(Oracle.DisputeDisputantDetectedOcrIssues.Y));
+        Assert.Equal(Domain.Models.DisputeDisputantDetectedOcrIssues.N, _sut.Map<Domain.Models.DisputeDisputantDetectedOcrIssues>(Oracle.DisputeDisputantDetectedOcrIssues.N));
+        // Domain => Oracle
+        Assert.Equal(Oracle.DisputeDisputantDetectedOcrIssues.UNKNOWN, _sut.Map<Oracle.DisputeDisputantDetectedOcrIssues>(Domain.Models.DisputeDisputantDetectedOcrIssues.UNKNOWN));
+        Assert.Equal(Oracle.DisputeDisputantDetectedOcrIssues.Y, _sut.Map<Oracle.DisputeDisputantDetectedOcrIssues>(Domain.Models.DisputeDisputantDetectedOcrIssues.Y));
+        Assert.Equal(Oracle.DisputeDisputantDetectedOcrIssues.N, _sut.Map<Oracle.DisputeDisputantDetectedOcrIssues>(Domain.Models.DisputeDisputantDetectedOcrIssues.N));
+        #endregion DisputeDisputantDetectedOcrIssues
+
+        #region DisputeInterpreterRequired
+        // Oracle => Domain
+        Assert.Equal(Domain.Models.DisputeInterpreterRequired.UNKNOWN, _sut.Map<Domain.Models.DisputeInterpreterRequired>(Oracle.DisputeInterpreterRequired.UNKNOWN));
+        Assert.Equal(Domain.Models.DisputeInterpreterRequired.Y, _sut.Map<Domain.Models.DisputeInterpreterRequired>(Oracle.DisputeInterpreterRequired.Y));
+        Assert.Equal(Domain.Models.DisputeInterpreterRequired.N, _sut.Map<Domain.Models.DisputeInterpreterRequired>(Oracle.DisputeInterpreterRequired.N));
+        // Domain => Oracle
+        Assert.Equal(Oracle.DisputeInterpreterRequired.UNKNOWN, _sut.Map<Oracle.DisputeInterpreterRequired>(Domain.Models.DisputeInterpreterRequired.UNKNOWN));
+        Assert.Equal(Oracle.DisputeInterpreterRequired.Y, _sut.Map<Oracle.DisputeInterpreterRequired>(Domain.Models.DisputeInterpreterRequired.Y));
+        Assert.Equal(Oracle.DisputeInterpreterRequired.N, _sut.Map<Oracle.DisputeInterpreterRequired>(Domain.Models.DisputeInterpreterRequired.N));
+        #endregion DisputeInterpreterRequired
+
+        #region DisputeListItemDisputantDetectedOcrIssues
+        // Oracle => Domain
+        Assert.Equal(Domain.Models.DisputeListItemDisputantDetectedOcrIssues.UNKNOWN, _sut.Map<Domain.Models.DisputeListItemDisputantDetectedOcrIssues>(Oracle.DisputeListItemDisputantDetectedOcrIssues.UNKNOWN));
+        Assert.Equal(Domain.Models.DisputeListItemDisputantDetectedOcrIssues.Y, _sut.Map<Domain.Models.DisputeListItemDisputantDetectedOcrIssues>(Oracle.DisputeListItemDisputantDetectedOcrIssues.Y));
+        Assert.Equal(Domain.Models.DisputeListItemDisputantDetectedOcrIssues.N, _sut.Map<Domain.Models.DisputeListItemDisputantDetectedOcrIssues>(Oracle.DisputeListItemDisputantDetectedOcrIssues.N));
+        // Domain => Oracle
+        Assert.Equal(Oracle.DisputeListItemDisputantDetectedOcrIssues.UNKNOWN, _sut.Map<Oracle.DisputeListItemDisputantDetectedOcrIssues>(Domain.Models.DisputeListItemDisputantDetectedOcrIssues.UNKNOWN));
+        Assert.Equal(Oracle.DisputeListItemDisputantDetectedOcrIssues.Y, _sut.Map<Oracle.DisputeListItemDisputantDetectedOcrIssues>(Domain.Models.DisputeListItemDisputantDetectedOcrIssues.Y));
+        Assert.Equal(Oracle.DisputeListItemDisputantDetectedOcrIssues.N, _sut.Map<Oracle.DisputeListItemDisputantDetectedOcrIssues>(Domain.Models.DisputeListItemDisputantDetectedOcrIssues.N));
+        #endregion DisputeListItemDisputantDetectedOcrIssues
+
+        #region DisputeListItemJjDisputeStatus
+        // Oracle => Domain
+        Assert.Equal(Domain.Models.DisputeListItemJjDisputeStatus.UNKNOWN, _sut.Map<Domain.Models.DisputeListItemJjDisputeStatus>(Oracle.DisputeListItemJjDisputeStatus.UNKNOWN));
+        Assert.Equal(Domain.Models.DisputeListItemJjDisputeStatus.NEW, _sut.Map<Domain.Models.DisputeListItemJjDisputeStatus>(Oracle.DisputeListItemJjDisputeStatus.NEW));
+        Assert.Equal(Domain.Models.DisputeListItemJjDisputeStatus.IN_PROGRESS, _sut.Map<Domain.Models.DisputeListItemJjDisputeStatus>(Oracle.DisputeListItemJjDisputeStatus.IN_PROGRESS));
+        Assert.Equal(Domain.Models.DisputeListItemJjDisputeStatus.DATA_UPDATE, _sut.Map<Domain.Models.DisputeListItemJjDisputeStatus>(Oracle.DisputeListItemJjDisputeStatus.DATA_UPDATE));
+        Assert.Equal(Domain.Models.DisputeListItemJjDisputeStatus.CONFIRMED, _sut.Map<Domain.Models.DisputeListItemJjDisputeStatus>(Oracle.DisputeListItemJjDisputeStatus.CONFIRMED));
+        Assert.Equal(Domain.Models.DisputeListItemJjDisputeStatus.REQUIRE_COURT_HEARING, _sut.Map<Domain.Models.DisputeListItemJjDisputeStatus>(Oracle.DisputeListItemJjDisputeStatus.REQUIRE_COURT_HEARING));
+        Assert.Equal(Domain.Models.DisputeListItemJjDisputeStatus.REQUIRE_MORE_INFO, _sut.Map<Domain.Models.DisputeListItemJjDisputeStatus>(Oracle.DisputeListItemJjDisputeStatus.REQUIRE_MORE_INFO));
+        Assert.Equal(Domain.Models.DisputeListItemJjDisputeStatus.ACCEPTED, _sut.Map<Domain.Models.DisputeListItemJjDisputeStatus>(Oracle.DisputeListItemJjDisputeStatus.ACCEPTED));
+        Assert.Equal(Domain.Models.DisputeListItemJjDisputeStatus.REVIEW, _sut.Map<Domain.Models.DisputeListItemJjDisputeStatus>(Oracle.DisputeListItemJjDisputeStatus.REVIEW));
+        Assert.Equal(Domain.Models.DisputeListItemJjDisputeStatus.CONCLUDED, _sut.Map<Domain.Models.DisputeListItemJjDisputeStatus>(Oracle.DisputeListItemJjDisputeStatus.CONCLUDED));
+        Assert.Equal(Domain.Models.DisputeListItemJjDisputeStatus.CANCELLED, _sut.Map<Domain.Models.DisputeListItemJjDisputeStatus>(Oracle.DisputeListItemJjDisputeStatus.CANCELLED));
+        Assert.Equal(Domain.Models.DisputeListItemJjDisputeStatus.HEARING_SCHEDULED, _sut.Map<Domain.Models.DisputeListItemJjDisputeStatus>(Oracle.DisputeListItemJjDisputeStatus.HEARING_SCHEDULED));
+        // Domain => Oracle
+        Assert.Equal(Oracle.DisputeListItemJjDisputeStatus.UNKNOWN, _sut.Map<Oracle.DisputeListItemJjDisputeStatus>(Domain.Models.DisputeListItemJjDisputeStatus.UNKNOWN));
+        Assert.Equal(Oracle.DisputeListItemJjDisputeStatus.NEW, _sut.Map<Oracle.DisputeListItemJjDisputeStatus>(Domain.Models.DisputeListItemJjDisputeStatus.NEW));
+        Assert.Equal(Oracle.DisputeListItemJjDisputeStatus.IN_PROGRESS, _sut.Map<Oracle.DisputeListItemJjDisputeStatus>(Domain.Models.DisputeListItemJjDisputeStatus.IN_PROGRESS));
+        Assert.Equal(Oracle.DisputeListItemJjDisputeStatus.DATA_UPDATE, _sut.Map<Oracle.DisputeListItemJjDisputeStatus>(Domain.Models.DisputeListItemJjDisputeStatus.DATA_UPDATE));
+        Assert.Equal(Oracle.DisputeListItemJjDisputeStatus.CONFIRMED, _sut.Map<Oracle.DisputeListItemJjDisputeStatus>(Domain.Models.DisputeListItemJjDisputeStatus.CONFIRMED));
+        Assert.Equal(Oracle.DisputeListItemJjDisputeStatus.REQUIRE_COURT_HEARING, _sut.Map<Oracle.DisputeListItemJjDisputeStatus>(Domain.Models.DisputeListItemJjDisputeStatus.REQUIRE_COURT_HEARING));
+        Assert.Equal(Oracle.DisputeListItemJjDisputeStatus.REQUIRE_MORE_INFO, _sut.Map<Oracle.DisputeListItemJjDisputeStatus>(Domain.Models.DisputeListItemJjDisputeStatus.REQUIRE_MORE_INFO));
+        Assert.Equal(Oracle.DisputeListItemJjDisputeStatus.ACCEPTED, _sut.Map<Oracle.DisputeListItemJjDisputeStatus>(Domain.Models.DisputeListItemJjDisputeStatus.ACCEPTED));
+        Assert.Equal(Oracle.DisputeListItemJjDisputeStatus.REVIEW, _sut.Map<Oracle.DisputeListItemJjDisputeStatus>(Domain.Models.DisputeListItemJjDisputeStatus.REVIEW));
+        Assert.Equal(Oracle.DisputeListItemJjDisputeStatus.CONCLUDED, _sut.Map<Oracle.DisputeListItemJjDisputeStatus>(Domain.Models.DisputeListItemJjDisputeStatus.CONCLUDED));
+        Assert.Equal(Oracle.DisputeListItemJjDisputeStatus.CANCELLED, _sut.Map<Oracle.DisputeListItemJjDisputeStatus>(Domain.Models.DisputeListItemJjDisputeStatus.CANCELLED));
+        Assert.Equal(Oracle.DisputeListItemJjDisputeStatus.HEARING_SCHEDULED, _sut.Map<Oracle.DisputeListItemJjDisputeStatus>(Domain.Models.DisputeListItemJjDisputeStatus.HEARING_SCHEDULED));
+        #endregion DisputeListItemJjDisputeStatus
+
+        #region DisputeListItemRequestCourtAppearanceYn
+        // Oracle => Domain
+        Assert.Equal(Domain.Models.DisputeListItemRequestCourtAppearanceYn.UNKNOWN, _sut.Map<Domain.Models.DisputeListItemRequestCourtAppearanceYn>(Oracle.DisputeListItemRequestCourtAppearanceYn.UNKNOWN));
+        Assert.Equal(Domain.Models.DisputeListItemRequestCourtAppearanceYn.Y, _sut.Map<Domain.Models.DisputeListItemRequestCourtAppearanceYn>(Oracle.DisputeListItemRequestCourtAppearanceYn.Y));
+        Assert.Equal(Domain.Models.DisputeListItemRequestCourtAppearanceYn.N, _sut.Map<Domain.Models.DisputeListItemRequestCourtAppearanceYn>(Oracle.DisputeListItemRequestCourtAppearanceYn.N));
+        // Domain => Oracle
+        Assert.Equal(Oracle.DisputeListItemRequestCourtAppearanceYn.UNKNOWN, _sut.Map<Oracle.DisputeListItemRequestCourtAppearanceYn>(Domain.Models.DisputeListItemRequestCourtAppearanceYn.UNKNOWN));
+        Assert.Equal(Oracle.DisputeListItemRequestCourtAppearanceYn.Y, _sut.Map<Oracle.DisputeListItemRequestCourtAppearanceYn>(Domain.Models.DisputeListItemRequestCourtAppearanceYn.Y));
+        Assert.Equal(Oracle.DisputeListItemRequestCourtAppearanceYn.N, _sut.Map<Oracle.DisputeListItemRequestCourtAppearanceYn>(Domain.Models.DisputeListItemRequestCourtAppearanceYn.N));
+        #endregion DisputeListItemRequestCourtAppearanceYn
+
+        #region DisputeListItemStatus
+        // Oracle => Domain
+        Assert.Equal(Domain.Models.DisputeListItemStatus.UNKNOWN, _sut.Map<Domain.Models.DisputeListItemStatus>(Oracle.DisputeListItemStatus.UNKNOWN));
+        Assert.Equal(Domain.Models.DisputeListItemStatus.NEW, _sut.Map<Domain.Models.DisputeListItemStatus>(Oracle.DisputeListItemStatus.NEW));
+        Assert.Equal(Domain.Models.DisputeListItemStatus.VALIDATED, _sut.Map<Domain.Models.DisputeListItemStatus>(Oracle.DisputeListItemStatus.VALIDATED));
+        Assert.Equal(Domain.Models.DisputeListItemStatus.PROCESSING, _sut.Map<Domain.Models.DisputeListItemStatus>(Oracle.DisputeListItemStatus.PROCESSING));
+        Assert.Equal(Domain.Models.DisputeListItemStatus.REJECTED, _sut.Map<Domain.Models.DisputeListItemStatus>(Oracle.DisputeListItemStatus.REJECTED));
+        Assert.Equal(Domain.Models.DisputeListItemStatus.CANCELLED, _sut.Map<Domain.Models.DisputeListItemStatus>(Oracle.DisputeListItemStatus.CANCELLED));
+        Assert.Equal(Domain.Models.DisputeListItemStatus.CONCLUDED, _sut.Map<Domain.Models.DisputeListItemStatus>(Oracle.DisputeListItemStatus.CONCLUDED));
+        // Domain => Oracle
+        Assert.Equal(Oracle.DisputeListItemStatus.UNKNOWN, _sut.Map<Oracle.DisputeListItemStatus>(Domain.Models.DisputeListItemStatus.UNKNOWN));
+        Assert.Equal(Oracle.DisputeListItemStatus.NEW, _sut.Map<Oracle.DisputeListItemStatus>(Domain.Models.DisputeListItemStatus.NEW));
+        Assert.Equal(Oracle.DisputeListItemStatus.VALIDATED, _sut.Map<Oracle.DisputeListItemStatus>(Domain.Models.DisputeListItemStatus.VALIDATED));
+        Assert.Equal(Oracle.DisputeListItemStatus.PROCESSING, _sut.Map<Oracle.DisputeListItemStatus>(Domain.Models.DisputeListItemStatus.PROCESSING));
+        Assert.Equal(Oracle.DisputeListItemStatus.REJECTED, _sut.Map<Oracle.DisputeListItemStatus>(Domain.Models.DisputeListItemStatus.REJECTED));
+        Assert.Equal(Oracle.DisputeListItemStatus.CANCELLED, _sut.Map<Oracle.DisputeListItemStatus>(Domain.Models.DisputeListItemStatus.CANCELLED));
+        Assert.Equal(Oracle.DisputeListItemStatus.CONCLUDED, _sut.Map<Oracle.DisputeListItemStatus>(Domain.Models.DisputeListItemStatus.CONCLUDED));
+        #endregion DisputeListItemStatus
+
+        #region DisputeListItemSystemDetectedOcrIssues
+        // Oracle => Domain
+        Assert.Equal(Domain.Models.DisputeListItemSystemDetectedOcrIssues.UNKNOWN, _sut.Map<Domain.Models.DisputeListItemSystemDetectedOcrIssues>(Oracle.DisputeListItemSystemDetectedOcrIssues.UNKNOWN));
+        Assert.Equal(Domain.Models.DisputeListItemSystemDetectedOcrIssues.Y, _sut.Map<Domain.Models.DisputeListItemSystemDetectedOcrIssues>(Oracle.DisputeListItemSystemDetectedOcrIssues.Y));
+        Assert.Equal(Domain.Models.DisputeListItemSystemDetectedOcrIssues.N, _sut.Map<Domain.Models.DisputeListItemSystemDetectedOcrIssues>(Oracle.DisputeListItemSystemDetectedOcrIssues.N));
+        // Domain => Oracle
+        Assert.Equal(Oracle.DisputeListItemSystemDetectedOcrIssues.UNKNOWN, _sut.Map<Oracle.DisputeListItemSystemDetectedOcrIssues>(Domain.Models.DisputeListItemSystemDetectedOcrIssues.UNKNOWN));
+        Assert.Equal(Oracle.DisputeListItemSystemDetectedOcrIssues.Y, _sut.Map<Oracle.DisputeListItemSystemDetectedOcrIssues>(Domain.Models.DisputeListItemSystemDetectedOcrIssues.Y));
+        Assert.Equal(Oracle.DisputeListItemSystemDetectedOcrIssues.N, _sut.Map<Oracle.DisputeListItemSystemDetectedOcrIssues>(Domain.Models.DisputeListItemSystemDetectedOcrIssues.N));
+        #endregion DisputeListItemSystemDetectedOcrIssues
+
+        #region DisputeRepresentedByLawyer
+        // Oracle => Domain
+        Assert.Equal(Domain.Models.DisputeRepresentedByLawyer.UNKNOWN, _sut.Map<Domain.Models.DisputeRepresentedByLawyer>(Oracle.DisputeRepresentedByLawyer.UNKNOWN));
+        Assert.Equal(Domain.Models.DisputeRepresentedByLawyer.Y, _sut.Map<Domain.Models.DisputeRepresentedByLawyer>(Oracle.DisputeRepresentedByLawyer.Y));
+        Assert.Equal(Domain.Models.DisputeRepresentedByLawyer.N, _sut.Map<Domain.Models.DisputeRepresentedByLawyer>(Oracle.DisputeRepresentedByLawyer.N));
+        // Domain => Oracle
+        Assert.Equal(Oracle.DisputeRepresentedByLawyer.UNKNOWN, _sut.Map<Oracle.DisputeRepresentedByLawyer>(Domain.Models.DisputeRepresentedByLawyer.UNKNOWN));
+        Assert.Equal(Oracle.DisputeRepresentedByLawyer.Y, _sut.Map<Oracle.DisputeRepresentedByLawyer>(Domain.Models.DisputeRepresentedByLawyer.Y));
+        Assert.Equal(Oracle.DisputeRepresentedByLawyer.N, _sut.Map<Oracle.DisputeRepresentedByLawyer>(Domain.Models.DisputeRepresentedByLawyer.N));
+        #endregion DisputeRepresentedByLawyer
+
+        #region DisputeRequestCourtAppearanceYn
+        // Oracle => Domain
+        Assert.Equal(Domain.Models.DisputeRequestCourtAppearanceYn.UNKNOWN, _sut.Map<Domain.Models.DisputeRequestCourtAppearanceYn>(Oracle.DisputeRequestCourtAppearanceYn.UNKNOWN));
+        Assert.Equal(Domain.Models.DisputeRequestCourtAppearanceYn.Y, _sut.Map<Domain.Models.DisputeRequestCourtAppearanceYn>(Oracle.DisputeRequestCourtAppearanceYn.Y));
+        Assert.Equal(Domain.Models.DisputeRequestCourtAppearanceYn.N, _sut.Map<Domain.Models.DisputeRequestCourtAppearanceYn>(Oracle.DisputeRequestCourtAppearanceYn.N));
+        // Domain => Oracle
+        Assert.Equal(Oracle.DisputeRequestCourtAppearanceYn.UNKNOWN, _sut.Map<Oracle.DisputeRequestCourtAppearanceYn>(Domain.Models.DisputeRequestCourtAppearanceYn.UNKNOWN));
+        Assert.Equal(Oracle.DisputeRequestCourtAppearanceYn.Y, _sut.Map<Oracle.DisputeRequestCourtAppearanceYn>(Domain.Models.DisputeRequestCourtAppearanceYn.Y));
+        Assert.Equal(Oracle.DisputeRequestCourtAppearanceYn.N, _sut.Map<Oracle.DisputeRequestCourtAppearanceYn>(Domain.Models.DisputeRequestCourtAppearanceYn.N));
+        #endregion DisputeRequestCourtAppearanceYn
+
+        #region DisputeResultDisputeStatus
+        // Oracle => Domain
+        Assert.Equal(Domain.Models.DisputeResultDisputeStatus.UNKNOWN, _sut.Map<Domain.Models.DisputeResultDisputeStatus>(Oracle.DisputeResultDisputeStatus.UNKNOWN));
+        Assert.Equal(Domain.Models.DisputeResultDisputeStatus.NEW, _sut.Map<Domain.Models.DisputeResultDisputeStatus>(Oracle.DisputeResultDisputeStatus.NEW));
+        Assert.Equal(Domain.Models.DisputeResultDisputeStatus.VALIDATED, _sut.Map<Domain.Models.DisputeResultDisputeStatus>(Oracle.DisputeResultDisputeStatus.VALIDATED));
+        Assert.Equal(Domain.Models.DisputeResultDisputeStatus.PROCESSING, _sut.Map<Domain.Models.DisputeResultDisputeStatus>(Oracle.DisputeResultDisputeStatus.PROCESSING));
+        Assert.Equal(Domain.Models.DisputeResultDisputeStatus.REJECTED, _sut.Map<Domain.Models.DisputeResultDisputeStatus>(Oracle.DisputeResultDisputeStatus.REJECTED));
+        Assert.Equal(Domain.Models.DisputeResultDisputeStatus.CANCELLED, _sut.Map<Domain.Models.DisputeResultDisputeStatus>(Oracle.DisputeResultDisputeStatus.CANCELLED));
+        Assert.Equal(Domain.Models.DisputeResultDisputeStatus.CONCLUDED, _sut.Map<Domain.Models.DisputeResultDisputeStatus>(Oracle.DisputeResultDisputeStatus.CONCLUDED));
+        // Domain => Oracle
+        Assert.Equal(Oracle.DisputeResultDisputeStatus.UNKNOWN, _sut.Map<Oracle.DisputeResultDisputeStatus>(Domain.Models.DisputeResultDisputeStatus.UNKNOWN));
+        Assert.Equal(Oracle.DisputeResultDisputeStatus.NEW, _sut.Map<Oracle.DisputeResultDisputeStatus>(Domain.Models.DisputeResultDisputeStatus.NEW));
+        Assert.Equal(Oracle.DisputeResultDisputeStatus.VALIDATED, _sut.Map<Oracle.DisputeResultDisputeStatus>(Domain.Models.DisputeResultDisputeStatus.VALIDATED));
+        Assert.Equal(Oracle.DisputeResultDisputeStatus.PROCESSING, _sut.Map<Oracle.DisputeResultDisputeStatus>(Domain.Models.DisputeResultDisputeStatus.PROCESSING));
+        Assert.Equal(Oracle.DisputeResultDisputeStatus.REJECTED, _sut.Map<Oracle.DisputeResultDisputeStatus>(Domain.Models.DisputeResultDisputeStatus.REJECTED));
+        Assert.Equal(Oracle.DisputeResultDisputeStatus.CANCELLED, _sut.Map<Oracle.DisputeResultDisputeStatus>(Domain.Models.DisputeResultDisputeStatus.CANCELLED));
+        Assert.Equal(Oracle.DisputeResultDisputeStatus.CONCLUDED, _sut.Map<Oracle.DisputeResultDisputeStatus>(Domain.Models.DisputeResultDisputeStatus.CONCLUDED));
+        #endregion DisputeResultDisputeStatus
+
+        #region DisputeResultJjDisputeHearingType
+        // Oracle => Domain
+        Assert.Equal(Domain.Models.DisputeResultJjDisputeHearingType.UNKNOWN, _sut.Map<Domain.Models.DisputeResultJjDisputeHearingType>(Oracle.DisputeResultJjDisputeHearingType.UNKNOWN));
+        Assert.Equal(Domain.Models.DisputeResultJjDisputeHearingType.COURT_APPEARANCE, _sut.Map<Domain.Models.DisputeResultJjDisputeHearingType>(Oracle.DisputeResultJjDisputeHearingType.COURT_APPEARANCE));
+        Assert.Equal(Domain.Models.DisputeResultJjDisputeHearingType.WRITTEN_REASONS, _sut.Map<Domain.Models.DisputeResultJjDisputeHearingType>(Oracle.DisputeResultJjDisputeHearingType.WRITTEN_REASONS));
+        // Domain => Oracle
+        Assert.Equal(Oracle.DisputeResultJjDisputeHearingType.UNKNOWN, _sut.Map<Oracle.DisputeResultJjDisputeHearingType>(Domain.Models.DisputeResultJjDisputeHearingType.UNKNOWN));
+        Assert.Equal(Oracle.DisputeResultJjDisputeHearingType.COURT_APPEARANCE, _sut.Map<Oracle.DisputeResultJjDisputeHearingType>(Domain.Models.DisputeResultJjDisputeHearingType.COURT_APPEARANCE));
+        Assert.Equal(Oracle.DisputeResultJjDisputeHearingType.WRITTEN_REASONS, _sut.Map<Oracle.DisputeResultJjDisputeHearingType>(Domain.Models.DisputeResultJjDisputeHearingType.WRITTEN_REASONS));
+        #endregion DisputeResultJjDisputeHearingType
+
+        #region DisputeResultJjDisputeStatus
+        // Oracle => Domain
+        Assert.Equal(Domain.Models.DisputeResultJjDisputeStatus.UNKNOWN, _sut.Map<Domain.Models.DisputeResultJjDisputeStatus>(Oracle.DisputeResultJjDisputeStatus.UNKNOWN));
+        Assert.Equal(Domain.Models.DisputeResultJjDisputeStatus.NEW, _sut.Map<Domain.Models.DisputeResultJjDisputeStatus>(Oracle.DisputeResultJjDisputeStatus.NEW));
+        Assert.Equal(Domain.Models.DisputeResultJjDisputeStatus.IN_PROGRESS, _sut.Map<Domain.Models.DisputeResultJjDisputeStatus>(Oracle.DisputeResultJjDisputeStatus.IN_PROGRESS));
+        Assert.Equal(Domain.Models.DisputeResultJjDisputeStatus.DATA_UPDATE, _sut.Map<Domain.Models.DisputeResultJjDisputeStatus>(Oracle.DisputeResultJjDisputeStatus.DATA_UPDATE));
+        Assert.Equal(Domain.Models.DisputeResultJjDisputeStatus.CONFIRMED, _sut.Map<Domain.Models.DisputeResultJjDisputeStatus>(Oracle.DisputeResultJjDisputeStatus.CONFIRMED));
+        Assert.Equal(Domain.Models.DisputeResultJjDisputeStatus.REQUIRE_COURT_HEARING, _sut.Map<Domain.Models.DisputeResultJjDisputeStatus>(Oracle.DisputeResultJjDisputeStatus.REQUIRE_COURT_HEARING));
+        Assert.Equal(Domain.Models.DisputeResultJjDisputeStatus.REQUIRE_MORE_INFO, _sut.Map<Domain.Models.DisputeResultJjDisputeStatus>(Oracle.DisputeResultJjDisputeStatus.REQUIRE_MORE_INFO));
+        Assert.Equal(Domain.Models.DisputeResultJjDisputeStatus.ACCEPTED, _sut.Map<Domain.Models.DisputeResultJjDisputeStatus>(Oracle.DisputeResultJjDisputeStatus.ACCEPTED));
+        Assert.Equal(Domain.Models.DisputeResultJjDisputeStatus.REVIEW, _sut.Map<Domain.Models.DisputeResultJjDisputeStatus>(Oracle.DisputeResultJjDisputeStatus.REVIEW));
+        Assert.Equal(Domain.Models.DisputeResultJjDisputeStatus.CONCLUDED, _sut.Map<Domain.Models.DisputeResultJjDisputeStatus>(Oracle.DisputeResultJjDisputeStatus.CONCLUDED));
+        Assert.Equal(Domain.Models.DisputeResultJjDisputeStatus.CANCELLED, _sut.Map<Domain.Models.DisputeResultJjDisputeStatus>(Oracle.DisputeResultJjDisputeStatus.CANCELLED));
+        Assert.Equal(Domain.Models.DisputeResultJjDisputeStatus.HEARING_SCHEDULED, _sut.Map<Domain.Models.DisputeResultJjDisputeStatus>(Oracle.DisputeResultJjDisputeStatus.HEARING_SCHEDULED));
+        // Domain => Oracle
+        Assert.Equal(Oracle.DisputeResultJjDisputeStatus.UNKNOWN, _sut.Map<Oracle.DisputeResultJjDisputeStatus>(Domain.Models.DisputeResultJjDisputeStatus.UNKNOWN));
+        Assert.Equal(Oracle.DisputeResultJjDisputeStatus.NEW, _sut.Map<Oracle.DisputeResultJjDisputeStatus>(Domain.Models.DisputeResultJjDisputeStatus.NEW));
+        Assert.Equal(Oracle.DisputeResultJjDisputeStatus.IN_PROGRESS, _sut.Map<Oracle.DisputeResultJjDisputeStatus>(Domain.Models.DisputeResultJjDisputeStatus.IN_PROGRESS));
+        Assert.Equal(Oracle.DisputeResultJjDisputeStatus.DATA_UPDATE, _sut.Map<Oracle.DisputeResultJjDisputeStatus>(Domain.Models.DisputeResultJjDisputeStatus.DATA_UPDATE));
+        Assert.Equal(Oracle.DisputeResultJjDisputeStatus.CONFIRMED, _sut.Map<Oracle.DisputeResultJjDisputeStatus>(Domain.Models.DisputeResultJjDisputeStatus.CONFIRMED));
+        Assert.Equal(Oracle.DisputeResultJjDisputeStatus.REQUIRE_COURT_HEARING, _sut.Map<Oracle.DisputeResultJjDisputeStatus>(Domain.Models.DisputeResultJjDisputeStatus.REQUIRE_COURT_HEARING));
+        Assert.Equal(Oracle.DisputeResultJjDisputeStatus.REQUIRE_MORE_INFO, _sut.Map<Oracle.DisputeResultJjDisputeStatus>(Domain.Models.DisputeResultJjDisputeStatus.REQUIRE_MORE_INFO));
+        Assert.Equal(Oracle.DisputeResultJjDisputeStatus.ACCEPTED, _sut.Map<Oracle.DisputeResultJjDisputeStatus>(Domain.Models.DisputeResultJjDisputeStatus.ACCEPTED));
+        Assert.Equal(Oracle.DisputeResultJjDisputeStatus.REVIEW, _sut.Map<Oracle.DisputeResultJjDisputeStatus>(Domain.Models.DisputeResultJjDisputeStatus.REVIEW));
+        Assert.Equal(Oracle.DisputeResultJjDisputeStatus.CONCLUDED, _sut.Map<Oracle.DisputeResultJjDisputeStatus>(Domain.Models.DisputeResultJjDisputeStatus.CONCLUDED));
+        Assert.Equal(Oracle.DisputeResultJjDisputeStatus.CANCELLED, _sut.Map<Oracle.DisputeResultJjDisputeStatus>(Domain.Models.DisputeResultJjDisputeStatus.CANCELLED));
+        Assert.Equal(Oracle.DisputeResultJjDisputeStatus.HEARING_SCHEDULED, _sut.Map<Oracle.DisputeResultJjDisputeStatus>(Domain.Models.DisputeResultJjDisputeStatus.HEARING_SCHEDULED));
+        #endregion DisputeResultJjDisputeStatus
+
+        #region DisputeSignatoryType
+        // Oracle => Domain
+        Assert.Equal(Domain.Models.DisputeSignatoryType.U, _sut.Map<Domain.Models.DisputeSignatoryType>(Oracle.DisputeSignatoryType.U));
+        Assert.Equal(Domain.Models.DisputeSignatoryType.D, _sut.Map<Domain.Models.DisputeSignatoryType>(Oracle.DisputeSignatoryType.D));
+        Assert.Equal(Domain.Models.DisputeSignatoryType.A, _sut.Map<Domain.Models.DisputeSignatoryType>(Oracle.DisputeSignatoryType.A));
+        // Domain => Oracle
+        Assert.Equal(Oracle.DisputeSignatoryType.U, _sut.Map<Oracle.DisputeSignatoryType>(Domain.Models.DisputeSignatoryType.U));
+        Assert.Equal(Oracle.DisputeSignatoryType.D, _sut.Map<Oracle.DisputeSignatoryType>(Domain.Models.DisputeSignatoryType.D));
+        Assert.Equal(Oracle.DisputeSignatoryType.A, _sut.Map<Oracle.DisputeSignatoryType>(Domain.Models.DisputeSignatoryType.A));
+        #endregion DisputeSignatoryType
+
+        #region DisputeStatus
+        // Oracle => Domain
+        Assert.Equal(Domain.Models.DisputeStatus.UNKNOWN, _sut.Map<Domain.Models.DisputeStatus>(Oracle.DisputeStatus.UNKNOWN));
+        Assert.Equal(Domain.Models.DisputeStatus.NEW, _sut.Map<Domain.Models.DisputeStatus>(Oracle.DisputeStatus.NEW));
+        Assert.Equal(Domain.Models.DisputeStatus.VALIDATED, _sut.Map<Domain.Models.DisputeStatus>(Oracle.DisputeStatus.VALIDATED));
+        Assert.Equal(Domain.Models.DisputeStatus.PROCESSING, _sut.Map<Domain.Models.DisputeStatus>(Oracle.DisputeStatus.PROCESSING));
+        Assert.Equal(Domain.Models.DisputeStatus.REJECTED, _sut.Map<Domain.Models.DisputeStatus>(Oracle.DisputeStatus.REJECTED));
+        Assert.Equal(Domain.Models.DisputeStatus.CANCELLED, _sut.Map<Domain.Models.DisputeStatus>(Oracle.DisputeStatus.CANCELLED));
+        Assert.Equal(Domain.Models.DisputeStatus.CONCLUDED, _sut.Map<Domain.Models.DisputeStatus>(Oracle.DisputeStatus.CONCLUDED));
+        // Domain => Oracle
+        Assert.Equal(Oracle.DisputeStatus.UNKNOWN, _sut.Map<Oracle.DisputeStatus>(Domain.Models.DisputeStatus.UNKNOWN));
+        Assert.Equal(Oracle.DisputeStatus.NEW, _sut.Map<Oracle.DisputeStatus>(Domain.Models.DisputeStatus.NEW));
+        Assert.Equal(Oracle.DisputeStatus.VALIDATED, _sut.Map<Oracle.DisputeStatus>(Domain.Models.DisputeStatus.VALIDATED));
+        Assert.Equal(Oracle.DisputeStatus.PROCESSING, _sut.Map<Oracle.DisputeStatus>(Domain.Models.DisputeStatus.PROCESSING));
+        Assert.Equal(Oracle.DisputeStatus.REJECTED, _sut.Map<Oracle.DisputeStatus>(Domain.Models.DisputeStatus.REJECTED));
+        Assert.Equal(Oracle.DisputeStatus.CANCELLED, _sut.Map<Oracle.DisputeStatus>(Domain.Models.DisputeStatus.CANCELLED));
+        Assert.Equal(Oracle.DisputeStatus.CONCLUDED, _sut.Map<Oracle.DisputeStatus>(Domain.Models.DisputeStatus.CONCLUDED));
+        #endregion DisputeStatus
+
+        #region DisputeSystemDetectedOcrIssues
+        // Oracle => Domain
+        Assert.Equal(Domain.Models.DisputeSystemDetectedOcrIssues.UNKNOWN, _sut.Map<Domain.Models.DisputeSystemDetectedOcrIssues>(Oracle.DisputeSystemDetectedOcrIssues.UNKNOWN));
+        Assert.Equal(Domain.Models.DisputeSystemDetectedOcrIssues.Y, _sut.Map<Domain.Models.DisputeSystemDetectedOcrIssues>(Oracle.DisputeSystemDetectedOcrIssues.Y));
+        Assert.Equal(Domain.Models.DisputeSystemDetectedOcrIssues.N, _sut.Map<Domain.Models.DisputeSystemDetectedOcrIssues>(Oracle.DisputeSystemDetectedOcrIssues.N));
+        // Domain => Oracle
+        Assert.Equal(Oracle.DisputeSystemDetectedOcrIssues.UNKNOWN, _sut.Map<Oracle.DisputeSystemDetectedOcrIssues>(Domain.Models.DisputeSystemDetectedOcrIssues.UNKNOWN));
+        Assert.Equal(Oracle.DisputeSystemDetectedOcrIssues.Y, _sut.Map<Oracle.DisputeSystemDetectedOcrIssues>(Domain.Models.DisputeSystemDetectedOcrIssues.Y));
+        Assert.Equal(Oracle.DisputeSystemDetectedOcrIssues.N, _sut.Map<Oracle.DisputeSystemDetectedOcrIssues>(Domain.Models.DisputeSystemDetectedOcrIssues.N));
+        #endregion DisputeSystemDetectedOcrIssues
+
+        #region DisputeUpdateRequestStatus
+        // Oracle => Domain
+        Assert.Equal(Domain.Models.DisputeUpdateRequestStatus.UNKNOWN, _sut.Map<Domain.Models.DisputeUpdateRequestStatus>(Oracle.DisputeUpdateRequestStatus.UNKNOWN));
+        Assert.Equal(Domain.Models.DisputeUpdateRequestStatus.ACCEPTED, _sut.Map<Domain.Models.DisputeUpdateRequestStatus>(Oracle.DisputeUpdateRequestStatus.ACCEPTED));
+        Assert.Equal(Domain.Models.DisputeUpdateRequestStatus.PENDING, _sut.Map<Domain.Models.DisputeUpdateRequestStatus>(Oracle.DisputeUpdateRequestStatus.PENDING));
+        Assert.Equal(Domain.Models.DisputeUpdateRequestStatus.REJECTED, _sut.Map<Domain.Models.DisputeUpdateRequestStatus>(Oracle.DisputeUpdateRequestStatus.REJECTED));
+        // Domain => Oracle
+        Assert.Equal(Oracle.DisputeUpdateRequestStatus.UNKNOWN, _sut.Map<Oracle.DisputeUpdateRequestStatus>(Domain.Models.DisputeUpdateRequestStatus.UNKNOWN));
+        Assert.Equal(Oracle.DisputeUpdateRequestStatus.ACCEPTED, _sut.Map<Oracle.DisputeUpdateRequestStatus>(Domain.Models.DisputeUpdateRequestStatus.ACCEPTED));
+        Assert.Equal(Oracle.DisputeUpdateRequestStatus.PENDING, _sut.Map<Oracle.DisputeUpdateRequestStatus>(Domain.Models.DisputeUpdateRequestStatus.PENDING));
+        Assert.Equal(Oracle.DisputeUpdateRequestStatus.REJECTED, _sut.Map<Oracle.DisputeUpdateRequestStatus>(Domain.Models.DisputeUpdateRequestStatus.REJECTED));
+        #endregion DisputeUpdateRequestStatus
+
+        #region DisputeUpdateRequestStatus2
+        // Oracle => Domain
+        Assert.Equal(Domain.Models.DisputeUpdateRequestStatus2.UNKNOWN, _sut.Map<Domain.Models.DisputeUpdateRequestStatus2>(Oracle.DisputeUpdateRequestStatus2.UNKNOWN));
+        Assert.Equal(Domain.Models.DisputeUpdateRequestStatus2.ACCEPTED, _sut.Map<Domain.Models.DisputeUpdateRequestStatus2>(Oracle.DisputeUpdateRequestStatus2.ACCEPTED));
+        Assert.Equal(Domain.Models.DisputeUpdateRequestStatus2.PENDING, _sut.Map<Domain.Models.DisputeUpdateRequestStatus2>(Oracle.DisputeUpdateRequestStatus2.PENDING));
+        Assert.Equal(Domain.Models.DisputeUpdateRequestStatus2.REJECTED, _sut.Map<Domain.Models.DisputeUpdateRequestStatus2>(Oracle.DisputeUpdateRequestStatus2.REJECTED));
+        // Domain => Oracle
+        Assert.Equal(Oracle.DisputeUpdateRequestStatus2.UNKNOWN, _sut.Map<Oracle.DisputeUpdateRequestStatus2>(Domain.Models.DisputeUpdateRequestStatus2.UNKNOWN));
+        Assert.Equal(Oracle.DisputeUpdateRequestStatus2.ACCEPTED, _sut.Map<Oracle.DisputeUpdateRequestStatus2>(Domain.Models.DisputeUpdateRequestStatus2.ACCEPTED));
+        Assert.Equal(Oracle.DisputeUpdateRequestStatus2.PENDING, _sut.Map<Oracle.DisputeUpdateRequestStatus2>(Domain.Models.DisputeUpdateRequestStatus2.PENDING));
+        Assert.Equal(Oracle.DisputeUpdateRequestStatus2.REJECTED, _sut.Map<Oracle.DisputeUpdateRequestStatus2>(Domain.Models.DisputeUpdateRequestStatus2.REJECTED));
+        #endregion DisputeUpdateRequestStatus2
+
+        #region DisputeUpdateRequestUpdateType
+        // Oracle => Domain
+        Assert.Equal(Domain.Models.DisputeUpdateRequestUpdateType.UNKNOWN, _sut.Map<Domain.Models.DisputeUpdateRequestUpdateType>(Oracle.DisputeUpdateRequestUpdateType.UNKNOWN));
+        Assert.Equal(Domain.Models.DisputeUpdateRequestUpdateType.DISPUTANT_ADDRESS, _sut.Map<Domain.Models.DisputeUpdateRequestUpdateType>(Oracle.DisputeUpdateRequestUpdateType.DISPUTANT_ADDRESS));
+        Assert.Equal(Domain.Models.DisputeUpdateRequestUpdateType.DISPUTANT_PHONE, _sut.Map<Domain.Models.DisputeUpdateRequestUpdateType>(Oracle.DisputeUpdateRequestUpdateType.DISPUTANT_PHONE));
+        Assert.Equal(Domain.Models.DisputeUpdateRequestUpdateType.DISPUTANT_NAME, _sut.Map<Domain.Models.DisputeUpdateRequestUpdateType>(Oracle.DisputeUpdateRequestUpdateType.DISPUTANT_NAME));
+        Assert.Equal(Domain.Models.DisputeUpdateRequestUpdateType.COUNT, _sut.Map<Domain.Models.DisputeUpdateRequestUpdateType>(Oracle.DisputeUpdateRequestUpdateType.COUNT));
+        Assert.Equal(Domain.Models.DisputeUpdateRequestUpdateType.DISPUTANT_EMAIL, _sut.Map<Domain.Models.DisputeUpdateRequestUpdateType>(Oracle.DisputeUpdateRequestUpdateType.DISPUTANT_EMAIL));
+        Assert.Equal(Domain.Models.DisputeUpdateRequestUpdateType.DISPUTANT_DOCUMENT, _sut.Map<Domain.Models.DisputeUpdateRequestUpdateType>(Oracle.DisputeUpdateRequestUpdateType.DISPUTANT_DOCUMENT));
+        Assert.Equal(Domain.Models.DisputeUpdateRequestUpdateType.COURT_OPTIONS, _sut.Map<Domain.Models.DisputeUpdateRequestUpdateType>(Oracle.DisputeUpdateRequestUpdateType.COURT_OPTIONS));
+        // Domain => Oracle
+        Assert.Equal(Oracle.DisputeUpdateRequestUpdateType.UNKNOWN, _sut.Map<Oracle.DisputeUpdateRequestUpdateType>(Domain.Models.DisputeUpdateRequestUpdateType.UNKNOWN));
+        Assert.Equal(Oracle.DisputeUpdateRequestUpdateType.DISPUTANT_ADDRESS, _sut.Map<Oracle.DisputeUpdateRequestUpdateType>(Domain.Models.DisputeUpdateRequestUpdateType.DISPUTANT_ADDRESS));
+        Assert.Equal(Oracle.DisputeUpdateRequestUpdateType.DISPUTANT_PHONE, _sut.Map<Oracle.DisputeUpdateRequestUpdateType>(Domain.Models.DisputeUpdateRequestUpdateType.DISPUTANT_PHONE));
+        Assert.Equal(Oracle.DisputeUpdateRequestUpdateType.DISPUTANT_NAME, _sut.Map<Oracle.DisputeUpdateRequestUpdateType>(Domain.Models.DisputeUpdateRequestUpdateType.DISPUTANT_NAME));
+        Assert.Equal(Oracle.DisputeUpdateRequestUpdateType.COUNT, _sut.Map<Oracle.DisputeUpdateRequestUpdateType>(Domain.Models.DisputeUpdateRequestUpdateType.COUNT));
+        Assert.Equal(Oracle.DisputeUpdateRequestUpdateType.DISPUTANT_EMAIL, _sut.Map<Oracle.DisputeUpdateRequestUpdateType>(Domain.Models.DisputeUpdateRequestUpdateType.DISPUTANT_EMAIL));
+        Assert.Equal(Oracle.DisputeUpdateRequestUpdateType.DISPUTANT_DOCUMENT, _sut.Map<Oracle.DisputeUpdateRequestUpdateType>(Domain.Models.DisputeUpdateRequestUpdateType.DISPUTANT_DOCUMENT));
+        Assert.Equal(Oracle.DisputeUpdateRequestUpdateType.COURT_OPTIONS, _sut.Map<Oracle.DisputeUpdateRequestUpdateType>(Domain.Models.DisputeUpdateRequestUpdateType.COURT_OPTIONS));
+        #endregion DisputeUpdateRequestUpdateType
+
+        #region DocumentType
+        // Oracle => Domain
+        Assert.Equal(Domain.Models.DocumentType.UNKNOWN, _sut.Map<Domain.Models.DocumentType>(Oracle.DocumentType.UNKNOWN));
+        Assert.Equal(Domain.Models.DocumentType.NOTICE_OF_DISPUTE, _sut.Map<Domain.Models.DocumentType>(Oracle.DocumentType.NOTICE_OF_DISPUTE));
+        Assert.Equal(Domain.Models.DocumentType.TICKET_IMAGE, _sut.Map<Domain.Models.DocumentType>(Oracle.DocumentType.TICKET_IMAGE));
+        // Domain => Oracle
+        Assert.Equal(Oracle.DocumentType.UNKNOWN, _sut.Map<Oracle.DocumentType>(Domain.Models.DocumentType.UNKNOWN));
+        Assert.Equal(Oracle.DocumentType.NOTICE_OF_DISPUTE, _sut.Map<Oracle.DocumentType>(Domain.Models.DocumentType.NOTICE_OF_DISPUTE));
+        Assert.Equal(Oracle.DocumentType.TICKET_IMAGE, _sut.Map<Oracle.DocumentType>(Domain.Models.DocumentType.TICKET_IMAGE));
+        #endregion DocumentType
+
+        #region EmailHistorySuccessfullySent
+        // Oracle => Domain
+        Assert.Equal(Domain.Models.EmailHistorySuccessfullySent.UNKNOWN, _sut.Map<Domain.Models.EmailHistorySuccessfullySent>(Oracle.EmailHistorySuccessfullySent.UNKNOWN));
+        Assert.Equal(Domain.Models.EmailHistorySuccessfullySent.Y, _sut.Map<Domain.Models.EmailHistorySuccessfullySent>(Oracle.EmailHistorySuccessfullySent.Y));
+        Assert.Equal(Domain.Models.EmailHistorySuccessfullySent.N, _sut.Map<Domain.Models.EmailHistorySuccessfullySent>(Oracle.EmailHistorySuccessfullySent.N));
+        // Domain => Oracle
+        Assert.Equal(Oracle.EmailHistorySuccessfullySent.UNKNOWN, _sut.Map<Oracle.EmailHistorySuccessfullySent>(Domain.Models.EmailHistorySuccessfullySent.UNKNOWN));
+        Assert.Equal(Oracle.EmailHistorySuccessfullySent.Y, _sut.Map<Oracle.EmailHistorySuccessfullySent>(Domain.Models.EmailHistorySuccessfullySent.Y));
+        Assert.Equal(Oracle.EmailHistorySuccessfullySent.N, _sut.Map<Oracle.EmailHistorySuccessfullySent>(Domain.Models.EmailHistorySuccessfullySent.N));
+        #endregion EmailHistorySuccessfullySent
+
+        #region ExcludeStatus
+        // Oracle => Domain
+        Assert.Equal(Domain.Models.ExcludeStatus.UNKNOWN, _sut.Map<Domain.Models.ExcludeStatus>(Oracle.ExcludeStatus.UNKNOWN));
+        Assert.Equal(Domain.Models.ExcludeStatus.NEW, _sut.Map<Domain.Models.ExcludeStatus>(Oracle.ExcludeStatus.NEW));
+        Assert.Equal(Domain.Models.ExcludeStatus.VALIDATED, _sut.Map<Domain.Models.ExcludeStatus>(Oracle.ExcludeStatus.VALIDATED));
+        Assert.Equal(Domain.Models.ExcludeStatus.PROCESSING, _sut.Map<Domain.Models.ExcludeStatus>(Oracle.ExcludeStatus.PROCESSING));
+        Assert.Equal(Domain.Models.ExcludeStatus.REJECTED, _sut.Map<Domain.Models.ExcludeStatus>(Oracle.ExcludeStatus.REJECTED));
+        Assert.Equal(Domain.Models.ExcludeStatus.CANCELLED, _sut.Map<Domain.Models.ExcludeStatus>(Oracle.ExcludeStatus.CANCELLED));
+        Assert.Equal(Domain.Models.ExcludeStatus.CONCLUDED, _sut.Map<Domain.Models.ExcludeStatus>(Oracle.ExcludeStatus.CONCLUDED));
+        // Domain => Oracle
+        Assert.Equal(Oracle.ExcludeStatus.UNKNOWN, _sut.Map<Oracle.ExcludeStatus>(Domain.Models.ExcludeStatus.UNKNOWN));
+        Assert.Equal(Oracle.ExcludeStatus.NEW, _sut.Map<Oracle.ExcludeStatus>(Domain.Models.ExcludeStatus.NEW));
+        Assert.Equal(Oracle.ExcludeStatus.VALIDATED, _sut.Map<Oracle.ExcludeStatus>(Domain.Models.ExcludeStatus.VALIDATED));
+        Assert.Equal(Oracle.ExcludeStatus.PROCESSING, _sut.Map<Oracle.ExcludeStatus>(Domain.Models.ExcludeStatus.PROCESSING));
+        Assert.Equal(Oracle.ExcludeStatus.REJECTED, _sut.Map<Oracle.ExcludeStatus>(Domain.Models.ExcludeStatus.REJECTED));
+        Assert.Equal(Oracle.ExcludeStatus.CANCELLED, _sut.Map<Oracle.ExcludeStatus>(Domain.Models.ExcludeStatus.CANCELLED));
+        Assert.Equal(Oracle.ExcludeStatus.CONCLUDED, _sut.Map<Oracle.ExcludeStatus>(Domain.Models.ExcludeStatus.CONCLUDED));
+        #endregion ExcludeStatus
+
+        #region ExcludeStatus2
+        // Oracle => Domain
+        Assert.Equal(Domain.Models.ExcludeStatus2.UNKNOWN, _sut.Map<Domain.Models.ExcludeStatus2>(Oracle.ExcludeStatus2.UNKNOWN));
+        Assert.Equal(Domain.Models.ExcludeStatus2.NEW, _sut.Map<Domain.Models.ExcludeStatus2>(Oracle.ExcludeStatus2.NEW));
+        Assert.Equal(Domain.Models.ExcludeStatus2.VALIDATED, _sut.Map<Domain.Models.ExcludeStatus2>(Oracle.ExcludeStatus2.VALIDATED));
+        Assert.Equal(Domain.Models.ExcludeStatus2.PROCESSING, _sut.Map<Domain.Models.ExcludeStatus2>(Oracle.ExcludeStatus2.PROCESSING));
+        Assert.Equal(Domain.Models.ExcludeStatus2.REJECTED, _sut.Map<Domain.Models.ExcludeStatus2>(Oracle.ExcludeStatus2.REJECTED));
+        Assert.Equal(Domain.Models.ExcludeStatus2.CANCELLED, _sut.Map<Domain.Models.ExcludeStatus2>(Oracle.ExcludeStatus2.CANCELLED));
+        Assert.Equal(Domain.Models.ExcludeStatus2.CONCLUDED, _sut.Map<Domain.Models.ExcludeStatus2>(Oracle.ExcludeStatus2.CONCLUDED));
+        // Domain => Oracle
+        Assert.Equal(Oracle.ExcludeStatus2.UNKNOWN, _sut.Map<Oracle.ExcludeStatus2>(Domain.Models.ExcludeStatus2.UNKNOWN));
+        Assert.Equal(Oracle.ExcludeStatus2.NEW, _sut.Map<Oracle.ExcludeStatus2>(Domain.Models.ExcludeStatus2.NEW));
+        Assert.Equal(Oracle.ExcludeStatus2.VALIDATED, _sut.Map<Oracle.ExcludeStatus2>(Domain.Models.ExcludeStatus2.VALIDATED));
+        Assert.Equal(Oracle.ExcludeStatus2.PROCESSING, _sut.Map<Oracle.ExcludeStatus2>(Domain.Models.ExcludeStatus2.PROCESSING));
+        Assert.Equal(Oracle.ExcludeStatus2.REJECTED, _sut.Map<Oracle.ExcludeStatus2>(Domain.Models.ExcludeStatus2.REJECTED));
+        Assert.Equal(Oracle.ExcludeStatus2.CANCELLED, _sut.Map<Oracle.ExcludeStatus2>(Domain.Models.ExcludeStatus2.CANCELLED));
+        Assert.Equal(Oracle.ExcludeStatus2.CONCLUDED, _sut.Map<Oracle.ExcludeStatus2>(Domain.Models.ExcludeStatus2.CONCLUDED));
+        #endregion ExcludeStatus2
+
+        #region FileHistoryAuditLogEntryType
+        // Oracle => Domain
+        Assert.Equal(Domain.Models.FileHistoryAuditLogEntryType.UNKNOWN, _sut.Map<Domain.Models.FileHistoryAuditLogEntryType>(Oracle.FileHistoryAuditLogEntryType.UNKNOWN));
+        Assert.Equal(Domain.Models.FileHistoryAuditLogEntryType.ARFL, _sut.Map<Domain.Models.FileHistoryAuditLogEntryType>(Oracle.FileHistoryAuditLogEntryType.ARFL));
+        Assert.Equal(Domain.Models.FileHistoryAuditLogEntryType.CAIN, _sut.Map<Domain.Models.FileHistoryAuditLogEntryType>(Oracle.FileHistoryAuditLogEntryType.CAIN));
+        Assert.Equal(Domain.Models.FileHistoryAuditLogEntryType.CAWT, _sut.Map<Domain.Models.FileHistoryAuditLogEntryType>(Oracle.FileHistoryAuditLogEntryType.CAWT));
+        Assert.Equal(Domain.Models.FileHistoryAuditLogEntryType.CCAN, _sut.Map<Domain.Models.FileHistoryAuditLogEntryType>(Oracle.FileHistoryAuditLogEntryType.CCAN));
+        Assert.Equal(Domain.Models.FileHistoryAuditLogEntryType.CCON, _sut.Map<Domain.Models.FileHistoryAuditLogEntryType>(Oracle.FileHistoryAuditLogEntryType.CCON));
+        Assert.Equal(Domain.Models.FileHistoryAuditLogEntryType.CCWR, _sut.Map<Domain.Models.FileHistoryAuditLogEntryType>(Oracle.FileHistoryAuditLogEntryType.CCWR));
+        Assert.Equal(Domain.Models.FileHistoryAuditLogEntryType.CLEG, _sut.Map<Domain.Models.FileHistoryAuditLogEntryType>(Oracle.FileHistoryAuditLogEntryType.CLEG));
+        Assert.Equal(Domain.Models.FileHistoryAuditLogEntryType.CUEM, _sut.Map<Domain.Models.FileHistoryAuditLogEntryType>(Oracle.FileHistoryAuditLogEntryType.CUEM));
+        Assert.Equal(Domain.Models.FileHistoryAuditLogEntryType.CUEV, _sut.Map<Domain.Models.FileHistoryAuditLogEntryType>(Oracle.FileHistoryAuditLogEntryType.CUEV));
+        Assert.Equal(Domain.Models.FileHistoryAuditLogEntryType.CUIN, _sut.Map<Domain.Models.FileHistoryAuditLogEntryType>(Oracle.FileHistoryAuditLogEntryType.CUIN));
+        Assert.Equal(Domain.Models.FileHistoryAuditLogEntryType.CULG, _sut.Map<Domain.Models.FileHistoryAuditLogEntryType>(Oracle.FileHistoryAuditLogEntryType.CULG));
+        Assert.Equal(Domain.Models.FileHistoryAuditLogEntryType.CUPD, _sut.Map<Domain.Models.FileHistoryAuditLogEntryType>(Oracle.FileHistoryAuditLogEntryType.CUPD));
+        Assert.Equal(Domain.Models.FileHistoryAuditLogEntryType.CUWR, _sut.Map<Domain.Models.FileHistoryAuditLogEntryType>(Oracle.FileHistoryAuditLogEntryType.CUWR));
+        Assert.Equal(Domain.Models.FileHistoryAuditLogEntryType.CUWT, _sut.Map<Domain.Models.FileHistoryAuditLogEntryType>(Oracle.FileHistoryAuditLogEntryType.CUWT));
+        Assert.Equal(Domain.Models.FileHistoryAuditLogEntryType.DURA, _sut.Map<Domain.Models.FileHistoryAuditLogEntryType>(Oracle.FileHistoryAuditLogEntryType.DURA));
+        Assert.Equal(Domain.Models.FileHistoryAuditLogEntryType.DURR, _sut.Map<Domain.Models.FileHistoryAuditLogEntryType>(Oracle.FileHistoryAuditLogEntryType.DURR));
+        Assert.Equal(Domain.Models.FileHistoryAuditLogEntryType.EMCA, _sut.Map<Domain.Models.FileHistoryAuditLogEntryType>(Oracle.FileHistoryAuditLogEntryType.EMCA));
+        Assert.Equal(Domain.Models.FileHistoryAuditLogEntryType.EMCF, _sut.Map<Domain.Models.FileHistoryAuditLogEntryType>(Oracle.FileHistoryAuditLogEntryType.EMCF));
+        Assert.Equal(Domain.Models.FileHistoryAuditLogEntryType.EMCR, _sut.Map<Domain.Models.FileHistoryAuditLogEntryType>(Oracle.FileHistoryAuditLogEntryType.EMCR));
+        Assert.Equal(Domain.Models.FileHistoryAuditLogEntryType.EMDC, _sut.Map<Domain.Models.FileHistoryAuditLogEntryType>(Oracle.FileHistoryAuditLogEntryType.EMDC));
+        Assert.Equal(Domain.Models.FileHistoryAuditLogEntryType.EMFD, _sut.Map<Domain.Models.FileHistoryAuditLogEntryType>(Oracle.FileHistoryAuditLogEntryType.EMFD));
+        Assert.Equal(Domain.Models.FileHistoryAuditLogEntryType.EMPR, _sut.Map<Domain.Models.FileHistoryAuditLogEntryType>(Oracle.FileHistoryAuditLogEntryType.EMPR));
+        Assert.Equal(Domain.Models.FileHistoryAuditLogEntryType.EMRJ, _sut.Map<Domain.Models.FileHistoryAuditLogEntryType>(Oracle.FileHistoryAuditLogEntryType.EMRJ));
+        Assert.Equal(Domain.Models.FileHistoryAuditLogEntryType.EMRV, _sut.Map<Domain.Models.FileHistoryAuditLogEntryType>(Oracle.FileHistoryAuditLogEntryType.EMRV));
+        Assert.Equal(Domain.Models.FileHistoryAuditLogEntryType.EMST, _sut.Map<Domain.Models.FileHistoryAuditLogEntryType>(Oracle.FileHistoryAuditLogEntryType.EMST));
+        Assert.Equal(Domain.Models.FileHistoryAuditLogEntryType.EMUP, _sut.Map<Domain.Models.FileHistoryAuditLogEntryType>(Oracle.FileHistoryAuditLogEntryType.EMUP));
+        Assert.Equal(Domain.Models.FileHistoryAuditLogEntryType.EMVF, _sut.Map<Domain.Models.FileHistoryAuditLogEntryType>(Oracle.FileHistoryAuditLogEntryType.EMVF));
+        Assert.Equal(Domain.Models.FileHistoryAuditLogEntryType.ESUR, _sut.Map<Domain.Models.FileHistoryAuditLogEntryType>(Oracle.FileHistoryAuditLogEntryType.ESUR));
+        Assert.Equal(Domain.Models.FileHistoryAuditLogEntryType.FDLD, _sut.Map<Domain.Models.FileHistoryAuditLogEntryType>(Oracle.FileHistoryAuditLogEntryType.FDLD));
+        Assert.Equal(Domain.Models.FileHistoryAuditLogEntryType.FDLS, _sut.Map<Domain.Models.FileHistoryAuditLogEntryType>(Oracle.FileHistoryAuditLogEntryType.FDLS));
+        Assert.Equal(Domain.Models.FileHistoryAuditLogEntryType.FUPD, _sut.Map<Domain.Models.FileHistoryAuditLogEntryType>(Oracle.FileHistoryAuditLogEntryType.FUPD));
+        Assert.Equal(Domain.Models.FileHistoryAuditLogEntryType.FUPS, _sut.Map<Domain.Models.FileHistoryAuditLogEntryType>(Oracle.FileHistoryAuditLogEntryType.FUPS));
+        Assert.Equal(Domain.Models.FileHistoryAuditLogEntryType.FRMK, _sut.Map<Domain.Models.FileHistoryAuditLogEntryType>(Oracle.FileHistoryAuditLogEntryType.FRMK));
+        Assert.Equal(Domain.Models.FileHistoryAuditLogEntryType.INIT, _sut.Map<Domain.Models.FileHistoryAuditLogEntryType>(Oracle.FileHistoryAuditLogEntryType.INIT));
+        Assert.Equal(Domain.Models.FileHistoryAuditLogEntryType.JASG, _sut.Map<Domain.Models.FileHistoryAuditLogEntryType>(Oracle.FileHistoryAuditLogEntryType.JASG));
+        Assert.Equal(Domain.Models.FileHistoryAuditLogEntryType.JCNF, _sut.Map<Domain.Models.FileHistoryAuditLogEntryType>(Oracle.FileHistoryAuditLogEntryType.JCNF));
+        Assert.Equal(Domain.Models.FileHistoryAuditLogEntryType.JDIV, _sut.Map<Domain.Models.FileHistoryAuditLogEntryType>(Oracle.FileHistoryAuditLogEntryType.JDIV));
+        Assert.Equal(Domain.Models.FileHistoryAuditLogEntryType.JPRG, _sut.Map<Domain.Models.FileHistoryAuditLogEntryType>(Oracle.FileHistoryAuditLogEntryType.JPRG));
+        Assert.Equal(Domain.Models.FileHistoryAuditLogEntryType.OCNT, _sut.Map<Domain.Models.FileHistoryAuditLogEntryType>(Oracle.FileHistoryAuditLogEntryType.OCNT));
+        Assert.Equal(Domain.Models.FileHistoryAuditLogEntryType.RCLD, _sut.Map<Domain.Models.FileHistoryAuditLogEntryType>(Oracle.FileHistoryAuditLogEntryType.RCLD));
+        Assert.Equal(Domain.Models.FileHistoryAuditLogEntryType.RECN, _sut.Map<Domain.Models.FileHistoryAuditLogEntryType>(Oracle.FileHistoryAuditLogEntryType.RECN));
+        Assert.Equal(Domain.Models.FileHistoryAuditLogEntryType.SADM, _sut.Map<Domain.Models.FileHistoryAuditLogEntryType>(Oracle.FileHistoryAuditLogEntryType.SADM));
+        Assert.Equal(Domain.Models.FileHistoryAuditLogEntryType.SCAN, _sut.Map<Domain.Models.FileHistoryAuditLogEntryType>(Oracle.FileHistoryAuditLogEntryType.SCAN));
+        Assert.Equal(Domain.Models.FileHistoryAuditLogEntryType.SPRC, _sut.Map<Domain.Models.FileHistoryAuditLogEntryType>(Oracle.FileHistoryAuditLogEntryType.SPRC));
+        Assert.Equal(Domain.Models.FileHistoryAuditLogEntryType.SREJ, _sut.Map<Domain.Models.FileHistoryAuditLogEntryType>(Oracle.FileHistoryAuditLogEntryType.SREJ));
+        Assert.Equal(Domain.Models.FileHistoryAuditLogEntryType.SUB, _sut.Map<Domain.Models.FileHistoryAuditLogEntryType>(Oracle.FileHistoryAuditLogEntryType.SUB));
+        Assert.Equal(Domain.Models.FileHistoryAuditLogEntryType.SUPL, _sut.Map<Domain.Models.FileHistoryAuditLogEntryType>(Oracle.FileHistoryAuditLogEntryType.SUPL));
+        Assert.Equal(Domain.Models.FileHistoryAuditLogEntryType.SVAL, _sut.Map<Domain.Models.FileHistoryAuditLogEntryType>(Oracle.FileHistoryAuditLogEntryType.SVAL));
+        Assert.Equal(Domain.Models.FileHistoryAuditLogEntryType.URSR, _sut.Map<Domain.Models.FileHistoryAuditLogEntryType>(Oracle.FileHistoryAuditLogEntryType.URSR));
+        Assert.Equal(Domain.Models.FileHistoryAuditLogEntryType.VREV, _sut.Map<Domain.Models.FileHistoryAuditLogEntryType>(Oracle.FileHistoryAuditLogEntryType.VREV));
+        Assert.Equal(Domain.Models.FileHistoryAuditLogEntryType.VSUB, _sut.Map<Domain.Models.FileHistoryAuditLogEntryType>(Oracle.FileHistoryAuditLogEntryType.VSUB));
+        // Domain => Oracle
+        Assert.Equal(Oracle.FileHistoryAuditLogEntryType.UNKNOWN, _sut.Map<Oracle.FileHistoryAuditLogEntryType>(Domain.Models.FileHistoryAuditLogEntryType.UNKNOWN));
+        Assert.Equal(Oracle.FileHistoryAuditLogEntryType.ARFL, _sut.Map<Oracle.FileHistoryAuditLogEntryType>(Domain.Models.FileHistoryAuditLogEntryType.ARFL));
+        Assert.Equal(Oracle.FileHistoryAuditLogEntryType.CAIN, _sut.Map<Oracle.FileHistoryAuditLogEntryType>(Domain.Models.FileHistoryAuditLogEntryType.CAIN));
+        Assert.Equal(Oracle.FileHistoryAuditLogEntryType.CAWT, _sut.Map<Oracle.FileHistoryAuditLogEntryType>(Domain.Models.FileHistoryAuditLogEntryType.CAWT));
+        Assert.Equal(Oracle.FileHistoryAuditLogEntryType.CCAN, _sut.Map<Oracle.FileHistoryAuditLogEntryType>(Domain.Models.FileHistoryAuditLogEntryType.CCAN));
+        Assert.Equal(Oracle.FileHistoryAuditLogEntryType.CCON, _sut.Map<Oracle.FileHistoryAuditLogEntryType>(Domain.Models.FileHistoryAuditLogEntryType.CCON));
+        Assert.Equal(Oracle.FileHistoryAuditLogEntryType.CCWR, _sut.Map<Oracle.FileHistoryAuditLogEntryType>(Domain.Models.FileHistoryAuditLogEntryType.CCWR));
+        Assert.Equal(Oracle.FileHistoryAuditLogEntryType.CLEG, _sut.Map<Oracle.FileHistoryAuditLogEntryType>(Domain.Models.FileHistoryAuditLogEntryType.CLEG));
+        Assert.Equal(Oracle.FileHistoryAuditLogEntryType.CUEM, _sut.Map<Oracle.FileHistoryAuditLogEntryType>(Domain.Models.FileHistoryAuditLogEntryType.CUEM));
+        Assert.Equal(Oracle.FileHistoryAuditLogEntryType.CUEV, _sut.Map<Oracle.FileHistoryAuditLogEntryType>(Domain.Models.FileHistoryAuditLogEntryType.CUEV));
+        Assert.Equal(Oracle.FileHistoryAuditLogEntryType.CUIN, _sut.Map<Oracle.FileHistoryAuditLogEntryType>(Domain.Models.FileHistoryAuditLogEntryType.CUIN));
+        Assert.Equal(Oracle.FileHistoryAuditLogEntryType.CULG, _sut.Map<Oracle.FileHistoryAuditLogEntryType>(Domain.Models.FileHistoryAuditLogEntryType.CULG));
+        Assert.Equal(Oracle.FileHistoryAuditLogEntryType.CUPD, _sut.Map<Oracle.FileHistoryAuditLogEntryType>(Domain.Models.FileHistoryAuditLogEntryType.CUPD));
+        Assert.Equal(Oracle.FileHistoryAuditLogEntryType.CUWR, _sut.Map<Oracle.FileHistoryAuditLogEntryType>(Domain.Models.FileHistoryAuditLogEntryType.CUWR));
+        Assert.Equal(Oracle.FileHistoryAuditLogEntryType.CUWT, _sut.Map<Oracle.FileHistoryAuditLogEntryType>(Domain.Models.FileHistoryAuditLogEntryType.CUWT));
+        Assert.Equal(Oracle.FileHistoryAuditLogEntryType.DURA, _sut.Map<Oracle.FileHistoryAuditLogEntryType>(Domain.Models.FileHistoryAuditLogEntryType.DURA));
+        Assert.Equal(Oracle.FileHistoryAuditLogEntryType.DURR, _sut.Map<Oracle.FileHistoryAuditLogEntryType>(Domain.Models.FileHistoryAuditLogEntryType.DURR));
+        Assert.Equal(Oracle.FileHistoryAuditLogEntryType.EMCA, _sut.Map<Oracle.FileHistoryAuditLogEntryType>(Domain.Models.FileHistoryAuditLogEntryType.EMCA));
+        Assert.Equal(Oracle.FileHistoryAuditLogEntryType.EMCF, _sut.Map<Oracle.FileHistoryAuditLogEntryType>(Domain.Models.FileHistoryAuditLogEntryType.EMCF));
+        Assert.Equal(Oracle.FileHistoryAuditLogEntryType.EMCR, _sut.Map<Oracle.FileHistoryAuditLogEntryType>(Domain.Models.FileHistoryAuditLogEntryType.EMCR));
+        Assert.Equal(Oracle.FileHistoryAuditLogEntryType.EMDC, _sut.Map<Oracle.FileHistoryAuditLogEntryType>(Domain.Models.FileHistoryAuditLogEntryType.EMDC));
+        Assert.Equal(Oracle.FileHistoryAuditLogEntryType.EMFD, _sut.Map<Oracle.FileHistoryAuditLogEntryType>(Domain.Models.FileHistoryAuditLogEntryType.EMFD));
+        Assert.Equal(Oracle.FileHistoryAuditLogEntryType.EMPR, _sut.Map<Oracle.FileHistoryAuditLogEntryType>(Domain.Models.FileHistoryAuditLogEntryType.EMPR));
+        Assert.Equal(Oracle.FileHistoryAuditLogEntryType.EMRJ, _sut.Map<Oracle.FileHistoryAuditLogEntryType>(Domain.Models.FileHistoryAuditLogEntryType.EMRJ));
+        Assert.Equal(Oracle.FileHistoryAuditLogEntryType.EMRV, _sut.Map<Oracle.FileHistoryAuditLogEntryType>(Domain.Models.FileHistoryAuditLogEntryType.EMRV));
+        Assert.Equal(Oracle.FileHistoryAuditLogEntryType.EMST, _sut.Map<Oracle.FileHistoryAuditLogEntryType>(Domain.Models.FileHistoryAuditLogEntryType.EMST));
+        Assert.Equal(Oracle.FileHistoryAuditLogEntryType.EMUP, _sut.Map<Oracle.FileHistoryAuditLogEntryType>(Domain.Models.FileHistoryAuditLogEntryType.EMUP));
+        Assert.Equal(Oracle.FileHistoryAuditLogEntryType.EMVF, _sut.Map<Oracle.FileHistoryAuditLogEntryType>(Domain.Models.FileHistoryAuditLogEntryType.EMVF));
+        Assert.Equal(Oracle.FileHistoryAuditLogEntryType.ESUR, _sut.Map<Oracle.FileHistoryAuditLogEntryType>(Domain.Models.FileHistoryAuditLogEntryType.ESUR));
+        Assert.Equal(Oracle.FileHistoryAuditLogEntryType.FDLD, _sut.Map<Oracle.FileHistoryAuditLogEntryType>(Domain.Models.FileHistoryAuditLogEntryType.FDLD));
+        Assert.Equal(Oracle.FileHistoryAuditLogEntryType.FDLS, _sut.Map<Oracle.FileHistoryAuditLogEntryType>(Domain.Models.FileHistoryAuditLogEntryType.FDLS));
+        Assert.Equal(Oracle.FileHistoryAuditLogEntryType.FUPD, _sut.Map<Oracle.FileHistoryAuditLogEntryType>(Domain.Models.FileHistoryAuditLogEntryType.FUPD));
+        Assert.Equal(Oracle.FileHistoryAuditLogEntryType.FUPS, _sut.Map<Oracle.FileHistoryAuditLogEntryType>(Domain.Models.FileHistoryAuditLogEntryType.FUPS));
+        Assert.Equal(Oracle.FileHistoryAuditLogEntryType.FRMK, _sut.Map<Oracle.FileHistoryAuditLogEntryType>(Domain.Models.FileHistoryAuditLogEntryType.FRMK));
+        Assert.Equal(Oracle.FileHistoryAuditLogEntryType.INIT, _sut.Map<Oracle.FileHistoryAuditLogEntryType>(Domain.Models.FileHistoryAuditLogEntryType.INIT));
+        Assert.Equal(Oracle.FileHistoryAuditLogEntryType.JASG, _sut.Map<Oracle.FileHistoryAuditLogEntryType>(Domain.Models.FileHistoryAuditLogEntryType.JASG));
+        Assert.Equal(Oracle.FileHistoryAuditLogEntryType.JCNF, _sut.Map<Oracle.FileHistoryAuditLogEntryType>(Domain.Models.FileHistoryAuditLogEntryType.JCNF));
+        Assert.Equal(Oracle.FileHistoryAuditLogEntryType.JDIV, _sut.Map<Oracle.FileHistoryAuditLogEntryType>(Domain.Models.FileHistoryAuditLogEntryType.JDIV));
+        Assert.Equal(Oracle.FileHistoryAuditLogEntryType.JPRG, _sut.Map<Oracle.FileHistoryAuditLogEntryType>(Domain.Models.FileHistoryAuditLogEntryType.JPRG));
+        Assert.Equal(Oracle.FileHistoryAuditLogEntryType.OCNT, _sut.Map<Oracle.FileHistoryAuditLogEntryType>(Domain.Models.FileHistoryAuditLogEntryType.OCNT));
+        Assert.Equal(Oracle.FileHistoryAuditLogEntryType.RCLD, _sut.Map<Oracle.FileHistoryAuditLogEntryType>(Domain.Models.FileHistoryAuditLogEntryType.RCLD));
+        Assert.Equal(Oracle.FileHistoryAuditLogEntryType.RECN, _sut.Map<Oracle.FileHistoryAuditLogEntryType>(Domain.Models.FileHistoryAuditLogEntryType.RECN));
+        Assert.Equal(Oracle.FileHistoryAuditLogEntryType.SADM, _sut.Map<Oracle.FileHistoryAuditLogEntryType>(Domain.Models.FileHistoryAuditLogEntryType.SADM));
+        Assert.Equal(Oracle.FileHistoryAuditLogEntryType.SCAN, _sut.Map<Oracle.FileHistoryAuditLogEntryType>(Domain.Models.FileHistoryAuditLogEntryType.SCAN));
+        Assert.Equal(Oracle.FileHistoryAuditLogEntryType.SPRC, _sut.Map<Oracle.FileHistoryAuditLogEntryType>(Domain.Models.FileHistoryAuditLogEntryType.SPRC));
+        Assert.Equal(Oracle.FileHistoryAuditLogEntryType.SREJ, _sut.Map<Oracle.FileHistoryAuditLogEntryType>(Domain.Models.FileHistoryAuditLogEntryType.SREJ));
+        Assert.Equal(Oracle.FileHistoryAuditLogEntryType.SUB, _sut.Map<Oracle.FileHistoryAuditLogEntryType>(Domain.Models.FileHistoryAuditLogEntryType.SUB));
+        Assert.Equal(Oracle.FileHistoryAuditLogEntryType.SUPL, _sut.Map<Oracle.FileHistoryAuditLogEntryType>(Domain.Models.FileHistoryAuditLogEntryType.SUPL));
+        Assert.Equal(Oracle.FileHistoryAuditLogEntryType.SVAL, _sut.Map<Oracle.FileHistoryAuditLogEntryType>(Domain.Models.FileHistoryAuditLogEntryType.SVAL));
+        Assert.Equal(Oracle.FileHistoryAuditLogEntryType.URSR, _sut.Map<Oracle.FileHistoryAuditLogEntryType>(Domain.Models.FileHistoryAuditLogEntryType.URSR));
+        Assert.Equal(Oracle.FileHistoryAuditLogEntryType.VREV, _sut.Map<Oracle.FileHistoryAuditLogEntryType>(Domain.Models.FileHistoryAuditLogEntryType.VREV));
+        Assert.Equal(Oracle.FileHistoryAuditLogEntryType.VSUB, _sut.Map<Oracle.FileHistoryAuditLogEntryType>(Domain.Models.FileHistoryAuditLogEntryType.VSUB));
+        #endregion FileHistoryAuditLogEntryType
+
+        #region JJDisputeAccidentYn
+        // Oracle => Domain
+        Assert.Equal(Domain.Models.JJDisputeAccidentYn.UNKNOWN, _sut.Map<Domain.Models.JJDisputeAccidentYn>(Oracle.JJDisputeAccidentYn.UNKNOWN));
+        Assert.Equal(Domain.Models.JJDisputeAccidentYn.Y, _sut.Map<Domain.Models.JJDisputeAccidentYn>(Oracle.JJDisputeAccidentYn.Y));
+        Assert.Equal(Domain.Models.JJDisputeAccidentYn.N, _sut.Map<Domain.Models.JJDisputeAccidentYn>(Oracle.JJDisputeAccidentYn.N));
+        // Domain => Oracle
+        Assert.Equal(Oracle.JJDisputeAccidentYn.UNKNOWN, _sut.Map<Oracle.JJDisputeAccidentYn>(Domain.Models.JJDisputeAccidentYn.UNKNOWN));
+        Assert.Equal(Oracle.JJDisputeAccidentYn.Y, _sut.Map<Oracle.JJDisputeAccidentYn>(Domain.Models.JJDisputeAccidentYn.Y));
+        Assert.Equal(Oracle.JJDisputeAccidentYn.N, _sut.Map<Oracle.JJDisputeAccidentYn>(Domain.Models.JJDisputeAccidentYn.N));
+        #endregion JJDisputeAccidentYn
+
+        #region JJDisputeAppearInCourt
+        // Oracle => Domain
+        Assert.Equal(Domain.Models.JJDisputeAppearInCourt.UNKNOWN, _sut.Map<Domain.Models.JJDisputeAppearInCourt>(Oracle.JJDisputeAppearInCourt.UNKNOWN));
+        Assert.Equal(Domain.Models.JJDisputeAppearInCourt.Y, _sut.Map<Domain.Models.JJDisputeAppearInCourt>(Oracle.JJDisputeAppearInCourt.Y));
+        Assert.Equal(Domain.Models.JJDisputeAppearInCourt.N, _sut.Map<Domain.Models.JJDisputeAppearInCourt>(Oracle.JJDisputeAppearInCourt.N));
+        // Domain => Oracle
+        Assert.Equal(Oracle.JJDisputeAppearInCourt.UNKNOWN, _sut.Map<Oracle.JJDisputeAppearInCourt>(Domain.Models.JJDisputeAppearInCourt.UNKNOWN));
+        Assert.Equal(Oracle.JJDisputeAppearInCourt.Y, _sut.Map<Oracle.JJDisputeAppearInCourt>(Domain.Models.JJDisputeAppearInCourt.Y));
+        Assert.Equal(Oracle.JJDisputeAppearInCourt.N, _sut.Map<Oracle.JJDisputeAppearInCourt>(Domain.Models.JJDisputeAppearInCourt.N));
+        #endregion JJDisputeAppearInCourt
+
+        #region JJDisputeContactType
+        // Oracle => Domain
+        Assert.Equal(Domain.Models.JJDisputeContactType.UNKNOWN, _sut.Map<Domain.Models.JJDisputeContactType>(Oracle.JJDisputeContactType.UNKNOWN));
+        Assert.Equal(Domain.Models.JJDisputeContactType.INDIVIDUAL, _sut.Map<Domain.Models.JJDisputeContactType>(Oracle.JJDisputeContactType.INDIVIDUAL));
+        Assert.Equal(Domain.Models.JJDisputeContactType.LAWYER, _sut.Map<Domain.Models.JJDisputeContactType>(Oracle.JJDisputeContactType.LAWYER));
+        Assert.Equal(Domain.Models.JJDisputeContactType.OTHER, _sut.Map<Domain.Models.JJDisputeContactType>(Oracle.JJDisputeContactType.OTHER));
+        // Domain => Oracle
+        Assert.Equal(Oracle.JJDisputeContactType.UNKNOWN, _sut.Map<Oracle.JJDisputeContactType>(Domain.Models.JJDisputeContactType.UNKNOWN));
+        Assert.Equal(Oracle.JJDisputeContactType.INDIVIDUAL, _sut.Map<Oracle.JJDisputeContactType>(Domain.Models.JJDisputeContactType.INDIVIDUAL));
+        Assert.Equal(Oracle.JJDisputeContactType.LAWYER, _sut.Map<Oracle.JJDisputeContactType>(Domain.Models.JJDisputeContactType.LAWYER));
+        Assert.Equal(Oracle.JJDisputeContactType.OTHER, _sut.Map<Oracle.JJDisputeContactType>(Domain.Models.JJDisputeContactType.OTHER));
+        #endregion JJDisputeContactType
+
+        #region JJDisputeCourtAppearanceRoPAppCd
+        // Oracle => Domain
+        Assert.Equal(Domain.Models.JJDisputeCourtAppearanceRoPAppCd.UNKNOWN, _sut.Map<Domain.Models.JJDisputeCourtAppearanceRoPAppCd>(Oracle.JJDisputeCourtAppearanceRoPAppCd.UNKNOWN));
+        Assert.Equal(Domain.Models.JJDisputeCourtAppearanceRoPAppCd.A, _sut.Map<Domain.Models.JJDisputeCourtAppearanceRoPAppCd>(Oracle.JJDisputeCourtAppearanceRoPAppCd.A));
+        Assert.Equal(Domain.Models.JJDisputeCourtAppearanceRoPAppCd.P, _sut.Map<Domain.Models.JJDisputeCourtAppearanceRoPAppCd>(Oracle.JJDisputeCourtAppearanceRoPAppCd.P));
+        Assert.Equal(Domain.Models.JJDisputeCourtAppearanceRoPAppCd.N, _sut.Map<Domain.Models.JJDisputeCourtAppearanceRoPAppCd>(Oracle.JJDisputeCourtAppearanceRoPAppCd.N));
+        // Domain => Oracle
+        Assert.Equal(Oracle.JJDisputeCourtAppearanceRoPAppCd.UNKNOWN, _sut.Map<Oracle.JJDisputeCourtAppearanceRoPAppCd>(Domain.Models.JJDisputeCourtAppearanceRoPAppCd.UNKNOWN));
+        Assert.Equal(Oracle.JJDisputeCourtAppearanceRoPAppCd.A, _sut.Map<Oracle.JJDisputeCourtAppearanceRoPAppCd>(Domain.Models.JJDisputeCourtAppearanceRoPAppCd.A));
+        Assert.Equal(Oracle.JJDisputeCourtAppearanceRoPAppCd.P, _sut.Map<Oracle.JJDisputeCourtAppearanceRoPAppCd>(Domain.Models.JJDisputeCourtAppearanceRoPAppCd.P));
+        Assert.Equal(Oracle.JJDisputeCourtAppearanceRoPAppCd.N, _sut.Map<Oracle.JJDisputeCourtAppearanceRoPAppCd>(Domain.Models.JJDisputeCourtAppearanceRoPAppCd.N));
+        #endregion JJDisputeCourtAppearanceRoPAppCd
+
+        #region JJDisputeCourtAppearanceRoPCrown
+        // Oracle => Domain
+        Assert.Equal(Domain.Models.JJDisputeCourtAppearanceRoPCrown.UNKNOWN, _sut.Map<Domain.Models.JJDisputeCourtAppearanceRoPCrown>(Oracle.JJDisputeCourtAppearanceRoPCrown.UNKNOWN));
+        Assert.Equal(Domain.Models.JJDisputeCourtAppearanceRoPCrown.P, _sut.Map<Domain.Models.JJDisputeCourtAppearanceRoPCrown>(Oracle.JJDisputeCourtAppearanceRoPCrown.P));
+        Assert.Equal(Domain.Models.JJDisputeCourtAppearanceRoPCrown.N, _sut.Map<Domain.Models.JJDisputeCourtAppearanceRoPCrown>(Oracle.JJDisputeCourtAppearanceRoPCrown.N));
+        // Domain => Oracle
+        Assert.Equal(Oracle.JJDisputeCourtAppearanceRoPCrown.UNKNOWN, _sut.Map<Oracle.JJDisputeCourtAppearanceRoPCrown>(Domain.Models.JJDisputeCourtAppearanceRoPCrown.UNKNOWN));
+        Assert.Equal(Oracle.JJDisputeCourtAppearanceRoPCrown.P, _sut.Map<Oracle.JJDisputeCourtAppearanceRoPCrown>(Domain.Models.JJDisputeCourtAppearanceRoPCrown.P));
+        Assert.Equal(Oracle.JJDisputeCourtAppearanceRoPCrown.N, _sut.Map<Oracle.JJDisputeCourtAppearanceRoPCrown>(Domain.Models.JJDisputeCourtAppearanceRoPCrown.N));
+        #endregion JJDisputeCourtAppearanceRoPCrown
+
+        #region JJDisputeCourtAppearanceRoPDattCd
+        // Oracle => Domain
+        Assert.Equal(Domain.Models.JJDisputeCourtAppearanceRoPDattCd.UNKNOWN, _sut.Map<Domain.Models.JJDisputeCourtAppearanceRoPDattCd>(Oracle.JJDisputeCourtAppearanceRoPDattCd.UNKNOWN));
+        Assert.Equal(Domain.Models.JJDisputeCourtAppearanceRoPDattCd.A, _sut.Map<Domain.Models.JJDisputeCourtAppearanceRoPDattCd>(Oracle.JJDisputeCourtAppearanceRoPDattCd.A));
+        Assert.Equal(Domain.Models.JJDisputeCourtAppearanceRoPDattCd.C, _sut.Map<Domain.Models.JJDisputeCourtAppearanceRoPDattCd>(Oracle.JJDisputeCourtAppearanceRoPDattCd.C));
+        Assert.Equal(Domain.Models.JJDisputeCourtAppearanceRoPDattCd.N, _sut.Map<Domain.Models.JJDisputeCourtAppearanceRoPDattCd>(Oracle.JJDisputeCourtAppearanceRoPDattCd.N));
+        // Domain => Oracle
+        Assert.Equal(Oracle.JJDisputeCourtAppearanceRoPDattCd.UNKNOWN, _sut.Map<Oracle.JJDisputeCourtAppearanceRoPDattCd>(Domain.Models.JJDisputeCourtAppearanceRoPDattCd.UNKNOWN));
+        Assert.Equal(Oracle.JJDisputeCourtAppearanceRoPDattCd.A, _sut.Map<Oracle.JJDisputeCourtAppearanceRoPDattCd>(Domain.Models.JJDisputeCourtAppearanceRoPDattCd.A));
+        Assert.Equal(Oracle.JJDisputeCourtAppearanceRoPDattCd.C, _sut.Map<Oracle.JJDisputeCourtAppearanceRoPDattCd>(Domain.Models.JJDisputeCourtAppearanceRoPDattCd.C));
+        Assert.Equal(Oracle.JJDisputeCourtAppearanceRoPDattCd.N, _sut.Map<Oracle.JJDisputeCourtAppearanceRoPDattCd>(Domain.Models.JJDisputeCourtAppearanceRoPDattCd.N));
+        #endregion JJDisputeCourtAppearanceRoPDattCd
+
+        #region JJDisputeCourtAppearanceRoPJjSeized
+        // Oracle => Domain
+        Assert.Equal(Domain.Models.JJDisputeCourtAppearanceRoPJjSeized.UNKNOWN, _sut.Map<Domain.Models.JJDisputeCourtAppearanceRoPJjSeized>(Oracle.JJDisputeCourtAppearanceRoPJjSeized.UNKNOWN));
+        Assert.Equal(Domain.Models.JJDisputeCourtAppearanceRoPJjSeized.Y, _sut.Map<Domain.Models.JJDisputeCourtAppearanceRoPJjSeized>(Oracle.JJDisputeCourtAppearanceRoPJjSeized.Y));
+        Assert.Equal(Domain.Models.JJDisputeCourtAppearanceRoPJjSeized.N, _sut.Map<Domain.Models.JJDisputeCourtAppearanceRoPJjSeized>(Oracle.JJDisputeCourtAppearanceRoPJjSeized.N));
+        // Domain => Oracle
+        Assert.Equal(Oracle.JJDisputeCourtAppearanceRoPJjSeized.UNKNOWN, _sut.Map<Oracle.JJDisputeCourtAppearanceRoPJjSeized>(Domain.Models.JJDisputeCourtAppearanceRoPJjSeized.UNKNOWN));
+        Assert.Equal(Oracle.JJDisputeCourtAppearanceRoPJjSeized.Y, _sut.Map<Oracle.JJDisputeCourtAppearanceRoPJjSeized>(Domain.Models.JJDisputeCourtAppearanceRoPJjSeized.Y));
+        Assert.Equal(Oracle.JJDisputeCourtAppearanceRoPJjSeized.N, _sut.Map<Oracle.JJDisputeCourtAppearanceRoPJjSeized>(Domain.Models.JJDisputeCourtAppearanceRoPJjSeized.N));
+        #endregion JJDisputeCourtAppearanceRoPJjSeized
+
+        #region JJDisputedCountAppearInCourt
+        // Oracle => Domain
+        Assert.Equal(Domain.Models.JJDisputedCountAppearInCourt.UNKNOWN, _sut.Map<Domain.Models.JJDisputedCountAppearInCourt>(Oracle.JJDisputedCountAppearInCourt.UNKNOWN));
+        Assert.Equal(Domain.Models.JJDisputedCountAppearInCourt.Y, _sut.Map<Domain.Models.JJDisputedCountAppearInCourt>(Oracle.JJDisputedCountAppearInCourt.Y));
+        Assert.Equal(Domain.Models.JJDisputedCountAppearInCourt.N, _sut.Map<Domain.Models.JJDisputedCountAppearInCourt>(Oracle.JJDisputedCountAppearInCourt.N));
+        // Domain => Oracle
+        Assert.Equal(Oracle.JJDisputedCountAppearInCourt.UNKNOWN, _sut.Map<Oracle.JJDisputedCountAppearInCourt>(Domain.Models.JJDisputedCountAppearInCourt.UNKNOWN));
+        Assert.Equal(Oracle.JJDisputedCountAppearInCourt.Y, _sut.Map<Oracle.JJDisputedCountAppearInCourt>(Domain.Models.JJDisputedCountAppearInCourt.Y));
+        Assert.Equal(Oracle.JJDisputedCountAppearInCourt.N, _sut.Map<Oracle.JJDisputedCountAppearInCourt>(Domain.Models.JJDisputedCountAppearInCourt.N));
+        #endregion JJDisputedCountAppearInCourt
+
+        #region JJDisputedCountIncludesSurcharge
+        // Oracle => Domain
+        Assert.Equal(Domain.Models.JJDisputedCountIncludesSurcharge.UNKNOWN, _sut.Map<Domain.Models.JJDisputedCountIncludesSurcharge>(Oracle.JJDisputedCountIncludesSurcharge.UNKNOWN));
+        Assert.Equal(Domain.Models.JJDisputedCountIncludesSurcharge.Y, _sut.Map<Domain.Models.JJDisputedCountIncludesSurcharge>(Oracle.JJDisputedCountIncludesSurcharge.Y));
+        Assert.Equal(Domain.Models.JJDisputedCountIncludesSurcharge.N, _sut.Map<Domain.Models.JJDisputedCountIncludesSurcharge>(Oracle.JJDisputedCountIncludesSurcharge.N));
+        // Domain => Oracle
+        Assert.Equal(Oracle.JJDisputedCountIncludesSurcharge.UNKNOWN, _sut.Map<Oracle.JJDisputedCountIncludesSurcharge>(Domain.Models.JJDisputedCountIncludesSurcharge.UNKNOWN));
+        Assert.Equal(Oracle.JJDisputedCountIncludesSurcharge.Y, _sut.Map<Oracle.JJDisputedCountIncludesSurcharge>(Domain.Models.JJDisputedCountIncludesSurcharge.Y));
+        Assert.Equal(Oracle.JJDisputedCountIncludesSurcharge.N, _sut.Map<Oracle.JJDisputedCountIncludesSurcharge>(Domain.Models.JJDisputedCountIncludesSurcharge.N));
+        #endregion JJDisputedCountIncludesSurcharge
+
+        #region JJDisputedCountLatestPlea
+        // Oracle => Domain
+        Assert.Equal(Domain.Models.JJDisputedCountLatestPlea.UNKNOWN, _sut.Map<Domain.Models.JJDisputedCountLatestPlea>(Oracle.JJDisputedCountLatestPlea.UNKNOWN));
+        Assert.Equal(Domain.Models.JJDisputedCountLatestPlea.G, _sut.Map<Domain.Models.JJDisputedCountLatestPlea>(Oracle.JJDisputedCountLatestPlea.G));
+        Assert.Equal(Domain.Models.JJDisputedCountLatestPlea.N, _sut.Map<Domain.Models.JJDisputedCountLatestPlea>(Oracle.JJDisputedCountLatestPlea.N));
+        // Domain => Oracle
+        Assert.Equal(Oracle.JJDisputedCountLatestPlea.UNKNOWN, _sut.Map<Oracle.JJDisputedCountLatestPlea>(Domain.Models.JJDisputedCountLatestPlea.UNKNOWN));
+        Assert.Equal(Oracle.JJDisputedCountLatestPlea.G, _sut.Map<Oracle.JJDisputedCountLatestPlea>(Domain.Models.JJDisputedCountLatestPlea.G));
+        Assert.Equal(Oracle.JJDisputedCountLatestPlea.N, _sut.Map<Oracle.JJDisputedCountLatestPlea>(Domain.Models.JJDisputedCountLatestPlea.N));
+        #endregion JJDisputedCountLatestPlea
+
+        #region JJDisputedCountPlea
+        // Oracle => Domain
+        Assert.Equal(Domain.Models.JJDisputedCountPlea.UNKNOWN, _sut.Map<Domain.Models.JJDisputedCountPlea>(Oracle.JJDisputedCountPlea.UNKNOWN));
+        Assert.Equal(Domain.Models.JJDisputedCountPlea.G, _sut.Map<Domain.Models.JJDisputedCountPlea>(Oracle.JJDisputedCountPlea.G));
+        Assert.Equal(Domain.Models.JJDisputedCountPlea.N, _sut.Map<Domain.Models.JJDisputedCountPlea>(Oracle.JJDisputedCountPlea.N));
+        // Domain => Oracle
+        Assert.Equal(Oracle.JJDisputedCountPlea.UNKNOWN, _sut.Map<Oracle.JJDisputedCountPlea>(Domain.Models.JJDisputedCountPlea.UNKNOWN));
+        Assert.Equal(Oracle.JJDisputedCountPlea.G, _sut.Map<Oracle.JJDisputedCountPlea>(Domain.Models.JJDisputedCountPlea.G));
+        Assert.Equal(Oracle.JJDisputedCountPlea.N, _sut.Map<Oracle.JJDisputedCountPlea>(Domain.Models.JJDisputedCountPlea.N));
+        #endregion JJDisputedCountPlea
+
+        #region JJDisputedCountRequestReduction
+        // Oracle => Domain
+        Assert.Equal(Domain.Models.JJDisputedCountRequestReduction.UNKNOWN, _sut.Map<Domain.Models.JJDisputedCountRequestReduction>(Oracle.JJDisputedCountRequestReduction.UNKNOWN));
+        Assert.Equal(Domain.Models.JJDisputedCountRequestReduction.Y, _sut.Map<Domain.Models.JJDisputedCountRequestReduction>(Oracle.JJDisputedCountRequestReduction.Y));
+        Assert.Equal(Domain.Models.JJDisputedCountRequestReduction.N, _sut.Map<Domain.Models.JJDisputedCountRequestReduction>(Oracle.JJDisputedCountRequestReduction.N));
+        // Domain => Oracle
+        Assert.Equal(Oracle.JJDisputedCountRequestReduction.UNKNOWN, _sut.Map<Oracle.JJDisputedCountRequestReduction>(Domain.Models.JJDisputedCountRequestReduction.UNKNOWN));
+        Assert.Equal(Oracle.JJDisputedCountRequestReduction.Y, _sut.Map<Oracle.JJDisputedCountRequestReduction>(Domain.Models.JJDisputedCountRequestReduction.Y));
+        Assert.Equal(Oracle.JJDisputedCountRequestReduction.N, _sut.Map<Oracle.JJDisputedCountRequestReduction>(Domain.Models.JJDisputedCountRequestReduction.N));
+        #endregion JJDisputedCountRequestReduction
+
+        #region JJDisputedCountRequestTimeToPay
+        // Oracle => Domain
+        Assert.Equal(Domain.Models.JJDisputedCountRequestTimeToPay.UNKNOWN, _sut.Map<Domain.Models.JJDisputedCountRequestTimeToPay>(Oracle.JJDisputedCountRequestTimeToPay.UNKNOWN));
+        Assert.Equal(Domain.Models.JJDisputedCountRequestTimeToPay.Y, _sut.Map<Domain.Models.JJDisputedCountRequestTimeToPay>(Oracle.JJDisputedCountRequestTimeToPay.Y));
+        Assert.Equal(Domain.Models.JJDisputedCountRequestTimeToPay.N, _sut.Map<Domain.Models.JJDisputedCountRequestTimeToPay>(Oracle.JJDisputedCountRequestTimeToPay.N));
+        // Domain => Oracle
+        Assert.Equal(Oracle.JJDisputedCountRequestTimeToPay.UNKNOWN, _sut.Map<Oracle.JJDisputedCountRequestTimeToPay>(Domain.Models.JJDisputedCountRequestTimeToPay.UNKNOWN));
+        Assert.Equal(Oracle.JJDisputedCountRequestTimeToPay.Y, _sut.Map<Oracle.JJDisputedCountRequestTimeToPay>(Domain.Models.JJDisputedCountRequestTimeToPay.Y));
+        Assert.Equal(Oracle.JJDisputedCountRequestTimeToPay.N, _sut.Map<Oracle.JJDisputedCountRequestTimeToPay>(Domain.Models.JJDisputedCountRequestTimeToPay.N));
+        #endregion JJDisputedCountRequestTimeToPay
+
+        #region JJDisputedCountRoPAbatement
+        // Oracle => Domain
+        Assert.Equal(Domain.Models.JJDisputedCountRoPAbatement.UNKNOWN, _sut.Map<Domain.Models.JJDisputedCountRoPAbatement>(Oracle.JJDisputedCountRoPAbatement.UNKNOWN));
+        Assert.Equal(Domain.Models.JJDisputedCountRoPAbatement.Y, _sut.Map<Domain.Models.JJDisputedCountRoPAbatement>(Oracle.JJDisputedCountRoPAbatement.Y));
+        Assert.Equal(Domain.Models.JJDisputedCountRoPAbatement.N, _sut.Map<Domain.Models.JJDisputedCountRoPAbatement>(Oracle.JJDisputedCountRoPAbatement.N));
+        // Domain => Oracle
+        Assert.Equal(Oracle.JJDisputedCountRoPAbatement.UNKNOWN, _sut.Map<Oracle.JJDisputedCountRoPAbatement>(Domain.Models.JJDisputedCountRoPAbatement.UNKNOWN));
+        Assert.Equal(Oracle.JJDisputedCountRoPAbatement.Y, _sut.Map<Oracle.JJDisputedCountRoPAbatement>(Domain.Models.JJDisputedCountRoPAbatement.Y));
+        Assert.Equal(Oracle.JJDisputedCountRoPAbatement.N, _sut.Map<Oracle.JJDisputedCountRoPAbatement>(Domain.Models.JJDisputedCountRoPAbatement.N));
+        #endregion JJDisputedCountRoPAbatement
+
+        #region JJDisputedCountRoPDismissed
+        // Oracle => Domain
+        Assert.Equal(Domain.Models.JJDisputedCountRoPDismissed.UNKNOWN, _sut.Map<Domain.Models.JJDisputedCountRoPDismissed>(Oracle.JJDisputedCountRoPDismissed.UNKNOWN));
+        Assert.Equal(Domain.Models.JJDisputedCountRoPDismissed.Y, _sut.Map<Domain.Models.JJDisputedCountRoPDismissed>(Oracle.JJDisputedCountRoPDismissed.Y));
+        Assert.Equal(Domain.Models.JJDisputedCountRoPDismissed.N, _sut.Map<Domain.Models.JJDisputedCountRoPDismissed>(Oracle.JJDisputedCountRoPDismissed.N));
+        // Domain => Oracle
+        Assert.Equal(Oracle.JJDisputedCountRoPDismissed.UNKNOWN, _sut.Map<Oracle.JJDisputedCountRoPDismissed>(Domain.Models.JJDisputedCountRoPDismissed.UNKNOWN));
+        Assert.Equal(Oracle.JJDisputedCountRoPDismissed.Y, _sut.Map<Oracle.JJDisputedCountRoPDismissed>(Domain.Models.JJDisputedCountRoPDismissed.Y));
+        Assert.Equal(Oracle.JJDisputedCountRoPDismissed.N, _sut.Map<Oracle.JJDisputedCountRoPDismissed>(Domain.Models.JJDisputedCountRoPDismissed.N));
+        #endregion JJDisputedCountRoPDismissed
+
+        #region JJDisputedCountRoPFinding
+        // Oracle => Domain
+        Assert.Equal(Domain.Models.JJDisputedCountRoPFinding.UNKNOWN, _sut.Map<Domain.Models.JJDisputedCountRoPFinding>(Oracle.JJDisputedCountRoPFinding.UNKNOWN));
+        Assert.Equal(Domain.Models.JJDisputedCountRoPFinding.GUILTY, _sut.Map<Domain.Models.JJDisputedCountRoPFinding>(Oracle.JJDisputedCountRoPFinding.GUILTY));
+        Assert.Equal(Domain.Models.JJDisputedCountRoPFinding.NOT_GUILTY, _sut.Map<Domain.Models.JJDisputedCountRoPFinding>(Oracle.JJDisputedCountRoPFinding.NOT_GUILTY));
+        Assert.Equal(Domain.Models.JJDisputedCountRoPFinding.CANCELLED, _sut.Map<Domain.Models.JJDisputedCountRoPFinding>(Oracle.JJDisputedCountRoPFinding.CANCELLED));
+        Assert.Equal(Domain.Models.JJDisputedCountRoPFinding.PAID_PRIOR_TO_APPEARANCE, _sut.Map<Domain.Models.JJDisputedCountRoPFinding>(Oracle.JJDisputedCountRoPFinding.PAID_PRIOR_TO_APPEARANCE));
+        Assert.Equal(Domain.Models.JJDisputedCountRoPFinding.GUILTY_LESSER, _sut.Map<Domain.Models.JJDisputedCountRoPFinding>(Oracle.JJDisputedCountRoPFinding.GUILTY_LESSER));
+        // Domain => Oracle
+        Assert.Equal(Oracle.JJDisputedCountRoPFinding.UNKNOWN, _sut.Map<Oracle.JJDisputedCountRoPFinding>(Domain.Models.JJDisputedCountRoPFinding.UNKNOWN));
+        Assert.Equal(Oracle.JJDisputedCountRoPFinding.GUILTY, _sut.Map<Oracle.JJDisputedCountRoPFinding>(Domain.Models.JJDisputedCountRoPFinding.GUILTY));
+        Assert.Equal(Oracle.JJDisputedCountRoPFinding.NOT_GUILTY, _sut.Map<Oracle.JJDisputedCountRoPFinding>(Domain.Models.JJDisputedCountRoPFinding.NOT_GUILTY));
+        Assert.Equal(Oracle.JJDisputedCountRoPFinding.CANCELLED, _sut.Map<Oracle.JJDisputedCountRoPFinding>(Domain.Models.JJDisputedCountRoPFinding.CANCELLED));
+        Assert.Equal(Oracle.JJDisputedCountRoPFinding.PAID_PRIOR_TO_APPEARANCE, _sut.Map<Oracle.JJDisputedCountRoPFinding>(Domain.Models.JJDisputedCountRoPFinding.PAID_PRIOR_TO_APPEARANCE));
+        Assert.Equal(Oracle.JJDisputedCountRoPFinding.GUILTY_LESSER, _sut.Map<Oracle.JJDisputedCountRoPFinding>(Domain.Models.JJDisputedCountRoPFinding.GUILTY_LESSER));
+        #endregion JJDisputedCountRoPFinding
+
+        #region JJDisputedCountRoPForWantOfProsecution
+        // Oracle => Domain
+        Assert.Equal(Domain.Models.JJDisputedCountRoPForWantOfProsecution.UNKNOWN, _sut.Map<Domain.Models.JJDisputedCountRoPForWantOfProsecution>(Oracle.JJDisputedCountRoPForWantOfProsecution.UNKNOWN));
+        Assert.Equal(Domain.Models.JJDisputedCountRoPForWantOfProsecution.Y, _sut.Map<Domain.Models.JJDisputedCountRoPForWantOfProsecution>(Oracle.JJDisputedCountRoPForWantOfProsecution.Y));
+        Assert.Equal(Domain.Models.JJDisputedCountRoPForWantOfProsecution.N, _sut.Map<Domain.Models.JJDisputedCountRoPForWantOfProsecution>(Oracle.JJDisputedCountRoPForWantOfProsecution.N));
+        // Domain => Oracle
+        Assert.Equal(Oracle.JJDisputedCountRoPForWantOfProsecution.UNKNOWN, _sut.Map<Oracle.JJDisputedCountRoPForWantOfProsecution>(Domain.Models.JJDisputedCountRoPForWantOfProsecution.UNKNOWN));
+        Assert.Equal(Oracle.JJDisputedCountRoPForWantOfProsecution.Y, _sut.Map<Oracle.JJDisputedCountRoPForWantOfProsecution>(Domain.Models.JJDisputedCountRoPForWantOfProsecution.Y));
+        Assert.Equal(Oracle.JJDisputedCountRoPForWantOfProsecution.N, _sut.Map<Oracle.JJDisputedCountRoPForWantOfProsecution>(Domain.Models.JJDisputedCountRoPForWantOfProsecution.N));
+        #endregion JJDisputedCountRoPForWantOfProsecution
+
+        #region JJDisputedCountRoPJailIntermittent
+        // Oracle => Domain
+        Assert.Equal(Domain.Models.JJDisputedCountRoPJailIntermittent.UNKNOWN, _sut.Map<Domain.Models.JJDisputedCountRoPJailIntermittent>(Oracle.JJDisputedCountRoPJailIntermittent.UNKNOWN));
+        Assert.Equal(Domain.Models.JJDisputedCountRoPJailIntermittent.Y, _sut.Map<Domain.Models.JJDisputedCountRoPJailIntermittent>(Oracle.JJDisputedCountRoPJailIntermittent.Y));
+        Assert.Equal(Domain.Models.JJDisputedCountRoPJailIntermittent.N, _sut.Map<Domain.Models.JJDisputedCountRoPJailIntermittent>(Oracle.JJDisputedCountRoPJailIntermittent.N));
+        // Domain => Oracle
+        Assert.Equal(Oracle.JJDisputedCountRoPJailIntermittent.UNKNOWN, _sut.Map<Oracle.JJDisputedCountRoPJailIntermittent>(Domain.Models.JJDisputedCountRoPJailIntermittent.UNKNOWN));
+        Assert.Equal(Oracle.JJDisputedCountRoPJailIntermittent.Y, _sut.Map<Oracle.JJDisputedCountRoPJailIntermittent>(Domain.Models.JJDisputedCountRoPJailIntermittent.Y));
+        Assert.Equal(Oracle.JJDisputedCountRoPJailIntermittent.N, _sut.Map<Oracle.JJDisputedCountRoPJailIntermittent>(Domain.Models.JJDisputedCountRoPJailIntermittent.N));
+        #endregion JJDisputedCountRoPJailIntermittent
+
+        #region JJDisputedCountRoPWithdrawn
+        // Oracle => Domain
+        Assert.Equal(Domain.Models.JJDisputedCountRoPWithdrawn.UNKNOWN, _sut.Map<Domain.Models.JJDisputedCountRoPWithdrawn>(Oracle.JJDisputedCountRoPWithdrawn.UNKNOWN));
+        Assert.Equal(Domain.Models.JJDisputedCountRoPWithdrawn.Y, _sut.Map<Domain.Models.JJDisputedCountRoPWithdrawn>(Oracle.JJDisputedCountRoPWithdrawn.Y));
+        Assert.Equal(Domain.Models.JJDisputedCountRoPWithdrawn.N, _sut.Map<Domain.Models.JJDisputedCountRoPWithdrawn>(Oracle.JJDisputedCountRoPWithdrawn.N));
+        // Domain => Oracle
+        Assert.Equal(Oracle.JJDisputedCountRoPWithdrawn.UNKNOWN, _sut.Map<Oracle.JJDisputedCountRoPWithdrawn>(Domain.Models.JJDisputedCountRoPWithdrawn.UNKNOWN));
+        Assert.Equal(Oracle.JJDisputedCountRoPWithdrawn.Y, _sut.Map<Oracle.JJDisputedCountRoPWithdrawn>(Domain.Models.JJDisputedCountRoPWithdrawn.Y));
+        Assert.Equal(Oracle.JJDisputedCountRoPWithdrawn.N, _sut.Map<Oracle.JJDisputedCountRoPWithdrawn>(Domain.Models.JJDisputedCountRoPWithdrawn.N));
+        #endregion JJDisputedCountRoPWithdrawn
+
+        #region JJDisputeDisputantAttendanceType
+        // Oracle => Domain
+        Assert.Equal(Domain.Models.JJDisputeDisputantAttendanceType.UNKNOWN, _sut.Map<Domain.Models.JJDisputeDisputantAttendanceType>(Oracle.JJDisputeDisputantAttendanceType.UNKNOWN));
+        Assert.Equal(Domain.Models.JJDisputeDisputantAttendanceType.WRITTEN_REASONS, _sut.Map<Domain.Models.JJDisputeDisputantAttendanceType>(Oracle.JJDisputeDisputantAttendanceType.WRITTEN_REASONS));
+        Assert.Equal(Domain.Models.JJDisputeDisputantAttendanceType.VIDEO_CONFERENCE, _sut.Map<Domain.Models.JJDisputeDisputantAttendanceType>(Oracle.JJDisputeDisputantAttendanceType.VIDEO_CONFERENCE));
+        Assert.Equal(Domain.Models.JJDisputeDisputantAttendanceType.TELEPHONE_CONFERENCE, _sut.Map<Domain.Models.JJDisputeDisputantAttendanceType>(Oracle.JJDisputeDisputantAttendanceType.TELEPHONE_CONFERENCE));
+        Assert.Equal(Domain.Models.JJDisputeDisputantAttendanceType.MSTEAMS_AUDIO, _sut.Map<Domain.Models.JJDisputeDisputantAttendanceType>(Oracle.JJDisputeDisputantAttendanceType.MSTEAMS_AUDIO));
+        Assert.Equal(Domain.Models.JJDisputeDisputantAttendanceType.MSTEAMS_VIDEO, _sut.Map<Domain.Models.JJDisputeDisputantAttendanceType>(Oracle.JJDisputeDisputantAttendanceType.MSTEAMS_VIDEO));
+        Assert.Equal(Domain.Models.JJDisputeDisputantAttendanceType.IN_PERSON, _sut.Map<Domain.Models.JJDisputeDisputantAttendanceType>(Oracle.JJDisputeDisputantAttendanceType.IN_PERSON));
+        // Domain => Oracle
+        Assert.Equal(Oracle.JJDisputeDisputantAttendanceType.UNKNOWN, _sut.Map<Oracle.JJDisputeDisputantAttendanceType>(Domain.Models.JJDisputeDisputantAttendanceType.UNKNOWN));
+        Assert.Equal(Oracle.JJDisputeDisputantAttendanceType.WRITTEN_REASONS, _sut.Map<Oracle.JJDisputeDisputantAttendanceType>(Domain.Models.JJDisputeDisputantAttendanceType.WRITTEN_REASONS));
+        Assert.Equal(Oracle.JJDisputeDisputantAttendanceType.VIDEO_CONFERENCE, _sut.Map<Oracle.JJDisputeDisputantAttendanceType>(Domain.Models.JJDisputeDisputantAttendanceType.VIDEO_CONFERENCE));
+        Assert.Equal(Oracle.JJDisputeDisputantAttendanceType.TELEPHONE_CONFERENCE, _sut.Map<Oracle.JJDisputeDisputantAttendanceType>(Domain.Models.JJDisputeDisputantAttendanceType.TELEPHONE_CONFERENCE));
+        Assert.Equal(Oracle.JJDisputeDisputantAttendanceType.MSTEAMS_AUDIO, _sut.Map<Oracle.JJDisputeDisputantAttendanceType>(Domain.Models.JJDisputeDisputantAttendanceType.MSTEAMS_AUDIO));
+        Assert.Equal(Oracle.JJDisputeDisputantAttendanceType.MSTEAMS_VIDEO, _sut.Map<Oracle.JJDisputeDisputantAttendanceType>(Domain.Models.JJDisputeDisputantAttendanceType.MSTEAMS_VIDEO));
+        Assert.Equal(Oracle.JJDisputeDisputantAttendanceType.IN_PERSON, _sut.Map<Oracle.JJDisputeDisputantAttendanceType>(Domain.Models.JJDisputeDisputantAttendanceType.IN_PERSON));
+        #endregion JJDisputeDisputantAttendanceType
+
+        #region JJDisputeElectronicTicketYn
+        // Oracle => Domain
+        Assert.Equal(Domain.Models.JJDisputeElectronicTicketYn.UNKNOWN, _sut.Map<Domain.Models.JJDisputeElectronicTicketYn>(Oracle.JJDisputeElectronicTicketYn.UNKNOWN));
+        Assert.Equal(Domain.Models.JJDisputeElectronicTicketYn.Y, _sut.Map<Domain.Models.JJDisputeElectronicTicketYn>(Oracle.JJDisputeElectronicTicketYn.Y));
+        Assert.Equal(Domain.Models.JJDisputeElectronicTicketYn.N, _sut.Map<Domain.Models.JJDisputeElectronicTicketYn>(Oracle.JJDisputeElectronicTicketYn.N));
+        // Domain => Oracle
+        Assert.Equal(Oracle.JJDisputeElectronicTicketYn.UNKNOWN, _sut.Map<Oracle.JJDisputeElectronicTicketYn>(Domain.Models.JJDisputeElectronicTicketYn.UNKNOWN));
+        Assert.Equal(Oracle.JJDisputeElectronicTicketYn.Y, _sut.Map<Oracle.JJDisputeElectronicTicketYn>(Domain.Models.JJDisputeElectronicTicketYn.Y));
+        Assert.Equal(Oracle.JJDisputeElectronicTicketYn.N, _sut.Map<Oracle.JJDisputeElectronicTicketYn>(Domain.Models.JJDisputeElectronicTicketYn.N));
+        #endregion JJDisputeElectronicTicketYn
+
+        #region JJDisputeHearingType
+        // Oracle => Domain
+        Assert.Equal(Domain.Models.JJDisputeHearingType.UNKNOWN, _sut.Map<Domain.Models.JJDisputeHearingType>(Oracle.JJDisputeHearingType.UNKNOWN));
+        Assert.Equal(Domain.Models.JJDisputeHearingType.COURT_APPEARANCE, _sut.Map<Domain.Models.JJDisputeHearingType>(Oracle.JJDisputeHearingType.COURT_APPEARANCE));
+        Assert.Equal(Domain.Models.JJDisputeHearingType.WRITTEN_REASONS, _sut.Map<Domain.Models.JJDisputeHearingType>(Oracle.JJDisputeHearingType.WRITTEN_REASONS));
+        // Domain => Oracle
+        Assert.Equal(Oracle.JJDisputeHearingType.UNKNOWN, _sut.Map<Oracle.JJDisputeHearingType>(Domain.Models.JJDisputeHearingType.UNKNOWN));
+        Assert.Equal(Oracle.JJDisputeHearingType.COURT_APPEARANCE, _sut.Map<Oracle.JJDisputeHearingType>(Domain.Models.JJDisputeHearingType.COURT_APPEARANCE));
+        Assert.Equal(Oracle.JJDisputeHearingType.WRITTEN_REASONS, _sut.Map<Oracle.JJDisputeHearingType>(Domain.Models.JJDisputeHearingType.WRITTEN_REASONS));
+        #endregion JJDisputeHearingType
+
+        #region JJDisputeMultipleOfficersYn
+        // Oracle => Domain
+        Assert.Equal(Domain.Models.JJDisputeMultipleOfficersYn.UNKNOWN, _sut.Map<Domain.Models.JJDisputeMultipleOfficersYn>(Oracle.JJDisputeMultipleOfficersYn.UNKNOWN));
+        Assert.Equal(Domain.Models.JJDisputeMultipleOfficersYn.Y, _sut.Map<Domain.Models.JJDisputeMultipleOfficersYn>(Oracle.JJDisputeMultipleOfficersYn.Y));
+        Assert.Equal(Domain.Models.JJDisputeMultipleOfficersYn.N, _sut.Map<Domain.Models.JJDisputeMultipleOfficersYn>(Oracle.JJDisputeMultipleOfficersYn.N));
+        // Domain => Oracle
+        Assert.Equal(Oracle.JJDisputeMultipleOfficersYn.UNKNOWN, _sut.Map<Oracle.JJDisputeMultipleOfficersYn>(Domain.Models.JJDisputeMultipleOfficersYn.UNKNOWN));
+        Assert.Equal(Oracle.JJDisputeMultipleOfficersYn.Y, _sut.Map<Oracle.JJDisputeMultipleOfficersYn>(Domain.Models.JJDisputeMultipleOfficersYn.Y));
+        Assert.Equal(Oracle.JJDisputeMultipleOfficersYn.N, _sut.Map<Oracle.JJDisputeMultipleOfficersYn>(Domain.Models.JJDisputeMultipleOfficersYn.N));
+        #endregion JJDisputeMultipleOfficersYn
+
+        #region JJDisputeNoticeOfHearingYn
+        // Oracle => Domain
+        Assert.Equal(Domain.Models.JJDisputeNoticeOfHearingYn.UNKNOWN, _sut.Map<Domain.Models.JJDisputeNoticeOfHearingYn>(Oracle.JJDisputeNoticeOfHearingYn.UNKNOWN));
+        Assert.Equal(Domain.Models.JJDisputeNoticeOfHearingYn.Y, _sut.Map<Domain.Models.JJDisputeNoticeOfHearingYn>(Oracle.JJDisputeNoticeOfHearingYn.Y));
+        Assert.Equal(Domain.Models.JJDisputeNoticeOfHearingYn.N, _sut.Map<Domain.Models.JJDisputeNoticeOfHearingYn>(Oracle.JJDisputeNoticeOfHearingYn.N));
+        // Domain => Oracle
+        Assert.Equal(Oracle.JJDisputeNoticeOfHearingYn.UNKNOWN, _sut.Map<Oracle.JJDisputeNoticeOfHearingYn>(Domain.Models.JJDisputeNoticeOfHearingYn.UNKNOWN));
+        Assert.Equal(Oracle.JJDisputeNoticeOfHearingYn.Y, _sut.Map<Oracle.JJDisputeNoticeOfHearingYn>(Domain.Models.JJDisputeNoticeOfHearingYn.Y));
+        Assert.Equal(Oracle.JJDisputeNoticeOfHearingYn.N, _sut.Map<Oracle.JJDisputeNoticeOfHearingYn>(Domain.Models.JJDisputeNoticeOfHearingYn.N));
+        #endregion JJDisputeNoticeOfHearingYn
+
+        #region JJDisputeSignatoryType
+        // Oracle => Domain
+        Assert.Equal(Domain.Models.JJDisputeSignatoryType.U, _sut.Map<Domain.Models.JJDisputeSignatoryType>(Oracle.JJDisputeSignatoryType.U));
+        Assert.Equal(Domain.Models.JJDisputeSignatoryType.D, _sut.Map<Domain.Models.JJDisputeSignatoryType>(Oracle.JJDisputeSignatoryType.D));
+        Assert.Equal(Domain.Models.JJDisputeSignatoryType.A, _sut.Map<Domain.Models.JJDisputeSignatoryType>(Oracle.JJDisputeSignatoryType.A));
+        // Domain => Oracle
+        Assert.Equal(Oracle.JJDisputeSignatoryType.U, _sut.Map<Oracle.JJDisputeSignatoryType>(Domain.Models.JJDisputeSignatoryType.U));
+        Assert.Equal(Oracle.JJDisputeSignatoryType.D, _sut.Map<Oracle.JJDisputeSignatoryType>(Domain.Models.JJDisputeSignatoryType.D));
+        Assert.Equal(Oracle.JJDisputeSignatoryType.A, _sut.Map<Oracle.JJDisputeSignatoryType>(Domain.Models.JJDisputeSignatoryType.A));
+        #endregion JJDisputeSignatoryType
+
+        #region JJDisputeStatus
+        // Oracle => Domain
+        Assert.Equal(Domain.Models.JJDisputeStatus.UNKNOWN, _sut.Map<Domain.Models.JJDisputeStatus>(Oracle.JJDisputeStatus.UNKNOWN));
+        Assert.Equal(Domain.Models.JJDisputeStatus.NEW, _sut.Map<Domain.Models.JJDisputeStatus>(Oracle.JJDisputeStatus.NEW));
+        Assert.Equal(Domain.Models.JJDisputeStatus.IN_PROGRESS, _sut.Map<Domain.Models.JJDisputeStatus>(Oracle.JJDisputeStatus.IN_PROGRESS));
+        Assert.Equal(Domain.Models.JJDisputeStatus.DATA_UPDATE, _sut.Map<Domain.Models.JJDisputeStatus>(Oracle.JJDisputeStatus.DATA_UPDATE));
+        Assert.Equal(Domain.Models.JJDisputeStatus.CONFIRMED, _sut.Map<Domain.Models.JJDisputeStatus>(Oracle.JJDisputeStatus.CONFIRMED));
+        Assert.Equal(Domain.Models.JJDisputeStatus.REQUIRE_COURT_HEARING, _sut.Map<Domain.Models.JJDisputeStatus>(Oracle.JJDisputeStatus.REQUIRE_COURT_HEARING));
+        Assert.Equal(Domain.Models.JJDisputeStatus.REQUIRE_MORE_INFO, _sut.Map<Domain.Models.JJDisputeStatus>(Oracle.JJDisputeStatus.REQUIRE_MORE_INFO));
+        Assert.Equal(Domain.Models.JJDisputeStatus.ACCEPTED, _sut.Map<Domain.Models.JJDisputeStatus>(Oracle.JJDisputeStatus.ACCEPTED));
+        Assert.Equal(Domain.Models.JJDisputeStatus.REVIEW, _sut.Map<Domain.Models.JJDisputeStatus>(Oracle.JJDisputeStatus.REVIEW));
+        Assert.Equal(Domain.Models.JJDisputeStatus.CONCLUDED, _sut.Map<Domain.Models.JJDisputeStatus>(Oracle.JJDisputeStatus.CONCLUDED));
+        Assert.Equal(Domain.Models.JJDisputeStatus.CANCELLED, _sut.Map<Domain.Models.JJDisputeStatus>(Oracle.JJDisputeStatus.CANCELLED));
+        Assert.Equal(Domain.Models.JJDisputeStatus.HEARING_SCHEDULED, _sut.Map<Domain.Models.JJDisputeStatus>(Oracle.JJDisputeStatus.HEARING_SCHEDULED));
+        // Domain => Oracle
+        Assert.Equal(Oracle.JJDisputeStatus.UNKNOWN, _sut.Map<Oracle.JJDisputeStatus>(Domain.Models.JJDisputeStatus.UNKNOWN));
+        Assert.Equal(Oracle.JJDisputeStatus.NEW, _sut.Map<Oracle.JJDisputeStatus>(Domain.Models.JJDisputeStatus.NEW));
+        Assert.Equal(Oracle.JJDisputeStatus.IN_PROGRESS, _sut.Map<Oracle.JJDisputeStatus>(Domain.Models.JJDisputeStatus.IN_PROGRESS));
+        Assert.Equal(Oracle.JJDisputeStatus.DATA_UPDATE, _sut.Map<Oracle.JJDisputeStatus>(Domain.Models.JJDisputeStatus.DATA_UPDATE));
+        Assert.Equal(Oracle.JJDisputeStatus.CONFIRMED, _sut.Map<Oracle.JJDisputeStatus>(Domain.Models.JJDisputeStatus.CONFIRMED));
+        Assert.Equal(Oracle.JJDisputeStatus.REQUIRE_COURT_HEARING, _sut.Map<Oracle.JJDisputeStatus>(Domain.Models.JJDisputeStatus.REQUIRE_COURT_HEARING));
+        Assert.Equal(Oracle.JJDisputeStatus.REQUIRE_MORE_INFO, _sut.Map<Oracle.JJDisputeStatus>(Domain.Models.JJDisputeStatus.REQUIRE_MORE_INFO));
+        Assert.Equal(Oracle.JJDisputeStatus.ACCEPTED, _sut.Map<Oracle.JJDisputeStatus>(Domain.Models.JJDisputeStatus.ACCEPTED));
+        Assert.Equal(Oracle.JJDisputeStatus.REVIEW, _sut.Map<Oracle.JJDisputeStatus>(Domain.Models.JJDisputeStatus.REVIEW));
+        Assert.Equal(Oracle.JJDisputeStatus.CONCLUDED, _sut.Map<Oracle.JJDisputeStatus>(Domain.Models.JJDisputeStatus.CONCLUDED));
+        Assert.Equal(Oracle.JJDisputeStatus.CANCELLED, _sut.Map<Oracle.JJDisputeStatus>(Domain.Models.JJDisputeStatus.CANCELLED));
+        Assert.Equal(Oracle.JJDisputeStatus.HEARING_SCHEDULED, _sut.Map<Oracle.JJDisputeStatus>(Domain.Models.JJDisputeStatus.HEARING_SCHEDULED));
+        #endregion JJDisputeStatus
+
+        #region Status
+        // Oracle => Domain
+        Assert.Equal(Domain.Models.Status.UNKNOWN, _sut.Map<Domain.Models.Status>(Oracle.Status.UNKNOWN));
+        Assert.Equal(Domain.Models.Status.ACCEPTED, _sut.Map<Domain.Models.Status>(Oracle.Status.ACCEPTED));
+        Assert.Equal(Domain.Models.Status.PENDING, _sut.Map<Domain.Models.Status>(Oracle.Status.PENDING));
+        Assert.Equal(Domain.Models.Status.REJECTED, _sut.Map<Domain.Models.Status>(Oracle.Status.REJECTED));
+        // Domain => Oracle
+        Assert.Equal(Oracle.Status.UNKNOWN, _sut.Map<Oracle.Status>(Domain.Models.Status.UNKNOWN));
+        Assert.Equal(Oracle.Status.ACCEPTED, _sut.Map<Oracle.Status>(Domain.Models.Status.ACCEPTED));
+        Assert.Equal(Oracle.Status.PENDING, _sut.Map<Oracle.Status>(Domain.Models.Status.PENDING));
+        Assert.Equal(Oracle.Status.REJECTED, _sut.Map<Oracle.Status>(Domain.Models.Status.REJECTED));
+        #endregion Status
+
+        #region TicketImageDataJustinDocumentReportType
+        // Oracle => Domain
+        Assert.Equal(Domain.Models.TicketImageDataJustinDocumentReportType.UNKNOWN, _sut.Map<Domain.Models.TicketImageDataJustinDocumentReportType>(Oracle.TicketImageDataJustinDocumentReportType.UNKNOWN));
+        Assert.Equal(Domain.Models.TicketImageDataJustinDocumentReportType.NOTICE_OF_DISPUTE, _sut.Map<Domain.Models.TicketImageDataJustinDocumentReportType>(Oracle.TicketImageDataJustinDocumentReportType.NOTICE_OF_DISPUTE));
+        Assert.Equal(Domain.Models.TicketImageDataJustinDocumentReportType.TICKET_IMAGE, _sut.Map<Domain.Models.TicketImageDataJustinDocumentReportType>(Oracle.TicketImageDataJustinDocumentReportType.TICKET_IMAGE));
+        // Domain => Oracle
+        Assert.Equal(Oracle.TicketImageDataJustinDocumentReportType.UNKNOWN, _sut.Map<Oracle.TicketImageDataJustinDocumentReportType>(Domain.Models.TicketImageDataJustinDocumentReportType.UNKNOWN));
+        Assert.Equal(Oracle.TicketImageDataJustinDocumentReportType.NOTICE_OF_DISPUTE, _sut.Map<Oracle.TicketImageDataJustinDocumentReportType>(Domain.Models.TicketImageDataJustinDocumentReportType.NOTICE_OF_DISPUTE));
+        Assert.Equal(Oracle.TicketImageDataJustinDocumentReportType.TICKET_IMAGE, _sut.Map<Oracle.TicketImageDataJustinDocumentReportType>(Domain.Models.TicketImageDataJustinDocumentReportType.TICKET_IMAGE));
+        #endregion TicketImageDataJustinDocumentReportType
+
+        #region ViolationTicketCountIsAct
+        // Oracle => Domain
+        Assert.Equal(Domain.Models.ViolationTicketCountIsAct.UNKNOWN, _sut.Map<Domain.Models.ViolationTicketCountIsAct>(Oracle.ViolationTicketCountIsAct.UNKNOWN));
+        Assert.Equal(Domain.Models.ViolationTicketCountIsAct.Y, _sut.Map<Domain.Models.ViolationTicketCountIsAct>(Oracle.ViolationTicketCountIsAct.Y));
+        Assert.Equal(Domain.Models.ViolationTicketCountIsAct.N, _sut.Map<Domain.Models.ViolationTicketCountIsAct>(Oracle.ViolationTicketCountIsAct.N));
+        // Domain => Oracle
+        Assert.Equal(Oracle.ViolationTicketCountIsAct.UNKNOWN, _sut.Map<Oracle.ViolationTicketCountIsAct>(Domain.Models.ViolationTicketCountIsAct.UNKNOWN));
+        Assert.Equal(Oracle.ViolationTicketCountIsAct.Y, _sut.Map<Oracle.ViolationTicketCountIsAct>(Domain.Models.ViolationTicketCountIsAct.Y));
+        Assert.Equal(Oracle.ViolationTicketCountIsAct.N, _sut.Map<Oracle.ViolationTicketCountIsAct>(Domain.Models.ViolationTicketCountIsAct.N));
+        #endregion ViolationTicketCountIsAct
+
+        #region ViolationTicketCountIsRegulation
+        // Oracle => Domain
+        Assert.Equal(Domain.Models.ViolationTicketCountIsRegulation.UNKNOWN, _sut.Map<Domain.Models.ViolationTicketCountIsRegulation>(Oracle.ViolationTicketCountIsRegulation.UNKNOWN));
+        Assert.Equal(Domain.Models.ViolationTicketCountIsRegulation.Y, _sut.Map<Domain.Models.ViolationTicketCountIsRegulation>(Oracle.ViolationTicketCountIsRegulation.Y));
+        Assert.Equal(Domain.Models.ViolationTicketCountIsRegulation.N, _sut.Map<Domain.Models.ViolationTicketCountIsRegulation>(Oracle.ViolationTicketCountIsRegulation.N));
+        // Domain => Oracle
+        Assert.Equal(Oracle.ViolationTicketCountIsRegulation.UNKNOWN, _sut.Map<Oracle.ViolationTicketCountIsRegulation>(Domain.Models.ViolationTicketCountIsRegulation.UNKNOWN));
+        Assert.Equal(Oracle.ViolationTicketCountIsRegulation.Y, _sut.Map<Oracle.ViolationTicketCountIsRegulation>(Domain.Models.ViolationTicketCountIsRegulation.Y));
+        Assert.Equal(Oracle.ViolationTicketCountIsRegulation.N, _sut.Map<Oracle.ViolationTicketCountIsRegulation>(Domain.Models.ViolationTicketCountIsRegulation.N));
+        #endregion ViolationTicketCountIsRegulation
+
+        #region ViolationTicketIsChangeOfAddress
+        // Oracle => Domain
+        Assert.Equal(Domain.Models.ViolationTicketIsChangeOfAddress.UNKNOWN, _sut.Map<Domain.Models.ViolationTicketIsChangeOfAddress>(Oracle.ViolationTicketIsChangeOfAddress.UNKNOWN));
+        Assert.Equal(Domain.Models.ViolationTicketIsChangeOfAddress.Y, _sut.Map<Domain.Models.ViolationTicketIsChangeOfAddress>(Oracle.ViolationTicketIsChangeOfAddress.Y));
+        Assert.Equal(Domain.Models.ViolationTicketIsChangeOfAddress.N, _sut.Map<Domain.Models.ViolationTicketIsChangeOfAddress>(Oracle.ViolationTicketIsChangeOfAddress.N));
+        // Domain => Oracle
+        Assert.Equal(Oracle.ViolationTicketIsChangeOfAddress.UNKNOWN, _sut.Map<Oracle.ViolationTicketIsChangeOfAddress>(Domain.Models.ViolationTicketIsChangeOfAddress.UNKNOWN));
+        Assert.Equal(Oracle.ViolationTicketIsChangeOfAddress.Y, _sut.Map<Oracle.ViolationTicketIsChangeOfAddress>(Domain.Models.ViolationTicketIsChangeOfAddress.Y));
+        Assert.Equal(Oracle.ViolationTicketIsChangeOfAddress.N, _sut.Map<Oracle.ViolationTicketIsChangeOfAddress>(Domain.Models.ViolationTicketIsChangeOfAddress.N));
+        #endregion ViolationTicketIsChangeOfAddress
+
+        #region ViolationTicketIsDriver
+        // Oracle => Domain
+        Assert.Equal(Domain.Models.ViolationTicketIsDriver.UNKNOWN, _sut.Map<Domain.Models.ViolationTicketIsDriver>(Oracle.ViolationTicketIsDriver.UNKNOWN));
+        Assert.Equal(Domain.Models.ViolationTicketIsDriver.Y, _sut.Map<Domain.Models.ViolationTicketIsDriver>(Oracle.ViolationTicketIsDriver.Y));
+        Assert.Equal(Domain.Models.ViolationTicketIsDriver.N, _sut.Map<Domain.Models.ViolationTicketIsDriver>(Oracle.ViolationTicketIsDriver.N));
+        // Domain => Oracle
+        Assert.Equal(Oracle.ViolationTicketIsDriver.UNKNOWN, _sut.Map<Oracle.ViolationTicketIsDriver>(Domain.Models.ViolationTicketIsDriver.UNKNOWN));
+        Assert.Equal(Oracle.ViolationTicketIsDriver.Y, _sut.Map<Oracle.ViolationTicketIsDriver>(Domain.Models.ViolationTicketIsDriver.Y));
+        Assert.Equal(Oracle.ViolationTicketIsDriver.N, _sut.Map<Oracle.ViolationTicketIsDriver>(Domain.Models.ViolationTicketIsDriver.N));
+        #endregion ViolationTicketIsDriver
+
+        #region ViolationTicketIsOwner
+        // Oracle => Domain
+        Assert.Equal(Domain.Models.ViolationTicketIsOwner.UNKNOWN, _sut.Map<Domain.Models.ViolationTicketIsOwner>(Oracle.ViolationTicketIsOwner.UNKNOWN));
+        Assert.Equal(Domain.Models.ViolationTicketIsOwner.Y, _sut.Map<Domain.Models.ViolationTicketIsOwner>(Oracle.ViolationTicketIsOwner.Y));
+        Assert.Equal(Domain.Models.ViolationTicketIsOwner.N, _sut.Map<Domain.Models.ViolationTicketIsOwner>(Oracle.ViolationTicketIsOwner.N));
+        // Domain => Oracle
+        Assert.Equal(Oracle.ViolationTicketIsOwner.UNKNOWN, _sut.Map<Oracle.ViolationTicketIsOwner>(Domain.Models.ViolationTicketIsOwner.UNKNOWN));
+        Assert.Equal(Oracle.ViolationTicketIsOwner.Y, _sut.Map<Oracle.ViolationTicketIsOwner>(Domain.Models.ViolationTicketIsOwner.Y));
+        Assert.Equal(Oracle.ViolationTicketIsOwner.N, _sut.Map<Oracle.ViolationTicketIsOwner>(Domain.Models.ViolationTicketIsOwner.N));
+        #endregion ViolationTicketIsOwner
+
+        #region ViolationTicketIsYoungPerson
+        // Oracle => Domain
+        Assert.Equal(Domain.Models.ViolationTicketIsYoungPerson.UNKNOWN, _sut.Map<Domain.Models.ViolationTicketIsYoungPerson>(Oracle.ViolationTicketIsYoungPerson.UNKNOWN));
+        Assert.Equal(Domain.Models.ViolationTicketIsYoungPerson.Y, _sut.Map<Domain.Models.ViolationTicketIsYoungPerson>(Oracle.ViolationTicketIsYoungPerson.Y));
+        Assert.Equal(Domain.Models.ViolationTicketIsYoungPerson.N, _sut.Map<Domain.Models.ViolationTicketIsYoungPerson>(Oracle.ViolationTicketIsYoungPerson.N));
+        // Domain => Oracle
+        Assert.Equal(Oracle.ViolationTicketIsYoungPerson.UNKNOWN, _sut.Map<Oracle.ViolationTicketIsYoungPerson>(Domain.Models.ViolationTicketIsYoungPerson.UNKNOWN));
+        Assert.Equal(Oracle.ViolationTicketIsYoungPerson.Y, _sut.Map<Oracle.ViolationTicketIsYoungPerson>(Domain.Models.ViolationTicketIsYoungPerson.Y));
+        Assert.Equal(Oracle.ViolationTicketIsYoungPerson.N, _sut.Map<Oracle.ViolationTicketIsYoungPerson>(Domain.Models.ViolationTicketIsYoungPerson.N));
+        #endregion ViolationTicketIsYoungPerson
+
+
+    }
+}

--- a/src/backend/TrafficCourts/TrafficCourts.OracleDataApi/Client/V1/OracleDomainModelMappingProfile.cs
+++ b/src/backend/TrafficCourts/TrafficCourts.OracleDataApi/Client/V1/OracleDomainModelMappingProfile.cs
@@ -1,9 +1,9 @@
-﻿
-using Oracle = TrafficCourts.OracleDataApi.Client.V1;
+﻿using Oracle = TrafficCourts.OracleDataApi.Client.V1;
 using DomainModel = TrafficCourts.Domain.Models;
 
 namespace TrafficCourts.OracleDataApi.Client.V1;
 
+[System.CodeDom.Compiler.GeneratedCode("DomainModelMappingTestGenerator.generate_mapper", "")]
 public class OracleDomainModelMappingProfile : AutoMapper.Profile
 {
     public OracleDomainModelMappingProfile()
@@ -38,7 +38,6 @@ public class OracleDomainModelMappingProfile : AutoMapper.Profile
         CreateMap<Oracle.JJDisputeStatus, DomainModel.JJDisputeStatus>().ConvertUsing<EnumTypeConverter>();
         CreateMap<Oracle.Status, DomainModel.Status>().ConvertUsing<EnumTypeConverter>();
         CreateMap<Oracle.TicketImageDataJustinDocumentReportType, DomainModel.TicketImageDataJustinDocumentReportType>().ConvertUsing<EnumTypeConverter>();
-        //CreateMap<Oracle.ViolationTicketVersion, DomainModel.ViolationTicketVersion>().ConvertUsing<EnumTypeConverter>();
         CreateMap<Oracle.DisputeAppearanceLessThan14DaysYn, DomainModel.DisputeAppearanceLessThan14DaysYn>().ConvertUsing<EnumTypeConverter>();
         CreateMap<Oracle.DisputeCountRequestCourtAppearance, DomainModel.DisputeCountRequestCourtAppearance>().ConvertUsing<EnumTypeConverter>();
         CreateMap<Oracle.DisputeCountRequestReduction, DomainModel.DisputeCountRequestReduction>().ConvertUsing<EnumTypeConverter>();
@@ -78,1812 +77,1784 @@ public class OracleDomainModelMappingProfile : AutoMapper.Profile
         CreateMap<Oracle.Dispute, DomainModel.Dispute>()
             .ForMember(dest => dest.FileData, opt => opt.Ignore())
             .ReverseMap();
-
         CreateMap<Oracle.DisputeCount, DomainModel.DisputeCount>().ReverseMap();
         CreateMap<Oracle.DisputeListItem, DomainModel.DisputeListItem>().ReverseMap();
         CreateMap<Oracle.DisputeResult, DomainModel.DisputeResult>().ReverseMap();
         CreateMap<Oracle.DisputeUpdateRequest, DomainModel.DisputeUpdateRequest>().ReverseMap();
         CreateMap<Oracle.EmailHistory, DomainModel.EmailHistory>().ReverseMap();
         CreateMap<Oracle.FileHistory, DomainModel.FileHistory>().ReverseMap();
-
         CreateMap<Oracle.JJDispute, DomainModel.JJDispute>()
             .ForMember(dest => dest.FileData, opt => opt.Ignore())
             .ForMember(dest => dest.LockId, opt => opt.Ignore())
             .ForMember(dest => dest.LockedBy, opt => opt.Ignore())
             .ForMember(dest => dest.LockExpiresAtUtc, opt => opt.Ignore())
             .ReverseMap();
-        
         CreateMap<Oracle.JJDisputeCourtAppearanceRoP, DomainModel.JJDisputeCourtAppearanceRoP>().ReverseMap();
         CreateMap<Oracle.JJDisputedCount, DomainModel.JJDisputedCount>().ReverseMap();
         CreateMap<Oracle.JJDisputedCountRoP, DomainModel.JJDisputedCountRoP>().ReverseMap();
         CreateMap<Oracle.JJDisputeRemark, DomainModel.JJDisputeRemark>().ReverseMap();
         CreateMap<Oracle.TicketImageDataJustinDocument, DomainModel.TicketImageDataJustinDocument>().ReverseMap();
-
         CreateMap<Oracle.ViolationTicket, DomainModel.ViolationTicket>()
             .ForMember(dest => dest.ViolationTicketImage, opt => opt.Ignore())
             .ForMember(dest => dest.OcrViolationTicket, opt => opt.Ignore())
             .ReverseMap();
-        
         CreateMap<Oracle.ViolationTicketCount, DomainModel.ViolationTicketCount>().ReverseMap();
 
-        //CreateMap<Models.FileMetadata, DomainModel.FileMetadata>().ReverseMap();
         // FileResponse does not have a default constructor
         CreateMap<Oracle.FileResponse, DomainModel.FileResponse>()
             .ConstructUsing(src => new DomainModel.FileResponse(src.StatusCode, src.Headers, src.Stream, null, null));
         CreateMap<DomainModel.FileResponse, Oracle.FileResponse>()
             .ConstructUsing(src => new Oracle.FileResponse(src.StatusCode, src.Headers, src.Stream, null, null));
     }
-
-    class EnumTypeConverter :
-        // Oracle to Domain Model
-        AutoMapper.ITypeConverter<Oracle.DisputeContactTypeCd, DomainModel.DisputeContactTypeCd>,
-        AutoMapper.ITypeConverter<Oracle.DisputeCountPleaCode, DomainModel.DisputeCountPleaCode>,
-        AutoMapper.ITypeConverter<Oracle.DisputeListItemJjDisputeStatus, DomainModel.DisputeListItemJjDisputeStatus>,
-        AutoMapper.ITypeConverter<Oracle.DisputeListItemStatus, DomainModel.DisputeListItemStatus>,
-        AutoMapper.ITypeConverter<Oracle.DisputeResultDisputeStatus, DomainModel.DisputeResultDisputeStatus>,
-        AutoMapper.ITypeConverter<Oracle.DisputeResultJjDisputeHearingType, DomainModel.DisputeResultJjDisputeHearingType>,
-        AutoMapper.ITypeConverter<Oracle.DisputeResultJjDisputeStatus, DomainModel.DisputeResultJjDisputeStatus>,
-        AutoMapper.ITypeConverter<Oracle.DisputeSignatoryType, DomainModel.DisputeSignatoryType>,
-        AutoMapper.ITypeConverter<Oracle.DisputeStatus, DomainModel.DisputeStatus>,
-        AutoMapper.ITypeConverter<Oracle.DisputeUpdateRequestStatus, DomainModel.DisputeUpdateRequestStatus>,
-        AutoMapper.ITypeConverter<Oracle.DisputeUpdateRequestStatus2, DomainModel.DisputeUpdateRequestStatus2>,
-        AutoMapper.ITypeConverter<Oracle.DisputeUpdateRequestUpdateType, DomainModel.DisputeUpdateRequestUpdateType>,
-        AutoMapper.ITypeConverter<Oracle.DocumentType, DomainModel.DocumentType>,
-        AutoMapper.ITypeConverter<Oracle.ExcludeStatus, DomainModel.ExcludeStatus>,
-        AutoMapper.ITypeConverter<Oracle.ExcludeStatus2, DomainModel.ExcludeStatus2>,
-        AutoMapper.ITypeConverter<Oracle.FileHistoryAuditLogEntryType, DomainModel.FileHistoryAuditLogEntryType>,
-        AutoMapper.ITypeConverter<Oracle.JJDisputeContactType, DomainModel.JJDisputeContactType>,
-        AutoMapper.ITypeConverter<Oracle.JJDisputeCourtAppearanceRoPAppCd, DomainModel.JJDisputeCourtAppearanceRoPAppCd>,
-        AutoMapper.ITypeConverter<Oracle.JJDisputeCourtAppearanceRoPCrown, DomainModel.JJDisputeCourtAppearanceRoPCrown>,
-        AutoMapper.ITypeConverter<Oracle.JJDisputeCourtAppearanceRoPDattCd, DomainModel.JJDisputeCourtAppearanceRoPDattCd>,
-        AutoMapper.ITypeConverter<Oracle.JJDisputedCountLatestPlea, DomainModel.JJDisputedCountLatestPlea>,
-        AutoMapper.ITypeConverter<Oracle.JJDisputedCountPlea, DomainModel.JJDisputedCountPlea>,
-        AutoMapper.ITypeConverter<Oracle.JJDisputedCountRoPFinding, DomainModel.JJDisputedCountRoPFinding>,
-        AutoMapper.ITypeConverter<Oracle.JJDisputeDisputantAttendanceType, DomainModel.JJDisputeDisputantAttendanceType>,
-        AutoMapper.ITypeConverter<Oracle.JJDisputeHearingType, DomainModel.JJDisputeHearingType>,
-        AutoMapper.ITypeConverter<Oracle.JJDisputeSignatoryType, DomainModel.JJDisputeSignatoryType>,
-        AutoMapper.ITypeConverter<Oracle.JJDisputeStatus, DomainModel.JJDisputeStatus>,
-        AutoMapper.ITypeConverter<Oracle.Status, DomainModel.Status>,
-        AutoMapper.ITypeConverter<Oracle.TicketImageDataJustinDocumentReportType, DomainModel.TicketImageDataJustinDocumentReportType>,
-        //AutoMapper.ITypeConverter<Oracle.ViolationTicketVersion, DomainModel.ViolationTicketVersion>,
-        // Oracle to Domain Model (Unknown, Yes or No)
-        AutoMapper.ITypeConverter<Oracle.DisputeAppearanceLessThan14DaysYn, DomainModel.DisputeAppearanceLessThan14DaysYn>,
-        AutoMapper.ITypeConverter<Oracle.DisputeCountRequestCourtAppearance, DomainModel.DisputeCountRequestCourtAppearance>,
-        AutoMapper.ITypeConverter<Oracle.DisputeCountRequestReduction, DomainModel.DisputeCountRequestReduction>,
-        AutoMapper.ITypeConverter<Oracle.DisputeCountRequestTimeToPay, DomainModel.DisputeCountRequestTimeToPay>,
-        AutoMapper.ITypeConverter<Oracle.DisputeDisputantDetectedOcrIssues, DomainModel.DisputeDisputantDetectedOcrIssues>,
-        AutoMapper.ITypeConverter<Oracle.DisputeInterpreterRequired, DomainModel.DisputeInterpreterRequired>,
-        AutoMapper.ITypeConverter<Oracle.DisputeListItemDisputantDetectedOcrIssues, DomainModel.DisputeListItemDisputantDetectedOcrIssues>,
-        AutoMapper.ITypeConverter<Oracle.DisputeListItemRequestCourtAppearanceYn, DomainModel.DisputeListItemRequestCourtAppearanceYn>,
-        AutoMapper.ITypeConverter<Oracle.DisputeListItemSystemDetectedOcrIssues, DomainModel.DisputeListItemSystemDetectedOcrIssues>,
-        AutoMapper.ITypeConverter<Oracle.DisputeRepresentedByLawyer, DomainModel.DisputeRepresentedByLawyer>,
-        AutoMapper.ITypeConverter<Oracle.DisputeRequestCourtAppearanceYn, DomainModel.DisputeRequestCourtAppearanceYn>,
-        AutoMapper.ITypeConverter<Oracle.DisputeSystemDetectedOcrIssues, DomainModel.DisputeSystemDetectedOcrIssues>,
-        AutoMapper.ITypeConverter<Oracle.EmailHistorySuccessfullySent, DomainModel.EmailHistorySuccessfullySent>,
-        AutoMapper.ITypeConverter<Oracle.JJDisputeAccidentYn, DomainModel.JJDisputeAccidentYn>,
-        AutoMapper.ITypeConverter<Oracle.JJDisputeAppearInCourt, DomainModel.JJDisputeAppearInCourt>,
-        AutoMapper.ITypeConverter<Oracle.JJDisputeCourtAppearanceRoPJjSeized, DomainModel.JJDisputeCourtAppearanceRoPJjSeized>,
-        AutoMapper.ITypeConverter<Oracle.JJDisputedCountAppearInCourt, DomainModel.JJDisputedCountAppearInCourt>,
-        AutoMapper.ITypeConverter<Oracle.JJDisputedCountIncludesSurcharge, DomainModel.JJDisputedCountIncludesSurcharge>,
-        AutoMapper.ITypeConverter<Oracle.JJDisputedCountRequestReduction, DomainModel.JJDisputedCountRequestReduction>,
-        AutoMapper.ITypeConverter<Oracle.JJDisputedCountRequestTimeToPay, DomainModel.JJDisputedCountRequestTimeToPay>,
-        AutoMapper.ITypeConverter<Oracle.JJDisputedCountRoPAbatement, DomainModel.JJDisputedCountRoPAbatement>,
-        AutoMapper.ITypeConverter<Oracle.JJDisputedCountRoPDismissed, DomainModel.JJDisputedCountRoPDismissed>,
-        AutoMapper.ITypeConverter<Oracle.JJDisputedCountRoPForWantOfProsecution, DomainModel.JJDisputedCountRoPForWantOfProsecution>,
-        AutoMapper.ITypeConverter<Oracle.JJDisputedCountRoPJailIntermittent, DomainModel.JJDisputedCountRoPJailIntermittent>,
-        AutoMapper.ITypeConverter<Oracle.JJDisputedCountRoPWithdrawn, DomainModel.JJDisputedCountRoPWithdrawn>,
-        AutoMapper.ITypeConverter<Oracle.JJDisputeElectronicTicketYn, DomainModel.JJDisputeElectronicTicketYn>,
-        AutoMapper.ITypeConverter<Oracle.JJDisputeMultipleOfficersYn, DomainModel.JJDisputeMultipleOfficersYn>,
-        AutoMapper.ITypeConverter<Oracle.JJDisputeNoticeOfHearingYn, DomainModel.JJDisputeNoticeOfHearingYn>,
-        AutoMapper.ITypeConverter<Oracle.ViolationTicketCountIsAct, DomainModel.ViolationTicketCountIsAct>,
-        AutoMapper.ITypeConverter<Oracle.ViolationTicketCountIsRegulation, DomainModel.ViolationTicketCountIsRegulation>,
-        AutoMapper.ITypeConverter<Oracle.ViolationTicketIsChangeOfAddress, DomainModel.ViolationTicketIsChangeOfAddress>,
-        AutoMapper.ITypeConverter<Oracle.ViolationTicketIsDriver, DomainModel.ViolationTicketIsDriver>,
-        AutoMapper.ITypeConverter<Oracle.ViolationTicketIsOwner, DomainModel.ViolationTicketIsOwner>,
-        AutoMapper.ITypeConverter<Oracle.ViolationTicketIsYoungPerson, DomainModel.ViolationTicketIsYoungPerson>,
-        // Domain Model to Oracle
-        AutoMapper.ITypeConverter<DomainModel.DisputeContactTypeCd, Oracle.DisputeContactTypeCd>,
-        AutoMapper.ITypeConverter<DomainModel.DisputeCountPleaCode, Oracle.DisputeCountPleaCode>,
-        AutoMapper.ITypeConverter<DomainModel.DisputeListItemJjDisputeStatus, Oracle.DisputeListItemJjDisputeStatus>,
-        AutoMapper.ITypeConverter<DomainModel.DisputeListItemStatus, Oracle.DisputeListItemStatus>,
-        AutoMapper.ITypeConverter<DomainModel.DisputeResultDisputeStatus, Oracle.DisputeResultDisputeStatus>,
-        AutoMapper.ITypeConverter<DomainModel.DisputeResultJjDisputeHearingType, Oracle.DisputeResultJjDisputeHearingType>,
-        AutoMapper.ITypeConverter<DomainModel.DisputeResultJjDisputeStatus, Oracle.DisputeResultJjDisputeStatus>,
-        AutoMapper.ITypeConverter<DomainModel.DisputeSignatoryType, Oracle.DisputeSignatoryType>,
-        AutoMapper.ITypeConverter<DomainModel.DisputeStatus, Oracle.DisputeStatus>,
-        AutoMapper.ITypeConverter<DomainModel.DisputeUpdateRequestStatus, Oracle.DisputeUpdateRequestStatus>,
-        AutoMapper.ITypeConverter<DomainModel.DisputeUpdateRequestStatus2, Oracle.DisputeUpdateRequestStatus2>,
-        AutoMapper.ITypeConverter<DomainModel.DisputeUpdateRequestUpdateType, Oracle.DisputeUpdateRequestUpdateType>,
-        AutoMapper.ITypeConverter<DomainModel.DocumentType, Oracle.DocumentType>,
-        AutoMapper.ITypeConverter<DomainModel.ExcludeStatus, Oracle.ExcludeStatus>,
-        AutoMapper.ITypeConverter<DomainModel.ExcludeStatus2, Oracle.ExcludeStatus2>,
-        AutoMapper.ITypeConverter<DomainModel.FileHistoryAuditLogEntryType, Oracle.FileHistoryAuditLogEntryType>,
-        AutoMapper.ITypeConverter<DomainModel.JJDisputeContactType, Oracle.JJDisputeContactType>,
-        AutoMapper.ITypeConverter<DomainModel.JJDisputeCourtAppearanceRoPAppCd, Oracle.JJDisputeCourtAppearanceRoPAppCd>,
-        AutoMapper.ITypeConverter<DomainModel.JJDisputeCourtAppearanceRoPCrown, Oracle.JJDisputeCourtAppearanceRoPCrown>,
-        AutoMapper.ITypeConverter<DomainModel.JJDisputeCourtAppearanceRoPDattCd, Oracle.JJDisputeCourtAppearanceRoPDattCd>,
-        AutoMapper.ITypeConverter<DomainModel.JJDisputedCountLatestPlea, Oracle.JJDisputedCountLatestPlea>,
-        AutoMapper.ITypeConverter<DomainModel.JJDisputedCountPlea, Oracle.JJDisputedCountPlea>,
-        AutoMapper.ITypeConverter<DomainModel.JJDisputedCountRoPFinding, Oracle.JJDisputedCountRoPFinding>,
-        AutoMapper.ITypeConverter<DomainModel.JJDisputeDisputantAttendanceType, Oracle.JJDisputeDisputantAttendanceType>,
-        AutoMapper.ITypeConverter<DomainModel.JJDisputeHearingType, Oracle.JJDisputeHearingType>,
-        AutoMapper.ITypeConverter<DomainModel.JJDisputeSignatoryType, Oracle.JJDisputeSignatoryType>,
-        AutoMapper.ITypeConverter<DomainModel.JJDisputeStatus, Oracle.JJDisputeStatus>,
-        AutoMapper.ITypeConverter<DomainModel.Status, Oracle.Status>,
-        AutoMapper.ITypeConverter<DomainModel.TicketImageDataJustinDocumentReportType, Oracle.TicketImageDataJustinDocumentReportType>,
-        //AutoMapper.ITypeConverter<DomainModel.ViolationTicketVersion, Oracle.ViolationTicketVersion>,
-        // Domain Model to Oracle (Unknown, Yes or No)
-        AutoMapper.ITypeConverter<DomainModel.DisputeAppearanceLessThan14DaysYn, Oracle.DisputeAppearanceLessThan14DaysYn>,
-        AutoMapper.ITypeConverter<DomainModel.DisputeCountRequestCourtAppearance, Oracle.DisputeCountRequestCourtAppearance>,
-        AutoMapper.ITypeConverter<DomainModel.DisputeCountRequestReduction, Oracle.DisputeCountRequestReduction>,
-        AutoMapper.ITypeConverter<DomainModel.DisputeCountRequestTimeToPay, Oracle.DisputeCountRequestTimeToPay>,
-        AutoMapper.ITypeConverter<DomainModel.DisputeDisputantDetectedOcrIssues, Oracle.DisputeDisputantDetectedOcrIssues>,
-        AutoMapper.ITypeConverter<DomainModel.DisputeInterpreterRequired, Oracle.DisputeInterpreterRequired>,
-        AutoMapper.ITypeConverter<DomainModel.DisputeListItemDisputantDetectedOcrIssues, Oracle.DisputeListItemDisputantDetectedOcrIssues>,
-        AutoMapper.ITypeConverter<DomainModel.DisputeListItemRequestCourtAppearanceYn, Oracle.DisputeListItemRequestCourtAppearanceYn>,
-        AutoMapper.ITypeConverter<DomainModel.DisputeListItemSystemDetectedOcrIssues, Oracle.DisputeListItemSystemDetectedOcrIssues>,
-        AutoMapper.ITypeConverter<DomainModel.DisputeRepresentedByLawyer, Oracle.DisputeRepresentedByLawyer>,
-        AutoMapper.ITypeConverter<DomainModel.DisputeRequestCourtAppearanceYn, Oracle.DisputeRequestCourtAppearanceYn>,
-        AutoMapper.ITypeConverter<DomainModel.DisputeSystemDetectedOcrIssues, Oracle.DisputeSystemDetectedOcrIssues>,
-        AutoMapper.ITypeConverter<DomainModel.EmailHistorySuccessfullySent, Oracle.EmailHistorySuccessfullySent>,
-        AutoMapper.ITypeConverter<DomainModel.JJDisputeAccidentYn, Oracle.JJDisputeAccidentYn>,
-        AutoMapper.ITypeConverter<DomainModel.JJDisputeAppearInCourt, Oracle.JJDisputeAppearInCourt>,
-        AutoMapper.ITypeConverter<DomainModel.JJDisputeCourtAppearanceRoPJjSeized, Oracle.JJDisputeCourtAppearanceRoPJjSeized>,
-        AutoMapper.ITypeConverter<DomainModel.JJDisputedCountAppearInCourt, Oracle.JJDisputedCountAppearInCourt>,
-        AutoMapper.ITypeConverter<DomainModel.JJDisputedCountIncludesSurcharge, Oracle.JJDisputedCountIncludesSurcharge>,
-        AutoMapper.ITypeConverter<DomainModel.JJDisputedCountRequestReduction, Oracle.JJDisputedCountRequestReduction>,
-        AutoMapper.ITypeConverter<DomainModel.JJDisputedCountRequestTimeToPay, Oracle.JJDisputedCountRequestTimeToPay>,
-        AutoMapper.ITypeConverter<DomainModel.JJDisputedCountRoPAbatement, Oracle.JJDisputedCountRoPAbatement>,
-        AutoMapper.ITypeConverter<DomainModel.JJDisputedCountRoPDismissed, Oracle.JJDisputedCountRoPDismissed>,
-        AutoMapper.ITypeConverter<DomainModel.JJDisputedCountRoPForWantOfProsecution, Oracle.JJDisputedCountRoPForWantOfProsecution>,
-        AutoMapper.ITypeConverter<DomainModel.JJDisputedCountRoPJailIntermittent, Oracle.JJDisputedCountRoPJailIntermittent>,
-        AutoMapper.ITypeConverter<DomainModel.JJDisputedCountRoPWithdrawn, Oracle.JJDisputedCountRoPWithdrawn>,
-        AutoMapper.ITypeConverter<DomainModel.JJDisputeElectronicTicketYn, Oracle.JJDisputeElectronicTicketYn>,
-        AutoMapper.ITypeConverter<DomainModel.JJDisputeMultipleOfficersYn, Oracle.JJDisputeMultipleOfficersYn>,
-        AutoMapper.ITypeConverter<DomainModel.JJDisputeNoticeOfHearingYn, Oracle.JJDisputeNoticeOfHearingYn>,
-        AutoMapper.ITypeConverter<DomainModel.ViolationTicketCountIsAct, Oracle.ViolationTicketCountIsAct>,
-        AutoMapper.ITypeConverter<DomainModel.ViolationTicketCountIsRegulation, Oracle.ViolationTicketCountIsRegulation>,
-        AutoMapper.ITypeConverter<DomainModel.ViolationTicketIsChangeOfAddress, Oracle.ViolationTicketIsChangeOfAddress>,
-        AutoMapper.ITypeConverter<DomainModel.ViolationTicketIsDriver, Oracle.ViolationTicketIsDriver>,
-        AutoMapper.ITypeConverter<DomainModel.ViolationTicketIsOwner, Oracle.ViolationTicketIsOwner>,
-        AutoMapper.ITypeConverter<DomainModel.ViolationTicketIsYoungPerson, Oracle.ViolationTicketIsYoungPerson>
-    {
-        public DomainModel.DisputeContactTypeCd Convert(Oracle.DisputeContactTypeCd source, DomainModel.DisputeContactTypeCd destination, AutoMapper.ResolutionContext context)
-        {
-            return source switch
-            {
-                Oracle.DisputeContactTypeCd.UNKNOWN => DomainModel.DisputeContactTypeCd.UNKNOWN,
-                Oracle.DisputeContactTypeCd.INDIVIDUAL => DomainModel.DisputeContactTypeCd.INDIVIDUAL,
-                Oracle.DisputeContactTypeCd.LAWYER => DomainModel.DisputeContactTypeCd.LAWYER,
-                Oracle.DisputeContactTypeCd.OTHER => DomainModel.DisputeContactTypeCd.OTHER,
-                _ => DomainModel.DisputeContactTypeCd.UNKNOWN
-            };
-        }
-
-        public Oracle.DisputeContactTypeCd Convert(DomainModel.DisputeContactTypeCd source, Oracle.DisputeContactTypeCd destination, AutoMapper.ResolutionContext context)
-        {
-            return source switch
-            {
-                DomainModel.DisputeContactTypeCd.UNKNOWN => Oracle.DisputeContactTypeCd.UNKNOWN,
-                DomainModel.DisputeContactTypeCd.INDIVIDUAL => Oracle.DisputeContactTypeCd.INDIVIDUAL,
-                DomainModel.DisputeContactTypeCd.LAWYER => Oracle.DisputeContactTypeCd.LAWYER,
-                DomainModel.DisputeContactTypeCd.OTHER => Oracle.DisputeContactTypeCd.OTHER,
-                _ => Oracle.DisputeContactTypeCd.UNKNOWN
-            };
-        }
-
-        public DomainModel.DisputeCountPleaCode Convert(Oracle.DisputeCountPleaCode source, DomainModel.DisputeCountPleaCode destination, AutoMapper.ResolutionContext context)
-        {
-            return source switch
-            {
-                Oracle.DisputeCountPleaCode.UNKNOWN => DomainModel.DisputeCountPleaCode.UNKNOWN,
-                Oracle.DisputeCountPleaCode.G => DomainModel.DisputeCountPleaCode.G,
-                Oracle.DisputeCountPleaCode.N => DomainModel.DisputeCountPleaCode.N,
-                _ => DomainModel.DisputeCountPleaCode.UNKNOWN
-            };
-        }
-
-        public Oracle.DisputeCountPleaCode Convert(DomainModel.DisputeCountPleaCode source, Oracle.DisputeCountPleaCode destination, AutoMapper.ResolutionContext context)
-        {
-            return source switch
-            {
-                DomainModel.DisputeCountPleaCode.UNKNOWN => Oracle.DisputeCountPleaCode.UNKNOWN,
-                DomainModel.DisputeCountPleaCode.G => Oracle.DisputeCountPleaCode.G,
-                DomainModel.DisputeCountPleaCode.N => Oracle.DisputeCountPleaCode.N,
-                _ => Oracle.DisputeCountPleaCode.UNKNOWN
-            };
-        }
-
-        public DomainModel.DisputeListItemJjDisputeStatus Convert(Oracle.DisputeListItemJjDisputeStatus source, DomainModel.DisputeListItemJjDisputeStatus destination, AutoMapper.ResolutionContext context)
-        {
-            return source switch
-            {
-                Oracle.DisputeListItemJjDisputeStatus.UNKNOWN => DomainModel.DisputeListItemJjDisputeStatus.UNKNOWN,
-                Oracle.DisputeListItemJjDisputeStatus.NEW => DomainModel.DisputeListItemJjDisputeStatus.NEW,
-                Oracle.DisputeListItemJjDisputeStatus.IN_PROGRESS => DomainModel.DisputeListItemJjDisputeStatus.IN_PROGRESS,
-                Oracle.DisputeListItemJjDisputeStatus.DATA_UPDATE => DomainModel.DisputeListItemJjDisputeStatus.DATA_UPDATE,
-                Oracle.DisputeListItemJjDisputeStatus.CONFIRMED => DomainModel.DisputeListItemJjDisputeStatus.CONFIRMED,
-                Oracle.DisputeListItemJjDisputeStatus.REQUIRE_COURT_HEARING => DomainModel.DisputeListItemJjDisputeStatus.REQUIRE_COURT_HEARING,
-                Oracle.DisputeListItemJjDisputeStatus.REQUIRE_MORE_INFO => DomainModel.DisputeListItemJjDisputeStatus.REQUIRE_MORE_INFO,
-                Oracle.DisputeListItemJjDisputeStatus.ACCEPTED => DomainModel.DisputeListItemJjDisputeStatus.ACCEPTED,
-                Oracle.DisputeListItemJjDisputeStatus.REVIEW => DomainModel.DisputeListItemJjDisputeStatus.REVIEW,
-                Oracle.DisputeListItemJjDisputeStatus.CONCLUDED => DomainModel.DisputeListItemJjDisputeStatus.CONCLUDED,
-                Oracle.DisputeListItemJjDisputeStatus.CANCELLED => DomainModel.DisputeListItemJjDisputeStatus.CANCELLED,
-                Oracle.DisputeListItemJjDisputeStatus.HEARING_SCHEDULED => DomainModel.DisputeListItemJjDisputeStatus.HEARING_SCHEDULED,
-                _ => DomainModel.DisputeListItemJjDisputeStatus.UNKNOWN
-            };
-        }
-
-        public Oracle.DisputeListItemJjDisputeStatus Convert(DomainModel.DisputeListItemJjDisputeStatus source, Oracle.DisputeListItemJjDisputeStatus destination, AutoMapper.ResolutionContext context)
-        {
-            return source switch
-            {
-                DomainModel.DisputeListItemJjDisputeStatus.UNKNOWN => Oracle.DisputeListItemJjDisputeStatus.UNKNOWN,
-                DomainModel.DisputeListItemJjDisputeStatus.NEW => Oracle.DisputeListItemJjDisputeStatus.NEW,
-                DomainModel.DisputeListItemJjDisputeStatus.IN_PROGRESS => Oracle.DisputeListItemJjDisputeStatus.IN_PROGRESS,
-                DomainModel.DisputeListItemJjDisputeStatus.DATA_UPDATE => Oracle.DisputeListItemJjDisputeStatus.DATA_UPDATE,
-                DomainModel.DisputeListItemJjDisputeStatus.CONFIRMED => Oracle.DisputeListItemJjDisputeStatus.CONFIRMED,
-                DomainModel.DisputeListItemJjDisputeStatus.REQUIRE_COURT_HEARING => Oracle.DisputeListItemJjDisputeStatus.REQUIRE_COURT_HEARING,
-                DomainModel.DisputeListItemJjDisputeStatus.REQUIRE_MORE_INFO => Oracle.DisputeListItemJjDisputeStatus.REQUIRE_MORE_INFO,
-                DomainModel.DisputeListItemJjDisputeStatus.ACCEPTED => Oracle.DisputeListItemJjDisputeStatus.ACCEPTED,
-                DomainModel.DisputeListItemJjDisputeStatus.REVIEW => Oracle.DisputeListItemJjDisputeStatus.REVIEW,
-                DomainModel.DisputeListItemJjDisputeStatus.CONCLUDED => Oracle.DisputeListItemJjDisputeStatus.CONCLUDED,
-                DomainModel.DisputeListItemJjDisputeStatus.CANCELLED => Oracle.DisputeListItemJjDisputeStatus.CANCELLED,
-                DomainModel.DisputeListItemJjDisputeStatus.HEARING_SCHEDULED => Oracle.DisputeListItemJjDisputeStatus.HEARING_SCHEDULED,
-                _ => Oracle.DisputeListItemJjDisputeStatus.UNKNOWN
-            };
-        }
-
-        public DomainModel.DisputeListItemStatus Convert(Oracle.DisputeListItemStatus source, DomainModel.DisputeListItemStatus destination, AutoMapper.ResolutionContext context)
-        {
-            return source switch
-            {
-                Oracle.DisputeListItemStatus.UNKNOWN => DomainModel.DisputeListItemStatus.UNKNOWN,
-                Oracle.DisputeListItemStatus.NEW => DomainModel.DisputeListItemStatus.NEW,
-                Oracle.DisputeListItemStatus.VALIDATED => DomainModel.DisputeListItemStatus.VALIDATED,
-                Oracle.DisputeListItemStatus.PROCESSING => DomainModel.DisputeListItemStatus.PROCESSING,
-                Oracle.DisputeListItemStatus.REJECTED => DomainModel.DisputeListItemStatus.REJECTED,
-                Oracle.DisputeListItemStatus.CANCELLED => DomainModel.DisputeListItemStatus.CANCELLED,
-                Oracle.DisputeListItemStatus.CONCLUDED => DomainModel.DisputeListItemStatus.CONCLUDED,
-                _ => DomainModel.DisputeListItemStatus.UNKNOWN
-            };
-        }
-
-        public Oracle.DisputeListItemStatus Convert(DomainModel.DisputeListItemStatus source, Oracle.DisputeListItemStatus destination, AutoMapper.ResolutionContext context)
-        {
-            return source switch
-            {
-                DomainModel.DisputeListItemStatus.UNKNOWN => Oracle.DisputeListItemStatus.UNKNOWN,
-                DomainModel.DisputeListItemStatus.NEW => Oracle.DisputeListItemStatus.NEW,
-                DomainModel.DisputeListItemStatus.VALIDATED => Oracle.DisputeListItemStatus.VALIDATED,
-                DomainModel.DisputeListItemStatus.PROCESSING => Oracle.DisputeListItemStatus.PROCESSING,
-                DomainModel.DisputeListItemStatus.REJECTED => Oracle.DisputeListItemStatus.REJECTED,
-                DomainModel.DisputeListItemStatus.CANCELLED => Oracle.DisputeListItemStatus.CANCELLED,
-                DomainModel.DisputeListItemStatus.CONCLUDED => Oracle.DisputeListItemStatus.CONCLUDED,
-                _ => Oracle.DisputeListItemStatus.UNKNOWN
-            };
-        }
-
-        public DomainModel.DisputeResultDisputeStatus Convert(Oracle.DisputeResultDisputeStatus source, DomainModel.DisputeResultDisputeStatus destination, AutoMapper.ResolutionContext context)
-        {
-            return source switch
-            {
-                Oracle.DisputeResultDisputeStatus.UNKNOWN => DomainModel.DisputeResultDisputeStatus.UNKNOWN,
-                Oracle.DisputeResultDisputeStatus.NEW => DomainModel.DisputeResultDisputeStatus.NEW,
-                Oracle.DisputeResultDisputeStatus.VALIDATED => DomainModel.DisputeResultDisputeStatus.VALIDATED,
-                Oracle.DisputeResultDisputeStatus.PROCESSING => DomainModel.DisputeResultDisputeStatus.PROCESSING,
-                Oracle.DisputeResultDisputeStatus.REJECTED => DomainModel.DisputeResultDisputeStatus.REJECTED,
-                Oracle.DisputeResultDisputeStatus.CANCELLED => DomainModel.DisputeResultDisputeStatus.CANCELLED,
-                Oracle.DisputeResultDisputeStatus.CONCLUDED => DomainModel.DisputeResultDisputeStatus.CONCLUDED,
-                _ => DomainModel.DisputeResultDisputeStatus.UNKNOWN
-            };
-        }
-
-        public Oracle.DisputeResultDisputeStatus Convert(DomainModel.DisputeResultDisputeStatus source, Oracle.DisputeResultDisputeStatus destination, AutoMapper.ResolutionContext context)
-        {
-            return source switch
-            {
-                DomainModel.DisputeResultDisputeStatus.UNKNOWN => Oracle.DisputeResultDisputeStatus.UNKNOWN,
-                DomainModel.DisputeResultDisputeStatus.NEW => Oracle.DisputeResultDisputeStatus.NEW,
-                DomainModel.DisputeResultDisputeStatus.VALIDATED => Oracle.DisputeResultDisputeStatus.VALIDATED,
-                DomainModel.DisputeResultDisputeStatus.PROCESSING => Oracle.DisputeResultDisputeStatus.PROCESSING,
-                DomainModel.DisputeResultDisputeStatus.REJECTED => Oracle.DisputeResultDisputeStatus.REJECTED,
-                DomainModel.DisputeResultDisputeStatus.CANCELLED => Oracle.DisputeResultDisputeStatus.CANCELLED,
-                DomainModel.DisputeResultDisputeStatus.CONCLUDED => Oracle.DisputeResultDisputeStatus.CONCLUDED,
-                _ => Oracle.DisputeResultDisputeStatus.UNKNOWN
-            };
-        }
-
-        public DomainModel.DisputeResultJjDisputeHearingType Convert(Oracle.DisputeResultJjDisputeHearingType source, DomainModel.DisputeResultJjDisputeHearingType destination, AutoMapper.ResolutionContext context)
-        {
-            return source switch
-            {
-                Oracle.DisputeResultJjDisputeHearingType.UNKNOWN => DomainModel.DisputeResultJjDisputeHearingType.UNKNOWN,
-                Oracle.DisputeResultJjDisputeHearingType.COURT_APPEARANCE => DomainModel.DisputeResultJjDisputeHearingType.COURT_APPEARANCE,
-                Oracle.DisputeResultJjDisputeHearingType.WRITTEN_REASONS => DomainModel.DisputeResultJjDisputeHearingType.WRITTEN_REASONS,
-                _ => DomainModel.DisputeResultJjDisputeHearingType.UNKNOWN
-            };
-        }
-
-        public Oracle.DisputeResultJjDisputeHearingType Convert(DomainModel.DisputeResultJjDisputeHearingType source, Oracle.DisputeResultJjDisputeHearingType destination, AutoMapper.ResolutionContext context)
-        {
-            return source switch
-            {
-                DomainModel.DisputeResultJjDisputeHearingType.UNKNOWN => Oracle.DisputeResultJjDisputeHearingType.UNKNOWN,
-                DomainModel.DisputeResultJjDisputeHearingType.COURT_APPEARANCE => Oracle.DisputeResultJjDisputeHearingType.COURT_APPEARANCE,
-                DomainModel.DisputeResultJjDisputeHearingType.WRITTEN_REASONS => Oracle.DisputeResultJjDisputeHearingType.WRITTEN_REASONS,
-                _ => Oracle.DisputeResultJjDisputeHearingType.UNKNOWN
-            };
-        }
-
-        public DomainModel.DisputeResultJjDisputeStatus Convert(Oracle.DisputeResultJjDisputeStatus source, DomainModel.DisputeResultJjDisputeStatus destination, AutoMapper.ResolutionContext context)
-        {
-            return source switch
-            {
-                Oracle.DisputeResultJjDisputeStatus.UNKNOWN => DomainModel.DisputeResultJjDisputeStatus.UNKNOWN,
-                Oracle.DisputeResultJjDisputeStatus.NEW => DomainModel.DisputeResultJjDisputeStatus.NEW,
-                Oracle.DisputeResultJjDisputeStatus.IN_PROGRESS => DomainModel.DisputeResultJjDisputeStatus.IN_PROGRESS,
-                Oracle.DisputeResultJjDisputeStatus.DATA_UPDATE => DomainModel.DisputeResultJjDisputeStatus.DATA_UPDATE,
-                Oracle.DisputeResultJjDisputeStatus.CONFIRMED => DomainModel.DisputeResultJjDisputeStatus.CONFIRMED,
-                Oracle.DisputeResultJjDisputeStatus.REQUIRE_COURT_HEARING => DomainModel.DisputeResultJjDisputeStatus.REQUIRE_COURT_HEARING,
-                Oracle.DisputeResultJjDisputeStatus.REQUIRE_MORE_INFO => DomainModel.DisputeResultJjDisputeStatus.REQUIRE_MORE_INFO,
-                Oracle.DisputeResultJjDisputeStatus.ACCEPTED => DomainModel.DisputeResultJjDisputeStatus.ACCEPTED,
-                Oracle.DisputeResultJjDisputeStatus.REVIEW => DomainModel.DisputeResultJjDisputeStatus.REVIEW,
-                Oracle.DisputeResultJjDisputeStatus.CONCLUDED => DomainModel.DisputeResultJjDisputeStatus.CONCLUDED,
-                Oracle.DisputeResultJjDisputeStatus.CANCELLED => DomainModel.DisputeResultJjDisputeStatus.CANCELLED,
-                Oracle.DisputeResultJjDisputeStatus.HEARING_SCHEDULED => DomainModel.DisputeResultJjDisputeStatus.HEARING_SCHEDULED,
-                _ => DomainModel.DisputeResultJjDisputeStatus.UNKNOWN
-            };
-        }
-
-        public Oracle.DisputeResultJjDisputeStatus Convert(DomainModel.DisputeResultJjDisputeStatus source, Oracle.DisputeResultJjDisputeStatus destination, AutoMapper.ResolutionContext context)
-        {
-            return source switch
-            {
-                DomainModel.DisputeResultJjDisputeStatus.UNKNOWN => Oracle.DisputeResultJjDisputeStatus.UNKNOWN,
-                DomainModel.DisputeResultJjDisputeStatus.NEW => Oracle.DisputeResultJjDisputeStatus.NEW,
-                DomainModel.DisputeResultJjDisputeStatus.IN_PROGRESS => Oracle.DisputeResultJjDisputeStatus.IN_PROGRESS,
-                DomainModel.DisputeResultJjDisputeStatus.DATA_UPDATE => Oracle.DisputeResultJjDisputeStatus.DATA_UPDATE,
-                DomainModel.DisputeResultJjDisputeStatus.CONFIRMED => Oracle.DisputeResultJjDisputeStatus.CONFIRMED,
-                DomainModel.DisputeResultJjDisputeStatus.REQUIRE_COURT_HEARING => Oracle.DisputeResultJjDisputeStatus.REQUIRE_COURT_HEARING,
-                DomainModel.DisputeResultJjDisputeStatus.REQUIRE_MORE_INFO => Oracle.DisputeResultJjDisputeStatus.REQUIRE_MORE_INFO,
-                DomainModel.DisputeResultJjDisputeStatus.ACCEPTED => Oracle.DisputeResultJjDisputeStatus.ACCEPTED,
-                DomainModel.DisputeResultJjDisputeStatus.REVIEW => Oracle.DisputeResultJjDisputeStatus.REVIEW,
-                DomainModel.DisputeResultJjDisputeStatus.CONCLUDED => Oracle.DisputeResultJjDisputeStatus.CONCLUDED,
-                DomainModel.DisputeResultJjDisputeStatus.CANCELLED => Oracle.DisputeResultJjDisputeStatus.CANCELLED,
-                DomainModel.DisputeResultJjDisputeStatus.HEARING_SCHEDULED => Oracle.DisputeResultJjDisputeStatus.HEARING_SCHEDULED,
-                _ => Oracle.DisputeResultJjDisputeStatus.UNKNOWN
-            };
-        }
-
-        public DomainModel.DisputeSignatoryType Convert(Oracle.DisputeSignatoryType source, DomainModel.DisputeSignatoryType destination, AutoMapper.ResolutionContext context)
-        {
-            return source switch
-            {
-                Oracle.DisputeSignatoryType.U => DomainModel.DisputeSignatoryType.U,
-                Oracle.DisputeSignatoryType.D => DomainModel.DisputeSignatoryType.D,
-                Oracle.DisputeSignatoryType.A => DomainModel.DisputeSignatoryType.A,
-                _ => DomainModel.DisputeSignatoryType.U
-            };
-        }
-
-        public Oracle.DisputeSignatoryType Convert(DomainModel.DisputeSignatoryType source, Oracle.DisputeSignatoryType destination, AutoMapper.ResolutionContext context)
-        {
-            return source switch
-            {
-                DomainModel.DisputeSignatoryType.U => Oracle.DisputeSignatoryType.U,
-                DomainModel.DisputeSignatoryType.D => Oracle.DisputeSignatoryType.D,
-                DomainModel.DisputeSignatoryType.A => Oracle.DisputeSignatoryType.A,
-                _ => Oracle.DisputeSignatoryType.U
-            };
-        }
-
-        public DomainModel.DisputeStatus Convert(Oracle.DisputeStatus source, DomainModel.DisputeStatus destination, AutoMapper.ResolutionContext context)
-        {
-            return source switch
-            {
-                Oracle.DisputeStatus.UNKNOWN => DomainModel.DisputeStatus.UNKNOWN,
-                Oracle.DisputeStatus.NEW => DomainModel.DisputeStatus.NEW,
-                Oracle.DisputeStatus.VALIDATED => DomainModel.DisputeStatus.VALIDATED,
-                Oracle.DisputeStatus.PROCESSING => DomainModel.DisputeStatus.PROCESSING,
-                Oracle.DisputeStatus.REJECTED => DomainModel.DisputeStatus.REJECTED,
-                Oracle.DisputeStatus.CANCELLED => DomainModel.DisputeStatus.CANCELLED,
-                Oracle.DisputeStatus.CONCLUDED => DomainModel.DisputeStatus.CONCLUDED,
-                _ => DomainModel.DisputeStatus.UNKNOWN
-            };
-        }
-
-        public Oracle.DisputeStatus Convert(DomainModel.DisputeStatus source, Oracle.DisputeStatus destination, AutoMapper.ResolutionContext context)
-        {
-            return source switch
-            {
-                DomainModel.DisputeStatus.UNKNOWN => Oracle.DisputeStatus.UNKNOWN,
-                DomainModel.DisputeStatus.NEW => Oracle.DisputeStatus.NEW,
-                DomainModel.DisputeStatus.VALIDATED => Oracle.DisputeStatus.VALIDATED,
-                DomainModel.DisputeStatus.PROCESSING => Oracle.DisputeStatus.PROCESSING,
-                DomainModel.DisputeStatus.REJECTED => Oracle.DisputeStatus.REJECTED,
-                DomainModel.DisputeStatus.CANCELLED => Oracle.DisputeStatus.CANCELLED,
-                DomainModel.DisputeStatus.CONCLUDED => Oracle.DisputeStatus.CONCLUDED,
-                _ => Oracle.DisputeStatus.UNKNOWN
-            };
-        }
-
-        public DomainModel.DisputeUpdateRequestStatus Convert(Oracle.DisputeUpdateRequestStatus source, DomainModel.DisputeUpdateRequestStatus destination, AutoMapper.ResolutionContext context)
-        {
-            return source switch
-            {
-                Oracle.DisputeUpdateRequestStatus.UNKNOWN => DomainModel.DisputeUpdateRequestStatus.UNKNOWN,
-                Oracle.DisputeUpdateRequestStatus.ACCEPTED => DomainModel.DisputeUpdateRequestStatus.ACCEPTED,
-                Oracle.DisputeUpdateRequestStatus.PENDING => DomainModel.DisputeUpdateRequestStatus.PENDING,
-                Oracle.DisputeUpdateRequestStatus.REJECTED => DomainModel.DisputeUpdateRequestStatus.REJECTED,
-                _ => DomainModel.DisputeUpdateRequestStatus.UNKNOWN
-            };
-        }
-
-        public Oracle.DisputeUpdateRequestStatus Convert(DomainModel.DisputeUpdateRequestStatus source, Oracle.DisputeUpdateRequestStatus destination, AutoMapper.ResolutionContext context)
-        {
-            return source switch
-            {
-                DomainModel.DisputeUpdateRequestStatus.UNKNOWN => Oracle.DisputeUpdateRequestStatus.UNKNOWN,
-                DomainModel.DisputeUpdateRequestStatus.ACCEPTED => Oracle.DisputeUpdateRequestStatus.ACCEPTED,
-                DomainModel.DisputeUpdateRequestStatus.PENDING => Oracle.DisputeUpdateRequestStatus.PENDING,
-                DomainModel.DisputeUpdateRequestStatus.REJECTED => Oracle.DisputeUpdateRequestStatus.REJECTED,
-                _ => Oracle.DisputeUpdateRequestStatus.UNKNOWN
-            };
-        }
-
-        public DomainModel.DisputeUpdateRequestStatus2 Convert(Oracle.DisputeUpdateRequestStatus2 source, DomainModel.DisputeUpdateRequestStatus2 destination, AutoMapper.ResolutionContext context)
-        {
-            return source switch
-            {
-                Oracle.DisputeUpdateRequestStatus2.UNKNOWN => DomainModel.DisputeUpdateRequestStatus2.UNKNOWN,
-                Oracle.DisputeUpdateRequestStatus2.ACCEPTED => DomainModel.DisputeUpdateRequestStatus2.ACCEPTED,
-                Oracle.DisputeUpdateRequestStatus2.PENDING => DomainModel.DisputeUpdateRequestStatus2.PENDING,
-                Oracle.DisputeUpdateRequestStatus2.REJECTED => DomainModel.DisputeUpdateRequestStatus2.REJECTED,
-                _ => DomainModel.DisputeUpdateRequestStatus2.UNKNOWN
-            };
-        }
-
-        public Oracle.DisputeUpdateRequestStatus2 Convert(DomainModel.DisputeUpdateRequestStatus2 source, Oracle.DisputeUpdateRequestStatus2 destination, AutoMapper.ResolutionContext context)
-        {
-            return source switch
-            {
-                DomainModel.DisputeUpdateRequestStatus2.UNKNOWN => Oracle.DisputeUpdateRequestStatus2.UNKNOWN,
-                DomainModel.DisputeUpdateRequestStatus2.ACCEPTED => Oracle.DisputeUpdateRequestStatus2.ACCEPTED,
-                DomainModel.DisputeUpdateRequestStatus2.PENDING => Oracle.DisputeUpdateRequestStatus2.PENDING,
-                DomainModel.DisputeUpdateRequestStatus2.REJECTED => Oracle.DisputeUpdateRequestStatus2.REJECTED,
-                _ => Oracle.DisputeUpdateRequestStatus2.UNKNOWN
-            };
-        }
-
-        public DomainModel.DisputeUpdateRequestUpdateType Convert(Oracle.DisputeUpdateRequestUpdateType source, DomainModel.DisputeUpdateRequestUpdateType destination, AutoMapper.ResolutionContext context)
-        {
-            return source switch
-            {
-                Oracle.DisputeUpdateRequestUpdateType.UNKNOWN => DomainModel.DisputeUpdateRequestUpdateType.UNKNOWN,
-                Oracle.DisputeUpdateRequestUpdateType.DISPUTANT_ADDRESS => DomainModel.DisputeUpdateRequestUpdateType.DISPUTANT_ADDRESS,
-                Oracle.DisputeUpdateRequestUpdateType.DISPUTANT_PHONE => DomainModel.DisputeUpdateRequestUpdateType.DISPUTANT_PHONE,
-                Oracle.DisputeUpdateRequestUpdateType.DISPUTANT_NAME => DomainModel.DisputeUpdateRequestUpdateType.DISPUTANT_NAME,
-                Oracle.DisputeUpdateRequestUpdateType.COUNT => DomainModel.DisputeUpdateRequestUpdateType.COUNT,
-                Oracle.DisputeUpdateRequestUpdateType.DISPUTANT_EMAIL => DomainModel.DisputeUpdateRequestUpdateType.DISPUTANT_EMAIL,
-                Oracle.DisputeUpdateRequestUpdateType.DISPUTANT_DOCUMENT => DomainModel.DisputeUpdateRequestUpdateType.DISPUTANT_DOCUMENT,
-                Oracle.DisputeUpdateRequestUpdateType.COURT_OPTIONS => DomainModel.DisputeUpdateRequestUpdateType.COURT_OPTIONS,
-                _ => DomainModel.DisputeUpdateRequestUpdateType.UNKNOWN
-            };
-        }
-
-        public Oracle.DisputeUpdateRequestUpdateType Convert(DomainModel.DisputeUpdateRequestUpdateType source, Oracle.DisputeUpdateRequestUpdateType destination, AutoMapper.ResolutionContext context)
-        {
-            return source switch
-            {
-                DomainModel.DisputeUpdateRequestUpdateType.UNKNOWN => Oracle.DisputeUpdateRequestUpdateType.UNKNOWN,
-                DomainModel.DisputeUpdateRequestUpdateType.DISPUTANT_ADDRESS => Oracle.DisputeUpdateRequestUpdateType.DISPUTANT_ADDRESS,
-                DomainModel.DisputeUpdateRequestUpdateType.DISPUTANT_PHONE => Oracle.DisputeUpdateRequestUpdateType.DISPUTANT_PHONE,
-                DomainModel.DisputeUpdateRequestUpdateType.DISPUTANT_NAME => Oracle.DisputeUpdateRequestUpdateType.DISPUTANT_NAME,
-                DomainModel.DisputeUpdateRequestUpdateType.COUNT => Oracle.DisputeUpdateRequestUpdateType.COUNT,
-                DomainModel.DisputeUpdateRequestUpdateType.DISPUTANT_EMAIL => Oracle.DisputeUpdateRequestUpdateType.DISPUTANT_EMAIL,
-                DomainModel.DisputeUpdateRequestUpdateType.DISPUTANT_DOCUMENT => Oracle.DisputeUpdateRequestUpdateType.DISPUTANT_DOCUMENT,
-                DomainModel.DisputeUpdateRequestUpdateType.COURT_OPTIONS => Oracle.DisputeUpdateRequestUpdateType.COURT_OPTIONS,
-                _ => Oracle.DisputeUpdateRequestUpdateType.UNKNOWN
-            };
-        }
-
-        public DomainModel.DocumentType Convert(Oracle.DocumentType source, DomainModel.DocumentType destination, AutoMapper.ResolutionContext context)
-        {
-            return source switch
-            {
-                Oracle.DocumentType.UNKNOWN => DomainModel.DocumentType.UNKNOWN,
-                Oracle.DocumentType.NOTICE_OF_DISPUTE => DomainModel.DocumentType.NOTICE_OF_DISPUTE,
-                Oracle.DocumentType.TICKET_IMAGE => DomainModel.DocumentType.TICKET_IMAGE,
-                _ => DomainModel.DocumentType.UNKNOWN
-            };
-        }
-
-        public Oracle.DocumentType Convert(DomainModel.DocumentType source, Oracle.DocumentType destination, AutoMapper.ResolutionContext context)
-        {
-            return source switch
-            {
-                DomainModel.DocumentType.UNKNOWN => Oracle.DocumentType.UNKNOWN,
-                DomainModel.DocumentType.NOTICE_OF_DISPUTE => Oracle.DocumentType.NOTICE_OF_DISPUTE,
-                DomainModel.DocumentType.TICKET_IMAGE => Oracle.DocumentType.TICKET_IMAGE,
-                _ => Oracle.DocumentType.UNKNOWN
-            };
-        }
-
-        public DomainModel.ExcludeStatus Convert(Oracle.ExcludeStatus source, DomainModel.ExcludeStatus destination, AutoMapper.ResolutionContext context)
-        {
-            return source switch
-            {
-                Oracle.ExcludeStatus.UNKNOWN => DomainModel.ExcludeStatus.UNKNOWN,
-                Oracle.ExcludeStatus.NEW => DomainModel.ExcludeStatus.NEW,
-                Oracle.ExcludeStatus.VALIDATED => DomainModel.ExcludeStatus.VALIDATED,
-                Oracle.ExcludeStatus.PROCESSING => DomainModel.ExcludeStatus.PROCESSING,
-                Oracle.ExcludeStatus.REJECTED => DomainModel.ExcludeStatus.REJECTED,
-                Oracle.ExcludeStatus.CANCELLED => DomainModel.ExcludeStatus.CANCELLED,
-                Oracle.ExcludeStatus.CONCLUDED => DomainModel.ExcludeStatus.CONCLUDED,
-                _ => DomainModel.ExcludeStatus.UNKNOWN
-            };
-        }
-
-        public Oracle.ExcludeStatus Convert(DomainModel.ExcludeStatus source, Oracle.ExcludeStatus destination, AutoMapper.ResolutionContext context)
-        {
-            return source switch
-            {
-                DomainModel.ExcludeStatus.UNKNOWN => Oracle.ExcludeStatus.UNKNOWN,
-                DomainModel.ExcludeStatus.NEW => Oracle.ExcludeStatus.NEW,
-                DomainModel.ExcludeStatus.VALIDATED => Oracle.ExcludeStatus.VALIDATED,
-                DomainModel.ExcludeStatus.PROCESSING => Oracle.ExcludeStatus.PROCESSING,
-                DomainModel.ExcludeStatus.REJECTED => Oracle.ExcludeStatus.REJECTED,
-                DomainModel.ExcludeStatus.CANCELLED => Oracle.ExcludeStatus.CANCELLED,
-                DomainModel.ExcludeStatus.CONCLUDED => Oracle.ExcludeStatus.CONCLUDED,
-                _ => Oracle.ExcludeStatus.UNKNOWN
-            };
-        }
-
-        public DomainModel.ExcludeStatus2 Convert(Oracle.ExcludeStatus2 source, DomainModel.ExcludeStatus2 destination, AutoMapper.ResolutionContext context)
-        {
-            return source switch
-            {
-                Oracle.ExcludeStatus2.UNKNOWN => DomainModel.ExcludeStatus2.UNKNOWN,
-                Oracle.ExcludeStatus2.NEW => DomainModel.ExcludeStatus2.NEW,
-                Oracle.ExcludeStatus2.VALIDATED => DomainModel.ExcludeStatus2.VALIDATED,
-                Oracle.ExcludeStatus2.PROCESSING => DomainModel.ExcludeStatus2.PROCESSING,
-                Oracle.ExcludeStatus2.REJECTED => DomainModel.ExcludeStatus2.REJECTED,
-                Oracle.ExcludeStatus2.CANCELLED => DomainModel.ExcludeStatus2.CANCELLED,
-                Oracle.ExcludeStatus2.CONCLUDED => DomainModel.ExcludeStatus2.CONCLUDED,
-                _ => DomainModel.ExcludeStatus2.UNKNOWN
-            };
-        }
-
-        public Oracle.ExcludeStatus2 Convert(DomainModel.ExcludeStatus2 source, Oracle.ExcludeStatus2 destination, AutoMapper.ResolutionContext context)
-        {
-            return source switch
-            {
-                DomainModel.ExcludeStatus2.UNKNOWN => Oracle.ExcludeStatus2.UNKNOWN,
-                DomainModel.ExcludeStatus2.NEW => Oracle.ExcludeStatus2.NEW,
-                DomainModel.ExcludeStatus2.VALIDATED => Oracle.ExcludeStatus2.VALIDATED,
-                DomainModel.ExcludeStatus2.PROCESSING => Oracle.ExcludeStatus2.PROCESSING,
-                DomainModel.ExcludeStatus2.REJECTED => Oracle.ExcludeStatus2.REJECTED,
-                DomainModel.ExcludeStatus2.CANCELLED => Oracle.ExcludeStatus2.CANCELLED,
-                DomainModel.ExcludeStatus2.CONCLUDED => Oracle.ExcludeStatus2.CONCLUDED,
-                _ => Oracle.ExcludeStatus2.UNKNOWN
-            };
-        }
-
-        public DomainModel.FileHistoryAuditLogEntryType Convert(Oracle.FileHistoryAuditLogEntryType source, DomainModel.FileHistoryAuditLogEntryType destination, AutoMapper.ResolutionContext context)
-        {
-            return source switch
-            {
-                Oracle.FileHistoryAuditLogEntryType.UNKNOWN => DomainModel.FileHistoryAuditLogEntryType.UNKNOWN,
-                Oracle.FileHistoryAuditLogEntryType.ARFL => DomainModel.FileHistoryAuditLogEntryType.ARFL,
-                Oracle.FileHistoryAuditLogEntryType.CAIN => DomainModel.FileHistoryAuditLogEntryType.CAIN,
-                Oracle.FileHistoryAuditLogEntryType.CAWT => DomainModel.FileHistoryAuditLogEntryType.CAWT,
-                Oracle.FileHistoryAuditLogEntryType.CCAN => DomainModel.FileHistoryAuditLogEntryType.CCAN,
-                Oracle.FileHistoryAuditLogEntryType.CCON => DomainModel.FileHistoryAuditLogEntryType.CCON,
-                Oracle.FileHistoryAuditLogEntryType.CCWR => DomainModel.FileHistoryAuditLogEntryType.CCWR,
-                Oracle.FileHistoryAuditLogEntryType.CLEG => DomainModel.FileHistoryAuditLogEntryType.CLEG,
-                Oracle.FileHistoryAuditLogEntryType.CUEM => DomainModel.FileHistoryAuditLogEntryType.CUEM,
-                Oracle.FileHistoryAuditLogEntryType.CUEV => DomainModel.FileHistoryAuditLogEntryType.CUEV,
-                Oracle.FileHistoryAuditLogEntryType.CUIN => DomainModel.FileHistoryAuditLogEntryType.CUIN,
-                Oracle.FileHistoryAuditLogEntryType.CULG => DomainModel.FileHistoryAuditLogEntryType.CULG,
-                Oracle.FileHistoryAuditLogEntryType.CUPD => DomainModel.FileHistoryAuditLogEntryType.CUPD,
-                Oracle.FileHistoryAuditLogEntryType.CUWR => DomainModel.FileHistoryAuditLogEntryType.CUWR,
-                Oracle.FileHistoryAuditLogEntryType.CUWT => DomainModel.FileHistoryAuditLogEntryType.CUWT,
-                Oracle.FileHistoryAuditLogEntryType.DURA => DomainModel.FileHistoryAuditLogEntryType.DURA,
-                Oracle.FileHistoryAuditLogEntryType.DURR => DomainModel.FileHistoryAuditLogEntryType.DURR,
-                Oracle.FileHistoryAuditLogEntryType.EMCA => DomainModel.FileHistoryAuditLogEntryType.EMCA,
-                Oracle.FileHistoryAuditLogEntryType.EMCF => DomainModel.FileHistoryAuditLogEntryType.EMCF,
-                Oracle.FileHistoryAuditLogEntryType.EMCR => DomainModel.FileHistoryAuditLogEntryType.EMCR,
-                Oracle.FileHistoryAuditLogEntryType.EMDC => DomainModel.FileHistoryAuditLogEntryType.EMDC,
-                Oracle.FileHistoryAuditLogEntryType.EMFD => DomainModel.FileHistoryAuditLogEntryType.EMFD,
-                Oracle.FileHistoryAuditLogEntryType.EMPR => DomainModel.FileHistoryAuditLogEntryType.EMPR,
-                Oracle.FileHistoryAuditLogEntryType.EMRJ => DomainModel.FileHistoryAuditLogEntryType.EMRJ,
-                Oracle.FileHistoryAuditLogEntryType.EMRV => DomainModel.FileHistoryAuditLogEntryType.EMRV,
-                Oracle.FileHistoryAuditLogEntryType.EMST => DomainModel.FileHistoryAuditLogEntryType.EMST,
-                Oracle.FileHistoryAuditLogEntryType.EMUP => DomainModel.FileHistoryAuditLogEntryType.EMUP,
-                Oracle.FileHistoryAuditLogEntryType.EMVF => DomainModel.FileHistoryAuditLogEntryType.EMVF,
-                Oracle.FileHistoryAuditLogEntryType.ESUR => DomainModel.FileHistoryAuditLogEntryType.ESUR,
-                Oracle.FileHistoryAuditLogEntryType.FDLD => DomainModel.FileHistoryAuditLogEntryType.FDLD,
-                Oracle.FileHistoryAuditLogEntryType.FDLS => DomainModel.FileHistoryAuditLogEntryType.FDLS,
-                Oracle.FileHistoryAuditLogEntryType.FUPD => DomainModel.FileHistoryAuditLogEntryType.FUPD,
-                Oracle.FileHistoryAuditLogEntryType.FUPS => DomainModel.FileHistoryAuditLogEntryType.FUPS,
-                Oracle.FileHistoryAuditLogEntryType.FRMK => DomainModel.FileHistoryAuditLogEntryType.FRMK,
-                Oracle.FileHistoryAuditLogEntryType.INIT => DomainModel.FileHistoryAuditLogEntryType.INIT,
-                Oracle.FileHistoryAuditLogEntryType.JASG => DomainModel.FileHistoryAuditLogEntryType.JASG,
-                Oracle.FileHistoryAuditLogEntryType.JCNF => DomainModel.FileHistoryAuditLogEntryType.JCNF,
-                Oracle.FileHistoryAuditLogEntryType.JDIV => DomainModel.FileHistoryAuditLogEntryType.JDIV,
-                Oracle.FileHistoryAuditLogEntryType.JPRG => DomainModel.FileHistoryAuditLogEntryType.JPRG,
-                Oracle.FileHistoryAuditLogEntryType.OCNT => DomainModel.FileHistoryAuditLogEntryType.OCNT,
-                Oracle.FileHistoryAuditLogEntryType.RCLD => DomainModel.FileHistoryAuditLogEntryType.RCLD,
-                Oracle.FileHistoryAuditLogEntryType.RECN => DomainModel.FileHistoryAuditLogEntryType.RECN,
-                Oracle.FileHistoryAuditLogEntryType.SADM => DomainModel.FileHistoryAuditLogEntryType.SADM,
-                Oracle.FileHistoryAuditLogEntryType.SCAN => DomainModel.FileHistoryAuditLogEntryType.SCAN,
-                Oracle.FileHistoryAuditLogEntryType.SPRC => DomainModel.FileHistoryAuditLogEntryType.SPRC,
-                Oracle.FileHistoryAuditLogEntryType.SREJ => DomainModel.FileHistoryAuditLogEntryType.SREJ,
-                Oracle.FileHistoryAuditLogEntryType.SUB => DomainModel.FileHistoryAuditLogEntryType.SUB,
-                Oracle.FileHistoryAuditLogEntryType.SUPL => DomainModel.FileHistoryAuditLogEntryType.SUPL,
-                Oracle.FileHistoryAuditLogEntryType.SVAL => DomainModel.FileHistoryAuditLogEntryType.SVAL,
-                Oracle.FileHistoryAuditLogEntryType.URSR => DomainModel.FileHistoryAuditLogEntryType.URSR,
-                Oracle.FileHistoryAuditLogEntryType.VREV => DomainModel.FileHistoryAuditLogEntryType.VREV,
-                Oracle.FileHistoryAuditLogEntryType.VSUB => DomainModel.FileHistoryAuditLogEntryType.VSUB,
-                _ => DomainModel.FileHistoryAuditLogEntryType.UNKNOWN
-            };
-        }
-
-        public Oracle.FileHistoryAuditLogEntryType Convert(DomainModel.FileHistoryAuditLogEntryType source, Oracle.FileHistoryAuditLogEntryType destination, AutoMapper.ResolutionContext context)
-        {
-            return source switch
-            {
-                DomainModel.FileHistoryAuditLogEntryType.UNKNOWN => Oracle.FileHistoryAuditLogEntryType.UNKNOWN,
-                DomainModel.FileHistoryAuditLogEntryType.ARFL => Oracle.FileHistoryAuditLogEntryType.ARFL,
-                DomainModel.FileHistoryAuditLogEntryType.CAIN => Oracle.FileHistoryAuditLogEntryType.CAIN,
-                DomainModel.FileHistoryAuditLogEntryType.CAWT => Oracle.FileHistoryAuditLogEntryType.CAWT,
-                DomainModel.FileHistoryAuditLogEntryType.CCAN => Oracle.FileHistoryAuditLogEntryType.CCAN,
-                DomainModel.FileHistoryAuditLogEntryType.CCON => Oracle.FileHistoryAuditLogEntryType.CCON,
-                DomainModel.FileHistoryAuditLogEntryType.CCWR => Oracle.FileHistoryAuditLogEntryType.CCWR,
-                DomainModel.FileHistoryAuditLogEntryType.CLEG => Oracle.FileHistoryAuditLogEntryType.CLEG,
-                DomainModel.FileHistoryAuditLogEntryType.CUEM => Oracle.FileHistoryAuditLogEntryType.CUEM,
-                DomainModel.FileHistoryAuditLogEntryType.CUEV => Oracle.FileHistoryAuditLogEntryType.CUEV,
-                DomainModel.FileHistoryAuditLogEntryType.CUIN => Oracle.FileHistoryAuditLogEntryType.CUIN,
-                DomainModel.FileHistoryAuditLogEntryType.CULG => Oracle.FileHistoryAuditLogEntryType.CULG,
-                DomainModel.FileHistoryAuditLogEntryType.CUPD => Oracle.FileHistoryAuditLogEntryType.CUPD,
-                DomainModel.FileHistoryAuditLogEntryType.CUWR => Oracle.FileHistoryAuditLogEntryType.CUWR,
-                DomainModel.FileHistoryAuditLogEntryType.CUWT => Oracle.FileHistoryAuditLogEntryType.CUWT,
-                DomainModel.FileHistoryAuditLogEntryType.DURA => Oracle.FileHistoryAuditLogEntryType.DURA,
-                DomainModel.FileHistoryAuditLogEntryType.DURR => Oracle.FileHistoryAuditLogEntryType.DURR,
-                DomainModel.FileHistoryAuditLogEntryType.EMCA => Oracle.FileHistoryAuditLogEntryType.EMCA,
-                DomainModel.FileHistoryAuditLogEntryType.EMCF => Oracle.FileHistoryAuditLogEntryType.EMCF,
-                DomainModel.FileHistoryAuditLogEntryType.EMCR => Oracle.FileHistoryAuditLogEntryType.EMCR,
-                DomainModel.FileHistoryAuditLogEntryType.EMDC => Oracle.FileHistoryAuditLogEntryType.EMDC,
-                DomainModel.FileHistoryAuditLogEntryType.EMFD => Oracle.FileHistoryAuditLogEntryType.EMFD,
-                DomainModel.FileHistoryAuditLogEntryType.EMPR => Oracle.FileHistoryAuditLogEntryType.EMPR,
-                DomainModel.FileHistoryAuditLogEntryType.EMRJ => Oracle.FileHistoryAuditLogEntryType.EMRJ,
-                DomainModel.FileHistoryAuditLogEntryType.EMRV => Oracle.FileHistoryAuditLogEntryType.EMRV,
-                DomainModel.FileHistoryAuditLogEntryType.EMST => Oracle.FileHistoryAuditLogEntryType.EMST,
-                DomainModel.FileHistoryAuditLogEntryType.EMUP => Oracle.FileHistoryAuditLogEntryType.EMUP,
-                DomainModel.FileHistoryAuditLogEntryType.EMVF => Oracle.FileHistoryAuditLogEntryType.EMVF,
-                DomainModel.FileHistoryAuditLogEntryType.ESUR => Oracle.FileHistoryAuditLogEntryType.ESUR,
-                DomainModel.FileHistoryAuditLogEntryType.FDLD => Oracle.FileHistoryAuditLogEntryType.FDLD,
-                DomainModel.FileHistoryAuditLogEntryType.FDLS => Oracle.FileHistoryAuditLogEntryType.FDLS,
-                DomainModel.FileHistoryAuditLogEntryType.FUPD => Oracle.FileHistoryAuditLogEntryType.FUPD,
-                DomainModel.FileHistoryAuditLogEntryType.FUPS => Oracle.FileHistoryAuditLogEntryType.FUPS,
-                DomainModel.FileHistoryAuditLogEntryType.FRMK => Oracle.FileHistoryAuditLogEntryType.FRMK,
-                DomainModel.FileHistoryAuditLogEntryType.INIT => Oracle.FileHistoryAuditLogEntryType.INIT,
-                DomainModel.FileHistoryAuditLogEntryType.JASG => Oracle.FileHistoryAuditLogEntryType.JASG,
-                DomainModel.FileHistoryAuditLogEntryType.JCNF => Oracle.FileHistoryAuditLogEntryType.JCNF,
-                DomainModel.FileHistoryAuditLogEntryType.JDIV => Oracle.FileHistoryAuditLogEntryType.JDIV,
-                DomainModel.FileHistoryAuditLogEntryType.JPRG => Oracle.FileHistoryAuditLogEntryType.JPRG,
-                DomainModel.FileHistoryAuditLogEntryType.OCNT => Oracle.FileHistoryAuditLogEntryType.OCNT,
-                DomainModel.FileHistoryAuditLogEntryType.RCLD => Oracle.FileHistoryAuditLogEntryType.RCLD,
-                DomainModel.FileHistoryAuditLogEntryType.RECN => Oracle.FileHistoryAuditLogEntryType.RECN,
-                DomainModel.FileHistoryAuditLogEntryType.SADM => Oracle.FileHistoryAuditLogEntryType.SADM,
-                DomainModel.FileHistoryAuditLogEntryType.SCAN => Oracle.FileHistoryAuditLogEntryType.SCAN,
-                DomainModel.FileHistoryAuditLogEntryType.SPRC => Oracle.FileHistoryAuditLogEntryType.SPRC,
-                DomainModel.FileHistoryAuditLogEntryType.SREJ => Oracle.FileHistoryAuditLogEntryType.SREJ,
-                DomainModel.FileHistoryAuditLogEntryType.SUB => Oracle.FileHistoryAuditLogEntryType.SUB,
-                DomainModel.FileHistoryAuditLogEntryType.SUPL => Oracle.FileHistoryAuditLogEntryType.SUPL,
-                DomainModel.FileHistoryAuditLogEntryType.SVAL => Oracle.FileHistoryAuditLogEntryType.SVAL,
-                DomainModel.FileHistoryAuditLogEntryType.URSR => Oracle.FileHistoryAuditLogEntryType.URSR,
-                DomainModel.FileHistoryAuditLogEntryType.VREV => Oracle.FileHistoryAuditLogEntryType.VREV,
-                DomainModel.FileHistoryAuditLogEntryType.VSUB => Oracle.FileHistoryAuditLogEntryType.VSUB,
-                _ => Oracle.FileHistoryAuditLogEntryType.UNKNOWN
-            };
-        }
-
-        public DomainModel.JJDisputeContactType Convert(Oracle.JJDisputeContactType source, DomainModel.JJDisputeContactType destination, AutoMapper.ResolutionContext context)
-        {
-            return source switch
-            {
-                Oracle.JJDisputeContactType.UNKNOWN => DomainModel.JJDisputeContactType.UNKNOWN,
-                Oracle.JJDisputeContactType.INDIVIDUAL => DomainModel.JJDisputeContactType.INDIVIDUAL,
-                Oracle.JJDisputeContactType.LAWYER => DomainModel.JJDisputeContactType.LAWYER,
-                Oracle.JJDisputeContactType.OTHER => DomainModel.JJDisputeContactType.OTHER,
-                _ => DomainModel.JJDisputeContactType.UNKNOWN
-            };
-        }
-
-        public Oracle.JJDisputeContactType Convert(DomainModel.JJDisputeContactType source, Oracle.JJDisputeContactType destination, AutoMapper.ResolutionContext context)
-        {
-            return source switch
-            {
-                DomainModel.JJDisputeContactType.UNKNOWN => Oracle.JJDisputeContactType.UNKNOWN,
-                DomainModel.JJDisputeContactType.INDIVIDUAL => Oracle.JJDisputeContactType.INDIVIDUAL,
-                DomainModel.JJDisputeContactType.LAWYER => Oracle.JJDisputeContactType.LAWYER,
-                DomainModel.JJDisputeContactType.OTHER => Oracle.JJDisputeContactType.OTHER,
-                _ => Oracle.JJDisputeContactType.UNKNOWN
-            };
-        }
-
-        public DomainModel.JJDisputeCourtAppearanceRoPAppCd Convert(Oracle.JJDisputeCourtAppearanceRoPAppCd source, DomainModel.JJDisputeCourtAppearanceRoPAppCd destination, AutoMapper.ResolutionContext context)
-        {
-            return source switch
-            {
-                Oracle.JJDisputeCourtAppearanceRoPAppCd.UNKNOWN => DomainModel.JJDisputeCourtAppearanceRoPAppCd.UNKNOWN,
-                Oracle.JJDisputeCourtAppearanceRoPAppCd.A => DomainModel.JJDisputeCourtAppearanceRoPAppCd.A,
-                Oracle.JJDisputeCourtAppearanceRoPAppCd.P => DomainModel.JJDisputeCourtAppearanceRoPAppCd.P,
-                Oracle.JJDisputeCourtAppearanceRoPAppCd.N => DomainModel.JJDisputeCourtAppearanceRoPAppCd.N,
-                _ => DomainModel.JJDisputeCourtAppearanceRoPAppCd.UNKNOWN
-            };
-        }
-
-        public Oracle.JJDisputeCourtAppearanceRoPAppCd Convert(DomainModel.JJDisputeCourtAppearanceRoPAppCd source, Oracle.JJDisputeCourtAppearanceRoPAppCd destination, AutoMapper.ResolutionContext context)
-        {
-            return source switch
-            {
-                DomainModel.JJDisputeCourtAppearanceRoPAppCd.UNKNOWN => Oracle.JJDisputeCourtAppearanceRoPAppCd.UNKNOWN,
-                DomainModel.JJDisputeCourtAppearanceRoPAppCd.A => Oracle.JJDisputeCourtAppearanceRoPAppCd.A,
-                DomainModel.JJDisputeCourtAppearanceRoPAppCd.P => Oracle.JJDisputeCourtAppearanceRoPAppCd.P,
-                DomainModel.JJDisputeCourtAppearanceRoPAppCd.N => Oracle.JJDisputeCourtAppearanceRoPAppCd.N,
-                _ => Oracle.JJDisputeCourtAppearanceRoPAppCd.UNKNOWN
-            };
-        }
-
-        public DomainModel.JJDisputeCourtAppearanceRoPCrown Convert(Oracle.JJDisputeCourtAppearanceRoPCrown source, DomainModel.JJDisputeCourtAppearanceRoPCrown destination, AutoMapper.ResolutionContext context)
-        {
-            return source switch
-            {
-                Oracle.JJDisputeCourtAppearanceRoPCrown.UNKNOWN => DomainModel.JJDisputeCourtAppearanceRoPCrown.UNKNOWN,
-                Oracle.JJDisputeCourtAppearanceRoPCrown.P => DomainModel.JJDisputeCourtAppearanceRoPCrown.P,
-                Oracle.JJDisputeCourtAppearanceRoPCrown.N => DomainModel.JJDisputeCourtAppearanceRoPCrown.N,
-                _ => DomainModel.JJDisputeCourtAppearanceRoPCrown.UNKNOWN
-            };
-        }
-
-        public Oracle.JJDisputeCourtAppearanceRoPCrown Convert(DomainModel.JJDisputeCourtAppearanceRoPCrown source, Oracle.JJDisputeCourtAppearanceRoPCrown destination, AutoMapper.ResolutionContext context)
-        {
-            return source switch
-            {
-                DomainModel.JJDisputeCourtAppearanceRoPCrown.UNKNOWN => Oracle.JJDisputeCourtAppearanceRoPCrown.UNKNOWN,
-                DomainModel.JJDisputeCourtAppearanceRoPCrown.P => Oracle.JJDisputeCourtAppearanceRoPCrown.P,
-                DomainModel.JJDisputeCourtAppearanceRoPCrown.N => Oracle.JJDisputeCourtAppearanceRoPCrown.N,
-                _ => Oracle.JJDisputeCourtAppearanceRoPCrown.UNKNOWN
-            };
-        }
-
-        public DomainModel.JJDisputeCourtAppearanceRoPDattCd Convert(Oracle.JJDisputeCourtAppearanceRoPDattCd source, DomainModel.JJDisputeCourtAppearanceRoPDattCd destination, AutoMapper.ResolutionContext context)
-        {
-            return source switch
-            {
-                Oracle.JJDisputeCourtAppearanceRoPDattCd.UNKNOWN => DomainModel.JJDisputeCourtAppearanceRoPDattCd.UNKNOWN,
-                Oracle.JJDisputeCourtAppearanceRoPDattCd.A => DomainModel.JJDisputeCourtAppearanceRoPDattCd.A,
-                Oracle.JJDisputeCourtAppearanceRoPDattCd.C => DomainModel.JJDisputeCourtAppearanceRoPDattCd.C,
-                Oracle.JJDisputeCourtAppearanceRoPDattCd.N => DomainModel.JJDisputeCourtAppearanceRoPDattCd.N,
-                _ => DomainModel.JJDisputeCourtAppearanceRoPDattCd.UNKNOWN
-            };
-        }
-
-        public Oracle.JJDisputeCourtAppearanceRoPDattCd Convert(DomainModel.JJDisputeCourtAppearanceRoPDattCd source, Oracle.JJDisputeCourtAppearanceRoPDattCd destination, AutoMapper.ResolutionContext context)
-        {
-            return source switch
-            {
-                DomainModel.JJDisputeCourtAppearanceRoPDattCd.UNKNOWN => Oracle.JJDisputeCourtAppearanceRoPDattCd.UNKNOWN,
-                DomainModel.JJDisputeCourtAppearanceRoPDattCd.A => Oracle.JJDisputeCourtAppearanceRoPDattCd.A,
-                DomainModel.JJDisputeCourtAppearanceRoPDattCd.C => Oracle.JJDisputeCourtAppearanceRoPDattCd.C,
-                DomainModel.JJDisputeCourtAppearanceRoPDattCd.N => Oracle.JJDisputeCourtAppearanceRoPDattCd.N,
-                _ => Oracle.JJDisputeCourtAppearanceRoPDattCd.UNKNOWN
-            };
-        }
-
-        public DomainModel.JJDisputedCountLatestPlea Convert(Oracle.JJDisputedCountLatestPlea source, DomainModel.JJDisputedCountLatestPlea destination, AutoMapper.ResolutionContext context)
-        {
-            return source switch
-            {
-                Oracle.JJDisputedCountLatestPlea.UNKNOWN => DomainModel.JJDisputedCountLatestPlea.UNKNOWN,
-                Oracle.JJDisputedCountLatestPlea.G => DomainModel.JJDisputedCountLatestPlea.G,
-                Oracle.JJDisputedCountLatestPlea.N => DomainModel.JJDisputedCountLatestPlea.N,
-                _ => DomainModel.JJDisputedCountLatestPlea.UNKNOWN
-            };
-        }
-
-        public Oracle.JJDisputedCountLatestPlea Convert(DomainModel.JJDisputedCountLatestPlea source, Oracle.JJDisputedCountLatestPlea destination, AutoMapper.ResolutionContext context)
-        {
-            return source switch
-            {
-                DomainModel.JJDisputedCountLatestPlea.UNKNOWN => Oracle.JJDisputedCountLatestPlea.UNKNOWN,
-                DomainModel.JJDisputedCountLatestPlea.G => Oracle.JJDisputedCountLatestPlea.G,
-                DomainModel.JJDisputedCountLatestPlea.N => Oracle.JJDisputedCountLatestPlea.N,
-                _ => Oracle.JJDisputedCountLatestPlea.UNKNOWN
-            };
-        }
-
-        public DomainModel.JJDisputedCountPlea Convert(Oracle.JJDisputedCountPlea source, DomainModel.JJDisputedCountPlea destination, AutoMapper.ResolutionContext context)
-        {
-            return source switch
-            {
-                Oracle.JJDisputedCountPlea.UNKNOWN => DomainModel.JJDisputedCountPlea.UNKNOWN,
-                Oracle.JJDisputedCountPlea.G => DomainModel.JJDisputedCountPlea.G,
-                Oracle.JJDisputedCountPlea.N => DomainModel.JJDisputedCountPlea.N,
-                _ => DomainModel.JJDisputedCountPlea.UNKNOWN
-            };
-        }
-
-        public Oracle.JJDisputedCountPlea Convert(DomainModel.JJDisputedCountPlea source, Oracle.JJDisputedCountPlea destination, AutoMapper.ResolutionContext context)
-        {
-            return source switch
-            {
-                DomainModel.JJDisputedCountPlea.UNKNOWN => Oracle.JJDisputedCountPlea.UNKNOWN,
-                DomainModel.JJDisputedCountPlea.G => Oracle.JJDisputedCountPlea.G,
-                DomainModel.JJDisputedCountPlea.N => Oracle.JJDisputedCountPlea.N,
-                _ => Oracle.JJDisputedCountPlea.UNKNOWN
-            };
-        }
-
-        public DomainModel.JJDisputedCountRoPFinding Convert(Oracle.JJDisputedCountRoPFinding source, DomainModel.JJDisputedCountRoPFinding destination, AutoMapper.ResolutionContext context)
-        {
-            return source switch
-            {
-                Oracle.JJDisputedCountRoPFinding.UNKNOWN => DomainModel.JJDisputedCountRoPFinding.UNKNOWN,
-                Oracle.JJDisputedCountRoPFinding.GUILTY => DomainModel.JJDisputedCountRoPFinding.GUILTY,
-                Oracle.JJDisputedCountRoPFinding.NOT_GUILTY => DomainModel.JJDisputedCountRoPFinding.NOT_GUILTY,
-                Oracle.JJDisputedCountRoPFinding.CANCELLED => DomainModel.JJDisputedCountRoPFinding.CANCELLED,
-                Oracle.JJDisputedCountRoPFinding.PAID_PRIOR_TO_APPEARANCE => DomainModel.JJDisputedCountRoPFinding.PAID_PRIOR_TO_APPEARANCE,
-                Oracle.JJDisputedCountRoPFinding.GUILTY_LESSER => DomainModel.JJDisputedCountRoPFinding.GUILTY_LESSER,
-                _ => DomainModel.JJDisputedCountRoPFinding.UNKNOWN
-            };
-        }
-
-        public Oracle.JJDisputedCountRoPFinding Convert(DomainModel.JJDisputedCountRoPFinding source, Oracle.JJDisputedCountRoPFinding destination, AutoMapper.ResolutionContext context)
-        {
-            return source switch
-            {
-                DomainModel.JJDisputedCountRoPFinding.UNKNOWN => Oracle.JJDisputedCountRoPFinding.UNKNOWN,
-                DomainModel.JJDisputedCountRoPFinding.GUILTY => Oracle.JJDisputedCountRoPFinding.GUILTY,
-                DomainModel.JJDisputedCountRoPFinding.NOT_GUILTY => Oracle.JJDisputedCountRoPFinding.NOT_GUILTY,
-                DomainModel.JJDisputedCountRoPFinding.CANCELLED => Oracle.JJDisputedCountRoPFinding.CANCELLED,
-                DomainModel.JJDisputedCountRoPFinding.PAID_PRIOR_TO_APPEARANCE => Oracle.JJDisputedCountRoPFinding.PAID_PRIOR_TO_APPEARANCE,
-                DomainModel.JJDisputedCountRoPFinding.GUILTY_LESSER => Oracle.JJDisputedCountRoPFinding.GUILTY_LESSER,
-                _ => Oracle.JJDisputedCountRoPFinding.UNKNOWN
-            };
-        }
-
-        public DomainModel.JJDisputeDisputantAttendanceType Convert(Oracle.JJDisputeDisputantAttendanceType source, DomainModel.JJDisputeDisputantAttendanceType destination, AutoMapper.ResolutionContext context)
-        {
-            return source switch
-            {
-                Oracle.JJDisputeDisputantAttendanceType.UNKNOWN => DomainModel.JJDisputeDisputantAttendanceType.UNKNOWN,
-                Oracle.JJDisputeDisputantAttendanceType.WRITTEN_REASONS => DomainModel.JJDisputeDisputantAttendanceType.WRITTEN_REASONS,
-                Oracle.JJDisputeDisputantAttendanceType.VIDEO_CONFERENCE => DomainModel.JJDisputeDisputantAttendanceType.VIDEO_CONFERENCE,
-                Oracle.JJDisputeDisputantAttendanceType.TELEPHONE_CONFERENCE => DomainModel.JJDisputeDisputantAttendanceType.TELEPHONE_CONFERENCE,
-                Oracle.JJDisputeDisputantAttendanceType.MSTEAMS_AUDIO => DomainModel.JJDisputeDisputantAttendanceType.MSTEAMS_AUDIO,
-                Oracle.JJDisputeDisputantAttendanceType.MSTEAMS_VIDEO => DomainModel.JJDisputeDisputantAttendanceType.MSTEAMS_VIDEO,
-                Oracle.JJDisputeDisputantAttendanceType.IN_PERSON => DomainModel.JJDisputeDisputantAttendanceType.IN_PERSON,
-                _ => DomainModel.JJDisputeDisputantAttendanceType.UNKNOWN
-            };
-        }
-
-        public Oracle.JJDisputeDisputantAttendanceType Convert(DomainModel.JJDisputeDisputantAttendanceType source, Oracle.JJDisputeDisputantAttendanceType destination, AutoMapper.ResolutionContext context)
-        {
-            return source switch
-            {
-                DomainModel.JJDisputeDisputantAttendanceType.UNKNOWN => Oracle.JJDisputeDisputantAttendanceType.UNKNOWN,
-                DomainModel.JJDisputeDisputantAttendanceType.WRITTEN_REASONS => Oracle.JJDisputeDisputantAttendanceType.WRITTEN_REASONS,
-                DomainModel.JJDisputeDisputantAttendanceType.VIDEO_CONFERENCE => Oracle.JJDisputeDisputantAttendanceType.VIDEO_CONFERENCE,
-                DomainModel.JJDisputeDisputantAttendanceType.TELEPHONE_CONFERENCE => Oracle.JJDisputeDisputantAttendanceType.TELEPHONE_CONFERENCE,
-                DomainModel.JJDisputeDisputantAttendanceType.MSTEAMS_AUDIO => Oracle.JJDisputeDisputantAttendanceType.MSTEAMS_AUDIO,
-                DomainModel.JJDisputeDisputantAttendanceType.MSTEAMS_VIDEO => Oracle.JJDisputeDisputantAttendanceType.MSTEAMS_VIDEO,
-                DomainModel.JJDisputeDisputantAttendanceType.IN_PERSON => Oracle.JJDisputeDisputantAttendanceType.IN_PERSON,
-                _ => Oracle.JJDisputeDisputantAttendanceType.UNKNOWN
-            };
-        }
-
-        public DomainModel.JJDisputeHearingType Convert(Oracle.JJDisputeHearingType source, DomainModel.JJDisputeHearingType destination, AutoMapper.ResolutionContext context)
-        {
-            return source switch
-            {
-                Oracle.JJDisputeHearingType.UNKNOWN => DomainModel.JJDisputeHearingType.UNKNOWN,
-                Oracle.JJDisputeHearingType.COURT_APPEARANCE => DomainModel.JJDisputeHearingType.COURT_APPEARANCE,
-                Oracle.JJDisputeHearingType.WRITTEN_REASONS => DomainModel.JJDisputeHearingType.WRITTEN_REASONS,
-                _ => DomainModel.JJDisputeHearingType.UNKNOWN
-            };
-        }
-
-        public Oracle.JJDisputeHearingType Convert(DomainModel.JJDisputeHearingType source, Oracle.JJDisputeHearingType destination, AutoMapper.ResolutionContext context)
-        {
-            return source switch
-            {
-                DomainModel.JJDisputeHearingType.UNKNOWN => Oracle.JJDisputeHearingType.UNKNOWN,
-                DomainModel.JJDisputeHearingType.COURT_APPEARANCE => Oracle.JJDisputeHearingType.COURT_APPEARANCE,
-                DomainModel.JJDisputeHearingType.WRITTEN_REASONS => Oracle.JJDisputeHearingType.WRITTEN_REASONS,
-                _ => Oracle.JJDisputeHearingType.UNKNOWN
-            };
-        }
-
-        public DomainModel.JJDisputeSignatoryType Convert(Oracle.JJDisputeSignatoryType source, DomainModel.JJDisputeSignatoryType destination, AutoMapper.ResolutionContext context)
-        {
-            return source switch
-            {
-                Oracle.JJDisputeSignatoryType.U => DomainModel.JJDisputeSignatoryType.U,
-                Oracle.JJDisputeSignatoryType.D => DomainModel.JJDisputeSignatoryType.D,
-                Oracle.JJDisputeSignatoryType.A => DomainModel.JJDisputeSignatoryType.A,
-                _ => DomainModel.JJDisputeSignatoryType.U
-            };
-        }
-
-        public Oracle.JJDisputeSignatoryType Convert(DomainModel.JJDisputeSignatoryType source, Oracle.JJDisputeSignatoryType destination, AutoMapper.ResolutionContext context)
-        {
-            return source switch
-            {
-                DomainModel.JJDisputeSignatoryType.U => Oracle.JJDisputeSignatoryType.U,
-                DomainModel.JJDisputeSignatoryType.D => Oracle.JJDisputeSignatoryType.D,
-                DomainModel.JJDisputeSignatoryType.A => Oracle.JJDisputeSignatoryType.A,
-                _ => Oracle.JJDisputeSignatoryType.U
-            };
-        }
-
-        public DomainModel.JJDisputeStatus Convert(Oracle.JJDisputeStatus source, DomainModel.JJDisputeStatus destination, AutoMapper.ResolutionContext context)
-        {
-            return source switch
-            {
-                Oracle.JJDisputeStatus.UNKNOWN => DomainModel.JJDisputeStatus.UNKNOWN,
-                Oracle.JJDisputeStatus.NEW => DomainModel.JJDisputeStatus.NEW,
-                Oracle.JJDisputeStatus.IN_PROGRESS => DomainModel.JJDisputeStatus.IN_PROGRESS,
-                Oracle.JJDisputeStatus.DATA_UPDATE => DomainModel.JJDisputeStatus.DATA_UPDATE,
-                Oracle.JJDisputeStatus.CONFIRMED => DomainModel.JJDisputeStatus.CONFIRMED,
-                Oracle.JJDisputeStatus.REQUIRE_COURT_HEARING => DomainModel.JJDisputeStatus.REQUIRE_COURT_HEARING,
-                Oracle.JJDisputeStatus.REQUIRE_MORE_INFO => DomainModel.JJDisputeStatus.REQUIRE_MORE_INFO,
-                Oracle.JJDisputeStatus.ACCEPTED => DomainModel.JJDisputeStatus.ACCEPTED,
-                Oracle.JJDisputeStatus.REVIEW => DomainModel.JJDisputeStatus.REVIEW,
-                Oracle.JJDisputeStatus.CONCLUDED => DomainModel.JJDisputeStatus.CONCLUDED,
-                Oracle.JJDisputeStatus.CANCELLED => DomainModel.JJDisputeStatus.CANCELLED,
-                Oracle.JJDisputeStatus.HEARING_SCHEDULED => DomainModel.JJDisputeStatus.HEARING_SCHEDULED,
-                _ => DomainModel.JJDisputeStatus.UNKNOWN
-            };
-        }
-
-        public Oracle.JJDisputeStatus Convert(DomainModel.JJDisputeStatus source, Oracle.JJDisputeStatus destination, AutoMapper.ResolutionContext context)
-        {
-            return source switch
-            {
-                DomainModel.JJDisputeStatus.UNKNOWN => Oracle.JJDisputeStatus.UNKNOWN,
-                DomainModel.JJDisputeStatus.NEW => Oracle.JJDisputeStatus.NEW,
-                DomainModel.JJDisputeStatus.IN_PROGRESS => Oracle.JJDisputeStatus.IN_PROGRESS,
-                DomainModel.JJDisputeStatus.DATA_UPDATE => Oracle.JJDisputeStatus.DATA_UPDATE,
-                DomainModel.JJDisputeStatus.CONFIRMED => Oracle.JJDisputeStatus.CONFIRMED,
-                DomainModel.JJDisputeStatus.REQUIRE_COURT_HEARING => Oracle.JJDisputeStatus.REQUIRE_COURT_HEARING,
-                DomainModel.JJDisputeStatus.REQUIRE_MORE_INFO => Oracle.JJDisputeStatus.REQUIRE_MORE_INFO,
-                DomainModel.JJDisputeStatus.ACCEPTED => Oracle.JJDisputeStatus.ACCEPTED,
-                DomainModel.JJDisputeStatus.REVIEW => Oracle.JJDisputeStatus.REVIEW,
-                DomainModel.JJDisputeStatus.CONCLUDED => Oracle.JJDisputeStatus.CONCLUDED,
-                DomainModel.JJDisputeStatus.CANCELLED => Oracle.JJDisputeStatus.CANCELLED,
-                DomainModel.JJDisputeStatus.HEARING_SCHEDULED => Oracle.JJDisputeStatus.HEARING_SCHEDULED,
-                _ => Oracle.JJDisputeStatus.UNKNOWN
-            };
-        }
-
-        public DomainModel.Status Convert(Oracle.Status source, DomainModel.Status destination, AutoMapper.ResolutionContext context)
-        {
-            return source switch
-            {
-                Oracle.Status.UNKNOWN => DomainModel.Status.UNKNOWN,
-                Oracle.Status.ACCEPTED => DomainModel.Status.ACCEPTED,
-                Oracle.Status.PENDING => DomainModel.Status.PENDING,
-                Oracle.Status.REJECTED => DomainModel.Status.REJECTED,
-                _ => DomainModel.Status.UNKNOWN
-            };
-        }
-
-        public Oracle.Status Convert(DomainModel.Status source, Oracle.Status destination, AutoMapper.ResolutionContext context)
-        {
-            return source switch
-            {
-                DomainModel.Status.UNKNOWN => Oracle.Status.UNKNOWN,
-                DomainModel.Status.ACCEPTED => Oracle.Status.ACCEPTED,
-                DomainModel.Status.PENDING => Oracle.Status.PENDING,
-                DomainModel.Status.REJECTED => Oracle.Status.REJECTED,
-                _ => Oracle.Status.UNKNOWN
-            };
-        }
-
-        public DomainModel.TicketImageDataJustinDocumentReportType Convert(Oracle.TicketImageDataJustinDocumentReportType source, DomainModel.TicketImageDataJustinDocumentReportType destination, AutoMapper.ResolutionContext context)
-        {
-            return source switch
-            {
-                Oracle.TicketImageDataJustinDocumentReportType.UNKNOWN => DomainModel.TicketImageDataJustinDocumentReportType.UNKNOWN,
-                Oracle.TicketImageDataJustinDocumentReportType.NOTICE_OF_DISPUTE => DomainModel.TicketImageDataJustinDocumentReportType.NOTICE_OF_DISPUTE,
-                Oracle.TicketImageDataJustinDocumentReportType.TICKET_IMAGE => DomainModel.TicketImageDataJustinDocumentReportType.TICKET_IMAGE,
-                _ => DomainModel.TicketImageDataJustinDocumentReportType.UNKNOWN
-            };
-        }
-
-        public Oracle.TicketImageDataJustinDocumentReportType Convert(DomainModel.TicketImageDataJustinDocumentReportType source, Oracle.TicketImageDataJustinDocumentReportType destination, AutoMapper.ResolutionContext context)
-        {
-            return source switch
-            {
-                DomainModel.TicketImageDataJustinDocumentReportType.UNKNOWN => Oracle.TicketImageDataJustinDocumentReportType.UNKNOWN,
-                DomainModel.TicketImageDataJustinDocumentReportType.NOTICE_OF_DISPUTE => Oracle.TicketImageDataJustinDocumentReportType.NOTICE_OF_DISPUTE,
-                DomainModel.TicketImageDataJustinDocumentReportType.TICKET_IMAGE => Oracle.TicketImageDataJustinDocumentReportType.TICKET_IMAGE,
-                _ => Oracle.TicketImageDataJustinDocumentReportType.UNKNOWN
-            };
-        }
-
-        //public DomainModel.ViolationTicketVersion Convert(Oracle.ViolationTicketVersion source, DomainModel.ViolationTicketVersion destination, AutoMapper.ResolutionContext context)
-        //{
-        //    return source switch
-        //    {
-        //        Oracle.ViolationTicketVersion.VT1 => DomainModel.ViolationTicketVersion.VT1,
-        //        Oracle.ViolationTicketVersion.VT2 => DomainModel.ViolationTicketVersion.VT2,
-        //        _ => DomainModel.ViolationTicketVersion.VT1
-        //    };
-        //}
-
-        //public Oracle.ViolationTicketVersion Convert(DomainModel.ViolationTicketVersion source, Oracle.ViolationTicketVersion destination, AutoMapper.ResolutionContext context)
-        //{
-        //    return source switch
-        //    {
-        //        DomainModel.ViolationTicketVersion.VT1 => Oracle.ViolationTicketVersion.VT1,
-        //        DomainModel.ViolationTicketVersion.VT2 => Oracle.ViolationTicketVersion.VT2,
-        //        _ => Oracle.ViolationTicketVersion.VT1
-        //    };
-        //}
-
-        public DomainModel.DisputeAppearanceLessThan14DaysYn Convert(Oracle.DisputeAppearanceLessThan14DaysYn source, DomainModel.DisputeAppearanceLessThan14DaysYn destination, AutoMapper.ResolutionContext context)
-        {
-            return source switch
-            {
-                Oracle.DisputeAppearanceLessThan14DaysYn.UNKNOWN => DomainModel.DisputeAppearanceLessThan14DaysYn.UNKNOWN,
-                Oracle.DisputeAppearanceLessThan14DaysYn.Y => DomainModel.DisputeAppearanceLessThan14DaysYn.Y,
-                Oracle.DisputeAppearanceLessThan14DaysYn.N => DomainModel.DisputeAppearanceLessThan14DaysYn.N,
-                _ => DomainModel.DisputeAppearanceLessThan14DaysYn.UNKNOWN
-            };
-        }
-
-        public Oracle.DisputeAppearanceLessThan14DaysYn Convert(DomainModel.DisputeAppearanceLessThan14DaysYn source, Oracle.DisputeAppearanceLessThan14DaysYn destination, AutoMapper.ResolutionContext context)
-        {
-            return source switch
-            {
-                DomainModel.DisputeAppearanceLessThan14DaysYn.UNKNOWN => Oracle.DisputeAppearanceLessThan14DaysYn.UNKNOWN,
-                DomainModel.DisputeAppearanceLessThan14DaysYn.Y => Oracle.DisputeAppearanceLessThan14DaysYn.Y,
-                DomainModel.DisputeAppearanceLessThan14DaysYn.N => Oracle.DisputeAppearanceLessThan14DaysYn.N,
-                _ => Oracle.DisputeAppearanceLessThan14DaysYn.UNKNOWN
-            };
-        }
-
-        public DomainModel.DisputeCountRequestCourtAppearance Convert(Oracle.DisputeCountRequestCourtAppearance source, DomainModel.DisputeCountRequestCourtAppearance destination, AutoMapper.ResolutionContext context)
-        {
-            return source switch
-            {
-                Oracle.DisputeCountRequestCourtAppearance.UNKNOWN => DomainModel.DisputeCountRequestCourtAppearance.UNKNOWN,
-                Oracle.DisputeCountRequestCourtAppearance.Y => DomainModel.DisputeCountRequestCourtAppearance.Y,
-                Oracle.DisputeCountRequestCourtAppearance.N => DomainModel.DisputeCountRequestCourtAppearance.N,
-                _ => DomainModel.DisputeCountRequestCourtAppearance.UNKNOWN
-            };
-        }
-
-        public Oracle.DisputeCountRequestCourtAppearance Convert(DomainModel.DisputeCountRequestCourtAppearance source, Oracle.DisputeCountRequestCourtAppearance destination, AutoMapper.ResolutionContext context)
-        {
-            return source switch
-            {
-                DomainModel.DisputeCountRequestCourtAppearance.UNKNOWN => Oracle.DisputeCountRequestCourtAppearance.UNKNOWN,
-                DomainModel.DisputeCountRequestCourtAppearance.Y => Oracle.DisputeCountRequestCourtAppearance.Y,
-                DomainModel.DisputeCountRequestCourtAppearance.N => Oracle.DisputeCountRequestCourtAppearance.N,
-                _ => Oracle.DisputeCountRequestCourtAppearance.UNKNOWN
-            };
-        }
-
-        public DomainModel.DisputeCountRequestReduction Convert(Oracle.DisputeCountRequestReduction source, DomainModel.DisputeCountRequestReduction destination, AutoMapper.ResolutionContext context)
-        {
-            return source switch
-            {
-                Oracle.DisputeCountRequestReduction.UNKNOWN => DomainModel.DisputeCountRequestReduction.UNKNOWN,
-                Oracle.DisputeCountRequestReduction.Y => DomainModel.DisputeCountRequestReduction.Y,
-                Oracle.DisputeCountRequestReduction.N => DomainModel.DisputeCountRequestReduction.N,
-                _ => DomainModel.DisputeCountRequestReduction.UNKNOWN
-            };
-        }
-
-        public Oracle.DisputeCountRequestReduction Convert(DomainModel.DisputeCountRequestReduction source, Oracle.DisputeCountRequestReduction destination, AutoMapper.ResolutionContext context)
-        {
-            return source switch
-            {
-                DomainModel.DisputeCountRequestReduction.UNKNOWN => Oracle.DisputeCountRequestReduction.UNKNOWN,
-                DomainModel.DisputeCountRequestReduction.Y => Oracle.DisputeCountRequestReduction.Y,
-                DomainModel.DisputeCountRequestReduction.N => Oracle.DisputeCountRequestReduction.N,
-                _ => Oracle.DisputeCountRequestReduction.UNKNOWN
-            };
-        }
-
-        public DomainModel.DisputeCountRequestTimeToPay Convert(Oracle.DisputeCountRequestTimeToPay source, DomainModel.DisputeCountRequestTimeToPay destination, AutoMapper.ResolutionContext context)
-        {
-            return source switch
-            {
-                Oracle.DisputeCountRequestTimeToPay.UNKNOWN => DomainModel.DisputeCountRequestTimeToPay.UNKNOWN,
-                Oracle.DisputeCountRequestTimeToPay.Y => DomainModel.DisputeCountRequestTimeToPay.Y,
-                Oracle.DisputeCountRequestTimeToPay.N => DomainModel.DisputeCountRequestTimeToPay.N,
-                _ => DomainModel.DisputeCountRequestTimeToPay.UNKNOWN
-            };
-        }
-
-        public Oracle.DisputeCountRequestTimeToPay Convert(DomainModel.DisputeCountRequestTimeToPay source, Oracle.DisputeCountRequestTimeToPay destination, AutoMapper.ResolutionContext context)
-        {
-            return source switch
-            {
-                DomainModel.DisputeCountRequestTimeToPay.UNKNOWN => Oracle.DisputeCountRequestTimeToPay.UNKNOWN,
-                DomainModel.DisputeCountRequestTimeToPay.Y => Oracle.DisputeCountRequestTimeToPay.Y,
-                DomainModel.DisputeCountRequestTimeToPay.N => Oracle.DisputeCountRequestTimeToPay.N,
-                _ => Oracle.DisputeCountRequestTimeToPay.UNKNOWN
-            };
-        }
-
-        public DomainModel.DisputeDisputantDetectedOcrIssues Convert(Oracle.DisputeDisputantDetectedOcrIssues source, DomainModel.DisputeDisputantDetectedOcrIssues destination, AutoMapper.ResolutionContext context)
-        {
-            return source switch
-            {
-                Oracle.DisputeDisputantDetectedOcrIssues.UNKNOWN => DomainModel.DisputeDisputantDetectedOcrIssues.UNKNOWN,
-                Oracle.DisputeDisputantDetectedOcrIssues.Y => DomainModel.DisputeDisputantDetectedOcrIssues.Y,
-                Oracle.DisputeDisputantDetectedOcrIssues.N => DomainModel.DisputeDisputantDetectedOcrIssues.N,
-                _ => DomainModel.DisputeDisputantDetectedOcrIssues.UNKNOWN
-            };
-        }
-
-        public Oracle.DisputeDisputantDetectedOcrIssues Convert(DomainModel.DisputeDisputantDetectedOcrIssues source, Oracle.DisputeDisputantDetectedOcrIssues destination, AutoMapper.ResolutionContext context)
-        {
-            return source switch
-            {
-                DomainModel.DisputeDisputantDetectedOcrIssues.UNKNOWN => Oracle.DisputeDisputantDetectedOcrIssues.UNKNOWN,
-                DomainModel.DisputeDisputantDetectedOcrIssues.Y => Oracle.DisputeDisputantDetectedOcrIssues.Y,
-                DomainModel.DisputeDisputantDetectedOcrIssues.N => Oracle.DisputeDisputantDetectedOcrIssues.N,
-                _ => Oracle.DisputeDisputantDetectedOcrIssues.UNKNOWN
-            };
-        }
-
-        public DomainModel.DisputeInterpreterRequired Convert(Oracle.DisputeInterpreterRequired source, DomainModel.DisputeInterpreterRequired destination, AutoMapper.ResolutionContext context)
-        {
-            return source switch
-            {
-                Oracle.DisputeInterpreterRequired.UNKNOWN => DomainModel.DisputeInterpreterRequired.UNKNOWN,
-                Oracle.DisputeInterpreterRequired.Y => DomainModel.DisputeInterpreterRequired.Y,
-                Oracle.DisputeInterpreterRequired.N => DomainModel.DisputeInterpreterRequired.N,
-                _ => DomainModel.DisputeInterpreterRequired.UNKNOWN
-            };
-        }
-
-        public Oracle.DisputeInterpreterRequired Convert(DomainModel.DisputeInterpreterRequired source, Oracle.DisputeInterpreterRequired destination, AutoMapper.ResolutionContext context)
-        {
-            return source switch
-            {
-                DomainModel.DisputeInterpreterRequired.UNKNOWN => Oracle.DisputeInterpreterRequired.UNKNOWN,
-                DomainModel.DisputeInterpreterRequired.Y => Oracle.DisputeInterpreterRequired.Y,
-                DomainModel.DisputeInterpreterRequired.N => Oracle.DisputeInterpreterRequired.N,
-                _ => Oracle.DisputeInterpreterRequired.UNKNOWN
-            };
-        }
-
-        public DomainModel.DisputeListItemDisputantDetectedOcrIssues Convert(Oracle.DisputeListItemDisputantDetectedOcrIssues source, DomainModel.DisputeListItemDisputantDetectedOcrIssues destination, AutoMapper.ResolutionContext context)
-        {
-            return source switch
-            {
-                Oracle.DisputeListItemDisputantDetectedOcrIssues.UNKNOWN => DomainModel.DisputeListItemDisputantDetectedOcrIssues.UNKNOWN,
-                Oracle.DisputeListItemDisputantDetectedOcrIssues.Y => DomainModel.DisputeListItemDisputantDetectedOcrIssues.Y,
-                Oracle.DisputeListItemDisputantDetectedOcrIssues.N => DomainModel.DisputeListItemDisputantDetectedOcrIssues.N,
-                _ => DomainModel.DisputeListItemDisputantDetectedOcrIssues.UNKNOWN
-            };
-        }
-
-        public Oracle.DisputeListItemDisputantDetectedOcrIssues Convert(DomainModel.DisputeListItemDisputantDetectedOcrIssues source, Oracle.DisputeListItemDisputantDetectedOcrIssues destination, AutoMapper.ResolutionContext context)
-        {
-            return source switch
-            {
-                DomainModel.DisputeListItemDisputantDetectedOcrIssues.UNKNOWN => Oracle.DisputeListItemDisputantDetectedOcrIssues.UNKNOWN,
-                DomainModel.DisputeListItemDisputantDetectedOcrIssues.Y => Oracle.DisputeListItemDisputantDetectedOcrIssues.Y,
-                DomainModel.DisputeListItemDisputantDetectedOcrIssues.N => Oracle.DisputeListItemDisputantDetectedOcrIssues.N,
-                _ => Oracle.DisputeListItemDisputantDetectedOcrIssues.UNKNOWN
-            };
-        }
-
-        public DomainModel.DisputeListItemRequestCourtAppearanceYn Convert(Oracle.DisputeListItemRequestCourtAppearanceYn source, DomainModel.DisputeListItemRequestCourtAppearanceYn destination, AutoMapper.ResolutionContext context)
-        {
-            return source switch
-            {
-                Oracle.DisputeListItemRequestCourtAppearanceYn.UNKNOWN => DomainModel.DisputeListItemRequestCourtAppearanceYn.UNKNOWN,
-                Oracle.DisputeListItemRequestCourtAppearanceYn.Y => DomainModel.DisputeListItemRequestCourtAppearanceYn.Y,
-                Oracle.DisputeListItemRequestCourtAppearanceYn.N => DomainModel.DisputeListItemRequestCourtAppearanceYn.N,
-                _ => DomainModel.DisputeListItemRequestCourtAppearanceYn.UNKNOWN
-            };
-        }
-
-        public Oracle.DisputeListItemRequestCourtAppearanceYn Convert(DomainModel.DisputeListItemRequestCourtAppearanceYn source, Oracle.DisputeListItemRequestCourtAppearanceYn destination, AutoMapper.ResolutionContext context)
-        {
-            return source switch
-            {
-                DomainModel.DisputeListItemRequestCourtAppearanceYn.UNKNOWN => Oracle.DisputeListItemRequestCourtAppearanceYn.UNKNOWN,
-                DomainModel.DisputeListItemRequestCourtAppearanceYn.Y => Oracle.DisputeListItemRequestCourtAppearanceYn.Y,
-                DomainModel.DisputeListItemRequestCourtAppearanceYn.N => Oracle.DisputeListItemRequestCourtAppearanceYn.N,
-                _ => Oracle.DisputeListItemRequestCourtAppearanceYn.UNKNOWN
-            };
-        }
-
-        public DomainModel.DisputeListItemSystemDetectedOcrIssues Convert(Oracle.DisputeListItemSystemDetectedOcrIssues source, DomainModel.DisputeListItemSystemDetectedOcrIssues destination, AutoMapper.ResolutionContext context)
-        {
-            return source switch
-            {
-                Oracle.DisputeListItemSystemDetectedOcrIssues.UNKNOWN => DomainModel.DisputeListItemSystemDetectedOcrIssues.UNKNOWN,
-                Oracle.DisputeListItemSystemDetectedOcrIssues.Y => DomainModel.DisputeListItemSystemDetectedOcrIssues.Y,
-                Oracle.DisputeListItemSystemDetectedOcrIssues.N => DomainModel.DisputeListItemSystemDetectedOcrIssues.N,
-                _ => DomainModel.DisputeListItemSystemDetectedOcrIssues.UNKNOWN
-            };
-        }
-
-        public Oracle.DisputeListItemSystemDetectedOcrIssues Convert(DomainModel.DisputeListItemSystemDetectedOcrIssues source, Oracle.DisputeListItemSystemDetectedOcrIssues destination, AutoMapper.ResolutionContext context)
-        {
-            return source switch
-            {
-                DomainModel.DisputeListItemSystemDetectedOcrIssues.UNKNOWN => Oracle.DisputeListItemSystemDetectedOcrIssues.UNKNOWN,
-                DomainModel.DisputeListItemSystemDetectedOcrIssues.Y => Oracle.DisputeListItemSystemDetectedOcrIssues.Y,
-                DomainModel.DisputeListItemSystemDetectedOcrIssues.N => Oracle.DisputeListItemSystemDetectedOcrIssues.N,
-                _ => Oracle.DisputeListItemSystemDetectedOcrIssues.UNKNOWN
-            };
-        }
-
-        public DomainModel.DisputeRepresentedByLawyer Convert(Oracle.DisputeRepresentedByLawyer source, DomainModel.DisputeRepresentedByLawyer destination, AutoMapper.ResolutionContext context)
-        {
-            return source switch
-            {
-                Oracle.DisputeRepresentedByLawyer.UNKNOWN => DomainModel.DisputeRepresentedByLawyer.UNKNOWN,
-                Oracle.DisputeRepresentedByLawyer.Y => DomainModel.DisputeRepresentedByLawyer.Y,
-                Oracle.DisputeRepresentedByLawyer.N => DomainModel.DisputeRepresentedByLawyer.N,
-                _ => DomainModel.DisputeRepresentedByLawyer.UNKNOWN
-            };
-        }
-
-        public Oracle.DisputeRepresentedByLawyer Convert(DomainModel.DisputeRepresentedByLawyer source, Oracle.DisputeRepresentedByLawyer destination, AutoMapper.ResolutionContext context)
-        {
-            return source switch
-            {
-                DomainModel.DisputeRepresentedByLawyer.UNKNOWN => Oracle.DisputeRepresentedByLawyer.UNKNOWN,
-                DomainModel.DisputeRepresentedByLawyer.Y => Oracle.DisputeRepresentedByLawyer.Y,
-                DomainModel.DisputeRepresentedByLawyer.N => Oracle.DisputeRepresentedByLawyer.N,
-                _ => Oracle.DisputeRepresentedByLawyer.UNKNOWN
-            };
-        }
-
-        public DomainModel.DisputeRequestCourtAppearanceYn Convert(Oracle.DisputeRequestCourtAppearanceYn source, DomainModel.DisputeRequestCourtAppearanceYn destination, AutoMapper.ResolutionContext context)
-        {
-            return source switch
-            {
-                Oracle.DisputeRequestCourtAppearanceYn.UNKNOWN => DomainModel.DisputeRequestCourtAppearanceYn.UNKNOWN,
-                Oracle.DisputeRequestCourtAppearanceYn.Y => DomainModel.DisputeRequestCourtAppearanceYn.Y,
-                Oracle.DisputeRequestCourtAppearanceYn.N => DomainModel.DisputeRequestCourtAppearanceYn.N,
-                _ => DomainModel.DisputeRequestCourtAppearanceYn.UNKNOWN
-            };
-        }
-
-        public Oracle.DisputeRequestCourtAppearanceYn Convert(DomainModel.DisputeRequestCourtAppearanceYn source, Oracle.DisputeRequestCourtAppearanceYn destination, AutoMapper.ResolutionContext context)
-        {
-            return source switch
-            {
-                DomainModel.DisputeRequestCourtAppearanceYn.UNKNOWN => Oracle.DisputeRequestCourtAppearanceYn.UNKNOWN,
-                DomainModel.DisputeRequestCourtAppearanceYn.Y => Oracle.DisputeRequestCourtAppearanceYn.Y,
-                DomainModel.DisputeRequestCourtAppearanceYn.N => Oracle.DisputeRequestCourtAppearanceYn.N,
-                _ => Oracle.DisputeRequestCourtAppearanceYn.UNKNOWN
-            };
-        }
-
-        public DomainModel.DisputeSystemDetectedOcrIssues Convert(Oracle.DisputeSystemDetectedOcrIssues source, DomainModel.DisputeSystemDetectedOcrIssues destination, AutoMapper.ResolutionContext context)
-        {
-            return source switch
-            {
-                Oracle.DisputeSystemDetectedOcrIssues.UNKNOWN => DomainModel.DisputeSystemDetectedOcrIssues.UNKNOWN,
-                Oracle.DisputeSystemDetectedOcrIssues.Y => DomainModel.DisputeSystemDetectedOcrIssues.Y,
-                Oracle.DisputeSystemDetectedOcrIssues.N => DomainModel.DisputeSystemDetectedOcrIssues.N,
-                _ => DomainModel.DisputeSystemDetectedOcrIssues.UNKNOWN
-            };
-        }
-
-        public Oracle.DisputeSystemDetectedOcrIssues Convert(DomainModel.DisputeSystemDetectedOcrIssues source, Oracle.DisputeSystemDetectedOcrIssues destination, AutoMapper.ResolutionContext context)
-        {
-            return source switch
-            {
-                DomainModel.DisputeSystemDetectedOcrIssues.UNKNOWN => Oracle.DisputeSystemDetectedOcrIssues.UNKNOWN,
-                DomainModel.DisputeSystemDetectedOcrIssues.Y => Oracle.DisputeSystemDetectedOcrIssues.Y,
-                DomainModel.DisputeSystemDetectedOcrIssues.N => Oracle.DisputeSystemDetectedOcrIssues.N,
-                _ => Oracle.DisputeSystemDetectedOcrIssues.UNKNOWN
-            };
-        }
-
-        public DomainModel.EmailHistorySuccessfullySent Convert(Oracle.EmailHistorySuccessfullySent source, DomainModel.EmailHistorySuccessfullySent destination, AutoMapper.ResolutionContext context)
-        {
-            return source switch
-            {
-                Oracle.EmailHistorySuccessfullySent.UNKNOWN => DomainModel.EmailHistorySuccessfullySent.UNKNOWN,
-                Oracle.EmailHistorySuccessfullySent.Y => DomainModel.EmailHistorySuccessfullySent.Y,
-                Oracle.EmailHistorySuccessfullySent.N => DomainModel.EmailHistorySuccessfullySent.N,
-                _ => DomainModel.EmailHistorySuccessfullySent.UNKNOWN
-            };
-        }
-
-        public Oracle.EmailHistorySuccessfullySent Convert(DomainModel.EmailHistorySuccessfullySent source, Oracle.EmailHistorySuccessfullySent destination, AutoMapper.ResolutionContext context)
-        {
-            return source switch
-            {
-                DomainModel.EmailHistorySuccessfullySent.UNKNOWN => Oracle.EmailHistorySuccessfullySent.UNKNOWN,
-                DomainModel.EmailHistorySuccessfullySent.Y => Oracle.EmailHistorySuccessfullySent.Y,
-                DomainModel.EmailHistorySuccessfullySent.N => Oracle.EmailHistorySuccessfullySent.N,
-                _ => Oracle.EmailHistorySuccessfullySent.UNKNOWN
-            };
-        }
-
-        public DomainModel.JJDisputeAccidentYn Convert(Oracle.JJDisputeAccidentYn source, DomainModel.JJDisputeAccidentYn destination, AutoMapper.ResolutionContext context)
-        {
-            return source switch
-            {
-                Oracle.JJDisputeAccidentYn.UNKNOWN => DomainModel.JJDisputeAccidentYn.UNKNOWN,
-                Oracle.JJDisputeAccidentYn.Y => DomainModel.JJDisputeAccidentYn.Y,
-                Oracle.JJDisputeAccidentYn.N => DomainModel.JJDisputeAccidentYn.N,
-                _ => DomainModel.JJDisputeAccidentYn.UNKNOWN
-            };
-        }
-
-        public Oracle.JJDisputeAccidentYn Convert(DomainModel.JJDisputeAccidentYn source, Oracle.JJDisputeAccidentYn destination, AutoMapper.ResolutionContext context)
-        {
-            return source switch
-            {
-                DomainModel.JJDisputeAccidentYn.UNKNOWN => Oracle.JJDisputeAccidentYn.UNKNOWN,
-                DomainModel.JJDisputeAccidentYn.Y => Oracle.JJDisputeAccidentYn.Y,
-                DomainModel.JJDisputeAccidentYn.N => Oracle.JJDisputeAccidentYn.N,
-                _ => Oracle.JJDisputeAccidentYn.UNKNOWN
-            };
-        }
-
-        public DomainModel.JJDisputeAppearInCourt Convert(Oracle.JJDisputeAppearInCourt source, DomainModel.JJDisputeAppearInCourt destination, AutoMapper.ResolutionContext context)
-        {
-            return source switch
-            {
-                Oracle.JJDisputeAppearInCourt.UNKNOWN => DomainModel.JJDisputeAppearInCourt.UNKNOWN,
-                Oracle.JJDisputeAppearInCourt.Y => DomainModel.JJDisputeAppearInCourt.Y,
-                Oracle.JJDisputeAppearInCourt.N => DomainModel.JJDisputeAppearInCourt.N,
-                _ => DomainModel.JJDisputeAppearInCourt.UNKNOWN
-            };
-        }
-
-        public Oracle.JJDisputeAppearInCourt Convert(DomainModel.JJDisputeAppearInCourt source, Oracle.JJDisputeAppearInCourt destination, AutoMapper.ResolutionContext context)
-        {
-            return source switch
-            {
-                DomainModel.JJDisputeAppearInCourt.UNKNOWN => Oracle.JJDisputeAppearInCourt.UNKNOWN,
-                DomainModel.JJDisputeAppearInCourt.Y => Oracle.JJDisputeAppearInCourt.Y,
-                DomainModel.JJDisputeAppearInCourt.N => Oracle.JJDisputeAppearInCourt.N,
-                _ => Oracle.JJDisputeAppearInCourt.UNKNOWN
-            };
-        }
-
-        public DomainModel.JJDisputeCourtAppearanceRoPJjSeized Convert(Oracle.JJDisputeCourtAppearanceRoPJjSeized source, DomainModel.JJDisputeCourtAppearanceRoPJjSeized destination, AutoMapper.ResolutionContext context)
-        {
-            return source switch
-            {
-                Oracle.JJDisputeCourtAppearanceRoPJjSeized.UNKNOWN => DomainModel.JJDisputeCourtAppearanceRoPJjSeized.UNKNOWN,
-                Oracle.JJDisputeCourtAppearanceRoPJjSeized.Y => DomainModel.JJDisputeCourtAppearanceRoPJjSeized.Y,
-                Oracle.JJDisputeCourtAppearanceRoPJjSeized.N => DomainModel.JJDisputeCourtAppearanceRoPJjSeized.N,
-                _ => DomainModel.JJDisputeCourtAppearanceRoPJjSeized.UNKNOWN
-            };
-        }
-
-        public Oracle.JJDisputeCourtAppearanceRoPJjSeized Convert(DomainModel.JJDisputeCourtAppearanceRoPJjSeized source, Oracle.JJDisputeCourtAppearanceRoPJjSeized destination, AutoMapper.ResolutionContext context)
-        {
-            return source switch
-            {
-                DomainModel.JJDisputeCourtAppearanceRoPJjSeized.UNKNOWN => Oracle.JJDisputeCourtAppearanceRoPJjSeized.UNKNOWN,
-                DomainModel.JJDisputeCourtAppearanceRoPJjSeized.Y => Oracle.JJDisputeCourtAppearanceRoPJjSeized.Y,
-                DomainModel.JJDisputeCourtAppearanceRoPJjSeized.N => Oracle.JJDisputeCourtAppearanceRoPJjSeized.N,
-                _ => Oracle.JJDisputeCourtAppearanceRoPJjSeized.UNKNOWN
-            };
-        }
-
-        public DomainModel.JJDisputedCountAppearInCourt Convert(Oracle.JJDisputedCountAppearInCourt source, DomainModel.JJDisputedCountAppearInCourt destination, AutoMapper.ResolutionContext context)
-        {
-            return source switch
-            {
-                Oracle.JJDisputedCountAppearInCourt.UNKNOWN => DomainModel.JJDisputedCountAppearInCourt.UNKNOWN,
-                Oracle.JJDisputedCountAppearInCourt.Y => DomainModel.JJDisputedCountAppearInCourt.Y,
-                Oracle.JJDisputedCountAppearInCourt.N => DomainModel.JJDisputedCountAppearInCourt.N,
-                _ => DomainModel.JJDisputedCountAppearInCourt.UNKNOWN
-            };
-        }
-
-        public Oracle.JJDisputedCountAppearInCourt Convert(DomainModel.JJDisputedCountAppearInCourt source, Oracle.JJDisputedCountAppearInCourt destination, AutoMapper.ResolutionContext context)
-        {
-            return source switch
-            {
-                DomainModel.JJDisputedCountAppearInCourt.UNKNOWN => Oracle.JJDisputedCountAppearInCourt.UNKNOWN,
-                DomainModel.JJDisputedCountAppearInCourt.Y => Oracle.JJDisputedCountAppearInCourt.Y,
-                DomainModel.JJDisputedCountAppearInCourt.N => Oracle.JJDisputedCountAppearInCourt.N,
-                _ => Oracle.JJDisputedCountAppearInCourt.UNKNOWN
-            };
-        }
-
-        public DomainModel.JJDisputedCountIncludesSurcharge Convert(Oracle.JJDisputedCountIncludesSurcharge source, DomainModel.JJDisputedCountIncludesSurcharge destination, AutoMapper.ResolutionContext context)
-        {
-            return source switch
-            {
-                Oracle.JJDisputedCountIncludesSurcharge.UNKNOWN => DomainModel.JJDisputedCountIncludesSurcharge.UNKNOWN,
-                Oracle.JJDisputedCountIncludesSurcharge.Y => DomainModel.JJDisputedCountIncludesSurcharge.Y,
-                Oracle.JJDisputedCountIncludesSurcharge.N => DomainModel.JJDisputedCountIncludesSurcharge.N,
-                _ => DomainModel.JJDisputedCountIncludesSurcharge.UNKNOWN
-            };
-        }
-
-        public Oracle.JJDisputedCountIncludesSurcharge Convert(DomainModel.JJDisputedCountIncludesSurcharge source, Oracle.JJDisputedCountIncludesSurcharge destination, AutoMapper.ResolutionContext context)
-        {
-            return source switch
-            {
-                DomainModel.JJDisputedCountIncludesSurcharge.UNKNOWN => Oracle.JJDisputedCountIncludesSurcharge.UNKNOWN,
-                DomainModel.JJDisputedCountIncludesSurcharge.Y => Oracle.JJDisputedCountIncludesSurcharge.Y,
-                DomainModel.JJDisputedCountIncludesSurcharge.N => Oracle.JJDisputedCountIncludesSurcharge.N,
-                _ => Oracle.JJDisputedCountIncludesSurcharge.UNKNOWN
-            };
-        }
-
-        public DomainModel.JJDisputedCountRequestReduction Convert(Oracle.JJDisputedCountRequestReduction source, DomainModel.JJDisputedCountRequestReduction destination, AutoMapper.ResolutionContext context)
-        {
-            return source switch
-            {
-                Oracle.JJDisputedCountRequestReduction.UNKNOWN => DomainModel.JJDisputedCountRequestReduction.UNKNOWN,
-                Oracle.JJDisputedCountRequestReduction.Y => DomainModel.JJDisputedCountRequestReduction.Y,
-                Oracle.JJDisputedCountRequestReduction.N => DomainModel.JJDisputedCountRequestReduction.N,
-                _ => DomainModel.JJDisputedCountRequestReduction.UNKNOWN
-            };
-        }
-
-        public Oracle.JJDisputedCountRequestReduction Convert(DomainModel.JJDisputedCountRequestReduction source, Oracle.JJDisputedCountRequestReduction destination, AutoMapper.ResolutionContext context)
-        {
-            return source switch
-            {
-                DomainModel.JJDisputedCountRequestReduction.UNKNOWN => Oracle.JJDisputedCountRequestReduction.UNKNOWN,
-                DomainModel.JJDisputedCountRequestReduction.Y => Oracle.JJDisputedCountRequestReduction.Y,
-                DomainModel.JJDisputedCountRequestReduction.N => Oracle.JJDisputedCountRequestReduction.N,
-                _ => Oracle.JJDisputedCountRequestReduction.UNKNOWN
-            };
-        }
-
-        public DomainModel.JJDisputedCountRequestTimeToPay Convert(Oracle.JJDisputedCountRequestTimeToPay source, DomainModel.JJDisputedCountRequestTimeToPay destination, AutoMapper.ResolutionContext context)
-        {
-            return source switch
-            {
-                Oracle.JJDisputedCountRequestTimeToPay.UNKNOWN => DomainModel.JJDisputedCountRequestTimeToPay.UNKNOWN,
-                Oracle.JJDisputedCountRequestTimeToPay.Y => DomainModel.JJDisputedCountRequestTimeToPay.Y,
-                Oracle.JJDisputedCountRequestTimeToPay.N => DomainModel.JJDisputedCountRequestTimeToPay.N,
-                _ => DomainModel.JJDisputedCountRequestTimeToPay.UNKNOWN
-            };
-        }
-
-        public Oracle.JJDisputedCountRequestTimeToPay Convert(DomainModel.JJDisputedCountRequestTimeToPay source, Oracle.JJDisputedCountRequestTimeToPay destination, AutoMapper.ResolutionContext context)
-        {
-            return source switch
-            {
-                DomainModel.JJDisputedCountRequestTimeToPay.UNKNOWN => Oracle.JJDisputedCountRequestTimeToPay.UNKNOWN,
-                DomainModel.JJDisputedCountRequestTimeToPay.Y => Oracle.JJDisputedCountRequestTimeToPay.Y,
-                DomainModel.JJDisputedCountRequestTimeToPay.N => Oracle.JJDisputedCountRequestTimeToPay.N,
-                _ => Oracle.JJDisputedCountRequestTimeToPay.UNKNOWN
-            };
-        }
-
-        public DomainModel.JJDisputedCountRoPAbatement Convert(Oracle.JJDisputedCountRoPAbatement source, DomainModel.JJDisputedCountRoPAbatement destination, AutoMapper.ResolutionContext context)
-        {
-            return source switch
-            {
-                Oracle.JJDisputedCountRoPAbatement.UNKNOWN => DomainModel.JJDisputedCountRoPAbatement.UNKNOWN,
-                Oracle.JJDisputedCountRoPAbatement.Y => DomainModel.JJDisputedCountRoPAbatement.Y,
-                Oracle.JJDisputedCountRoPAbatement.N => DomainModel.JJDisputedCountRoPAbatement.N,
-                _ => DomainModel.JJDisputedCountRoPAbatement.UNKNOWN
-            };
-        }
-
-        public Oracle.JJDisputedCountRoPAbatement Convert(DomainModel.JJDisputedCountRoPAbatement source, Oracle.JJDisputedCountRoPAbatement destination, AutoMapper.ResolutionContext context)
-        {
-            return source switch
-            {
-                DomainModel.JJDisputedCountRoPAbatement.UNKNOWN => Oracle.JJDisputedCountRoPAbatement.UNKNOWN,
-                DomainModel.JJDisputedCountRoPAbatement.Y => Oracle.JJDisputedCountRoPAbatement.Y,
-                DomainModel.JJDisputedCountRoPAbatement.N => Oracle.JJDisputedCountRoPAbatement.N,
-                _ => Oracle.JJDisputedCountRoPAbatement.UNKNOWN
-            };
-        }
-
-        public DomainModel.JJDisputedCountRoPDismissed Convert(Oracle.JJDisputedCountRoPDismissed source, DomainModel.JJDisputedCountRoPDismissed destination, AutoMapper.ResolutionContext context)
-        {
-            return source switch
-            {
-                Oracle.JJDisputedCountRoPDismissed.UNKNOWN => DomainModel.JJDisputedCountRoPDismissed.UNKNOWN,
-                Oracle.JJDisputedCountRoPDismissed.Y => DomainModel.JJDisputedCountRoPDismissed.Y,
-                Oracle.JJDisputedCountRoPDismissed.N => DomainModel.JJDisputedCountRoPDismissed.N,
-                _ => DomainModel.JJDisputedCountRoPDismissed.UNKNOWN
-            };
-        }
-
-        public Oracle.JJDisputedCountRoPDismissed Convert(DomainModel.JJDisputedCountRoPDismissed source, Oracle.JJDisputedCountRoPDismissed destination, AutoMapper.ResolutionContext context)
-        {
-            return source switch
-            {
-                DomainModel.JJDisputedCountRoPDismissed.UNKNOWN => Oracle.JJDisputedCountRoPDismissed.UNKNOWN,
-                DomainModel.JJDisputedCountRoPDismissed.Y => Oracle.JJDisputedCountRoPDismissed.Y,
-                DomainModel.JJDisputedCountRoPDismissed.N => Oracle.JJDisputedCountRoPDismissed.N,
-                _ => Oracle.JJDisputedCountRoPDismissed.UNKNOWN
-            };
-        }
-
-        public DomainModel.JJDisputedCountRoPForWantOfProsecution Convert(Oracle.JJDisputedCountRoPForWantOfProsecution source, DomainModel.JJDisputedCountRoPForWantOfProsecution destination, AutoMapper.ResolutionContext context)
-        {
-            return source switch
-            {
-                Oracle.JJDisputedCountRoPForWantOfProsecution.UNKNOWN => DomainModel.JJDisputedCountRoPForWantOfProsecution.UNKNOWN,
-                Oracle.JJDisputedCountRoPForWantOfProsecution.Y => DomainModel.JJDisputedCountRoPForWantOfProsecution.Y,
-                Oracle.JJDisputedCountRoPForWantOfProsecution.N => DomainModel.JJDisputedCountRoPForWantOfProsecution.N,
-                _ => DomainModel.JJDisputedCountRoPForWantOfProsecution.UNKNOWN
-            };
-        }
-
-        public Oracle.JJDisputedCountRoPForWantOfProsecution Convert(DomainModel.JJDisputedCountRoPForWantOfProsecution source, Oracle.JJDisputedCountRoPForWantOfProsecution destination, AutoMapper.ResolutionContext context)
-        {
-            return source switch
-            {
-                DomainModel.JJDisputedCountRoPForWantOfProsecution.UNKNOWN => Oracle.JJDisputedCountRoPForWantOfProsecution.UNKNOWN,
-                DomainModel.JJDisputedCountRoPForWantOfProsecution.Y => Oracle.JJDisputedCountRoPForWantOfProsecution.Y,
-                DomainModel.JJDisputedCountRoPForWantOfProsecution.N => Oracle.JJDisputedCountRoPForWantOfProsecution.N,
-                _ => Oracle.JJDisputedCountRoPForWantOfProsecution.UNKNOWN
-            };
-        }
-
-        public DomainModel.JJDisputedCountRoPJailIntermittent Convert(Oracle.JJDisputedCountRoPJailIntermittent source, DomainModel.JJDisputedCountRoPJailIntermittent destination, AutoMapper.ResolutionContext context)
-        {
-            return source switch
-            {
-                Oracle.JJDisputedCountRoPJailIntermittent.UNKNOWN => DomainModel.JJDisputedCountRoPJailIntermittent.UNKNOWN,
-                Oracle.JJDisputedCountRoPJailIntermittent.Y => DomainModel.JJDisputedCountRoPJailIntermittent.Y,
-                Oracle.JJDisputedCountRoPJailIntermittent.N => DomainModel.JJDisputedCountRoPJailIntermittent.N,
-                _ => DomainModel.JJDisputedCountRoPJailIntermittent.UNKNOWN
-            };
-        }
-
-        public Oracle.JJDisputedCountRoPJailIntermittent Convert(DomainModel.JJDisputedCountRoPJailIntermittent source, Oracle.JJDisputedCountRoPJailIntermittent destination, AutoMapper.ResolutionContext context)
-        {
-            return source switch
-            {
-                DomainModel.JJDisputedCountRoPJailIntermittent.UNKNOWN => Oracle.JJDisputedCountRoPJailIntermittent.UNKNOWN,
-                DomainModel.JJDisputedCountRoPJailIntermittent.Y => Oracle.JJDisputedCountRoPJailIntermittent.Y,
-                DomainModel.JJDisputedCountRoPJailIntermittent.N => Oracle.JJDisputedCountRoPJailIntermittent.N,
-                _ => Oracle.JJDisputedCountRoPJailIntermittent.UNKNOWN
-            };
-        }
-
-        public DomainModel.JJDisputedCountRoPWithdrawn Convert(Oracle.JJDisputedCountRoPWithdrawn source, DomainModel.JJDisputedCountRoPWithdrawn destination, AutoMapper.ResolutionContext context)
-        {
-            return source switch
-            {
-                Oracle.JJDisputedCountRoPWithdrawn.UNKNOWN => DomainModel.JJDisputedCountRoPWithdrawn.UNKNOWN,
-                Oracle.JJDisputedCountRoPWithdrawn.Y => DomainModel.JJDisputedCountRoPWithdrawn.Y,
-                Oracle.JJDisputedCountRoPWithdrawn.N => DomainModel.JJDisputedCountRoPWithdrawn.N,
-                _ => DomainModel.JJDisputedCountRoPWithdrawn.UNKNOWN
-            };
-        }
-
-        public Oracle.JJDisputedCountRoPWithdrawn Convert(DomainModel.JJDisputedCountRoPWithdrawn source, Oracle.JJDisputedCountRoPWithdrawn destination, AutoMapper.ResolutionContext context)
-        {
-            return source switch
-            {
-                DomainModel.JJDisputedCountRoPWithdrawn.UNKNOWN => Oracle.JJDisputedCountRoPWithdrawn.UNKNOWN,
-                DomainModel.JJDisputedCountRoPWithdrawn.Y => Oracle.JJDisputedCountRoPWithdrawn.Y,
-                DomainModel.JJDisputedCountRoPWithdrawn.N => Oracle.JJDisputedCountRoPWithdrawn.N,
-                _ => Oracle.JJDisputedCountRoPWithdrawn.UNKNOWN
-            };
-        }
-
-        public DomainModel.JJDisputeElectronicTicketYn Convert(Oracle.JJDisputeElectronicTicketYn source, DomainModel.JJDisputeElectronicTicketYn destination, AutoMapper.ResolutionContext context)
-        {
-            return source switch
-            {
-                Oracle.JJDisputeElectronicTicketYn.UNKNOWN => DomainModel.JJDisputeElectronicTicketYn.UNKNOWN,
-                Oracle.JJDisputeElectronicTicketYn.Y => DomainModel.JJDisputeElectronicTicketYn.Y,
-                Oracle.JJDisputeElectronicTicketYn.N => DomainModel.JJDisputeElectronicTicketYn.N,
-                _ => DomainModel.JJDisputeElectronicTicketYn.UNKNOWN
-            };
-        }
-
-        public Oracle.JJDisputeElectronicTicketYn Convert(DomainModel.JJDisputeElectronicTicketYn source, Oracle.JJDisputeElectronicTicketYn destination, AutoMapper.ResolutionContext context)
-        {
-            return source switch
-            {
-                DomainModel.JJDisputeElectronicTicketYn.UNKNOWN => Oracle.JJDisputeElectronicTicketYn.UNKNOWN,
-                DomainModel.JJDisputeElectronicTicketYn.Y => Oracle.JJDisputeElectronicTicketYn.Y,
-                DomainModel.JJDisputeElectronicTicketYn.N => Oracle.JJDisputeElectronicTicketYn.N,
-                _ => Oracle.JJDisputeElectronicTicketYn.UNKNOWN
-            };
-        }
-
-        public DomainModel.JJDisputeMultipleOfficersYn Convert(Oracle.JJDisputeMultipleOfficersYn source, DomainModel.JJDisputeMultipleOfficersYn destination, AutoMapper.ResolutionContext context)
-        {
-            return source switch
-            {
-                Oracle.JJDisputeMultipleOfficersYn.UNKNOWN => DomainModel.JJDisputeMultipleOfficersYn.UNKNOWN,
-                Oracle.JJDisputeMultipleOfficersYn.Y => DomainModel.JJDisputeMultipleOfficersYn.Y,
-                Oracle.JJDisputeMultipleOfficersYn.N => DomainModel.JJDisputeMultipleOfficersYn.N,
-                _ => DomainModel.JJDisputeMultipleOfficersYn.UNKNOWN
-            };
-        }
-
-        public Oracle.JJDisputeMultipleOfficersYn Convert(DomainModel.JJDisputeMultipleOfficersYn source, Oracle.JJDisputeMultipleOfficersYn destination, AutoMapper.ResolutionContext context)
-        {
-            return source switch
-            {
-                DomainModel.JJDisputeMultipleOfficersYn.UNKNOWN => Oracle.JJDisputeMultipleOfficersYn.UNKNOWN,
-                DomainModel.JJDisputeMultipleOfficersYn.Y => Oracle.JJDisputeMultipleOfficersYn.Y,
-                DomainModel.JJDisputeMultipleOfficersYn.N => Oracle.JJDisputeMultipleOfficersYn.N,
-                _ => Oracle.JJDisputeMultipleOfficersYn.UNKNOWN
-            };
-        }
-
-        public DomainModel.JJDisputeNoticeOfHearingYn Convert(Oracle.JJDisputeNoticeOfHearingYn source, DomainModel.JJDisputeNoticeOfHearingYn destination, AutoMapper.ResolutionContext context)
-        {
-            return source switch
-            {
-                Oracle.JJDisputeNoticeOfHearingYn.UNKNOWN => DomainModel.JJDisputeNoticeOfHearingYn.UNKNOWN,
-                Oracle.JJDisputeNoticeOfHearingYn.Y => DomainModel.JJDisputeNoticeOfHearingYn.Y,
-                Oracle.JJDisputeNoticeOfHearingYn.N => DomainModel.JJDisputeNoticeOfHearingYn.N,
-                _ => DomainModel.JJDisputeNoticeOfHearingYn.UNKNOWN
-            };
-        }
-
-        public Oracle.JJDisputeNoticeOfHearingYn Convert(DomainModel.JJDisputeNoticeOfHearingYn source, Oracle.JJDisputeNoticeOfHearingYn destination, AutoMapper.ResolutionContext context)
-        {
-            return source switch
-            {
-                DomainModel.JJDisputeNoticeOfHearingYn.UNKNOWN => Oracle.JJDisputeNoticeOfHearingYn.UNKNOWN,
-                DomainModel.JJDisputeNoticeOfHearingYn.Y => Oracle.JJDisputeNoticeOfHearingYn.Y,
-                DomainModel.JJDisputeNoticeOfHearingYn.N => Oracle.JJDisputeNoticeOfHearingYn.N,
-                _ => Oracle.JJDisputeNoticeOfHearingYn.UNKNOWN
-            };
-        }
-
-        public DomainModel.ViolationTicketCountIsAct Convert(Oracle.ViolationTicketCountIsAct source, DomainModel.ViolationTicketCountIsAct destination, AutoMapper.ResolutionContext context)
-        {
-            return source switch
-            {
-                Oracle.ViolationTicketCountIsAct.UNKNOWN => DomainModel.ViolationTicketCountIsAct.UNKNOWN,
-                Oracle.ViolationTicketCountIsAct.Y => DomainModel.ViolationTicketCountIsAct.Y,
-                Oracle.ViolationTicketCountIsAct.N => DomainModel.ViolationTicketCountIsAct.N,
-                _ => DomainModel.ViolationTicketCountIsAct.UNKNOWN
-            };
-        }
-
-        public Oracle.ViolationTicketCountIsAct Convert(DomainModel.ViolationTicketCountIsAct source, Oracle.ViolationTicketCountIsAct destination, AutoMapper.ResolutionContext context)
-        {
-            return source switch
-            {
-                DomainModel.ViolationTicketCountIsAct.UNKNOWN => Oracle.ViolationTicketCountIsAct.UNKNOWN,
-                DomainModel.ViolationTicketCountIsAct.Y => Oracle.ViolationTicketCountIsAct.Y,
-                DomainModel.ViolationTicketCountIsAct.N => Oracle.ViolationTicketCountIsAct.N,
-                _ => Oracle.ViolationTicketCountIsAct.UNKNOWN
-            };
-        }
-
-        public DomainModel.ViolationTicketCountIsRegulation Convert(Oracle.ViolationTicketCountIsRegulation source, DomainModel.ViolationTicketCountIsRegulation destination, AutoMapper.ResolutionContext context)
-        {
-            return source switch
-            {
-                Oracle.ViolationTicketCountIsRegulation.UNKNOWN => DomainModel.ViolationTicketCountIsRegulation.UNKNOWN,
-                Oracle.ViolationTicketCountIsRegulation.Y => DomainModel.ViolationTicketCountIsRegulation.Y,
-                Oracle.ViolationTicketCountIsRegulation.N => DomainModel.ViolationTicketCountIsRegulation.N,
-                _ => DomainModel.ViolationTicketCountIsRegulation.UNKNOWN
-            };
-        }
-
-        public Oracle.ViolationTicketCountIsRegulation Convert(DomainModel.ViolationTicketCountIsRegulation source, Oracle.ViolationTicketCountIsRegulation destination, AutoMapper.ResolutionContext context)
-        {
-            return source switch
-            {
-                DomainModel.ViolationTicketCountIsRegulation.UNKNOWN => Oracle.ViolationTicketCountIsRegulation.UNKNOWN,
-                DomainModel.ViolationTicketCountIsRegulation.Y => Oracle.ViolationTicketCountIsRegulation.Y,
-                DomainModel.ViolationTicketCountIsRegulation.N => Oracle.ViolationTicketCountIsRegulation.N,
-                _ => Oracle.ViolationTicketCountIsRegulation.UNKNOWN
-            };
-        }
-
-        public DomainModel.ViolationTicketIsChangeOfAddress Convert(Oracle.ViolationTicketIsChangeOfAddress source, DomainModel.ViolationTicketIsChangeOfAddress destination, AutoMapper.ResolutionContext context)
-        {
-            return source switch
-            {
-                Oracle.ViolationTicketIsChangeOfAddress.UNKNOWN => DomainModel.ViolationTicketIsChangeOfAddress.UNKNOWN,
-                Oracle.ViolationTicketIsChangeOfAddress.Y => DomainModel.ViolationTicketIsChangeOfAddress.Y,
-                Oracle.ViolationTicketIsChangeOfAddress.N => DomainModel.ViolationTicketIsChangeOfAddress.N,
-                _ => DomainModel.ViolationTicketIsChangeOfAddress.UNKNOWN
-            };
-        }
-
-        public Oracle.ViolationTicketIsChangeOfAddress Convert(DomainModel.ViolationTicketIsChangeOfAddress source, Oracle.ViolationTicketIsChangeOfAddress destination, AutoMapper.ResolutionContext context)
-        {
-            return source switch
-            {
-                DomainModel.ViolationTicketIsChangeOfAddress.UNKNOWN => Oracle.ViolationTicketIsChangeOfAddress.UNKNOWN,
-                DomainModel.ViolationTicketIsChangeOfAddress.Y => Oracle.ViolationTicketIsChangeOfAddress.Y,
-                DomainModel.ViolationTicketIsChangeOfAddress.N => Oracle.ViolationTicketIsChangeOfAddress.N,
-                _ => Oracle.ViolationTicketIsChangeOfAddress.UNKNOWN
-            };
-        }
-
-        public DomainModel.ViolationTicketIsDriver Convert(Oracle.ViolationTicketIsDriver source, DomainModel.ViolationTicketIsDriver destination, AutoMapper.ResolutionContext context)
-        {
-            return source switch
-            {
-                Oracle.ViolationTicketIsDriver.UNKNOWN => DomainModel.ViolationTicketIsDriver.UNKNOWN,
-                Oracle.ViolationTicketIsDriver.Y => DomainModel.ViolationTicketIsDriver.Y,
-                Oracle.ViolationTicketIsDriver.N => DomainModel.ViolationTicketIsDriver.N,
-                _ => DomainModel.ViolationTicketIsDriver.UNKNOWN
-            };
-        }
-
-        public Oracle.ViolationTicketIsDriver Convert(DomainModel.ViolationTicketIsDriver source, Oracle.ViolationTicketIsDriver destination, AutoMapper.ResolutionContext context)
-        {
-            return source switch
-            {
-                DomainModel.ViolationTicketIsDriver.UNKNOWN => Oracle.ViolationTicketIsDriver.UNKNOWN,
-                DomainModel.ViolationTicketIsDriver.Y => Oracle.ViolationTicketIsDriver.Y,
-                DomainModel.ViolationTicketIsDriver.N => Oracle.ViolationTicketIsDriver.N,
-                _ => Oracle.ViolationTicketIsDriver.UNKNOWN
-            };
-        }
-
-        public DomainModel.ViolationTicketIsOwner Convert(Oracle.ViolationTicketIsOwner source, DomainModel.ViolationTicketIsOwner destination, AutoMapper.ResolutionContext context)
-        {
-            return source switch
-            {
-                Oracle.ViolationTicketIsOwner.UNKNOWN => DomainModel.ViolationTicketIsOwner.UNKNOWN,
-                Oracle.ViolationTicketIsOwner.Y => DomainModel.ViolationTicketIsOwner.Y,
-                Oracle.ViolationTicketIsOwner.N => DomainModel.ViolationTicketIsOwner.N,
-                _ => DomainModel.ViolationTicketIsOwner.UNKNOWN
-            };
-        }
-
-        public Oracle.ViolationTicketIsOwner Convert(DomainModel.ViolationTicketIsOwner source, Oracle.ViolationTicketIsOwner destination, AutoMapper.ResolutionContext context)
-        {
-            return source switch
-            {
-                DomainModel.ViolationTicketIsOwner.UNKNOWN => Oracle.ViolationTicketIsOwner.UNKNOWN,
-                DomainModel.ViolationTicketIsOwner.Y => Oracle.ViolationTicketIsOwner.Y,
-                DomainModel.ViolationTicketIsOwner.N => Oracle.ViolationTicketIsOwner.N,
-                _ => Oracle.ViolationTicketIsOwner.UNKNOWN
-            };
-        }
-
-        public DomainModel.ViolationTicketIsYoungPerson Convert(Oracle.ViolationTicketIsYoungPerson source, DomainModel.ViolationTicketIsYoungPerson destination, AutoMapper.ResolutionContext context)
-        {
-            return source switch
-            {
-                Oracle.ViolationTicketIsYoungPerson.UNKNOWN => DomainModel.ViolationTicketIsYoungPerson.UNKNOWN,
-                Oracle.ViolationTicketIsYoungPerson.Y => DomainModel.ViolationTicketIsYoungPerson.Y,
-                Oracle.ViolationTicketIsYoungPerson.N => DomainModel.ViolationTicketIsYoungPerson.N,
-                _ => DomainModel.ViolationTicketIsYoungPerson.UNKNOWN
-            };
-        }
-
-        public Oracle.ViolationTicketIsYoungPerson Convert(DomainModel.ViolationTicketIsYoungPerson source, Oracle.ViolationTicketIsYoungPerson destination, AutoMapper.ResolutionContext context)
-        {
-            return source switch
-            {
-                DomainModel.ViolationTicketIsYoungPerson.UNKNOWN => Oracle.ViolationTicketIsYoungPerson.UNKNOWN,
-                DomainModel.ViolationTicketIsYoungPerson.Y => Oracle.ViolationTicketIsYoungPerson.Y,
-                DomainModel.ViolationTicketIsYoungPerson.N => Oracle.ViolationTicketIsYoungPerson.N,
-                _ => Oracle.ViolationTicketIsYoungPerson.UNKNOWN
-            };
-        }
-
-    }
 }
 
+[System.CodeDom.Compiler.GeneratedCode("DomainModelMappingTestGenerator.generate_mapper", "")]
+internal class EnumTypeConverter :
+    // Oracle to Domain Model
+    AutoMapper.ITypeConverter<Oracle.DisputeContactTypeCd, DomainModel.DisputeContactTypeCd>,
+    AutoMapper.ITypeConverter<Oracle.DisputeCountPleaCode, DomainModel.DisputeCountPleaCode>,
+    AutoMapper.ITypeConverter<Oracle.DisputeListItemJjDisputeStatus, DomainModel.DisputeListItemJjDisputeStatus>,
+    AutoMapper.ITypeConverter<Oracle.DisputeListItemStatus, DomainModel.DisputeListItemStatus>,
+    AutoMapper.ITypeConverter<Oracle.DisputeResultDisputeStatus, DomainModel.DisputeResultDisputeStatus>,
+    AutoMapper.ITypeConverter<Oracle.DisputeResultJjDisputeHearingType, DomainModel.DisputeResultJjDisputeHearingType>,
+    AutoMapper.ITypeConverter<Oracle.DisputeResultJjDisputeStatus, DomainModel.DisputeResultJjDisputeStatus>,
+    AutoMapper.ITypeConverter<Oracle.DisputeSignatoryType, DomainModel.DisputeSignatoryType>,
+    AutoMapper.ITypeConverter<Oracle.DisputeStatus, DomainModel.DisputeStatus>,
+    AutoMapper.ITypeConverter<Oracle.DisputeUpdateRequestStatus, DomainModel.DisputeUpdateRequestStatus>,
+    AutoMapper.ITypeConverter<Oracle.DisputeUpdateRequestStatus2, DomainModel.DisputeUpdateRequestStatus2>,
+    AutoMapper.ITypeConverter<Oracle.DisputeUpdateRequestUpdateType, DomainModel.DisputeUpdateRequestUpdateType>,
+    AutoMapper.ITypeConverter<Oracle.DocumentType, DomainModel.DocumentType>,
+    AutoMapper.ITypeConverter<Oracle.ExcludeStatus, DomainModel.ExcludeStatus>,
+    AutoMapper.ITypeConverter<Oracle.ExcludeStatus2, DomainModel.ExcludeStatus2>,
+    AutoMapper.ITypeConverter<Oracle.FileHistoryAuditLogEntryType, DomainModel.FileHistoryAuditLogEntryType>,
+    AutoMapper.ITypeConverter<Oracle.JJDisputeContactType, DomainModel.JJDisputeContactType>,
+    AutoMapper.ITypeConverter<Oracle.JJDisputeCourtAppearanceRoPAppCd, DomainModel.JJDisputeCourtAppearanceRoPAppCd>,
+    AutoMapper.ITypeConverter<Oracle.JJDisputeCourtAppearanceRoPCrown, DomainModel.JJDisputeCourtAppearanceRoPCrown>,
+    AutoMapper.ITypeConverter<Oracle.JJDisputeCourtAppearanceRoPDattCd, DomainModel.JJDisputeCourtAppearanceRoPDattCd>,
+    AutoMapper.ITypeConverter<Oracle.JJDisputedCountLatestPlea, DomainModel.JJDisputedCountLatestPlea>,
+    AutoMapper.ITypeConverter<Oracle.JJDisputedCountPlea, DomainModel.JJDisputedCountPlea>,
+    AutoMapper.ITypeConverter<Oracle.JJDisputedCountRoPFinding, DomainModel.JJDisputedCountRoPFinding>,
+    AutoMapper.ITypeConverter<Oracle.JJDisputeDisputantAttendanceType, DomainModel.JJDisputeDisputantAttendanceType>,
+    AutoMapper.ITypeConverter<Oracle.JJDisputeHearingType, DomainModel.JJDisputeHearingType>,
+    AutoMapper.ITypeConverter<Oracle.JJDisputeSignatoryType, DomainModel.JJDisputeSignatoryType>,
+    AutoMapper.ITypeConverter<Oracle.JJDisputeStatus, DomainModel.JJDisputeStatus>,
+    AutoMapper.ITypeConverter<Oracle.Status, DomainModel.Status>,
+    AutoMapper.ITypeConverter<Oracle.TicketImageDataJustinDocumentReportType, DomainModel.TicketImageDataJustinDocumentReportType>,
+    // Oracle to Domain Model (Unknown, Yes or No)
+    AutoMapper.ITypeConverter<Oracle.DisputeAppearanceLessThan14DaysYn, DomainModel.DisputeAppearanceLessThan14DaysYn>,
+    AutoMapper.ITypeConverter<Oracle.DisputeCountRequestCourtAppearance, DomainModel.DisputeCountRequestCourtAppearance>,
+    AutoMapper.ITypeConverter<Oracle.DisputeCountRequestReduction, DomainModel.DisputeCountRequestReduction>,
+    AutoMapper.ITypeConverter<Oracle.DisputeCountRequestTimeToPay, DomainModel.DisputeCountRequestTimeToPay>,
+    AutoMapper.ITypeConverter<Oracle.DisputeDisputantDetectedOcrIssues, DomainModel.DisputeDisputantDetectedOcrIssues>,
+    AutoMapper.ITypeConverter<Oracle.DisputeInterpreterRequired, DomainModel.DisputeInterpreterRequired>,
+    AutoMapper.ITypeConverter<Oracle.DisputeListItemDisputantDetectedOcrIssues, DomainModel.DisputeListItemDisputantDetectedOcrIssues>,
+    AutoMapper.ITypeConverter<Oracle.DisputeListItemRequestCourtAppearanceYn, DomainModel.DisputeListItemRequestCourtAppearanceYn>,
+    AutoMapper.ITypeConverter<Oracle.DisputeListItemSystemDetectedOcrIssues, DomainModel.DisputeListItemSystemDetectedOcrIssues>,
+    AutoMapper.ITypeConverter<Oracle.DisputeRepresentedByLawyer, DomainModel.DisputeRepresentedByLawyer>,
+    AutoMapper.ITypeConverter<Oracle.DisputeRequestCourtAppearanceYn, DomainModel.DisputeRequestCourtAppearanceYn>,
+    AutoMapper.ITypeConverter<Oracle.DisputeSystemDetectedOcrIssues, DomainModel.DisputeSystemDetectedOcrIssues>,
+    AutoMapper.ITypeConverter<Oracle.EmailHistorySuccessfullySent, DomainModel.EmailHistorySuccessfullySent>,
+    AutoMapper.ITypeConverter<Oracle.JJDisputeAccidentYn, DomainModel.JJDisputeAccidentYn>,
+    AutoMapper.ITypeConverter<Oracle.JJDisputeAppearInCourt, DomainModel.JJDisputeAppearInCourt>,
+    AutoMapper.ITypeConverter<Oracle.JJDisputeCourtAppearanceRoPJjSeized, DomainModel.JJDisputeCourtAppearanceRoPJjSeized>,
+    AutoMapper.ITypeConverter<Oracle.JJDisputedCountAppearInCourt, DomainModel.JJDisputedCountAppearInCourt>,
+    AutoMapper.ITypeConverter<Oracle.JJDisputedCountIncludesSurcharge, DomainModel.JJDisputedCountIncludesSurcharge>,
+    AutoMapper.ITypeConverter<Oracle.JJDisputedCountRequestReduction, DomainModel.JJDisputedCountRequestReduction>,
+    AutoMapper.ITypeConverter<Oracle.JJDisputedCountRequestTimeToPay, DomainModel.JJDisputedCountRequestTimeToPay>,
+    AutoMapper.ITypeConverter<Oracle.JJDisputedCountRoPAbatement, DomainModel.JJDisputedCountRoPAbatement>,
+    AutoMapper.ITypeConverter<Oracle.JJDisputedCountRoPDismissed, DomainModel.JJDisputedCountRoPDismissed>,
+    AutoMapper.ITypeConverter<Oracle.JJDisputedCountRoPForWantOfProsecution, DomainModel.JJDisputedCountRoPForWantOfProsecution>,
+    AutoMapper.ITypeConverter<Oracle.JJDisputedCountRoPJailIntermittent, DomainModel.JJDisputedCountRoPJailIntermittent>,
+    AutoMapper.ITypeConverter<Oracle.JJDisputedCountRoPWithdrawn, DomainModel.JJDisputedCountRoPWithdrawn>,
+    AutoMapper.ITypeConverter<Oracle.JJDisputeElectronicTicketYn, DomainModel.JJDisputeElectronicTicketYn>,
+    AutoMapper.ITypeConverter<Oracle.JJDisputeMultipleOfficersYn, DomainModel.JJDisputeMultipleOfficersYn>,
+    AutoMapper.ITypeConverter<Oracle.JJDisputeNoticeOfHearingYn, DomainModel.JJDisputeNoticeOfHearingYn>,
+    AutoMapper.ITypeConverter<Oracle.ViolationTicketCountIsAct, DomainModel.ViolationTicketCountIsAct>,
+    AutoMapper.ITypeConverter<Oracle.ViolationTicketCountIsRegulation, DomainModel.ViolationTicketCountIsRegulation>,
+    AutoMapper.ITypeConverter<Oracle.ViolationTicketIsChangeOfAddress, DomainModel.ViolationTicketIsChangeOfAddress>,
+    AutoMapper.ITypeConverter<Oracle.ViolationTicketIsDriver, DomainModel.ViolationTicketIsDriver>,
+    AutoMapper.ITypeConverter<Oracle.ViolationTicketIsOwner, DomainModel.ViolationTicketIsOwner>,
+    AutoMapper.ITypeConverter<Oracle.ViolationTicketIsYoungPerson, DomainModel.ViolationTicketIsYoungPerson>,
+    // Domain Model to Oracle
+    AutoMapper.ITypeConverter<DomainModel.DisputeContactTypeCd, Oracle.DisputeContactTypeCd>,
+    AutoMapper.ITypeConverter<DomainModel.DisputeCountPleaCode, Oracle.DisputeCountPleaCode>,
+    AutoMapper.ITypeConverter<DomainModel.DisputeListItemJjDisputeStatus, Oracle.DisputeListItemJjDisputeStatus>,
+    AutoMapper.ITypeConverter<DomainModel.DisputeListItemStatus, Oracle.DisputeListItemStatus>,
+    AutoMapper.ITypeConverter<DomainModel.DisputeResultDisputeStatus, Oracle.DisputeResultDisputeStatus>,
+    AutoMapper.ITypeConverter<DomainModel.DisputeResultJjDisputeHearingType, Oracle.DisputeResultJjDisputeHearingType>,
+    AutoMapper.ITypeConverter<DomainModel.DisputeResultJjDisputeStatus, Oracle.DisputeResultJjDisputeStatus>,
+    AutoMapper.ITypeConverter<DomainModel.DisputeSignatoryType, Oracle.DisputeSignatoryType>,
+    AutoMapper.ITypeConverter<DomainModel.DisputeStatus, Oracle.DisputeStatus>,
+    AutoMapper.ITypeConverter<DomainModel.DisputeUpdateRequestStatus, Oracle.DisputeUpdateRequestStatus>,
+    AutoMapper.ITypeConverter<DomainModel.DisputeUpdateRequestStatus2, Oracle.DisputeUpdateRequestStatus2>,
+    AutoMapper.ITypeConverter<DomainModel.DisputeUpdateRequestUpdateType, Oracle.DisputeUpdateRequestUpdateType>,
+    AutoMapper.ITypeConverter<DomainModel.DocumentType, Oracle.DocumentType>,
+    AutoMapper.ITypeConverter<DomainModel.ExcludeStatus, Oracle.ExcludeStatus>,
+    AutoMapper.ITypeConverter<DomainModel.ExcludeStatus2, Oracle.ExcludeStatus2>,
+    AutoMapper.ITypeConverter<DomainModel.FileHistoryAuditLogEntryType, Oracle.FileHistoryAuditLogEntryType>,
+    AutoMapper.ITypeConverter<DomainModel.JJDisputeContactType, Oracle.JJDisputeContactType>,
+    AutoMapper.ITypeConverter<DomainModel.JJDisputeCourtAppearanceRoPAppCd, Oracle.JJDisputeCourtAppearanceRoPAppCd>,
+    AutoMapper.ITypeConverter<DomainModel.JJDisputeCourtAppearanceRoPCrown, Oracle.JJDisputeCourtAppearanceRoPCrown>,
+    AutoMapper.ITypeConverter<DomainModel.JJDisputeCourtAppearanceRoPDattCd, Oracle.JJDisputeCourtAppearanceRoPDattCd>,
+    AutoMapper.ITypeConverter<DomainModel.JJDisputedCountLatestPlea, Oracle.JJDisputedCountLatestPlea>,
+    AutoMapper.ITypeConverter<DomainModel.JJDisputedCountPlea, Oracle.JJDisputedCountPlea>,
+    AutoMapper.ITypeConverter<DomainModel.JJDisputedCountRoPFinding, Oracle.JJDisputedCountRoPFinding>,
+    AutoMapper.ITypeConverter<DomainModel.JJDisputeDisputantAttendanceType, Oracle.JJDisputeDisputantAttendanceType>,
+    AutoMapper.ITypeConverter<DomainModel.JJDisputeHearingType, Oracle.JJDisputeHearingType>,
+    AutoMapper.ITypeConverter<DomainModel.JJDisputeSignatoryType, Oracle.JJDisputeSignatoryType>,
+    AutoMapper.ITypeConverter<DomainModel.JJDisputeStatus, Oracle.JJDisputeStatus>,
+    AutoMapper.ITypeConverter<DomainModel.Status, Oracle.Status>,
+    AutoMapper.ITypeConverter<DomainModel.TicketImageDataJustinDocumentReportType, Oracle.TicketImageDataJustinDocumentReportType>,
+    // Domain Model to Oracle (Unknown, Yes or No)
+    AutoMapper.ITypeConverter<DomainModel.DisputeAppearanceLessThan14DaysYn, Oracle.DisputeAppearanceLessThan14DaysYn>,
+    AutoMapper.ITypeConverter<DomainModel.DisputeCountRequestCourtAppearance, Oracle.DisputeCountRequestCourtAppearance>,
+    AutoMapper.ITypeConverter<DomainModel.DisputeCountRequestReduction, Oracle.DisputeCountRequestReduction>,
+    AutoMapper.ITypeConverter<DomainModel.DisputeCountRequestTimeToPay, Oracle.DisputeCountRequestTimeToPay>,
+    AutoMapper.ITypeConverter<DomainModel.DisputeDisputantDetectedOcrIssues, Oracle.DisputeDisputantDetectedOcrIssues>,
+    AutoMapper.ITypeConverter<DomainModel.DisputeInterpreterRequired, Oracle.DisputeInterpreterRequired>,
+    AutoMapper.ITypeConverter<DomainModel.DisputeListItemDisputantDetectedOcrIssues, Oracle.DisputeListItemDisputantDetectedOcrIssues>,
+    AutoMapper.ITypeConverter<DomainModel.DisputeListItemRequestCourtAppearanceYn, Oracle.DisputeListItemRequestCourtAppearanceYn>,
+    AutoMapper.ITypeConverter<DomainModel.DisputeListItemSystemDetectedOcrIssues, Oracle.DisputeListItemSystemDetectedOcrIssues>,
+    AutoMapper.ITypeConverter<DomainModel.DisputeRepresentedByLawyer, Oracle.DisputeRepresentedByLawyer>,
+    AutoMapper.ITypeConverter<DomainModel.DisputeRequestCourtAppearanceYn, Oracle.DisputeRequestCourtAppearanceYn>,
+    AutoMapper.ITypeConverter<DomainModel.DisputeSystemDetectedOcrIssues, Oracle.DisputeSystemDetectedOcrIssues>,
+    AutoMapper.ITypeConverter<DomainModel.EmailHistorySuccessfullySent, Oracle.EmailHistorySuccessfullySent>,
+    AutoMapper.ITypeConverter<DomainModel.JJDisputeAccidentYn, Oracle.JJDisputeAccidentYn>,
+    AutoMapper.ITypeConverter<DomainModel.JJDisputeAppearInCourt, Oracle.JJDisputeAppearInCourt>,
+    AutoMapper.ITypeConverter<DomainModel.JJDisputeCourtAppearanceRoPJjSeized, Oracle.JJDisputeCourtAppearanceRoPJjSeized>,
+    AutoMapper.ITypeConverter<DomainModel.JJDisputedCountAppearInCourt, Oracle.JJDisputedCountAppearInCourt>,
+    AutoMapper.ITypeConverter<DomainModel.JJDisputedCountIncludesSurcharge, Oracle.JJDisputedCountIncludesSurcharge>,
+    AutoMapper.ITypeConverter<DomainModel.JJDisputedCountRequestReduction, Oracle.JJDisputedCountRequestReduction>,
+    AutoMapper.ITypeConverter<DomainModel.JJDisputedCountRequestTimeToPay, Oracle.JJDisputedCountRequestTimeToPay>,
+    AutoMapper.ITypeConverter<DomainModel.JJDisputedCountRoPAbatement, Oracle.JJDisputedCountRoPAbatement>,
+    AutoMapper.ITypeConverter<DomainModel.JJDisputedCountRoPDismissed, Oracle.JJDisputedCountRoPDismissed>,
+    AutoMapper.ITypeConverter<DomainModel.JJDisputedCountRoPForWantOfProsecution, Oracle.JJDisputedCountRoPForWantOfProsecution>,
+    AutoMapper.ITypeConverter<DomainModel.JJDisputedCountRoPJailIntermittent, Oracle.JJDisputedCountRoPJailIntermittent>,
+    AutoMapper.ITypeConverter<DomainModel.JJDisputedCountRoPWithdrawn, Oracle.JJDisputedCountRoPWithdrawn>,
+    AutoMapper.ITypeConverter<DomainModel.JJDisputeElectronicTicketYn, Oracle.JJDisputeElectronicTicketYn>,
+    AutoMapper.ITypeConverter<DomainModel.JJDisputeMultipleOfficersYn, Oracle.JJDisputeMultipleOfficersYn>,
+    AutoMapper.ITypeConverter<DomainModel.JJDisputeNoticeOfHearingYn, Oracle.JJDisputeNoticeOfHearingYn>,
+    AutoMapper.ITypeConverter<DomainModel.ViolationTicketCountIsAct, Oracle.ViolationTicketCountIsAct>,
+    AutoMapper.ITypeConverter<DomainModel.ViolationTicketCountIsRegulation, Oracle.ViolationTicketCountIsRegulation>,
+    AutoMapper.ITypeConverter<DomainModel.ViolationTicketIsChangeOfAddress, Oracle.ViolationTicketIsChangeOfAddress>,
+    AutoMapper.ITypeConverter<DomainModel.ViolationTicketIsDriver, Oracle.ViolationTicketIsDriver>,
+    AutoMapper.ITypeConverter<DomainModel.ViolationTicketIsOwner, Oracle.ViolationTicketIsOwner>,
+    AutoMapper.ITypeConverter<DomainModel.ViolationTicketIsYoungPerson, Oracle.ViolationTicketIsYoungPerson>
+{
+    public DomainModel.DisputeContactTypeCd Convert(Oracle.DisputeContactTypeCd source, DomainModel.DisputeContactTypeCd destination, AutoMapper.ResolutionContext context)
+    {
+        return source switch
+        {
+            Oracle.DisputeContactTypeCd.UNKNOWN => DomainModel.DisputeContactTypeCd.UNKNOWN,
+            Oracle.DisputeContactTypeCd.INDIVIDUAL => DomainModel.DisputeContactTypeCd.INDIVIDUAL,
+            Oracle.DisputeContactTypeCd.LAWYER => DomainModel.DisputeContactTypeCd.LAWYER,
+            Oracle.DisputeContactTypeCd.OTHER => DomainModel.DisputeContactTypeCd.OTHER,
+            _ => DomainModel.DisputeContactTypeCd.UNKNOWN
+        };
+    }
+
+    public Oracle.DisputeContactTypeCd Convert(DomainModel.DisputeContactTypeCd source, Oracle.DisputeContactTypeCd destination, AutoMapper.ResolutionContext context)
+    {
+        return source switch
+        {
+            DomainModel.DisputeContactTypeCd.UNKNOWN => Oracle.DisputeContactTypeCd.UNKNOWN,
+            DomainModel.DisputeContactTypeCd.INDIVIDUAL => Oracle.DisputeContactTypeCd.INDIVIDUAL,
+            DomainModel.DisputeContactTypeCd.LAWYER => Oracle.DisputeContactTypeCd.LAWYER,
+            DomainModel.DisputeContactTypeCd.OTHER => Oracle.DisputeContactTypeCd.OTHER,
+            _ => Oracle.DisputeContactTypeCd.UNKNOWN
+        };
+    }
+
+    public DomainModel.DisputeCountPleaCode Convert(Oracle.DisputeCountPleaCode source, DomainModel.DisputeCountPleaCode destination, AutoMapper.ResolutionContext context)
+    {
+        return source switch
+        {
+            Oracle.DisputeCountPleaCode.UNKNOWN => DomainModel.DisputeCountPleaCode.UNKNOWN,
+            Oracle.DisputeCountPleaCode.G => DomainModel.DisputeCountPleaCode.G,
+            Oracle.DisputeCountPleaCode.N => DomainModel.DisputeCountPleaCode.N,
+            _ => DomainModel.DisputeCountPleaCode.UNKNOWN
+        };
+    }
+
+    public Oracle.DisputeCountPleaCode Convert(DomainModel.DisputeCountPleaCode source, Oracle.DisputeCountPleaCode destination, AutoMapper.ResolutionContext context)
+    {
+        return source switch
+        {
+            DomainModel.DisputeCountPleaCode.UNKNOWN => Oracle.DisputeCountPleaCode.UNKNOWN,
+            DomainModel.DisputeCountPleaCode.G => Oracle.DisputeCountPleaCode.G,
+            DomainModel.DisputeCountPleaCode.N => Oracle.DisputeCountPleaCode.N,
+            _ => Oracle.DisputeCountPleaCode.UNKNOWN
+        };
+    }
+
+    public DomainModel.DisputeListItemJjDisputeStatus Convert(Oracle.DisputeListItemJjDisputeStatus source, DomainModel.DisputeListItemJjDisputeStatus destination, AutoMapper.ResolutionContext context)
+    {
+        return source switch
+        {
+            Oracle.DisputeListItemJjDisputeStatus.UNKNOWN => DomainModel.DisputeListItemJjDisputeStatus.UNKNOWN,
+            Oracle.DisputeListItemJjDisputeStatus.NEW => DomainModel.DisputeListItemJjDisputeStatus.NEW,
+            Oracle.DisputeListItemJjDisputeStatus.IN_PROGRESS => DomainModel.DisputeListItemJjDisputeStatus.IN_PROGRESS,
+            Oracle.DisputeListItemJjDisputeStatus.DATA_UPDATE => DomainModel.DisputeListItemJjDisputeStatus.DATA_UPDATE,
+            Oracle.DisputeListItemJjDisputeStatus.CONFIRMED => DomainModel.DisputeListItemJjDisputeStatus.CONFIRMED,
+            Oracle.DisputeListItemJjDisputeStatus.REQUIRE_COURT_HEARING => DomainModel.DisputeListItemJjDisputeStatus.REQUIRE_COURT_HEARING,
+            Oracle.DisputeListItemJjDisputeStatus.REQUIRE_MORE_INFO => DomainModel.DisputeListItemJjDisputeStatus.REQUIRE_MORE_INFO,
+            Oracle.DisputeListItemJjDisputeStatus.ACCEPTED => DomainModel.DisputeListItemJjDisputeStatus.ACCEPTED,
+            Oracle.DisputeListItemJjDisputeStatus.REVIEW => DomainModel.DisputeListItemJjDisputeStatus.REVIEW,
+            Oracle.DisputeListItemJjDisputeStatus.CONCLUDED => DomainModel.DisputeListItemJjDisputeStatus.CONCLUDED,
+            Oracle.DisputeListItemJjDisputeStatus.CANCELLED => DomainModel.DisputeListItemJjDisputeStatus.CANCELLED,
+            Oracle.DisputeListItemJjDisputeStatus.HEARING_SCHEDULED => DomainModel.DisputeListItemJjDisputeStatus.HEARING_SCHEDULED,
+            _ => DomainModel.DisputeListItemJjDisputeStatus.UNKNOWN
+        };
+    }
+
+    public Oracle.DisputeListItemJjDisputeStatus Convert(DomainModel.DisputeListItemJjDisputeStatus source, Oracle.DisputeListItemJjDisputeStatus destination, AutoMapper.ResolutionContext context)
+    {
+        return source switch
+        {
+            DomainModel.DisputeListItemJjDisputeStatus.UNKNOWN => Oracle.DisputeListItemJjDisputeStatus.UNKNOWN,
+            DomainModel.DisputeListItemJjDisputeStatus.NEW => Oracle.DisputeListItemJjDisputeStatus.NEW,
+            DomainModel.DisputeListItemJjDisputeStatus.IN_PROGRESS => Oracle.DisputeListItemJjDisputeStatus.IN_PROGRESS,
+            DomainModel.DisputeListItemJjDisputeStatus.DATA_UPDATE => Oracle.DisputeListItemJjDisputeStatus.DATA_UPDATE,
+            DomainModel.DisputeListItemJjDisputeStatus.CONFIRMED => Oracle.DisputeListItemJjDisputeStatus.CONFIRMED,
+            DomainModel.DisputeListItemJjDisputeStatus.REQUIRE_COURT_HEARING => Oracle.DisputeListItemJjDisputeStatus.REQUIRE_COURT_HEARING,
+            DomainModel.DisputeListItemJjDisputeStatus.REQUIRE_MORE_INFO => Oracle.DisputeListItemJjDisputeStatus.REQUIRE_MORE_INFO,
+            DomainModel.DisputeListItemJjDisputeStatus.ACCEPTED => Oracle.DisputeListItemJjDisputeStatus.ACCEPTED,
+            DomainModel.DisputeListItemJjDisputeStatus.REVIEW => Oracle.DisputeListItemJjDisputeStatus.REVIEW,
+            DomainModel.DisputeListItemJjDisputeStatus.CONCLUDED => Oracle.DisputeListItemJjDisputeStatus.CONCLUDED,
+            DomainModel.DisputeListItemJjDisputeStatus.CANCELLED => Oracle.DisputeListItemJjDisputeStatus.CANCELLED,
+            DomainModel.DisputeListItemJjDisputeStatus.HEARING_SCHEDULED => Oracle.DisputeListItemJjDisputeStatus.HEARING_SCHEDULED,
+            _ => Oracle.DisputeListItemJjDisputeStatus.UNKNOWN
+        };
+    }
+
+    public DomainModel.DisputeListItemStatus Convert(Oracle.DisputeListItemStatus source, DomainModel.DisputeListItemStatus destination, AutoMapper.ResolutionContext context)
+    {
+        return source switch
+        {
+            Oracle.DisputeListItemStatus.UNKNOWN => DomainModel.DisputeListItemStatus.UNKNOWN,
+            Oracle.DisputeListItemStatus.NEW => DomainModel.DisputeListItemStatus.NEW,
+            Oracle.DisputeListItemStatus.VALIDATED => DomainModel.DisputeListItemStatus.VALIDATED,
+            Oracle.DisputeListItemStatus.PROCESSING => DomainModel.DisputeListItemStatus.PROCESSING,
+            Oracle.DisputeListItemStatus.REJECTED => DomainModel.DisputeListItemStatus.REJECTED,
+            Oracle.DisputeListItemStatus.CANCELLED => DomainModel.DisputeListItemStatus.CANCELLED,
+            Oracle.DisputeListItemStatus.CONCLUDED => DomainModel.DisputeListItemStatus.CONCLUDED,
+            _ => DomainModel.DisputeListItemStatus.UNKNOWN
+        };
+    }
+
+    public Oracle.DisputeListItemStatus Convert(DomainModel.DisputeListItemStatus source, Oracle.DisputeListItemStatus destination, AutoMapper.ResolutionContext context)
+    {
+        return source switch
+        {
+            DomainModel.DisputeListItemStatus.UNKNOWN => Oracle.DisputeListItemStatus.UNKNOWN,
+            DomainModel.DisputeListItemStatus.NEW => Oracle.DisputeListItemStatus.NEW,
+            DomainModel.DisputeListItemStatus.VALIDATED => Oracle.DisputeListItemStatus.VALIDATED,
+            DomainModel.DisputeListItemStatus.PROCESSING => Oracle.DisputeListItemStatus.PROCESSING,
+            DomainModel.DisputeListItemStatus.REJECTED => Oracle.DisputeListItemStatus.REJECTED,
+            DomainModel.DisputeListItemStatus.CANCELLED => Oracle.DisputeListItemStatus.CANCELLED,
+            DomainModel.DisputeListItemStatus.CONCLUDED => Oracle.DisputeListItemStatus.CONCLUDED,
+            _ => Oracle.DisputeListItemStatus.UNKNOWN
+        };
+    }
+
+    public DomainModel.DisputeResultDisputeStatus Convert(Oracle.DisputeResultDisputeStatus source, DomainModel.DisputeResultDisputeStatus destination, AutoMapper.ResolutionContext context)
+    {
+        return source switch
+        {
+            Oracle.DisputeResultDisputeStatus.UNKNOWN => DomainModel.DisputeResultDisputeStatus.UNKNOWN,
+            Oracle.DisputeResultDisputeStatus.NEW => DomainModel.DisputeResultDisputeStatus.NEW,
+            Oracle.DisputeResultDisputeStatus.VALIDATED => DomainModel.DisputeResultDisputeStatus.VALIDATED,
+            Oracle.DisputeResultDisputeStatus.PROCESSING => DomainModel.DisputeResultDisputeStatus.PROCESSING,
+            Oracle.DisputeResultDisputeStatus.REJECTED => DomainModel.DisputeResultDisputeStatus.REJECTED,
+            Oracle.DisputeResultDisputeStatus.CANCELLED => DomainModel.DisputeResultDisputeStatus.CANCELLED,
+            Oracle.DisputeResultDisputeStatus.CONCLUDED => DomainModel.DisputeResultDisputeStatus.CONCLUDED,
+            _ => DomainModel.DisputeResultDisputeStatus.UNKNOWN
+        };
+    }
+
+    public Oracle.DisputeResultDisputeStatus Convert(DomainModel.DisputeResultDisputeStatus source, Oracle.DisputeResultDisputeStatus destination, AutoMapper.ResolutionContext context)
+    {
+        return source switch
+        {
+            DomainModel.DisputeResultDisputeStatus.UNKNOWN => Oracle.DisputeResultDisputeStatus.UNKNOWN,
+            DomainModel.DisputeResultDisputeStatus.NEW => Oracle.DisputeResultDisputeStatus.NEW,
+            DomainModel.DisputeResultDisputeStatus.VALIDATED => Oracle.DisputeResultDisputeStatus.VALIDATED,
+            DomainModel.DisputeResultDisputeStatus.PROCESSING => Oracle.DisputeResultDisputeStatus.PROCESSING,
+            DomainModel.DisputeResultDisputeStatus.REJECTED => Oracle.DisputeResultDisputeStatus.REJECTED,
+            DomainModel.DisputeResultDisputeStatus.CANCELLED => Oracle.DisputeResultDisputeStatus.CANCELLED,
+            DomainModel.DisputeResultDisputeStatus.CONCLUDED => Oracle.DisputeResultDisputeStatus.CONCLUDED,
+            _ => Oracle.DisputeResultDisputeStatus.UNKNOWN
+        };
+    }
+
+    public DomainModel.DisputeResultJjDisputeHearingType Convert(Oracle.DisputeResultJjDisputeHearingType source, DomainModel.DisputeResultJjDisputeHearingType destination, AutoMapper.ResolutionContext context)
+    {
+        return source switch
+        {
+            Oracle.DisputeResultJjDisputeHearingType.UNKNOWN => DomainModel.DisputeResultJjDisputeHearingType.UNKNOWN,
+            Oracle.DisputeResultJjDisputeHearingType.COURT_APPEARANCE => DomainModel.DisputeResultJjDisputeHearingType.COURT_APPEARANCE,
+            Oracle.DisputeResultJjDisputeHearingType.WRITTEN_REASONS => DomainModel.DisputeResultJjDisputeHearingType.WRITTEN_REASONS,
+            _ => DomainModel.DisputeResultJjDisputeHearingType.UNKNOWN
+        };
+    }
+
+    public Oracle.DisputeResultJjDisputeHearingType Convert(DomainModel.DisputeResultJjDisputeHearingType source, Oracle.DisputeResultJjDisputeHearingType destination, AutoMapper.ResolutionContext context)
+    {
+        return source switch
+        {
+            DomainModel.DisputeResultJjDisputeHearingType.UNKNOWN => Oracle.DisputeResultJjDisputeHearingType.UNKNOWN,
+            DomainModel.DisputeResultJjDisputeHearingType.COURT_APPEARANCE => Oracle.DisputeResultJjDisputeHearingType.COURT_APPEARANCE,
+            DomainModel.DisputeResultJjDisputeHearingType.WRITTEN_REASONS => Oracle.DisputeResultJjDisputeHearingType.WRITTEN_REASONS,
+            _ => Oracle.DisputeResultJjDisputeHearingType.UNKNOWN
+        };
+    }
+
+    public DomainModel.DisputeResultJjDisputeStatus Convert(Oracle.DisputeResultJjDisputeStatus source, DomainModel.DisputeResultJjDisputeStatus destination, AutoMapper.ResolutionContext context)
+    {
+        return source switch
+        {
+            Oracle.DisputeResultJjDisputeStatus.UNKNOWN => DomainModel.DisputeResultJjDisputeStatus.UNKNOWN,
+            Oracle.DisputeResultJjDisputeStatus.NEW => DomainModel.DisputeResultJjDisputeStatus.NEW,
+            Oracle.DisputeResultJjDisputeStatus.IN_PROGRESS => DomainModel.DisputeResultJjDisputeStatus.IN_PROGRESS,
+            Oracle.DisputeResultJjDisputeStatus.DATA_UPDATE => DomainModel.DisputeResultJjDisputeStatus.DATA_UPDATE,
+            Oracle.DisputeResultJjDisputeStatus.CONFIRMED => DomainModel.DisputeResultJjDisputeStatus.CONFIRMED,
+            Oracle.DisputeResultJjDisputeStatus.REQUIRE_COURT_HEARING => DomainModel.DisputeResultJjDisputeStatus.REQUIRE_COURT_HEARING,
+            Oracle.DisputeResultJjDisputeStatus.REQUIRE_MORE_INFO => DomainModel.DisputeResultJjDisputeStatus.REQUIRE_MORE_INFO,
+            Oracle.DisputeResultJjDisputeStatus.ACCEPTED => DomainModel.DisputeResultJjDisputeStatus.ACCEPTED,
+            Oracle.DisputeResultJjDisputeStatus.REVIEW => DomainModel.DisputeResultJjDisputeStatus.REVIEW,
+            Oracle.DisputeResultJjDisputeStatus.CONCLUDED => DomainModel.DisputeResultJjDisputeStatus.CONCLUDED,
+            Oracle.DisputeResultJjDisputeStatus.CANCELLED => DomainModel.DisputeResultJjDisputeStatus.CANCELLED,
+            Oracle.DisputeResultJjDisputeStatus.HEARING_SCHEDULED => DomainModel.DisputeResultJjDisputeStatus.HEARING_SCHEDULED,
+            _ => DomainModel.DisputeResultJjDisputeStatus.UNKNOWN
+        };
+    }
+
+    public Oracle.DisputeResultJjDisputeStatus Convert(DomainModel.DisputeResultJjDisputeStatus source, Oracle.DisputeResultJjDisputeStatus destination, AutoMapper.ResolutionContext context)
+    {
+        return source switch
+        {
+            DomainModel.DisputeResultJjDisputeStatus.UNKNOWN => Oracle.DisputeResultJjDisputeStatus.UNKNOWN,
+            DomainModel.DisputeResultJjDisputeStatus.NEW => Oracle.DisputeResultJjDisputeStatus.NEW,
+            DomainModel.DisputeResultJjDisputeStatus.IN_PROGRESS => Oracle.DisputeResultJjDisputeStatus.IN_PROGRESS,
+            DomainModel.DisputeResultJjDisputeStatus.DATA_UPDATE => Oracle.DisputeResultJjDisputeStatus.DATA_UPDATE,
+            DomainModel.DisputeResultJjDisputeStatus.CONFIRMED => Oracle.DisputeResultJjDisputeStatus.CONFIRMED,
+            DomainModel.DisputeResultJjDisputeStatus.REQUIRE_COURT_HEARING => Oracle.DisputeResultJjDisputeStatus.REQUIRE_COURT_HEARING,
+            DomainModel.DisputeResultJjDisputeStatus.REQUIRE_MORE_INFO => Oracle.DisputeResultJjDisputeStatus.REQUIRE_MORE_INFO,
+            DomainModel.DisputeResultJjDisputeStatus.ACCEPTED => Oracle.DisputeResultJjDisputeStatus.ACCEPTED,
+            DomainModel.DisputeResultJjDisputeStatus.REVIEW => Oracle.DisputeResultJjDisputeStatus.REVIEW,
+            DomainModel.DisputeResultJjDisputeStatus.CONCLUDED => Oracle.DisputeResultJjDisputeStatus.CONCLUDED,
+            DomainModel.DisputeResultJjDisputeStatus.CANCELLED => Oracle.DisputeResultJjDisputeStatus.CANCELLED,
+            DomainModel.DisputeResultJjDisputeStatus.HEARING_SCHEDULED => Oracle.DisputeResultJjDisputeStatus.HEARING_SCHEDULED,
+            _ => Oracle.DisputeResultJjDisputeStatus.UNKNOWN
+        };
+    }
+
+    public DomainModel.DisputeSignatoryType Convert(Oracle.DisputeSignatoryType source, DomainModel.DisputeSignatoryType destination, AutoMapper.ResolutionContext context)
+    {
+        return source switch
+        {
+            Oracle.DisputeSignatoryType.U => DomainModel.DisputeSignatoryType.U,
+            Oracle.DisputeSignatoryType.D => DomainModel.DisputeSignatoryType.D,
+            Oracle.DisputeSignatoryType.A => DomainModel.DisputeSignatoryType.A,
+            _ => DomainModel.DisputeSignatoryType.U
+        };
+    }
+
+    public Oracle.DisputeSignatoryType Convert(DomainModel.DisputeSignatoryType source, Oracle.DisputeSignatoryType destination, AutoMapper.ResolutionContext context)
+    {
+        return source switch
+        {
+            DomainModel.DisputeSignatoryType.U => Oracle.DisputeSignatoryType.U,
+            DomainModel.DisputeSignatoryType.D => Oracle.DisputeSignatoryType.D,
+            DomainModel.DisputeSignatoryType.A => Oracle.DisputeSignatoryType.A,
+            _ => Oracle.DisputeSignatoryType.U
+        };
+    }
+
+    public DomainModel.DisputeStatus Convert(Oracle.DisputeStatus source, DomainModel.DisputeStatus destination, AutoMapper.ResolutionContext context)
+    {
+        return source switch
+        {
+            Oracle.DisputeStatus.UNKNOWN => DomainModel.DisputeStatus.UNKNOWN,
+            Oracle.DisputeStatus.NEW => DomainModel.DisputeStatus.NEW,
+            Oracle.DisputeStatus.VALIDATED => DomainModel.DisputeStatus.VALIDATED,
+            Oracle.DisputeStatus.PROCESSING => DomainModel.DisputeStatus.PROCESSING,
+            Oracle.DisputeStatus.REJECTED => DomainModel.DisputeStatus.REJECTED,
+            Oracle.DisputeStatus.CANCELLED => DomainModel.DisputeStatus.CANCELLED,
+            Oracle.DisputeStatus.CONCLUDED => DomainModel.DisputeStatus.CONCLUDED,
+            _ => DomainModel.DisputeStatus.UNKNOWN
+        };
+    }
+
+    public Oracle.DisputeStatus Convert(DomainModel.DisputeStatus source, Oracle.DisputeStatus destination, AutoMapper.ResolutionContext context)
+    {
+        return source switch
+        {
+            DomainModel.DisputeStatus.UNKNOWN => Oracle.DisputeStatus.UNKNOWN,
+            DomainModel.DisputeStatus.NEW => Oracle.DisputeStatus.NEW,
+            DomainModel.DisputeStatus.VALIDATED => Oracle.DisputeStatus.VALIDATED,
+            DomainModel.DisputeStatus.PROCESSING => Oracle.DisputeStatus.PROCESSING,
+            DomainModel.DisputeStatus.REJECTED => Oracle.DisputeStatus.REJECTED,
+            DomainModel.DisputeStatus.CANCELLED => Oracle.DisputeStatus.CANCELLED,
+            DomainModel.DisputeStatus.CONCLUDED => Oracle.DisputeStatus.CONCLUDED,
+            _ => Oracle.DisputeStatus.UNKNOWN
+        };
+    }
+
+    public DomainModel.DisputeUpdateRequestStatus Convert(Oracle.DisputeUpdateRequestStatus source, DomainModel.DisputeUpdateRequestStatus destination, AutoMapper.ResolutionContext context)
+    {
+        return source switch
+        {
+            Oracle.DisputeUpdateRequestStatus.UNKNOWN => DomainModel.DisputeUpdateRequestStatus.UNKNOWN,
+            Oracle.DisputeUpdateRequestStatus.ACCEPTED => DomainModel.DisputeUpdateRequestStatus.ACCEPTED,
+            Oracle.DisputeUpdateRequestStatus.PENDING => DomainModel.DisputeUpdateRequestStatus.PENDING,
+            Oracle.DisputeUpdateRequestStatus.REJECTED => DomainModel.DisputeUpdateRequestStatus.REJECTED,
+            _ => DomainModel.DisputeUpdateRequestStatus.UNKNOWN
+        };
+    }
+
+    public Oracle.DisputeUpdateRequestStatus Convert(DomainModel.DisputeUpdateRequestStatus source, Oracle.DisputeUpdateRequestStatus destination, AutoMapper.ResolutionContext context)
+    {
+        return source switch
+        {
+            DomainModel.DisputeUpdateRequestStatus.UNKNOWN => Oracle.DisputeUpdateRequestStatus.UNKNOWN,
+            DomainModel.DisputeUpdateRequestStatus.ACCEPTED => Oracle.DisputeUpdateRequestStatus.ACCEPTED,
+            DomainModel.DisputeUpdateRequestStatus.PENDING => Oracle.DisputeUpdateRequestStatus.PENDING,
+            DomainModel.DisputeUpdateRequestStatus.REJECTED => Oracle.DisputeUpdateRequestStatus.REJECTED,
+            _ => Oracle.DisputeUpdateRequestStatus.UNKNOWN
+        };
+    }
+
+    public DomainModel.DisputeUpdateRequestStatus2 Convert(Oracle.DisputeUpdateRequestStatus2 source, DomainModel.DisputeUpdateRequestStatus2 destination, AutoMapper.ResolutionContext context)
+    {
+        return source switch
+        {
+            Oracle.DisputeUpdateRequestStatus2.UNKNOWN => DomainModel.DisputeUpdateRequestStatus2.UNKNOWN,
+            Oracle.DisputeUpdateRequestStatus2.ACCEPTED => DomainModel.DisputeUpdateRequestStatus2.ACCEPTED,
+            Oracle.DisputeUpdateRequestStatus2.PENDING => DomainModel.DisputeUpdateRequestStatus2.PENDING,
+            Oracle.DisputeUpdateRequestStatus2.REJECTED => DomainModel.DisputeUpdateRequestStatus2.REJECTED,
+            _ => DomainModel.DisputeUpdateRequestStatus2.UNKNOWN
+        };
+    }
+
+    public Oracle.DisputeUpdateRequestStatus2 Convert(DomainModel.DisputeUpdateRequestStatus2 source, Oracle.DisputeUpdateRequestStatus2 destination, AutoMapper.ResolutionContext context)
+    {
+        return source switch
+        {
+            DomainModel.DisputeUpdateRequestStatus2.UNKNOWN => Oracle.DisputeUpdateRequestStatus2.UNKNOWN,
+            DomainModel.DisputeUpdateRequestStatus2.ACCEPTED => Oracle.DisputeUpdateRequestStatus2.ACCEPTED,
+            DomainModel.DisputeUpdateRequestStatus2.PENDING => Oracle.DisputeUpdateRequestStatus2.PENDING,
+            DomainModel.DisputeUpdateRequestStatus2.REJECTED => Oracle.DisputeUpdateRequestStatus2.REJECTED,
+            _ => Oracle.DisputeUpdateRequestStatus2.UNKNOWN
+        };
+    }
+
+    public DomainModel.DisputeUpdateRequestUpdateType Convert(Oracle.DisputeUpdateRequestUpdateType source, DomainModel.DisputeUpdateRequestUpdateType destination, AutoMapper.ResolutionContext context)
+    {
+        return source switch
+        {
+            Oracle.DisputeUpdateRequestUpdateType.UNKNOWN => DomainModel.DisputeUpdateRequestUpdateType.UNKNOWN,
+            Oracle.DisputeUpdateRequestUpdateType.DISPUTANT_ADDRESS => DomainModel.DisputeUpdateRequestUpdateType.DISPUTANT_ADDRESS,
+            Oracle.DisputeUpdateRequestUpdateType.DISPUTANT_PHONE => DomainModel.DisputeUpdateRequestUpdateType.DISPUTANT_PHONE,
+            Oracle.DisputeUpdateRequestUpdateType.DISPUTANT_NAME => DomainModel.DisputeUpdateRequestUpdateType.DISPUTANT_NAME,
+            Oracle.DisputeUpdateRequestUpdateType.COUNT => DomainModel.DisputeUpdateRequestUpdateType.COUNT,
+            Oracle.DisputeUpdateRequestUpdateType.DISPUTANT_EMAIL => DomainModel.DisputeUpdateRequestUpdateType.DISPUTANT_EMAIL,
+            Oracle.DisputeUpdateRequestUpdateType.DISPUTANT_DOCUMENT => DomainModel.DisputeUpdateRequestUpdateType.DISPUTANT_DOCUMENT,
+            Oracle.DisputeUpdateRequestUpdateType.COURT_OPTIONS => DomainModel.DisputeUpdateRequestUpdateType.COURT_OPTIONS,
+            _ => DomainModel.DisputeUpdateRequestUpdateType.UNKNOWN
+        };
+    }
+
+    public Oracle.DisputeUpdateRequestUpdateType Convert(DomainModel.DisputeUpdateRequestUpdateType source, Oracle.DisputeUpdateRequestUpdateType destination, AutoMapper.ResolutionContext context)
+    {
+        return source switch
+        {
+            DomainModel.DisputeUpdateRequestUpdateType.UNKNOWN => Oracle.DisputeUpdateRequestUpdateType.UNKNOWN,
+            DomainModel.DisputeUpdateRequestUpdateType.DISPUTANT_ADDRESS => Oracle.DisputeUpdateRequestUpdateType.DISPUTANT_ADDRESS,
+            DomainModel.DisputeUpdateRequestUpdateType.DISPUTANT_PHONE => Oracle.DisputeUpdateRequestUpdateType.DISPUTANT_PHONE,
+            DomainModel.DisputeUpdateRequestUpdateType.DISPUTANT_NAME => Oracle.DisputeUpdateRequestUpdateType.DISPUTANT_NAME,
+            DomainModel.DisputeUpdateRequestUpdateType.COUNT => Oracle.DisputeUpdateRequestUpdateType.COUNT,
+            DomainModel.DisputeUpdateRequestUpdateType.DISPUTANT_EMAIL => Oracle.DisputeUpdateRequestUpdateType.DISPUTANT_EMAIL,
+            DomainModel.DisputeUpdateRequestUpdateType.DISPUTANT_DOCUMENT => Oracle.DisputeUpdateRequestUpdateType.DISPUTANT_DOCUMENT,
+            DomainModel.DisputeUpdateRequestUpdateType.COURT_OPTIONS => Oracle.DisputeUpdateRequestUpdateType.COURT_OPTIONS,
+            _ => Oracle.DisputeUpdateRequestUpdateType.UNKNOWN
+        };
+    }
+
+    public DomainModel.DocumentType Convert(Oracle.DocumentType source, DomainModel.DocumentType destination, AutoMapper.ResolutionContext context)
+    {
+        return source switch
+        {
+            Oracle.DocumentType.UNKNOWN => DomainModel.DocumentType.UNKNOWN,
+            Oracle.DocumentType.NOTICE_OF_DISPUTE => DomainModel.DocumentType.NOTICE_OF_DISPUTE,
+            Oracle.DocumentType.TICKET_IMAGE => DomainModel.DocumentType.TICKET_IMAGE,
+            _ => DomainModel.DocumentType.UNKNOWN
+        };
+    }
+
+    public Oracle.DocumentType Convert(DomainModel.DocumentType source, Oracle.DocumentType destination, AutoMapper.ResolutionContext context)
+    {
+        return source switch
+        {
+            DomainModel.DocumentType.UNKNOWN => Oracle.DocumentType.UNKNOWN,
+            DomainModel.DocumentType.NOTICE_OF_DISPUTE => Oracle.DocumentType.NOTICE_OF_DISPUTE,
+            DomainModel.DocumentType.TICKET_IMAGE => Oracle.DocumentType.TICKET_IMAGE,
+            _ => Oracle.DocumentType.UNKNOWN
+        };
+    }
+
+    public DomainModel.ExcludeStatus Convert(Oracle.ExcludeStatus source, DomainModel.ExcludeStatus destination, AutoMapper.ResolutionContext context)
+    {
+        return source switch
+        {
+            Oracle.ExcludeStatus.UNKNOWN => DomainModel.ExcludeStatus.UNKNOWN,
+            Oracle.ExcludeStatus.NEW => DomainModel.ExcludeStatus.NEW,
+            Oracle.ExcludeStatus.VALIDATED => DomainModel.ExcludeStatus.VALIDATED,
+            Oracle.ExcludeStatus.PROCESSING => DomainModel.ExcludeStatus.PROCESSING,
+            Oracle.ExcludeStatus.REJECTED => DomainModel.ExcludeStatus.REJECTED,
+            Oracle.ExcludeStatus.CANCELLED => DomainModel.ExcludeStatus.CANCELLED,
+            Oracle.ExcludeStatus.CONCLUDED => DomainModel.ExcludeStatus.CONCLUDED,
+            _ => DomainModel.ExcludeStatus.UNKNOWN
+        };
+    }
+
+    public Oracle.ExcludeStatus Convert(DomainModel.ExcludeStatus source, Oracle.ExcludeStatus destination, AutoMapper.ResolutionContext context)
+    {
+        return source switch
+        {
+            DomainModel.ExcludeStatus.UNKNOWN => Oracle.ExcludeStatus.UNKNOWN,
+            DomainModel.ExcludeStatus.NEW => Oracle.ExcludeStatus.NEW,
+            DomainModel.ExcludeStatus.VALIDATED => Oracle.ExcludeStatus.VALIDATED,
+            DomainModel.ExcludeStatus.PROCESSING => Oracle.ExcludeStatus.PROCESSING,
+            DomainModel.ExcludeStatus.REJECTED => Oracle.ExcludeStatus.REJECTED,
+            DomainModel.ExcludeStatus.CANCELLED => Oracle.ExcludeStatus.CANCELLED,
+            DomainModel.ExcludeStatus.CONCLUDED => Oracle.ExcludeStatus.CONCLUDED,
+            _ => Oracle.ExcludeStatus.UNKNOWN
+        };
+    }
+
+    public DomainModel.ExcludeStatus2 Convert(Oracle.ExcludeStatus2 source, DomainModel.ExcludeStatus2 destination, AutoMapper.ResolutionContext context)
+    {
+        return source switch
+        {
+            Oracle.ExcludeStatus2.UNKNOWN => DomainModel.ExcludeStatus2.UNKNOWN,
+            Oracle.ExcludeStatus2.NEW => DomainModel.ExcludeStatus2.NEW,
+            Oracle.ExcludeStatus2.VALIDATED => DomainModel.ExcludeStatus2.VALIDATED,
+            Oracle.ExcludeStatus2.PROCESSING => DomainModel.ExcludeStatus2.PROCESSING,
+            Oracle.ExcludeStatus2.REJECTED => DomainModel.ExcludeStatus2.REJECTED,
+            Oracle.ExcludeStatus2.CANCELLED => DomainModel.ExcludeStatus2.CANCELLED,
+            Oracle.ExcludeStatus2.CONCLUDED => DomainModel.ExcludeStatus2.CONCLUDED,
+            _ => DomainModel.ExcludeStatus2.UNKNOWN
+        };
+    }
+
+    public Oracle.ExcludeStatus2 Convert(DomainModel.ExcludeStatus2 source, Oracle.ExcludeStatus2 destination, AutoMapper.ResolutionContext context)
+    {
+        return source switch
+        {
+            DomainModel.ExcludeStatus2.UNKNOWN => Oracle.ExcludeStatus2.UNKNOWN,
+            DomainModel.ExcludeStatus2.NEW => Oracle.ExcludeStatus2.NEW,
+            DomainModel.ExcludeStatus2.VALIDATED => Oracle.ExcludeStatus2.VALIDATED,
+            DomainModel.ExcludeStatus2.PROCESSING => Oracle.ExcludeStatus2.PROCESSING,
+            DomainModel.ExcludeStatus2.REJECTED => Oracle.ExcludeStatus2.REJECTED,
+            DomainModel.ExcludeStatus2.CANCELLED => Oracle.ExcludeStatus2.CANCELLED,
+            DomainModel.ExcludeStatus2.CONCLUDED => Oracle.ExcludeStatus2.CONCLUDED,
+            _ => Oracle.ExcludeStatus2.UNKNOWN
+        };
+    }
+
+    public DomainModel.FileHistoryAuditLogEntryType Convert(Oracle.FileHistoryAuditLogEntryType source, DomainModel.FileHistoryAuditLogEntryType destination, AutoMapper.ResolutionContext context)
+    {
+        return source switch
+        {
+            Oracle.FileHistoryAuditLogEntryType.UNKNOWN => DomainModel.FileHistoryAuditLogEntryType.UNKNOWN,
+            Oracle.FileHistoryAuditLogEntryType.ARFL => DomainModel.FileHistoryAuditLogEntryType.ARFL,
+            Oracle.FileHistoryAuditLogEntryType.CAIN => DomainModel.FileHistoryAuditLogEntryType.CAIN,
+            Oracle.FileHistoryAuditLogEntryType.CAWT => DomainModel.FileHistoryAuditLogEntryType.CAWT,
+            Oracle.FileHistoryAuditLogEntryType.CCAN => DomainModel.FileHistoryAuditLogEntryType.CCAN,
+            Oracle.FileHistoryAuditLogEntryType.CCON => DomainModel.FileHistoryAuditLogEntryType.CCON,
+            Oracle.FileHistoryAuditLogEntryType.CCWR => DomainModel.FileHistoryAuditLogEntryType.CCWR,
+            Oracle.FileHistoryAuditLogEntryType.CLEG => DomainModel.FileHistoryAuditLogEntryType.CLEG,
+            Oracle.FileHistoryAuditLogEntryType.CUEM => DomainModel.FileHistoryAuditLogEntryType.CUEM,
+            Oracle.FileHistoryAuditLogEntryType.CUEV => DomainModel.FileHistoryAuditLogEntryType.CUEV,
+            Oracle.FileHistoryAuditLogEntryType.CUIN => DomainModel.FileHistoryAuditLogEntryType.CUIN,
+            Oracle.FileHistoryAuditLogEntryType.CULG => DomainModel.FileHistoryAuditLogEntryType.CULG,
+            Oracle.FileHistoryAuditLogEntryType.CUPD => DomainModel.FileHistoryAuditLogEntryType.CUPD,
+            Oracle.FileHistoryAuditLogEntryType.CUWR => DomainModel.FileHistoryAuditLogEntryType.CUWR,
+            Oracle.FileHistoryAuditLogEntryType.CUWT => DomainModel.FileHistoryAuditLogEntryType.CUWT,
+            Oracle.FileHistoryAuditLogEntryType.DURA => DomainModel.FileHistoryAuditLogEntryType.DURA,
+            Oracle.FileHistoryAuditLogEntryType.DURR => DomainModel.FileHistoryAuditLogEntryType.DURR,
+            Oracle.FileHistoryAuditLogEntryType.EMCA => DomainModel.FileHistoryAuditLogEntryType.EMCA,
+            Oracle.FileHistoryAuditLogEntryType.EMCF => DomainModel.FileHistoryAuditLogEntryType.EMCF,
+            Oracle.FileHistoryAuditLogEntryType.EMCR => DomainModel.FileHistoryAuditLogEntryType.EMCR,
+            Oracle.FileHistoryAuditLogEntryType.EMDC => DomainModel.FileHistoryAuditLogEntryType.EMDC,
+            Oracle.FileHistoryAuditLogEntryType.EMFD => DomainModel.FileHistoryAuditLogEntryType.EMFD,
+            Oracle.FileHistoryAuditLogEntryType.EMPR => DomainModel.FileHistoryAuditLogEntryType.EMPR,
+            Oracle.FileHistoryAuditLogEntryType.EMRJ => DomainModel.FileHistoryAuditLogEntryType.EMRJ,
+            Oracle.FileHistoryAuditLogEntryType.EMRV => DomainModel.FileHistoryAuditLogEntryType.EMRV,
+            Oracle.FileHistoryAuditLogEntryType.EMST => DomainModel.FileHistoryAuditLogEntryType.EMST,
+            Oracle.FileHistoryAuditLogEntryType.EMUP => DomainModel.FileHistoryAuditLogEntryType.EMUP,
+            Oracle.FileHistoryAuditLogEntryType.EMVF => DomainModel.FileHistoryAuditLogEntryType.EMVF,
+            Oracle.FileHistoryAuditLogEntryType.ESUR => DomainModel.FileHistoryAuditLogEntryType.ESUR,
+            Oracle.FileHistoryAuditLogEntryType.FDLD => DomainModel.FileHistoryAuditLogEntryType.FDLD,
+            Oracle.FileHistoryAuditLogEntryType.FDLS => DomainModel.FileHistoryAuditLogEntryType.FDLS,
+            Oracle.FileHistoryAuditLogEntryType.FUPD => DomainModel.FileHistoryAuditLogEntryType.FUPD,
+            Oracle.FileHistoryAuditLogEntryType.FUPS => DomainModel.FileHistoryAuditLogEntryType.FUPS,
+            Oracle.FileHistoryAuditLogEntryType.FRMK => DomainModel.FileHistoryAuditLogEntryType.FRMK,
+            Oracle.FileHistoryAuditLogEntryType.INIT => DomainModel.FileHistoryAuditLogEntryType.INIT,
+            Oracle.FileHistoryAuditLogEntryType.JASG => DomainModel.FileHistoryAuditLogEntryType.JASG,
+            Oracle.FileHistoryAuditLogEntryType.JCNF => DomainModel.FileHistoryAuditLogEntryType.JCNF,
+            Oracle.FileHistoryAuditLogEntryType.JDIV => DomainModel.FileHistoryAuditLogEntryType.JDIV,
+            Oracle.FileHistoryAuditLogEntryType.JPRG => DomainModel.FileHistoryAuditLogEntryType.JPRG,
+            Oracle.FileHistoryAuditLogEntryType.OCNT => DomainModel.FileHistoryAuditLogEntryType.OCNT,
+            Oracle.FileHistoryAuditLogEntryType.RCLD => DomainModel.FileHistoryAuditLogEntryType.RCLD,
+            Oracle.FileHistoryAuditLogEntryType.RECN => DomainModel.FileHistoryAuditLogEntryType.RECN,
+            Oracle.FileHistoryAuditLogEntryType.SADM => DomainModel.FileHistoryAuditLogEntryType.SADM,
+            Oracle.FileHistoryAuditLogEntryType.SCAN => DomainModel.FileHistoryAuditLogEntryType.SCAN,
+            Oracle.FileHistoryAuditLogEntryType.SPRC => DomainModel.FileHistoryAuditLogEntryType.SPRC,
+            Oracle.FileHistoryAuditLogEntryType.SREJ => DomainModel.FileHistoryAuditLogEntryType.SREJ,
+            Oracle.FileHistoryAuditLogEntryType.SUB => DomainModel.FileHistoryAuditLogEntryType.SUB,
+            Oracle.FileHistoryAuditLogEntryType.SUPL => DomainModel.FileHistoryAuditLogEntryType.SUPL,
+            Oracle.FileHistoryAuditLogEntryType.SVAL => DomainModel.FileHistoryAuditLogEntryType.SVAL,
+            Oracle.FileHistoryAuditLogEntryType.URSR => DomainModel.FileHistoryAuditLogEntryType.URSR,
+            Oracle.FileHistoryAuditLogEntryType.VREV => DomainModel.FileHistoryAuditLogEntryType.VREV,
+            Oracle.FileHistoryAuditLogEntryType.VSUB => DomainModel.FileHistoryAuditLogEntryType.VSUB,
+            _ => DomainModel.FileHistoryAuditLogEntryType.UNKNOWN
+        };
+    }
+
+    public Oracle.FileHistoryAuditLogEntryType Convert(DomainModel.FileHistoryAuditLogEntryType source, Oracle.FileHistoryAuditLogEntryType destination, AutoMapper.ResolutionContext context)
+    {
+        return source switch
+        {
+            DomainModel.FileHistoryAuditLogEntryType.UNKNOWN => Oracle.FileHistoryAuditLogEntryType.UNKNOWN,
+            DomainModel.FileHistoryAuditLogEntryType.ARFL => Oracle.FileHistoryAuditLogEntryType.ARFL,
+            DomainModel.FileHistoryAuditLogEntryType.CAIN => Oracle.FileHistoryAuditLogEntryType.CAIN,
+            DomainModel.FileHistoryAuditLogEntryType.CAWT => Oracle.FileHistoryAuditLogEntryType.CAWT,
+            DomainModel.FileHistoryAuditLogEntryType.CCAN => Oracle.FileHistoryAuditLogEntryType.CCAN,
+            DomainModel.FileHistoryAuditLogEntryType.CCON => Oracle.FileHistoryAuditLogEntryType.CCON,
+            DomainModel.FileHistoryAuditLogEntryType.CCWR => Oracle.FileHistoryAuditLogEntryType.CCWR,
+            DomainModel.FileHistoryAuditLogEntryType.CLEG => Oracle.FileHistoryAuditLogEntryType.CLEG,
+            DomainModel.FileHistoryAuditLogEntryType.CUEM => Oracle.FileHistoryAuditLogEntryType.CUEM,
+            DomainModel.FileHistoryAuditLogEntryType.CUEV => Oracle.FileHistoryAuditLogEntryType.CUEV,
+            DomainModel.FileHistoryAuditLogEntryType.CUIN => Oracle.FileHistoryAuditLogEntryType.CUIN,
+            DomainModel.FileHistoryAuditLogEntryType.CULG => Oracle.FileHistoryAuditLogEntryType.CULG,
+            DomainModel.FileHistoryAuditLogEntryType.CUPD => Oracle.FileHistoryAuditLogEntryType.CUPD,
+            DomainModel.FileHistoryAuditLogEntryType.CUWR => Oracle.FileHistoryAuditLogEntryType.CUWR,
+            DomainModel.FileHistoryAuditLogEntryType.CUWT => Oracle.FileHistoryAuditLogEntryType.CUWT,
+            DomainModel.FileHistoryAuditLogEntryType.DURA => Oracle.FileHistoryAuditLogEntryType.DURA,
+            DomainModel.FileHistoryAuditLogEntryType.DURR => Oracle.FileHistoryAuditLogEntryType.DURR,
+            DomainModel.FileHistoryAuditLogEntryType.EMCA => Oracle.FileHistoryAuditLogEntryType.EMCA,
+            DomainModel.FileHistoryAuditLogEntryType.EMCF => Oracle.FileHistoryAuditLogEntryType.EMCF,
+            DomainModel.FileHistoryAuditLogEntryType.EMCR => Oracle.FileHistoryAuditLogEntryType.EMCR,
+            DomainModel.FileHistoryAuditLogEntryType.EMDC => Oracle.FileHistoryAuditLogEntryType.EMDC,
+            DomainModel.FileHistoryAuditLogEntryType.EMFD => Oracle.FileHistoryAuditLogEntryType.EMFD,
+            DomainModel.FileHistoryAuditLogEntryType.EMPR => Oracle.FileHistoryAuditLogEntryType.EMPR,
+            DomainModel.FileHistoryAuditLogEntryType.EMRJ => Oracle.FileHistoryAuditLogEntryType.EMRJ,
+            DomainModel.FileHistoryAuditLogEntryType.EMRV => Oracle.FileHistoryAuditLogEntryType.EMRV,
+            DomainModel.FileHistoryAuditLogEntryType.EMST => Oracle.FileHistoryAuditLogEntryType.EMST,
+            DomainModel.FileHistoryAuditLogEntryType.EMUP => Oracle.FileHistoryAuditLogEntryType.EMUP,
+            DomainModel.FileHistoryAuditLogEntryType.EMVF => Oracle.FileHistoryAuditLogEntryType.EMVF,
+            DomainModel.FileHistoryAuditLogEntryType.ESUR => Oracle.FileHistoryAuditLogEntryType.ESUR,
+            DomainModel.FileHistoryAuditLogEntryType.FDLD => Oracle.FileHistoryAuditLogEntryType.FDLD,
+            DomainModel.FileHistoryAuditLogEntryType.FDLS => Oracle.FileHistoryAuditLogEntryType.FDLS,
+            DomainModel.FileHistoryAuditLogEntryType.FUPD => Oracle.FileHistoryAuditLogEntryType.FUPD,
+            DomainModel.FileHistoryAuditLogEntryType.FUPS => Oracle.FileHistoryAuditLogEntryType.FUPS,
+            DomainModel.FileHistoryAuditLogEntryType.FRMK => Oracle.FileHistoryAuditLogEntryType.FRMK,
+            DomainModel.FileHistoryAuditLogEntryType.INIT => Oracle.FileHistoryAuditLogEntryType.INIT,
+            DomainModel.FileHistoryAuditLogEntryType.JASG => Oracle.FileHistoryAuditLogEntryType.JASG,
+            DomainModel.FileHistoryAuditLogEntryType.JCNF => Oracle.FileHistoryAuditLogEntryType.JCNF,
+            DomainModel.FileHistoryAuditLogEntryType.JDIV => Oracle.FileHistoryAuditLogEntryType.JDIV,
+            DomainModel.FileHistoryAuditLogEntryType.JPRG => Oracle.FileHistoryAuditLogEntryType.JPRG,
+            DomainModel.FileHistoryAuditLogEntryType.OCNT => Oracle.FileHistoryAuditLogEntryType.OCNT,
+            DomainModel.FileHistoryAuditLogEntryType.RCLD => Oracle.FileHistoryAuditLogEntryType.RCLD,
+            DomainModel.FileHistoryAuditLogEntryType.RECN => Oracle.FileHistoryAuditLogEntryType.RECN,
+            DomainModel.FileHistoryAuditLogEntryType.SADM => Oracle.FileHistoryAuditLogEntryType.SADM,
+            DomainModel.FileHistoryAuditLogEntryType.SCAN => Oracle.FileHistoryAuditLogEntryType.SCAN,
+            DomainModel.FileHistoryAuditLogEntryType.SPRC => Oracle.FileHistoryAuditLogEntryType.SPRC,
+            DomainModel.FileHistoryAuditLogEntryType.SREJ => Oracle.FileHistoryAuditLogEntryType.SREJ,
+            DomainModel.FileHistoryAuditLogEntryType.SUB => Oracle.FileHistoryAuditLogEntryType.SUB,
+            DomainModel.FileHistoryAuditLogEntryType.SUPL => Oracle.FileHistoryAuditLogEntryType.SUPL,
+            DomainModel.FileHistoryAuditLogEntryType.SVAL => Oracle.FileHistoryAuditLogEntryType.SVAL,
+            DomainModel.FileHistoryAuditLogEntryType.URSR => Oracle.FileHistoryAuditLogEntryType.URSR,
+            DomainModel.FileHistoryAuditLogEntryType.VREV => Oracle.FileHistoryAuditLogEntryType.VREV,
+            DomainModel.FileHistoryAuditLogEntryType.VSUB => Oracle.FileHistoryAuditLogEntryType.VSUB,
+            _ => Oracle.FileHistoryAuditLogEntryType.UNKNOWN
+        };
+    }
+
+    public DomainModel.JJDisputeContactType Convert(Oracle.JJDisputeContactType source, DomainModel.JJDisputeContactType destination, AutoMapper.ResolutionContext context)
+    {
+        return source switch
+        {
+            Oracle.JJDisputeContactType.UNKNOWN => DomainModel.JJDisputeContactType.UNKNOWN,
+            Oracle.JJDisputeContactType.INDIVIDUAL => DomainModel.JJDisputeContactType.INDIVIDUAL,
+            Oracle.JJDisputeContactType.LAWYER => DomainModel.JJDisputeContactType.LAWYER,
+            Oracle.JJDisputeContactType.OTHER => DomainModel.JJDisputeContactType.OTHER,
+            _ => DomainModel.JJDisputeContactType.UNKNOWN
+        };
+    }
+
+    public Oracle.JJDisputeContactType Convert(DomainModel.JJDisputeContactType source, Oracle.JJDisputeContactType destination, AutoMapper.ResolutionContext context)
+    {
+        return source switch
+        {
+            DomainModel.JJDisputeContactType.UNKNOWN => Oracle.JJDisputeContactType.UNKNOWN,
+            DomainModel.JJDisputeContactType.INDIVIDUAL => Oracle.JJDisputeContactType.INDIVIDUAL,
+            DomainModel.JJDisputeContactType.LAWYER => Oracle.JJDisputeContactType.LAWYER,
+            DomainModel.JJDisputeContactType.OTHER => Oracle.JJDisputeContactType.OTHER,
+            _ => Oracle.JJDisputeContactType.UNKNOWN
+        };
+    }
+
+    public DomainModel.JJDisputeCourtAppearanceRoPAppCd Convert(Oracle.JJDisputeCourtAppearanceRoPAppCd source, DomainModel.JJDisputeCourtAppearanceRoPAppCd destination, AutoMapper.ResolutionContext context)
+    {
+        return source switch
+        {
+            Oracle.JJDisputeCourtAppearanceRoPAppCd.UNKNOWN => DomainModel.JJDisputeCourtAppearanceRoPAppCd.UNKNOWN,
+            Oracle.JJDisputeCourtAppearanceRoPAppCd.A => DomainModel.JJDisputeCourtAppearanceRoPAppCd.A,
+            Oracle.JJDisputeCourtAppearanceRoPAppCd.P => DomainModel.JJDisputeCourtAppearanceRoPAppCd.P,
+            Oracle.JJDisputeCourtAppearanceRoPAppCd.N => DomainModel.JJDisputeCourtAppearanceRoPAppCd.N,
+            _ => DomainModel.JJDisputeCourtAppearanceRoPAppCd.UNKNOWN
+        };
+    }
+
+    public Oracle.JJDisputeCourtAppearanceRoPAppCd Convert(DomainModel.JJDisputeCourtAppearanceRoPAppCd source, Oracle.JJDisputeCourtAppearanceRoPAppCd destination, AutoMapper.ResolutionContext context)
+    {
+        return source switch
+        {
+            DomainModel.JJDisputeCourtAppearanceRoPAppCd.UNKNOWN => Oracle.JJDisputeCourtAppearanceRoPAppCd.UNKNOWN,
+            DomainModel.JJDisputeCourtAppearanceRoPAppCd.A => Oracle.JJDisputeCourtAppearanceRoPAppCd.A,
+            DomainModel.JJDisputeCourtAppearanceRoPAppCd.P => Oracle.JJDisputeCourtAppearanceRoPAppCd.P,
+            DomainModel.JJDisputeCourtAppearanceRoPAppCd.N => Oracle.JJDisputeCourtAppearanceRoPAppCd.N,
+            _ => Oracle.JJDisputeCourtAppearanceRoPAppCd.UNKNOWN
+        };
+    }
+
+    public DomainModel.JJDisputeCourtAppearanceRoPCrown Convert(Oracle.JJDisputeCourtAppearanceRoPCrown source, DomainModel.JJDisputeCourtAppearanceRoPCrown destination, AutoMapper.ResolutionContext context)
+    {
+        return source switch
+        {
+            Oracle.JJDisputeCourtAppearanceRoPCrown.UNKNOWN => DomainModel.JJDisputeCourtAppearanceRoPCrown.UNKNOWN,
+            Oracle.JJDisputeCourtAppearanceRoPCrown.P => DomainModel.JJDisputeCourtAppearanceRoPCrown.P,
+            Oracle.JJDisputeCourtAppearanceRoPCrown.N => DomainModel.JJDisputeCourtAppearanceRoPCrown.N,
+            _ => DomainModel.JJDisputeCourtAppearanceRoPCrown.UNKNOWN
+        };
+    }
+
+    public Oracle.JJDisputeCourtAppearanceRoPCrown Convert(DomainModel.JJDisputeCourtAppearanceRoPCrown source, Oracle.JJDisputeCourtAppearanceRoPCrown destination, AutoMapper.ResolutionContext context)
+    {
+        return source switch
+        {
+            DomainModel.JJDisputeCourtAppearanceRoPCrown.UNKNOWN => Oracle.JJDisputeCourtAppearanceRoPCrown.UNKNOWN,
+            DomainModel.JJDisputeCourtAppearanceRoPCrown.P => Oracle.JJDisputeCourtAppearanceRoPCrown.P,
+            DomainModel.JJDisputeCourtAppearanceRoPCrown.N => Oracle.JJDisputeCourtAppearanceRoPCrown.N,
+            _ => Oracle.JJDisputeCourtAppearanceRoPCrown.UNKNOWN
+        };
+    }
+
+    public DomainModel.JJDisputeCourtAppearanceRoPDattCd Convert(Oracle.JJDisputeCourtAppearanceRoPDattCd source, DomainModel.JJDisputeCourtAppearanceRoPDattCd destination, AutoMapper.ResolutionContext context)
+    {
+        return source switch
+        {
+            Oracle.JJDisputeCourtAppearanceRoPDattCd.UNKNOWN => DomainModel.JJDisputeCourtAppearanceRoPDattCd.UNKNOWN,
+            Oracle.JJDisputeCourtAppearanceRoPDattCd.A => DomainModel.JJDisputeCourtAppearanceRoPDattCd.A,
+            Oracle.JJDisputeCourtAppearanceRoPDattCd.C => DomainModel.JJDisputeCourtAppearanceRoPDattCd.C,
+            Oracle.JJDisputeCourtAppearanceRoPDattCd.N => DomainModel.JJDisputeCourtAppearanceRoPDattCd.N,
+            _ => DomainModel.JJDisputeCourtAppearanceRoPDattCd.UNKNOWN
+        };
+    }
+
+    public Oracle.JJDisputeCourtAppearanceRoPDattCd Convert(DomainModel.JJDisputeCourtAppearanceRoPDattCd source, Oracle.JJDisputeCourtAppearanceRoPDattCd destination, AutoMapper.ResolutionContext context)
+    {
+        return source switch
+        {
+            DomainModel.JJDisputeCourtAppearanceRoPDattCd.UNKNOWN => Oracle.JJDisputeCourtAppearanceRoPDattCd.UNKNOWN,
+            DomainModel.JJDisputeCourtAppearanceRoPDattCd.A => Oracle.JJDisputeCourtAppearanceRoPDattCd.A,
+            DomainModel.JJDisputeCourtAppearanceRoPDattCd.C => Oracle.JJDisputeCourtAppearanceRoPDattCd.C,
+            DomainModel.JJDisputeCourtAppearanceRoPDattCd.N => Oracle.JJDisputeCourtAppearanceRoPDattCd.N,
+            _ => Oracle.JJDisputeCourtAppearanceRoPDattCd.UNKNOWN
+        };
+    }
+
+    public DomainModel.JJDisputedCountLatestPlea Convert(Oracle.JJDisputedCountLatestPlea source, DomainModel.JJDisputedCountLatestPlea destination, AutoMapper.ResolutionContext context)
+    {
+        return source switch
+        {
+            Oracle.JJDisputedCountLatestPlea.UNKNOWN => DomainModel.JJDisputedCountLatestPlea.UNKNOWN,
+            Oracle.JJDisputedCountLatestPlea.G => DomainModel.JJDisputedCountLatestPlea.G,
+            Oracle.JJDisputedCountLatestPlea.N => DomainModel.JJDisputedCountLatestPlea.N,
+            _ => DomainModel.JJDisputedCountLatestPlea.UNKNOWN
+        };
+    }
+
+    public Oracle.JJDisputedCountLatestPlea Convert(DomainModel.JJDisputedCountLatestPlea source, Oracle.JJDisputedCountLatestPlea destination, AutoMapper.ResolutionContext context)
+    {
+        return source switch
+        {
+            DomainModel.JJDisputedCountLatestPlea.UNKNOWN => Oracle.JJDisputedCountLatestPlea.UNKNOWN,
+            DomainModel.JJDisputedCountLatestPlea.G => Oracle.JJDisputedCountLatestPlea.G,
+            DomainModel.JJDisputedCountLatestPlea.N => Oracle.JJDisputedCountLatestPlea.N,
+            _ => Oracle.JJDisputedCountLatestPlea.UNKNOWN
+        };
+    }
+
+    public DomainModel.JJDisputedCountPlea Convert(Oracle.JJDisputedCountPlea source, DomainModel.JJDisputedCountPlea destination, AutoMapper.ResolutionContext context)
+    {
+        return source switch
+        {
+            Oracle.JJDisputedCountPlea.UNKNOWN => DomainModel.JJDisputedCountPlea.UNKNOWN,
+            Oracle.JJDisputedCountPlea.G => DomainModel.JJDisputedCountPlea.G,
+            Oracle.JJDisputedCountPlea.N => DomainModel.JJDisputedCountPlea.N,
+            _ => DomainModel.JJDisputedCountPlea.UNKNOWN
+        };
+    }
+
+    public Oracle.JJDisputedCountPlea Convert(DomainModel.JJDisputedCountPlea source, Oracle.JJDisputedCountPlea destination, AutoMapper.ResolutionContext context)
+    {
+        return source switch
+        {
+            DomainModel.JJDisputedCountPlea.UNKNOWN => Oracle.JJDisputedCountPlea.UNKNOWN,
+            DomainModel.JJDisputedCountPlea.G => Oracle.JJDisputedCountPlea.G,
+            DomainModel.JJDisputedCountPlea.N => Oracle.JJDisputedCountPlea.N,
+            _ => Oracle.JJDisputedCountPlea.UNKNOWN
+        };
+    }
+
+    public DomainModel.JJDisputedCountRoPFinding Convert(Oracle.JJDisputedCountRoPFinding source, DomainModel.JJDisputedCountRoPFinding destination, AutoMapper.ResolutionContext context)
+    {
+        return source switch
+        {
+            Oracle.JJDisputedCountRoPFinding.UNKNOWN => DomainModel.JJDisputedCountRoPFinding.UNKNOWN,
+            Oracle.JJDisputedCountRoPFinding.GUILTY => DomainModel.JJDisputedCountRoPFinding.GUILTY,
+            Oracle.JJDisputedCountRoPFinding.NOT_GUILTY => DomainModel.JJDisputedCountRoPFinding.NOT_GUILTY,
+            Oracle.JJDisputedCountRoPFinding.CANCELLED => DomainModel.JJDisputedCountRoPFinding.CANCELLED,
+            Oracle.JJDisputedCountRoPFinding.PAID_PRIOR_TO_APPEARANCE => DomainModel.JJDisputedCountRoPFinding.PAID_PRIOR_TO_APPEARANCE,
+            Oracle.JJDisputedCountRoPFinding.GUILTY_LESSER => DomainModel.JJDisputedCountRoPFinding.GUILTY_LESSER,
+            _ => DomainModel.JJDisputedCountRoPFinding.UNKNOWN
+        };
+    }
+
+    public Oracle.JJDisputedCountRoPFinding Convert(DomainModel.JJDisputedCountRoPFinding source, Oracle.JJDisputedCountRoPFinding destination, AutoMapper.ResolutionContext context)
+    {
+        return source switch
+        {
+            DomainModel.JJDisputedCountRoPFinding.UNKNOWN => Oracle.JJDisputedCountRoPFinding.UNKNOWN,
+            DomainModel.JJDisputedCountRoPFinding.GUILTY => Oracle.JJDisputedCountRoPFinding.GUILTY,
+            DomainModel.JJDisputedCountRoPFinding.NOT_GUILTY => Oracle.JJDisputedCountRoPFinding.NOT_GUILTY,
+            DomainModel.JJDisputedCountRoPFinding.CANCELLED => Oracle.JJDisputedCountRoPFinding.CANCELLED,
+            DomainModel.JJDisputedCountRoPFinding.PAID_PRIOR_TO_APPEARANCE => Oracle.JJDisputedCountRoPFinding.PAID_PRIOR_TO_APPEARANCE,
+            DomainModel.JJDisputedCountRoPFinding.GUILTY_LESSER => Oracle.JJDisputedCountRoPFinding.GUILTY_LESSER,
+            _ => Oracle.JJDisputedCountRoPFinding.UNKNOWN
+        };
+    }
+
+    public DomainModel.JJDisputeDisputantAttendanceType Convert(Oracle.JJDisputeDisputantAttendanceType source, DomainModel.JJDisputeDisputantAttendanceType destination, AutoMapper.ResolutionContext context)
+    {
+        return source switch
+        {
+            Oracle.JJDisputeDisputantAttendanceType.UNKNOWN => DomainModel.JJDisputeDisputantAttendanceType.UNKNOWN,
+            Oracle.JJDisputeDisputantAttendanceType.WRITTEN_REASONS => DomainModel.JJDisputeDisputantAttendanceType.WRITTEN_REASONS,
+            Oracle.JJDisputeDisputantAttendanceType.VIDEO_CONFERENCE => DomainModel.JJDisputeDisputantAttendanceType.VIDEO_CONFERENCE,
+            Oracle.JJDisputeDisputantAttendanceType.TELEPHONE_CONFERENCE => DomainModel.JJDisputeDisputantAttendanceType.TELEPHONE_CONFERENCE,
+            Oracle.JJDisputeDisputantAttendanceType.MSTEAMS_AUDIO => DomainModel.JJDisputeDisputantAttendanceType.MSTEAMS_AUDIO,
+            Oracle.JJDisputeDisputantAttendanceType.MSTEAMS_VIDEO => DomainModel.JJDisputeDisputantAttendanceType.MSTEAMS_VIDEO,
+            Oracle.JJDisputeDisputantAttendanceType.IN_PERSON => DomainModel.JJDisputeDisputantAttendanceType.IN_PERSON,
+            _ => DomainModel.JJDisputeDisputantAttendanceType.UNKNOWN
+        };
+    }
+
+    public Oracle.JJDisputeDisputantAttendanceType Convert(DomainModel.JJDisputeDisputantAttendanceType source, Oracle.JJDisputeDisputantAttendanceType destination, AutoMapper.ResolutionContext context)
+    {
+        return source switch
+        {
+            DomainModel.JJDisputeDisputantAttendanceType.UNKNOWN => Oracle.JJDisputeDisputantAttendanceType.UNKNOWN,
+            DomainModel.JJDisputeDisputantAttendanceType.WRITTEN_REASONS => Oracle.JJDisputeDisputantAttendanceType.WRITTEN_REASONS,
+            DomainModel.JJDisputeDisputantAttendanceType.VIDEO_CONFERENCE => Oracle.JJDisputeDisputantAttendanceType.VIDEO_CONFERENCE,
+            DomainModel.JJDisputeDisputantAttendanceType.TELEPHONE_CONFERENCE => Oracle.JJDisputeDisputantAttendanceType.TELEPHONE_CONFERENCE,
+            DomainModel.JJDisputeDisputantAttendanceType.MSTEAMS_AUDIO => Oracle.JJDisputeDisputantAttendanceType.MSTEAMS_AUDIO,
+            DomainModel.JJDisputeDisputantAttendanceType.MSTEAMS_VIDEO => Oracle.JJDisputeDisputantAttendanceType.MSTEAMS_VIDEO,
+            DomainModel.JJDisputeDisputantAttendanceType.IN_PERSON => Oracle.JJDisputeDisputantAttendanceType.IN_PERSON,
+            _ => Oracle.JJDisputeDisputantAttendanceType.UNKNOWN
+        };
+    }
+
+    public DomainModel.JJDisputeHearingType Convert(Oracle.JJDisputeHearingType source, DomainModel.JJDisputeHearingType destination, AutoMapper.ResolutionContext context)
+    {
+        return source switch
+        {
+            Oracle.JJDisputeHearingType.UNKNOWN => DomainModel.JJDisputeHearingType.UNKNOWN,
+            Oracle.JJDisputeHearingType.COURT_APPEARANCE => DomainModel.JJDisputeHearingType.COURT_APPEARANCE,
+            Oracle.JJDisputeHearingType.WRITTEN_REASONS => DomainModel.JJDisputeHearingType.WRITTEN_REASONS,
+            _ => DomainModel.JJDisputeHearingType.UNKNOWN
+        };
+    }
+
+    public Oracle.JJDisputeHearingType Convert(DomainModel.JJDisputeHearingType source, Oracle.JJDisputeHearingType destination, AutoMapper.ResolutionContext context)
+    {
+        return source switch
+        {
+            DomainModel.JJDisputeHearingType.UNKNOWN => Oracle.JJDisputeHearingType.UNKNOWN,
+            DomainModel.JJDisputeHearingType.COURT_APPEARANCE => Oracle.JJDisputeHearingType.COURT_APPEARANCE,
+            DomainModel.JJDisputeHearingType.WRITTEN_REASONS => Oracle.JJDisputeHearingType.WRITTEN_REASONS,
+            _ => Oracle.JJDisputeHearingType.UNKNOWN
+        };
+    }
+
+    public DomainModel.JJDisputeSignatoryType Convert(Oracle.JJDisputeSignatoryType source, DomainModel.JJDisputeSignatoryType destination, AutoMapper.ResolutionContext context)
+    {
+        return source switch
+        {
+            Oracle.JJDisputeSignatoryType.U => DomainModel.JJDisputeSignatoryType.U,
+            Oracle.JJDisputeSignatoryType.D => DomainModel.JJDisputeSignatoryType.D,
+            Oracle.JJDisputeSignatoryType.A => DomainModel.JJDisputeSignatoryType.A,
+            _ => DomainModel.JJDisputeSignatoryType.U
+        };
+    }
+
+    public Oracle.JJDisputeSignatoryType Convert(DomainModel.JJDisputeSignatoryType source, Oracle.JJDisputeSignatoryType destination, AutoMapper.ResolutionContext context)
+    {
+        return source switch
+        {
+            DomainModel.JJDisputeSignatoryType.U => Oracle.JJDisputeSignatoryType.U,
+            DomainModel.JJDisputeSignatoryType.D => Oracle.JJDisputeSignatoryType.D,
+            DomainModel.JJDisputeSignatoryType.A => Oracle.JJDisputeSignatoryType.A,
+            _ => Oracle.JJDisputeSignatoryType.U
+        };
+    }
+
+    public DomainModel.JJDisputeStatus Convert(Oracle.JJDisputeStatus source, DomainModel.JJDisputeStatus destination, AutoMapper.ResolutionContext context)
+    {
+        return source switch
+        {
+            Oracle.JJDisputeStatus.UNKNOWN => DomainModel.JJDisputeStatus.UNKNOWN,
+            Oracle.JJDisputeStatus.NEW => DomainModel.JJDisputeStatus.NEW,
+            Oracle.JJDisputeStatus.IN_PROGRESS => DomainModel.JJDisputeStatus.IN_PROGRESS,
+            Oracle.JJDisputeStatus.DATA_UPDATE => DomainModel.JJDisputeStatus.DATA_UPDATE,
+            Oracle.JJDisputeStatus.CONFIRMED => DomainModel.JJDisputeStatus.CONFIRMED,
+            Oracle.JJDisputeStatus.REQUIRE_COURT_HEARING => DomainModel.JJDisputeStatus.REQUIRE_COURT_HEARING,
+            Oracle.JJDisputeStatus.REQUIRE_MORE_INFO => DomainModel.JJDisputeStatus.REQUIRE_MORE_INFO,
+            Oracle.JJDisputeStatus.ACCEPTED => DomainModel.JJDisputeStatus.ACCEPTED,
+            Oracle.JJDisputeStatus.REVIEW => DomainModel.JJDisputeStatus.REVIEW,
+            Oracle.JJDisputeStatus.CONCLUDED => DomainModel.JJDisputeStatus.CONCLUDED,
+            Oracle.JJDisputeStatus.CANCELLED => DomainModel.JJDisputeStatus.CANCELLED,
+            Oracle.JJDisputeStatus.HEARING_SCHEDULED => DomainModel.JJDisputeStatus.HEARING_SCHEDULED,
+            _ => DomainModel.JJDisputeStatus.UNKNOWN
+        };
+    }
+
+    public Oracle.JJDisputeStatus Convert(DomainModel.JJDisputeStatus source, Oracle.JJDisputeStatus destination, AutoMapper.ResolutionContext context)
+    {
+        return source switch
+        {
+            DomainModel.JJDisputeStatus.UNKNOWN => Oracle.JJDisputeStatus.UNKNOWN,
+            DomainModel.JJDisputeStatus.NEW => Oracle.JJDisputeStatus.NEW,
+            DomainModel.JJDisputeStatus.IN_PROGRESS => Oracle.JJDisputeStatus.IN_PROGRESS,
+            DomainModel.JJDisputeStatus.DATA_UPDATE => Oracle.JJDisputeStatus.DATA_UPDATE,
+            DomainModel.JJDisputeStatus.CONFIRMED => Oracle.JJDisputeStatus.CONFIRMED,
+            DomainModel.JJDisputeStatus.REQUIRE_COURT_HEARING => Oracle.JJDisputeStatus.REQUIRE_COURT_HEARING,
+            DomainModel.JJDisputeStatus.REQUIRE_MORE_INFO => Oracle.JJDisputeStatus.REQUIRE_MORE_INFO,
+            DomainModel.JJDisputeStatus.ACCEPTED => Oracle.JJDisputeStatus.ACCEPTED,
+            DomainModel.JJDisputeStatus.REVIEW => Oracle.JJDisputeStatus.REVIEW,
+            DomainModel.JJDisputeStatus.CONCLUDED => Oracle.JJDisputeStatus.CONCLUDED,
+            DomainModel.JJDisputeStatus.CANCELLED => Oracle.JJDisputeStatus.CANCELLED,
+            DomainModel.JJDisputeStatus.HEARING_SCHEDULED => Oracle.JJDisputeStatus.HEARING_SCHEDULED,
+            _ => Oracle.JJDisputeStatus.UNKNOWN
+        };
+    }
+
+    public DomainModel.Status Convert(Oracle.Status source, DomainModel.Status destination, AutoMapper.ResolutionContext context)
+    {
+        return source switch
+        {
+            Oracle.Status.UNKNOWN => DomainModel.Status.UNKNOWN,
+            Oracle.Status.ACCEPTED => DomainModel.Status.ACCEPTED,
+            Oracle.Status.PENDING => DomainModel.Status.PENDING,
+            Oracle.Status.REJECTED => DomainModel.Status.REJECTED,
+            _ => DomainModel.Status.UNKNOWN
+        };
+    }
+
+    public Oracle.Status Convert(DomainModel.Status source, Oracle.Status destination, AutoMapper.ResolutionContext context)
+    {
+        return source switch
+        {
+            DomainModel.Status.UNKNOWN => Oracle.Status.UNKNOWN,
+            DomainModel.Status.ACCEPTED => Oracle.Status.ACCEPTED,
+            DomainModel.Status.PENDING => Oracle.Status.PENDING,
+            DomainModel.Status.REJECTED => Oracle.Status.REJECTED,
+            _ => Oracle.Status.UNKNOWN
+        };
+    }
+
+    public DomainModel.TicketImageDataJustinDocumentReportType Convert(Oracle.TicketImageDataJustinDocumentReportType source, DomainModel.TicketImageDataJustinDocumentReportType destination, AutoMapper.ResolutionContext context)
+    {
+        return source switch
+        {
+            Oracle.TicketImageDataJustinDocumentReportType.UNKNOWN => DomainModel.TicketImageDataJustinDocumentReportType.UNKNOWN,
+            Oracle.TicketImageDataJustinDocumentReportType.NOTICE_OF_DISPUTE => DomainModel.TicketImageDataJustinDocumentReportType.NOTICE_OF_DISPUTE,
+            Oracle.TicketImageDataJustinDocumentReportType.TICKET_IMAGE => DomainModel.TicketImageDataJustinDocumentReportType.TICKET_IMAGE,
+            _ => DomainModel.TicketImageDataJustinDocumentReportType.UNKNOWN
+        };
+    }
+
+    public Oracle.TicketImageDataJustinDocumentReportType Convert(DomainModel.TicketImageDataJustinDocumentReportType source, Oracle.TicketImageDataJustinDocumentReportType destination, AutoMapper.ResolutionContext context)
+    {
+        return source switch
+        {
+            DomainModel.TicketImageDataJustinDocumentReportType.UNKNOWN => Oracle.TicketImageDataJustinDocumentReportType.UNKNOWN,
+            DomainModel.TicketImageDataJustinDocumentReportType.NOTICE_OF_DISPUTE => Oracle.TicketImageDataJustinDocumentReportType.NOTICE_OF_DISPUTE,
+            DomainModel.TicketImageDataJustinDocumentReportType.TICKET_IMAGE => Oracle.TicketImageDataJustinDocumentReportType.TICKET_IMAGE,
+            _ => Oracle.TicketImageDataJustinDocumentReportType.UNKNOWN
+        };
+    }
+
+    public DomainModel.DisputeAppearanceLessThan14DaysYn Convert(Oracle.DisputeAppearanceLessThan14DaysYn source, DomainModel.DisputeAppearanceLessThan14DaysYn destination, AutoMapper.ResolutionContext context)
+    {
+        return source switch
+        {
+            Oracle.DisputeAppearanceLessThan14DaysYn.UNKNOWN => DomainModel.DisputeAppearanceLessThan14DaysYn.UNKNOWN,
+            Oracle.DisputeAppearanceLessThan14DaysYn.Y => DomainModel.DisputeAppearanceLessThan14DaysYn.Y,
+            Oracle.DisputeAppearanceLessThan14DaysYn.N => DomainModel.DisputeAppearanceLessThan14DaysYn.N,
+            _ => DomainModel.DisputeAppearanceLessThan14DaysYn.UNKNOWN
+        };
+    }
+
+    public Oracle.DisputeAppearanceLessThan14DaysYn Convert(DomainModel.DisputeAppearanceLessThan14DaysYn source, Oracle.DisputeAppearanceLessThan14DaysYn destination, AutoMapper.ResolutionContext context)
+    {
+        return source switch
+        {
+            DomainModel.DisputeAppearanceLessThan14DaysYn.UNKNOWN => Oracle.DisputeAppearanceLessThan14DaysYn.UNKNOWN,
+            DomainModel.DisputeAppearanceLessThan14DaysYn.Y => Oracle.DisputeAppearanceLessThan14DaysYn.Y,
+            DomainModel.DisputeAppearanceLessThan14DaysYn.N => Oracle.DisputeAppearanceLessThan14DaysYn.N,
+            _ => Oracle.DisputeAppearanceLessThan14DaysYn.UNKNOWN
+        };
+    }
+
+    public DomainModel.DisputeCountRequestCourtAppearance Convert(Oracle.DisputeCountRequestCourtAppearance source, DomainModel.DisputeCountRequestCourtAppearance destination, AutoMapper.ResolutionContext context)
+    {
+        return source switch
+        {
+            Oracle.DisputeCountRequestCourtAppearance.UNKNOWN => DomainModel.DisputeCountRequestCourtAppearance.UNKNOWN,
+            Oracle.DisputeCountRequestCourtAppearance.Y => DomainModel.DisputeCountRequestCourtAppearance.Y,
+            Oracle.DisputeCountRequestCourtAppearance.N => DomainModel.DisputeCountRequestCourtAppearance.N,
+            _ => DomainModel.DisputeCountRequestCourtAppearance.UNKNOWN
+        };
+    }
+
+    public Oracle.DisputeCountRequestCourtAppearance Convert(DomainModel.DisputeCountRequestCourtAppearance source, Oracle.DisputeCountRequestCourtAppearance destination, AutoMapper.ResolutionContext context)
+    {
+        return source switch
+        {
+            DomainModel.DisputeCountRequestCourtAppearance.UNKNOWN => Oracle.DisputeCountRequestCourtAppearance.UNKNOWN,
+            DomainModel.DisputeCountRequestCourtAppearance.Y => Oracle.DisputeCountRequestCourtAppearance.Y,
+            DomainModel.DisputeCountRequestCourtAppearance.N => Oracle.DisputeCountRequestCourtAppearance.N,
+            _ => Oracle.DisputeCountRequestCourtAppearance.UNKNOWN
+        };
+    }
+
+    public DomainModel.DisputeCountRequestReduction Convert(Oracle.DisputeCountRequestReduction source, DomainModel.DisputeCountRequestReduction destination, AutoMapper.ResolutionContext context)
+    {
+        return source switch
+        {
+            Oracle.DisputeCountRequestReduction.UNKNOWN => DomainModel.DisputeCountRequestReduction.UNKNOWN,
+            Oracle.DisputeCountRequestReduction.Y => DomainModel.DisputeCountRequestReduction.Y,
+            Oracle.DisputeCountRequestReduction.N => DomainModel.DisputeCountRequestReduction.N,
+            _ => DomainModel.DisputeCountRequestReduction.UNKNOWN
+        };
+    }
+
+    public Oracle.DisputeCountRequestReduction Convert(DomainModel.DisputeCountRequestReduction source, Oracle.DisputeCountRequestReduction destination, AutoMapper.ResolutionContext context)
+    {
+        return source switch
+        {
+            DomainModel.DisputeCountRequestReduction.UNKNOWN => Oracle.DisputeCountRequestReduction.UNKNOWN,
+            DomainModel.DisputeCountRequestReduction.Y => Oracle.DisputeCountRequestReduction.Y,
+            DomainModel.DisputeCountRequestReduction.N => Oracle.DisputeCountRequestReduction.N,
+            _ => Oracle.DisputeCountRequestReduction.UNKNOWN
+        };
+    }
+
+    public DomainModel.DisputeCountRequestTimeToPay Convert(Oracle.DisputeCountRequestTimeToPay source, DomainModel.DisputeCountRequestTimeToPay destination, AutoMapper.ResolutionContext context)
+    {
+        return source switch
+        {
+            Oracle.DisputeCountRequestTimeToPay.UNKNOWN => DomainModel.DisputeCountRequestTimeToPay.UNKNOWN,
+            Oracle.DisputeCountRequestTimeToPay.Y => DomainModel.DisputeCountRequestTimeToPay.Y,
+            Oracle.DisputeCountRequestTimeToPay.N => DomainModel.DisputeCountRequestTimeToPay.N,
+            _ => DomainModel.DisputeCountRequestTimeToPay.UNKNOWN
+        };
+    }
+
+    public Oracle.DisputeCountRequestTimeToPay Convert(DomainModel.DisputeCountRequestTimeToPay source, Oracle.DisputeCountRequestTimeToPay destination, AutoMapper.ResolutionContext context)
+    {
+        return source switch
+        {
+            DomainModel.DisputeCountRequestTimeToPay.UNKNOWN => Oracle.DisputeCountRequestTimeToPay.UNKNOWN,
+            DomainModel.DisputeCountRequestTimeToPay.Y => Oracle.DisputeCountRequestTimeToPay.Y,
+            DomainModel.DisputeCountRequestTimeToPay.N => Oracle.DisputeCountRequestTimeToPay.N,
+            _ => Oracle.DisputeCountRequestTimeToPay.UNKNOWN
+        };
+    }
+
+    public DomainModel.DisputeDisputantDetectedOcrIssues Convert(Oracle.DisputeDisputantDetectedOcrIssues source, DomainModel.DisputeDisputantDetectedOcrIssues destination, AutoMapper.ResolutionContext context)
+    {
+        return source switch
+        {
+            Oracle.DisputeDisputantDetectedOcrIssues.UNKNOWN => DomainModel.DisputeDisputantDetectedOcrIssues.UNKNOWN,
+            Oracle.DisputeDisputantDetectedOcrIssues.Y => DomainModel.DisputeDisputantDetectedOcrIssues.Y,
+            Oracle.DisputeDisputantDetectedOcrIssues.N => DomainModel.DisputeDisputantDetectedOcrIssues.N,
+            _ => DomainModel.DisputeDisputantDetectedOcrIssues.UNKNOWN
+        };
+    }
+
+    public Oracle.DisputeDisputantDetectedOcrIssues Convert(DomainModel.DisputeDisputantDetectedOcrIssues source, Oracle.DisputeDisputantDetectedOcrIssues destination, AutoMapper.ResolutionContext context)
+    {
+        return source switch
+        {
+            DomainModel.DisputeDisputantDetectedOcrIssues.UNKNOWN => Oracle.DisputeDisputantDetectedOcrIssues.UNKNOWN,
+            DomainModel.DisputeDisputantDetectedOcrIssues.Y => Oracle.DisputeDisputantDetectedOcrIssues.Y,
+            DomainModel.DisputeDisputantDetectedOcrIssues.N => Oracle.DisputeDisputantDetectedOcrIssues.N,
+            _ => Oracle.DisputeDisputantDetectedOcrIssues.UNKNOWN
+        };
+    }
+
+    public DomainModel.DisputeInterpreterRequired Convert(Oracle.DisputeInterpreterRequired source, DomainModel.DisputeInterpreterRequired destination, AutoMapper.ResolutionContext context)
+    {
+        return source switch
+        {
+            Oracle.DisputeInterpreterRequired.UNKNOWN => DomainModel.DisputeInterpreterRequired.UNKNOWN,
+            Oracle.DisputeInterpreterRequired.Y => DomainModel.DisputeInterpreterRequired.Y,
+            Oracle.DisputeInterpreterRequired.N => DomainModel.DisputeInterpreterRequired.N,
+            _ => DomainModel.DisputeInterpreterRequired.UNKNOWN
+        };
+    }
+
+    public Oracle.DisputeInterpreterRequired Convert(DomainModel.DisputeInterpreterRequired source, Oracle.DisputeInterpreterRequired destination, AutoMapper.ResolutionContext context)
+    {
+        return source switch
+        {
+            DomainModel.DisputeInterpreterRequired.UNKNOWN => Oracle.DisputeInterpreterRequired.UNKNOWN,
+            DomainModel.DisputeInterpreterRequired.Y => Oracle.DisputeInterpreterRequired.Y,
+            DomainModel.DisputeInterpreterRequired.N => Oracle.DisputeInterpreterRequired.N,
+            _ => Oracle.DisputeInterpreterRequired.UNKNOWN
+        };
+    }
+
+    public DomainModel.DisputeListItemDisputantDetectedOcrIssues Convert(Oracle.DisputeListItemDisputantDetectedOcrIssues source, DomainModel.DisputeListItemDisputantDetectedOcrIssues destination, AutoMapper.ResolutionContext context)
+    {
+        return source switch
+        {
+            Oracle.DisputeListItemDisputantDetectedOcrIssues.UNKNOWN => DomainModel.DisputeListItemDisputantDetectedOcrIssues.UNKNOWN,
+            Oracle.DisputeListItemDisputantDetectedOcrIssues.Y => DomainModel.DisputeListItemDisputantDetectedOcrIssues.Y,
+            Oracle.DisputeListItemDisputantDetectedOcrIssues.N => DomainModel.DisputeListItemDisputantDetectedOcrIssues.N,
+            _ => DomainModel.DisputeListItemDisputantDetectedOcrIssues.UNKNOWN
+        };
+    }
+
+    public Oracle.DisputeListItemDisputantDetectedOcrIssues Convert(DomainModel.DisputeListItemDisputantDetectedOcrIssues source, Oracle.DisputeListItemDisputantDetectedOcrIssues destination, AutoMapper.ResolutionContext context)
+    {
+        return source switch
+        {
+            DomainModel.DisputeListItemDisputantDetectedOcrIssues.UNKNOWN => Oracle.DisputeListItemDisputantDetectedOcrIssues.UNKNOWN,
+            DomainModel.DisputeListItemDisputantDetectedOcrIssues.Y => Oracle.DisputeListItemDisputantDetectedOcrIssues.Y,
+            DomainModel.DisputeListItemDisputantDetectedOcrIssues.N => Oracle.DisputeListItemDisputantDetectedOcrIssues.N,
+            _ => Oracle.DisputeListItemDisputantDetectedOcrIssues.UNKNOWN
+        };
+    }
+
+    public DomainModel.DisputeListItemRequestCourtAppearanceYn Convert(Oracle.DisputeListItemRequestCourtAppearanceYn source, DomainModel.DisputeListItemRequestCourtAppearanceYn destination, AutoMapper.ResolutionContext context)
+    {
+        return source switch
+        {
+            Oracle.DisputeListItemRequestCourtAppearanceYn.UNKNOWN => DomainModel.DisputeListItemRequestCourtAppearanceYn.UNKNOWN,
+            Oracle.DisputeListItemRequestCourtAppearanceYn.Y => DomainModel.DisputeListItemRequestCourtAppearanceYn.Y,
+            Oracle.DisputeListItemRequestCourtAppearanceYn.N => DomainModel.DisputeListItemRequestCourtAppearanceYn.N,
+            _ => DomainModel.DisputeListItemRequestCourtAppearanceYn.UNKNOWN
+        };
+    }
+
+    public Oracle.DisputeListItemRequestCourtAppearanceYn Convert(DomainModel.DisputeListItemRequestCourtAppearanceYn source, Oracle.DisputeListItemRequestCourtAppearanceYn destination, AutoMapper.ResolutionContext context)
+    {
+        return source switch
+        {
+            DomainModel.DisputeListItemRequestCourtAppearanceYn.UNKNOWN => Oracle.DisputeListItemRequestCourtAppearanceYn.UNKNOWN,
+            DomainModel.DisputeListItemRequestCourtAppearanceYn.Y => Oracle.DisputeListItemRequestCourtAppearanceYn.Y,
+            DomainModel.DisputeListItemRequestCourtAppearanceYn.N => Oracle.DisputeListItemRequestCourtAppearanceYn.N,
+            _ => Oracle.DisputeListItemRequestCourtAppearanceYn.UNKNOWN
+        };
+    }
+
+    public DomainModel.DisputeListItemSystemDetectedOcrIssues Convert(Oracle.DisputeListItemSystemDetectedOcrIssues source, DomainModel.DisputeListItemSystemDetectedOcrIssues destination, AutoMapper.ResolutionContext context)
+    {
+        return source switch
+        {
+            Oracle.DisputeListItemSystemDetectedOcrIssues.UNKNOWN => DomainModel.DisputeListItemSystemDetectedOcrIssues.UNKNOWN,
+            Oracle.DisputeListItemSystemDetectedOcrIssues.Y => DomainModel.DisputeListItemSystemDetectedOcrIssues.Y,
+            Oracle.DisputeListItemSystemDetectedOcrIssues.N => DomainModel.DisputeListItemSystemDetectedOcrIssues.N,
+            _ => DomainModel.DisputeListItemSystemDetectedOcrIssues.UNKNOWN
+        };
+    }
+
+    public Oracle.DisputeListItemSystemDetectedOcrIssues Convert(DomainModel.DisputeListItemSystemDetectedOcrIssues source, Oracle.DisputeListItemSystemDetectedOcrIssues destination, AutoMapper.ResolutionContext context)
+    {
+        return source switch
+        {
+            DomainModel.DisputeListItemSystemDetectedOcrIssues.UNKNOWN => Oracle.DisputeListItemSystemDetectedOcrIssues.UNKNOWN,
+            DomainModel.DisputeListItemSystemDetectedOcrIssues.Y => Oracle.DisputeListItemSystemDetectedOcrIssues.Y,
+            DomainModel.DisputeListItemSystemDetectedOcrIssues.N => Oracle.DisputeListItemSystemDetectedOcrIssues.N,
+            _ => Oracle.DisputeListItemSystemDetectedOcrIssues.UNKNOWN
+        };
+    }
+
+    public DomainModel.DisputeRepresentedByLawyer Convert(Oracle.DisputeRepresentedByLawyer source, DomainModel.DisputeRepresentedByLawyer destination, AutoMapper.ResolutionContext context)
+    {
+        return source switch
+        {
+            Oracle.DisputeRepresentedByLawyer.UNKNOWN => DomainModel.DisputeRepresentedByLawyer.UNKNOWN,
+            Oracle.DisputeRepresentedByLawyer.Y => DomainModel.DisputeRepresentedByLawyer.Y,
+            Oracle.DisputeRepresentedByLawyer.N => DomainModel.DisputeRepresentedByLawyer.N,
+            _ => DomainModel.DisputeRepresentedByLawyer.UNKNOWN
+        };
+    }
+
+    public Oracle.DisputeRepresentedByLawyer Convert(DomainModel.DisputeRepresentedByLawyer source, Oracle.DisputeRepresentedByLawyer destination, AutoMapper.ResolutionContext context)
+    {
+        return source switch
+        {
+            DomainModel.DisputeRepresentedByLawyer.UNKNOWN => Oracle.DisputeRepresentedByLawyer.UNKNOWN,
+            DomainModel.DisputeRepresentedByLawyer.Y => Oracle.DisputeRepresentedByLawyer.Y,
+            DomainModel.DisputeRepresentedByLawyer.N => Oracle.DisputeRepresentedByLawyer.N,
+            _ => Oracle.DisputeRepresentedByLawyer.UNKNOWN
+        };
+    }
+
+    public DomainModel.DisputeRequestCourtAppearanceYn Convert(Oracle.DisputeRequestCourtAppearanceYn source, DomainModel.DisputeRequestCourtAppearanceYn destination, AutoMapper.ResolutionContext context)
+    {
+        return source switch
+        {
+            Oracle.DisputeRequestCourtAppearanceYn.UNKNOWN => DomainModel.DisputeRequestCourtAppearanceYn.UNKNOWN,
+            Oracle.DisputeRequestCourtAppearanceYn.Y => DomainModel.DisputeRequestCourtAppearanceYn.Y,
+            Oracle.DisputeRequestCourtAppearanceYn.N => DomainModel.DisputeRequestCourtAppearanceYn.N,
+            _ => DomainModel.DisputeRequestCourtAppearanceYn.UNKNOWN
+        };
+    }
+
+    public Oracle.DisputeRequestCourtAppearanceYn Convert(DomainModel.DisputeRequestCourtAppearanceYn source, Oracle.DisputeRequestCourtAppearanceYn destination, AutoMapper.ResolutionContext context)
+    {
+        return source switch
+        {
+            DomainModel.DisputeRequestCourtAppearanceYn.UNKNOWN => Oracle.DisputeRequestCourtAppearanceYn.UNKNOWN,
+            DomainModel.DisputeRequestCourtAppearanceYn.Y => Oracle.DisputeRequestCourtAppearanceYn.Y,
+            DomainModel.DisputeRequestCourtAppearanceYn.N => Oracle.DisputeRequestCourtAppearanceYn.N,
+            _ => Oracle.DisputeRequestCourtAppearanceYn.UNKNOWN
+        };
+    }
+
+    public DomainModel.DisputeSystemDetectedOcrIssues Convert(Oracle.DisputeSystemDetectedOcrIssues source, DomainModel.DisputeSystemDetectedOcrIssues destination, AutoMapper.ResolutionContext context)
+    {
+        return source switch
+        {
+            Oracle.DisputeSystemDetectedOcrIssues.UNKNOWN => DomainModel.DisputeSystemDetectedOcrIssues.UNKNOWN,
+            Oracle.DisputeSystemDetectedOcrIssues.Y => DomainModel.DisputeSystemDetectedOcrIssues.Y,
+            Oracle.DisputeSystemDetectedOcrIssues.N => DomainModel.DisputeSystemDetectedOcrIssues.N,
+            _ => DomainModel.DisputeSystemDetectedOcrIssues.UNKNOWN
+        };
+    }
+
+    public Oracle.DisputeSystemDetectedOcrIssues Convert(DomainModel.DisputeSystemDetectedOcrIssues source, Oracle.DisputeSystemDetectedOcrIssues destination, AutoMapper.ResolutionContext context)
+    {
+        return source switch
+        {
+            DomainModel.DisputeSystemDetectedOcrIssues.UNKNOWN => Oracle.DisputeSystemDetectedOcrIssues.UNKNOWN,
+            DomainModel.DisputeSystemDetectedOcrIssues.Y => Oracle.DisputeSystemDetectedOcrIssues.Y,
+            DomainModel.DisputeSystemDetectedOcrIssues.N => Oracle.DisputeSystemDetectedOcrIssues.N,
+            _ => Oracle.DisputeSystemDetectedOcrIssues.UNKNOWN
+        };
+    }
+
+    public DomainModel.EmailHistorySuccessfullySent Convert(Oracle.EmailHistorySuccessfullySent source, DomainModel.EmailHistorySuccessfullySent destination, AutoMapper.ResolutionContext context)
+    {
+        return source switch
+        {
+            Oracle.EmailHistorySuccessfullySent.UNKNOWN => DomainModel.EmailHistorySuccessfullySent.UNKNOWN,
+            Oracle.EmailHistorySuccessfullySent.Y => DomainModel.EmailHistorySuccessfullySent.Y,
+            Oracle.EmailHistorySuccessfullySent.N => DomainModel.EmailHistorySuccessfullySent.N,
+            _ => DomainModel.EmailHistorySuccessfullySent.UNKNOWN
+        };
+    }
+
+    public Oracle.EmailHistorySuccessfullySent Convert(DomainModel.EmailHistorySuccessfullySent source, Oracle.EmailHistorySuccessfullySent destination, AutoMapper.ResolutionContext context)
+    {
+        return source switch
+        {
+            DomainModel.EmailHistorySuccessfullySent.UNKNOWN => Oracle.EmailHistorySuccessfullySent.UNKNOWN,
+            DomainModel.EmailHistorySuccessfullySent.Y => Oracle.EmailHistorySuccessfullySent.Y,
+            DomainModel.EmailHistorySuccessfullySent.N => Oracle.EmailHistorySuccessfullySent.N,
+            _ => Oracle.EmailHistorySuccessfullySent.UNKNOWN
+        };
+    }
+
+    public DomainModel.JJDisputeAccidentYn Convert(Oracle.JJDisputeAccidentYn source, DomainModel.JJDisputeAccidentYn destination, AutoMapper.ResolutionContext context)
+    {
+        return source switch
+        {
+            Oracle.JJDisputeAccidentYn.UNKNOWN => DomainModel.JJDisputeAccidentYn.UNKNOWN,
+            Oracle.JJDisputeAccidentYn.Y => DomainModel.JJDisputeAccidentYn.Y,
+            Oracle.JJDisputeAccidentYn.N => DomainModel.JJDisputeAccidentYn.N,
+            _ => DomainModel.JJDisputeAccidentYn.UNKNOWN
+        };
+    }
+
+    public Oracle.JJDisputeAccidentYn Convert(DomainModel.JJDisputeAccidentYn source, Oracle.JJDisputeAccidentYn destination, AutoMapper.ResolutionContext context)
+    {
+        return source switch
+        {
+            DomainModel.JJDisputeAccidentYn.UNKNOWN => Oracle.JJDisputeAccidentYn.UNKNOWN,
+            DomainModel.JJDisputeAccidentYn.Y => Oracle.JJDisputeAccidentYn.Y,
+            DomainModel.JJDisputeAccidentYn.N => Oracle.JJDisputeAccidentYn.N,
+            _ => Oracle.JJDisputeAccidentYn.UNKNOWN
+        };
+    }
+
+    public DomainModel.JJDisputeAppearInCourt Convert(Oracle.JJDisputeAppearInCourt source, DomainModel.JJDisputeAppearInCourt destination, AutoMapper.ResolutionContext context)
+    {
+        return source switch
+        {
+            Oracle.JJDisputeAppearInCourt.UNKNOWN => DomainModel.JJDisputeAppearInCourt.UNKNOWN,
+            Oracle.JJDisputeAppearInCourt.Y => DomainModel.JJDisputeAppearInCourt.Y,
+            Oracle.JJDisputeAppearInCourt.N => DomainModel.JJDisputeAppearInCourt.N,
+            _ => DomainModel.JJDisputeAppearInCourt.UNKNOWN
+        };
+    }
+
+    public Oracle.JJDisputeAppearInCourt Convert(DomainModel.JJDisputeAppearInCourt source, Oracle.JJDisputeAppearInCourt destination, AutoMapper.ResolutionContext context)
+    {
+        return source switch
+        {
+            DomainModel.JJDisputeAppearInCourt.UNKNOWN => Oracle.JJDisputeAppearInCourt.UNKNOWN,
+            DomainModel.JJDisputeAppearInCourt.Y => Oracle.JJDisputeAppearInCourt.Y,
+            DomainModel.JJDisputeAppearInCourt.N => Oracle.JJDisputeAppearInCourt.N,
+            _ => Oracle.JJDisputeAppearInCourt.UNKNOWN
+        };
+    }
+
+    public DomainModel.JJDisputeCourtAppearanceRoPJjSeized Convert(Oracle.JJDisputeCourtAppearanceRoPJjSeized source, DomainModel.JJDisputeCourtAppearanceRoPJjSeized destination, AutoMapper.ResolutionContext context)
+    {
+        return source switch
+        {
+            Oracle.JJDisputeCourtAppearanceRoPJjSeized.UNKNOWN => DomainModel.JJDisputeCourtAppearanceRoPJjSeized.UNKNOWN,
+            Oracle.JJDisputeCourtAppearanceRoPJjSeized.Y => DomainModel.JJDisputeCourtAppearanceRoPJjSeized.Y,
+            Oracle.JJDisputeCourtAppearanceRoPJjSeized.N => DomainModel.JJDisputeCourtAppearanceRoPJjSeized.N,
+            _ => DomainModel.JJDisputeCourtAppearanceRoPJjSeized.UNKNOWN
+        };
+    }
+
+    public Oracle.JJDisputeCourtAppearanceRoPJjSeized Convert(DomainModel.JJDisputeCourtAppearanceRoPJjSeized source, Oracle.JJDisputeCourtAppearanceRoPJjSeized destination, AutoMapper.ResolutionContext context)
+    {
+        return source switch
+        {
+            DomainModel.JJDisputeCourtAppearanceRoPJjSeized.UNKNOWN => Oracle.JJDisputeCourtAppearanceRoPJjSeized.UNKNOWN,
+            DomainModel.JJDisputeCourtAppearanceRoPJjSeized.Y => Oracle.JJDisputeCourtAppearanceRoPJjSeized.Y,
+            DomainModel.JJDisputeCourtAppearanceRoPJjSeized.N => Oracle.JJDisputeCourtAppearanceRoPJjSeized.N,
+            _ => Oracle.JJDisputeCourtAppearanceRoPJjSeized.UNKNOWN
+        };
+    }
+
+    public DomainModel.JJDisputedCountAppearInCourt Convert(Oracle.JJDisputedCountAppearInCourt source, DomainModel.JJDisputedCountAppearInCourt destination, AutoMapper.ResolutionContext context)
+    {
+        return source switch
+        {
+            Oracle.JJDisputedCountAppearInCourt.UNKNOWN => DomainModel.JJDisputedCountAppearInCourt.UNKNOWN,
+            Oracle.JJDisputedCountAppearInCourt.Y => DomainModel.JJDisputedCountAppearInCourt.Y,
+            Oracle.JJDisputedCountAppearInCourt.N => DomainModel.JJDisputedCountAppearInCourt.N,
+            _ => DomainModel.JJDisputedCountAppearInCourt.UNKNOWN
+        };
+    }
+
+    public Oracle.JJDisputedCountAppearInCourt Convert(DomainModel.JJDisputedCountAppearInCourt source, Oracle.JJDisputedCountAppearInCourt destination, AutoMapper.ResolutionContext context)
+    {
+        return source switch
+        {
+            DomainModel.JJDisputedCountAppearInCourt.UNKNOWN => Oracle.JJDisputedCountAppearInCourt.UNKNOWN,
+            DomainModel.JJDisputedCountAppearInCourt.Y => Oracle.JJDisputedCountAppearInCourt.Y,
+            DomainModel.JJDisputedCountAppearInCourt.N => Oracle.JJDisputedCountAppearInCourt.N,
+            _ => Oracle.JJDisputedCountAppearInCourt.UNKNOWN
+        };
+    }
+
+    public DomainModel.JJDisputedCountIncludesSurcharge Convert(Oracle.JJDisputedCountIncludesSurcharge source, DomainModel.JJDisputedCountIncludesSurcharge destination, AutoMapper.ResolutionContext context)
+    {
+        return source switch
+        {
+            Oracle.JJDisputedCountIncludesSurcharge.UNKNOWN => DomainModel.JJDisputedCountIncludesSurcharge.UNKNOWN,
+            Oracle.JJDisputedCountIncludesSurcharge.Y => DomainModel.JJDisputedCountIncludesSurcharge.Y,
+            Oracle.JJDisputedCountIncludesSurcharge.N => DomainModel.JJDisputedCountIncludesSurcharge.N,
+            _ => DomainModel.JJDisputedCountIncludesSurcharge.UNKNOWN
+        };
+    }
+
+    public Oracle.JJDisputedCountIncludesSurcharge Convert(DomainModel.JJDisputedCountIncludesSurcharge source, Oracle.JJDisputedCountIncludesSurcharge destination, AutoMapper.ResolutionContext context)
+    {
+        return source switch
+        {
+            DomainModel.JJDisputedCountIncludesSurcharge.UNKNOWN => Oracle.JJDisputedCountIncludesSurcharge.UNKNOWN,
+            DomainModel.JJDisputedCountIncludesSurcharge.Y => Oracle.JJDisputedCountIncludesSurcharge.Y,
+            DomainModel.JJDisputedCountIncludesSurcharge.N => Oracle.JJDisputedCountIncludesSurcharge.N,
+            _ => Oracle.JJDisputedCountIncludesSurcharge.UNKNOWN
+        };
+    }
+
+    public DomainModel.JJDisputedCountRequestReduction Convert(Oracle.JJDisputedCountRequestReduction source, DomainModel.JJDisputedCountRequestReduction destination, AutoMapper.ResolutionContext context)
+    {
+        return source switch
+        {
+            Oracle.JJDisputedCountRequestReduction.UNKNOWN => DomainModel.JJDisputedCountRequestReduction.UNKNOWN,
+            Oracle.JJDisputedCountRequestReduction.Y => DomainModel.JJDisputedCountRequestReduction.Y,
+            Oracle.JJDisputedCountRequestReduction.N => DomainModel.JJDisputedCountRequestReduction.N,
+            _ => DomainModel.JJDisputedCountRequestReduction.UNKNOWN
+        };
+    }
+
+    public Oracle.JJDisputedCountRequestReduction Convert(DomainModel.JJDisputedCountRequestReduction source, Oracle.JJDisputedCountRequestReduction destination, AutoMapper.ResolutionContext context)
+    {
+        return source switch
+        {
+            DomainModel.JJDisputedCountRequestReduction.UNKNOWN => Oracle.JJDisputedCountRequestReduction.UNKNOWN,
+            DomainModel.JJDisputedCountRequestReduction.Y => Oracle.JJDisputedCountRequestReduction.Y,
+            DomainModel.JJDisputedCountRequestReduction.N => Oracle.JJDisputedCountRequestReduction.N,
+            _ => Oracle.JJDisputedCountRequestReduction.UNKNOWN
+        };
+    }
+
+    public DomainModel.JJDisputedCountRequestTimeToPay Convert(Oracle.JJDisputedCountRequestTimeToPay source, DomainModel.JJDisputedCountRequestTimeToPay destination, AutoMapper.ResolutionContext context)
+    {
+        return source switch
+        {
+            Oracle.JJDisputedCountRequestTimeToPay.UNKNOWN => DomainModel.JJDisputedCountRequestTimeToPay.UNKNOWN,
+            Oracle.JJDisputedCountRequestTimeToPay.Y => DomainModel.JJDisputedCountRequestTimeToPay.Y,
+            Oracle.JJDisputedCountRequestTimeToPay.N => DomainModel.JJDisputedCountRequestTimeToPay.N,
+            _ => DomainModel.JJDisputedCountRequestTimeToPay.UNKNOWN
+        };
+    }
+
+    public Oracle.JJDisputedCountRequestTimeToPay Convert(DomainModel.JJDisputedCountRequestTimeToPay source, Oracle.JJDisputedCountRequestTimeToPay destination, AutoMapper.ResolutionContext context)
+    {
+        return source switch
+        {
+            DomainModel.JJDisputedCountRequestTimeToPay.UNKNOWN => Oracle.JJDisputedCountRequestTimeToPay.UNKNOWN,
+            DomainModel.JJDisputedCountRequestTimeToPay.Y => Oracle.JJDisputedCountRequestTimeToPay.Y,
+            DomainModel.JJDisputedCountRequestTimeToPay.N => Oracle.JJDisputedCountRequestTimeToPay.N,
+            _ => Oracle.JJDisputedCountRequestTimeToPay.UNKNOWN
+        };
+    }
+
+    public DomainModel.JJDisputedCountRoPAbatement Convert(Oracle.JJDisputedCountRoPAbatement source, DomainModel.JJDisputedCountRoPAbatement destination, AutoMapper.ResolutionContext context)
+    {
+        return source switch
+        {
+            Oracle.JJDisputedCountRoPAbatement.UNKNOWN => DomainModel.JJDisputedCountRoPAbatement.UNKNOWN,
+            Oracle.JJDisputedCountRoPAbatement.Y => DomainModel.JJDisputedCountRoPAbatement.Y,
+            Oracle.JJDisputedCountRoPAbatement.N => DomainModel.JJDisputedCountRoPAbatement.N,
+            _ => DomainModel.JJDisputedCountRoPAbatement.UNKNOWN
+        };
+    }
+
+    public Oracle.JJDisputedCountRoPAbatement Convert(DomainModel.JJDisputedCountRoPAbatement source, Oracle.JJDisputedCountRoPAbatement destination, AutoMapper.ResolutionContext context)
+    {
+        return source switch
+        {
+            DomainModel.JJDisputedCountRoPAbatement.UNKNOWN => Oracle.JJDisputedCountRoPAbatement.UNKNOWN,
+            DomainModel.JJDisputedCountRoPAbatement.Y => Oracle.JJDisputedCountRoPAbatement.Y,
+            DomainModel.JJDisputedCountRoPAbatement.N => Oracle.JJDisputedCountRoPAbatement.N,
+            _ => Oracle.JJDisputedCountRoPAbatement.UNKNOWN
+        };
+    }
+
+    public DomainModel.JJDisputedCountRoPDismissed Convert(Oracle.JJDisputedCountRoPDismissed source, DomainModel.JJDisputedCountRoPDismissed destination, AutoMapper.ResolutionContext context)
+    {
+        return source switch
+        {
+            Oracle.JJDisputedCountRoPDismissed.UNKNOWN => DomainModel.JJDisputedCountRoPDismissed.UNKNOWN,
+            Oracle.JJDisputedCountRoPDismissed.Y => DomainModel.JJDisputedCountRoPDismissed.Y,
+            Oracle.JJDisputedCountRoPDismissed.N => DomainModel.JJDisputedCountRoPDismissed.N,
+            _ => DomainModel.JJDisputedCountRoPDismissed.UNKNOWN
+        };
+    }
+
+    public Oracle.JJDisputedCountRoPDismissed Convert(DomainModel.JJDisputedCountRoPDismissed source, Oracle.JJDisputedCountRoPDismissed destination, AutoMapper.ResolutionContext context)
+    {
+        return source switch
+        {
+            DomainModel.JJDisputedCountRoPDismissed.UNKNOWN => Oracle.JJDisputedCountRoPDismissed.UNKNOWN,
+            DomainModel.JJDisputedCountRoPDismissed.Y => Oracle.JJDisputedCountRoPDismissed.Y,
+            DomainModel.JJDisputedCountRoPDismissed.N => Oracle.JJDisputedCountRoPDismissed.N,
+            _ => Oracle.JJDisputedCountRoPDismissed.UNKNOWN
+        };
+    }
+
+    public DomainModel.JJDisputedCountRoPForWantOfProsecution Convert(Oracle.JJDisputedCountRoPForWantOfProsecution source, DomainModel.JJDisputedCountRoPForWantOfProsecution destination, AutoMapper.ResolutionContext context)
+    {
+        return source switch
+        {
+            Oracle.JJDisputedCountRoPForWantOfProsecution.UNKNOWN => DomainModel.JJDisputedCountRoPForWantOfProsecution.UNKNOWN,
+            Oracle.JJDisputedCountRoPForWantOfProsecution.Y => DomainModel.JJDisputedCountRoPForWantOfProsecution.Y,
+            Oracle.JJDisputedCountRoPForWantOfProsecution.N => DomainModel.JJDisputedCountRoPForWantOfProsecution.N,
+            _ => DomainModel.JJDisputedCountRoPForWantOfProsecution.UNKNOWN
+        };
+    }
+
+    public Oracle.JJDisputedCountRoPForWantOfProsecution Convert(DomainModel.JJDisputedCountRoPForWantOfProsecution source, Oracle.JJDisputedCountRoPForWantOfProsecution destination, AutoMapper.ResolutionContext context)
+    {
+        return source switch
+        {
+            DomainModel.JJDisputedCountRoPForWantOfProsecution.UNKNOWN => Oracle.JJDisputedCountRoPForWantOfProsecution.UNKNOWN,
+            DomainModel.JJDisputedCountRoPForWantOfProsecution.Y => Oracle.JJDisputedCountRoPForWantOfProsecution.Y,
+            DomainModel.JJDisputedCountRoPForWantOfProsecution.N => Oracle.JJDisputedCountRoPForWantOfProsecution.N,
+            _ => Oracle.JJDisputedCountRoPForWantOfProsecution.UNKNOWN
+        };
+    }
+
+    public DomainModel.JJDisputedCountRoPJailIntermittent Convert(Oracle.JJDisputedCountRoPJailIntermittent source, DomainModel.JJDisputedCountRoPJailIntermittent destination, AutoMapper.ResolutionContext context)
+    {
+        return source switch
+        {
+            Oracle.JJDisputedCountRoPJailIntermittent.UNKNOWN => DomainModel.JJDisputedCountRoPJailIntermittent.UNKNOWN,
+            Oracle.JJDisputedCountRoPJailIntermittent.Y => DomainModel.JJDisputedCountRoPJailIntermittent.Y,
+            Oracle.JJDisputedCountRoPJailIntermittent.N => DomainModel.JJDisputedCountRoPJailIntermittent.N,
+            _ => DomainModel.JJDisputedCountRoPJailIntermittent.UNKNOWN
+        };
+    }
+
+    public Oracle.JJDisputedCountRoPJailIntermittent Convert(DomainModel.JJDisputedCountRoPJailIntermittent source, Oracle.JJDisputedCountRoPJailIntermittent destination, AutoMapper.ResolutionContext context)
+    {
+        return source switch
+        {
+            DomainModel.JJDisputedCountRoPJailIntermittent.UNKNOWN => Oracle.JJDisputedCountRoPJailIntermittent.UNKNOWN,
+            DomainModel.JJDisputedCountRoPJailIntermittent.Y => Oracle.JJDisputedCountRoPJailIntermittent.Y,
+            DomainModel.JJDisputedCountRoPJailIntermittent.N => Oracle.JJDisputedCountRoPJailIntermittent.N,
+            _ => Oracle.JJDisputedCountRoPJailIntermittent.UNKNOWN
+        };
+    }
+
+    public DomainModel.JJDisputedCountRoPWithdrawn Convert(Oracle.JJDisputedCountRoPWithdrawn source, DomainModel.JJDisputedCountRoPWithdrawn destination, AutoMapper.ResolutionContext context)
+    {
+        return source switch
+        {
+            Oracle.JJDisputedCountRoPWithdrawn.UNKNOWN => DomainModel.JJDisputedCountRoPWithdrawn.UNKNOWN,
+            Oracle.JJDisputedCountRoPWithdrawn.Y => DomainModel.JJDisputedCountRoPWithdrawn.Y,
+            Oracle.JJDisputedCountRoPWithdrawn.N => DomainModel.JJDisputedCountRoPWithdrawn.N,
+            _ => DomainModel.JJDisputedCountRoPWithdrawn.UNKNOWN
+        };
+    }
+
+    public Oracle.JJDisputedCountRoPWithdrawn Convert(DomainModel.JJDisputedCountRoPWithdrawn source, Oracle.JJDisputedCountRoPWithdrawn destination, AutoMapper.ResolutionContext context)
+    {
+        return source switch
+        {
+            DomainModel.JJDisputedCountRoPWithdrawn.UNKNOWN => Oracle.JJDisputedCountRoPWithdrawn.UNKNOWN,
+            DomainModel.JJDisputedCountRoPWithdrawn.Y => Oracle.JJDisputedCountRoPWithdrawn.Y,
+            DomainModel.JJDisputedCountRoPWithdrawn.N => Oracle.JJDisputedCountRoPWithdrawn.N,
+            _ => Oracle.JJDisputedCountRoPWithdrawn.UNKNOWN
+        };
+    }
+
+    public DomainModel.JJDisputeElectronicTicketYn Convert(Oracle.JJDisputeElectronicTicketYn source, DomainModel.JJDisputeElectronicTicketYn destination, AutoMapper.ResolutionContext context)
+    {
+        return source switch
+        {
+            Oracle.JJDisputeElectronicTicketYn.UNKNOWN => DomainModel.JJDisputeElectronicTicketYn.UNKNOWN,
+            Oracle.JJDisputeElectronicTicketYn.Y => DomainModel.JJDisputeElectronicTicketYn.Y,
+            Oracle.JJDisputeElectronicTicketYn.N => DomainModel.JJDisputeElectronicTicketYn.N,
+            _ => DomainModel.JJDisputeElectronicTicketYn.UNKNOWN
+        };
+    }
+
+    public Oracle.JJDisputeElectronicTicketYn Convert(DomainModel.JJDisputeElectronicTicketYn source, Oracle.JJDisputeElectronicTicketYn destination, AutoMapper.ResolutionContext context)
+    {
+        return source switch
+        {
+            DomainModel.JJDisputeElectronicTicketYn.UNKNOWN => Oracle.JJDisputeElectronicTicketYn.UNKNOWN,
+            DomainModel.JJDisputeElectronicTicketYn.Y => Oracle.JJDisputeElectronicTicketYn.Y,
+            DomainModel.JJDisputeElectronicTicketYn.N => Oracle.JJDisputeElectronicTicketYn.N,
+            _ => Oracle.JJDisputeElectronicTicketYn.UNKNOWN
+        };
+    }
+
+    public DomainModel.JJDisputeMultipleOfficersYn Convert(Oracle.JJDisputeMultipleOfficersYn source, DomainModel.JJDisputeMultipleOfficersYn destination, AutoMapper.ResolutionContext context)
+    {
+        return source switch
+        {
+            Oracle.JJDisputeMultipleOfficersYn.UNKNOWN => DomainModel.JJDisputeMultipleOfficersYn.UNKNOWN,
+            Oracle.JJDisputeMultipleOfficersYn.Y => DomainModel.JJDisputeMultipleOfficersYn.Y,
+            Oracle.JJDisputeMultipleOfficersYn.N => DomainModel.JJDisputeMultipleOfficersYn.N,
+            _ => DomainModel.JJDisputeMultipleOfficersYn.UNKNOWN
+        };
+    }
+
+    public Oracle.JJDisputeMultipleOfficersYn Convert(DomainModel.JJDisputeMultipleOfficersYn source, Oracle.JJDisputeMultipleOfficersYn destination, AutoMapper.ResolutionContext context)
+    {
+        return source switch
+        {
+            DomainModel.JJDisputeMultipleOfficersYn.UNKNOWN => Oracle.JJDisputeMultipleOfficersYn.UNKNOWN,
+            DomainModel.JJDisputeMultipleOfficersYn.Y => Oracle.JJDisputeMultipleOfficersYn.Y,
+            DomainModel.JJDisputeMultipleOfficersYn.N => Oracle.JJDisputeMultipleOfficersYn.N,
+            _ => Oracle.JJDisputeMultipleOfficersYn.UNKNOWN
+        };
+    }
+
+    public DomainModel.JJDisputeNoticeOfHearingYn Convert(Oracle.JJDisputeNoticeOfHearingYn source, DomainModel.JJDisputeNoticeOfHearingYn destination, AutoMapper.ResolutionContext context)
+    {
+        return source switch
+        {
+            Oracle.JJDisputeNoticeOfHearingYn.UNKNOWN => DomainModel.JJDisputeNoticeOfHearingYn.UNKNOWN,
+            Oracle.JJDisputeNoticeOfHearingYn.Y => DomainModel.JJDisputeNoticeOfHearingYn.Y,
+            Oracle.JJDisputeNoticeOfHearingYn.N => DomainModel.JJDisputeNoticeOfHearingYn.N,
+            _ => DomainModel.JJDisputeNoticeOfHearingYn.UNKNOWN
+        };
+    }
+
+    public Oracle.JJDisputeNoticeOfHearingYn Convert(DomainModel.JJDisputeNoticeOfHearingYn source, Oracle.JJDisputeNoticeOfHearingYn destination, AutoMapper.ResolutionContext context)
+    {
+        return source switch
+        {
+            DomainModel.JJDisputeNoticeOfHearingYn.UNKNOWN => Oracle.JJDisputeNoticeOfHearingYn.UNKNOWN,
+            DomainModel.JJDisputeNoticeOfHearingYn.Y => Oracle.JJDisputeNoticeOfHearingYn.Y,
+            DomainModel.JJDisputeNoticeOfHearingYn.N => Oracle.JJDisputeNoticeOfHearingYn.N,
+            _ => Oracle.JJDisputeNoticeOfHearingYn.UNKNOWN
+        };
+    }
+
+    public DomainModel.ViolationTicketCountIsAct Convert(Oracle.ViolationTicketCountIsAct source, DomainModel.ViolationTicketCountIsAct destination, AutoMapper.ResolutionContext context)
+    {
+        return source switch
+        {
+            Oracle.ViolationTicketCountIsAct.UNKNOWN => DomainModel.ViolationTicketCountIsAct.UNKNOWN,
+            Oracle.ViolationTicketCountIsAct.Y => DomainModel.ViolationTicketCountIsAct.Y,
+            Oracle.ViolationTicketCountIsAct.N => DomainModel.ViolationTicketCountIsAct.N,
+            _ => DomainModel.ViolationTicketCountIsAct.UNKNOWN
+        };
+    }
+
+    public Oracle.ViolationTicketCountIsAct Convert(DomainModel.ViolationTicketCountIsAct source, Oracle.ViolationTicketCountIsAct destination, AutoMapper.ResolutionContext context)
+    {
+        return source switch
+        {
+            DomainModel.ViolationTicketCountIsAct.UNKNOWN => Oracle.ViolationTicketCountIsAct.UNKNOWN,
+            DomainModel.ViolationTicketCountIsAct.Y => Oracle.ViolationTicketCountIsAct.Y,
+            DomainModel.ViolationTicketCountIsAct.N => Oracle.ViolationTicketCountIsAct.N,
+            _ => Oracle.ViolationTicketCountIsAct.UNKNOWN
+        };
+    }
+
+    public DomainModel.ViolationTicketCountIsRegulation Convert(Oracle.ViolationTicketCountIsRegulation source, DomainModel.ViolationTicketCountIsRegulation destination, AutoMapper.ResolutionContext context)
+    {
+        return source switch
+        {
+            Oracle.ViolationTicketCountIsRegulation.UNKNOWN => DomainModel.ViolationTicketCountIsRegulation.UNKNOWN,
+            Oracle.ViolationTicketCountIsRegulation.Y => DomainModel.ViolationTicketCountIsRegulation.Y,
+            Oracle.ViolationTicketCountIsRegulation.N => DomainModel.ViolationTicketCountIsRegulation.N,
+            _ => DomainModel.ViolationTicketCountIsRegulation.UNKNOWN
+        };
+    }
+
+    public Oracle.ViolationTicketCountIsRegulation Convert(DomainModel.ViolationTicketCountIsRegulation source, Oracle.ViolationTicketCountIsRegulation destination, AutoMapper.ResolutionContext context)
+    {
+        return source switch
+        {
+            DomainModel.ViolationTicketCountIsRegulation.UNKNOWN => Oracle.ViolationTicketCountIsRegulation.UNKNOWN,
+            DomainModel.ViolationTicketCountIsRegulation.Y => Oracle.ViolationTicketCountIsRegulation.Y,
+            DomainModel.ViolationTicketCountIsRegulation.N => Oracle.ViolationTicketCountIsRegulation.N,
+            _ => Oracle.ViolationTicketCountIsRegulation.UNKNOWN
+        };
+    }
+
+    public DomainModel.ViolationTicketIsChangeOfAddress Convert(Oracle.ViolationTicketIsChangeOfAddress source, DomainModel.ViolationTicketIsChangeOfAddress destination, AutoMapper.ResolutionContext context)
+    {
+        return source switch
+        {
+            Oracle.ViolationTicketIsChangeOfAddress.UNKNOWN => DomainModel.ViolationTicketIsChangeOfAddress.UNKNOWN,
+            Oracle.ViolationTicketIsChangeOfAddress.Y => DomainModel.ViolationTicketIsChangeOfAddress.Y,
+            Oracle.ViolationTicketIsChangeOfAddress.N => DomainModel.ViolationTicketIsChangeOfAddress.N,
+            _ => DomainModel.ViolationTicketIsChangeOfAddress.UNKNOWN
+        };
+    }
+
+    public Oracle.ViolationTicketIsChangeOfAddress Convert(DomainModel.ViolationTicketIsChangeOfAddress source, Oracle.ViolationTicketIsChangeOfAddress destination, AutoMapper.ResolutionContext context)
+    {
+        return source switch
+        {
+            DomainModel.ViolationTicketIsChangeOfAddress.UNKNOWN => Oracle.ViolationTicketIsChangeOfAddress.UNKNOWN,
+            DomainModel.ViolationTicketIsChangeOfAddress.Y => Oracle.ViolationTicketIsChangeOfAddress.Y,
+            DomainModel.ViolationTicketIsChangeOfAddress.N => Oracle.ViolationTicketIsChangeOfAddress.N,
+            _ => Oracle.ViolationTicketIsChangeOfAddress.UNKNOWN
+        };
+    }
+
+    public DomainModel.ViolationTicketIsDriver Convert(Oracle.ViolationTicketIsDriver source, DomainModel.ViolationTicketIsDriver destination, AutoMapper.ResolutionContext context)
+    {
+        return source switch
+        {
+            Oracle.ViolationTicketIsDriver.UNKNOWN => DomainModel.ViolationTicketIsDriver.UNKNOWN,
+            Oracle.ViolationTicketIsDriver.Y => DomainModel.ViolationTicketIsDriver.Y,
+            Oracle.ViolationTicketIsDriver.N => DomainModel.ViolationTicketIsDriver.N,
+            _ => DomainModel.ViolationTicketIsDriver.UNKNOWN
+        };
+    }
+
+    public Oracle.ViolationTicketIsDriver Convert(DomainModel.ViolationTicketIsDriver source, Oracle.ViolationTicketIsDriver destination, AutoMapper.ResolutionContext context)
+    {
+        return source switch
+        {
+            DomainModel.ViolationTicketIsDriver.UNKNOWN => Oracle.ViolationTicketIsDriver.UNKNOWN,
+            DomainModel.ViolationTicketIsDriver.Y => Oracle.ViolationTicketIsDriver.Y,
+            DomainModel.ViolationTicketIsDriver.N => Oracle.ViolationTicketIsDriver.N,
+            _ => Oracle.ViolationTicketIsDriver.UNKNOWN
+        };
+    }
+
+    public DomainModel.ViolationTicketIsOwner Convert(Oracle.ViolationTicketIsOwner source, DomainModel.ViolationTicketIsOwner destination, AutoMapper.ResolutionContext context)
+    {
+        return source switch
+        {
+            Oracle.ViolationTicketIsOwner.UNKNOWN => DomainModel.ViolationTicketIsOwner.UNKNOWN,
+            Oracle.ViolationTicketIsOwner.Y => DomainModel.ViolationTicketIsOwner.Y,
+            Oracle.ViolationTicketIsOwner.N => DomainModel.ViolationTicketIsOwner.N,
+            _ => DomainModel.ViolationTicketIsOwner.UNKNOWN
+        };
+    }
+
+    public Oracle.ViolationTicketIsOwner Convert(DomainModel.ViolationTicketIsOwner source, Oracle.ViolationTicketIsOwner destination, AutoMapper.ResolutionContext context)
+    {
+        return source switch
+        {
+            DomainModel.ViolationTicketIsOwner.UNKNOWN => Oracle.ViolationTicketIsOwner.UNKNOWN,
+            DomainModel.ViolationTicketIsOwner.Y => Oracle.ViolationTicketIsOwner.Y,
+            DomainModel.ViolationTicketIsOwner.N => Oracle.ViolationTicketIsOwner.N,
+            _ => Oracle.ViolationTicketIsOwner.UNKNOWN
+        };
+    }
+
+    public DomainModel.ViolationTicketIsYoungPerson Convert(Oracle.ViolationTicketIsYoungPerson source, DomainModel.ViolationTicketIsYoungPerson destination, AutoMapper.ResolutionContext context)
+    {
+        return source switch
+        {
+            Oracle.ViolationTicketIsYoungPerson.UNKNOWN => DomainModel.ViolationTicketIsYoungPerson.UNKNOWN,
+            Oracle.ViolationTicketIsYoungPerson.Y => DomainModel.ViolationTicketIsYoungPerson.Y,
+            Oracle.ViolationTicketIsYoungPerson.N => DomainModel.ViolationTicketIsYoungPerson.N,
+            _ => DomainModel.ViolationTicketIsYoungPerson.UNKNOWN
+        };
+    }
+
+    public Oracle.ViolationTicketIsYoungPerson Convert(DomainModel.ViolationTicketIsYoungPerson source, Oracle.ViolationTicketIsYoungPerson destination, AutoMapper.ResolutionContext context)
+    {
+        return source switch
+        {
+            DomainModel.ViolationTicketIsYoungPerson.UNKNOWN => Oracle.ViolationTicketIsYoungPerson.UNKNOWN,
+            DomainModel.ViolationTicketIsYoungPerson.Y => Oracle.ViolationTicketIsYoungPerson.Y,
+            DomainModel.ViolationTicketIsYoungPerson.N => Oracle.ViolationTicketIsYoungPerson.N,
+            _ => Oracle.ViolationTicketIsYoungPerson.UNKNOWN
+        };
+    }
+
+}


### PR DESCRIPTION
This should fix the problem with the data mappings. Should address the issue where it could not create EnumTypeConverter 

![image](https://github.com/bcgov/jag-traffic-courts-online/assets/1844480/50fb9477-beb6-4e8a-978d-a0db951a75b9)

# Description

This PR includes the following proposed change(s):

- move EnumTypeConverter from nested class to top level internal class
- update unit test generator to automatically exclude properties that exist on domain but not oracle
- update unit test generator to create explicit enum mappings
- add explicit enum mapping unit test.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [ ] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
