### PR TITLE
TCVP-2784 Added generic error message for 500 errors

### DIFF
--- a/src/frontend/citizen-portal/src/app/services/violation-ticket.service.ts
+++ b/src/frontend/citizen-portal/src/app/services/violation-ticket.service.ts
@@ -402,12 +402,17 @@ export class ViolationTicketService {
         this.openErrorScenarioEightDialog();
       }
       else { // fall back option
-        var errorMessages = "";
-        if (err.error?.errors) {
-          err.error.errors.forEach(error => { errorMessages += ". \n" + error });
+        if (err.status === 500) {
+            this.openErrorScenario500Dialog();
         }
-        this.logger.error("ViolationTicketService:onError validation error has occurred", errorMessages);
-        this.openErrorScenarioOneDialog();
+        else {
+            var errorMessages = "";
+            if (err.error?.errors) {
+              err.error.errors.forEach(error => { errorMessages += ". \n" + error });
+            }
+            this.logger.error("ViolationTicketService:onError validation error has occurred", errorMessages);
+            this.openErrorScenarioOneDialog();
+        }
       }
     }
     this.goToFind();
@@ -428,6 +433,10 @@ export class ViolationTicketService {
       cancelHide: true,
     };
     return this.dialog.open(ImageTicketNotFoundDialogComponent, { data })
+  }
+
+  private openErrorScenario500Dialog() {
+    return this.openImageTicketNotFoundDialog("Internal Server Error", "error500");
   }
 
   private openErrorScenarioOneDialog() {

--- a/src/frontend/citizen-portal/src/app/shared/dialogs/image-ticket-not-found-dialog/image-ticket-not-found-dialog.component.html
+++ b/src/frontend/citizen-portal/src/app/shared/dialogs/image-ticket-not-found-dialog/image-ticket-not-found-dialog.component.html
@@ -86,6 +86,11 @@
 
       Please click <a href="https://www2.gov.bc.ca/gov/content/justice/courthouse-services/fines-payments/pay-dispute-ticket/prov-violation-tickets/dispute-ticket">here</a> for more options.</p>
   </div>
+  <div *ngIf="options.messageKey === 'error500'">
+    <span class="flex-grow-1"></span>
+    <p>Please refresh the page and try again.</p>
+    <p>If the problem persists, please contact support at <a href="mailto:Courts.TCO@gov.bc.ca" target="blank">Courts.TCO@gov.bc.ca</a></p>
+  </div>
 </mat-dialog-content>
 <mat-dialog-actions>
   <span class="flex-grow-1"></span>


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

TCVP-2784 When the backend throws a 500 error, the citizen-portal now displays a generic Internal Server Error instead of the very misleading error "Your ticket could not be read".

![image](https://github.com/bcgov/jag-traffic-courts-online/assets/55215368/f778fd76-c4f2-4cbd-bc5d-544a6e7acb62)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Forced backend to throw 500 and confirmed error is displayed.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
