### PR TITLE
Created FormRecognizer cronjobs to cleanup old analyses

### DIFF
--- a/gitops/charts/form-recognizer-3.0/templates/cronjobs.yaml
+++ b/gitops/charts/form-recognizer-3.0/templates/cronjobs.yaml
@@ -1,0 +1,69 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ include "form-recognizer.fullname" . }}-cleanup-logs
+spec:
+  schedule: '@daily'
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          volumes:
+            - name: forms-recognizer-logs
+              persistentVolumeClaim:
+                claimName: {{ include "form-recognizer.fullname" . }}-logs
+          containers:
+            - name: {{ include "form-recognizer.fullname" . }}-cleanup-logs
+              securityContext:
+                capabilities:
+                  drop: ["ALL"]
+                runAsNonRoot: true
+                allowPrivilegeEscalation: false
+                seccompProfile:
+                  type: RuntimeDefault
+              image: alpine:3.17.2
+              # delete all logs older than 30 days
+              args:
+                - /bin/sh
+                - '-c'
+                - "LC_ALL=C find /logs -mtime +30 -delete || true;"
+              volumeMounts:
+                - name: forms-recognizer-logs
+                  mountPath: /logs
+          restartPolicy: OnFailure
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ include "form-recognizer.fullname" . }}-cleanup-requests
+spec:
+  schedule: '@hourly'
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          volumes:
+            - name: shared
+              persistentVolumeClaim:
+                claimName: {{ include "form-recognizer.fullname" . }}-shared
+          containers:
+            - name: cleanup-requests
+              securityContext:
+                capabilities:
+                  drop: ["ALL"]
+                runAsNonRoot: true
+                allowPrivilegeEscalation: false
+                seccompProfile:
+                  type: RuntimeDefault
+              image: alpine:3.17.2
+              # delete all logs older than 60 minutes
+              args:
+                - /bin/sh
+                - '-c'
+                - "LC_ALL=C find /shared/custom/.__default__.virtualdir -mmin +60 -delete || true;"
+              volumeMounts:
+                - name: shared
+                  mountPath: /shared
+          restartPolicy: Never


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

Created helm chart to cleanup old FormRecognizer3.0 analyses.
- delete logs older than 30 days (run daily)
- delete analyses older than 60 minutes (run hourly)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Deployed to DEV and TEST and confirmed functionality

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
