### PR TITLE
TCVP-2878 Filter corrupt files in COMS

### DIFF
--- a/src/backend/TrafficCourts/Citizen.Service/Controllers/DisputesController.cs
+++ b/src/backend/TrafficCourts/Citizen.Service/Controllers/DisputesController.cs
@@ -329,6 +329,12 @@ public class DisputesController : ControllerBase
             // can throw
             result.FileData = await _documentService.FindFilesAsync(properties, cancellationToken);
 
+            // TCVP-2878 Filter files that are corrupt in COMS (missing attributes)
+            if (result.FileData is not null) {
+                // If there is a missing fileName, remove it from the list as we can't display such an object in the UI.
+                result.FileData = result.FileData.Where(x => x.FileName is not null).ToList();
+            }
+
             return Ok(result);
         }
         catch (Exception exception)

--- a/src/backend/TrafficCourts/Staff.Service/Services/JJDisputeService.cs
+++ b/src/backend/TrafficCourts/Staff.Service/Services/JJDisputeService.cs
@@ -65,6 +65,12 @@ public partial class JJDisputeService : IJJDisputeService
             dispute.FileData = dispute.FileData.Where(x => x.DocumentSource != TrafficCourts.Domain.Models.DocumentSource.Citizen || x.DocumentStatus == DisputeUpdateRequestStatus.ACCEPTED.ToString()).ToList();
         }
 
+        // TCVP-2878 Filter files that are corrupt in COMS (missing attributes)
+        if (dispute.FileData is not null) {
+            // If there is a missing fileName, remove it from the list as we can't display such an object in the UI.
+            dispute.FileData = dispute.FileData.Where(x => x.FileName is not null).ToList();
+        }
+
         // Populate the statute description of each count of the JJDispute
         foreach (var count in dispute.JjDisputedCounts)
         {


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

TCVP-2878. The UI was showing documents from COMS with missing filenames. 

For now, filter these files so they are not shown to the user or staff.

![image-2024-04-01-08-03-17-681](https://github.com/bcgov/jag-traffic-courts-online/assets/55215368/504206cd-ee7d-4501-9eed-d4a4b5c69d58)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
