### PR TITLE
Remove setting user to 1001 in Workflow service Dockerfile

### DIFF
--- a/src/backend/TrafficCourts/Workflow.Service/Dockerfile
+++ b/src/backend/TrafficCourts/Workflow.Service/Dockerfile
@@ -41,6 +41,4 @@ WORKDIR /app
 COPY --from=publish /app/publish .
 USER root
 RUN chgrp 0 entrypoint.sh && chmod a+rwx,o-rwx entrypoint.sh
-# Run container by default as user with id 1001 (default)
-USER 1001
 ENTRYPOINT ["./entrypoint.sh", "dotnet", "TrafficCourts.Workflow.Service.dll"]


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- fixes the local dockerfile for running in docker compose
- remove setting user to 1001 which breaks stuff cause the `/etc/passwd` does not have a matching entry
- this setting would cause remote debugging to fail

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [x] Yes
- [ ] No

If Yes: Has Docker been updated accordingly?

- [x] Yes
- [ ] No

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
