### PR TITLE
TCVP-2882 Fix disputant updates not visible

### DIFF
--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/repository/impl/ords/DisputeRepositoryImpl.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/repository/impl/ords/DisputeRepositoryImpl.java
@@ -25,6 +25,7 @@ import ca.bc.gov.open.jag.tco.oracledataapi.model.Dispute;
 import ca.bc.gov.open.jag.tco.oracledataapi.model.DisputeListItem;
 import ca.bc.gov.open.jag.tco.oracledataapi.model.DisputeResult;
 import ca.bc.gov.open.jag.tco.oracledataapi.model.DisputeStatus;
+import ca.bc.gov.open.jag.tco.oracledataapi.model.DisputeUpdateRequestStatus;
 import ca.bc.gov.open.jag.tco.oracledataapi.model.EmptyObject;
 import ca.bc.gov.open.jag.tco.oracledataapi.model.ViolationTicketCount;
 import ca.bc.gov.open.jag.tco.oracledataapi.ords.occam.api.ViolationTicketApi;
@@ -70,7 +71,7 @@ public class DisputeRepositoryImpl implements DisputeRepository {
 	public List<DisputeListItem> findByStatusNotAndCreatedTsAfterAndNoticeOfDisputeGuid(DisputeStatus excludeStatus,
 			Date newerThan, String noticeOfDisputeGuid) {
 		String newerThanDate = null;
-		String statusShortName = excludeStatus != null ? excludeStatus.toShortName() : null;
+		String statusShortName = excludeStatus != null && !DisputeStatus.UNKNOWN.equals(excludeStatus) ? excludeStatus.toShortName() : null;
 
 		if (newerThan != null) {
 			SimpleDateFormat simpleDateFormat = new SimpleDateFormat(DateUtil.DATE_FORMAT);
@@ -120,7 +121,7 @@ public class DisputeRepositoryImpl implements DisputeRepository {
 	
 	@Override
 	public List<DisputeResult> findByStatusNotAndTicketNumber(DisputeStatus excludeStatus, String ticketNumber) {
-		String statusShortName = excludeStatus != null ? excludeStatus.toShortName() : null;
+		String statusShortName = excludeStatus != null && !DisputeStatus.UNKNOWN.equals(excludeStatus) ? excludeStatus.toShortName() : null;
 		
 		ViolationTicketListResponse response = violationTicketApi.violationTicketListGet(null, statusShortName, ticketNumber, null,
 				null);
@@ -299,7 +300,7 @@ public class DisputeRepositoryImpl implements DisputeRepository {
 	private List<Dispute> findByNoticeOfDisputeGuidImpl(DisputeStatus excludeStatus, Date newerThan,
 			String noticeOfDisputeGuid) {
 		String newerThanDate = null;
-		String statusShortName = excludeStatus != null ? excludeStatus.toShortName() : null;
+		String statusShortName = excludeStatus != null && !DisputeStatus.UNKNOWN.equals(excludeStatus) ? excludeStatus.toShortName() : null;
 
 		if (newerThan != null) {
 			SimpleDateFormat simpleDateFormat = new SimpleDateFormat(DateUtil.DATE_FORMAT);

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/repository/impl/ords/DisputeUpdateRequestRepositoryImpl.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/repository/impl/ords/DisputeUpdateRequestRepositoryImpl.java
@@ -39,7 +39,7 @@ public class DisputeUpdateRequestRepositoryImpl implements DisputeUpdateRequestR
 
 	@Override
 	public List<DisputeUpdateRequest> findByOptionalDisputeIdAndOptionalStatus(Long disputeId, DisputeUpdateRequestStatus status) {
-		String updateReqStatusShortName = status != null ? status.getShortName() : null;
+		String updateReqStatusShortName = status != null && !DisputeUpdateRequestStatus.UNKNOWN.equals(status) ? status.getShortName() : null;
 
 		UpdateRequestListResponse response = disputeUpdateRequestApi.v1DisputeUpdateRequestListGet(updateReqStatusShortName, null, disputeId, null);
 

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/service/DisputeService.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/service/DisputeService.java
@@ -432,7 +432,7 @@ public class DisputeService {
 		else if (issuedTime != null) {
 			disputeResults.addAll(disputeRepository.findByTicketNumberAndTime(ticketNumber, issuedTime));
 		}
-		else if (excludeStatus != null) {
+		else if (excludeStatus != null && !DisputeStatus.UNKNOWN.equals(excludeStatus)) {
 			disputeResults.addAll(disputeRepository.findByStatusNotAndTicketNumber(excludeStatus, ticketNumber));
 		}
 		else {


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- [TCVP-2882](https://justice.gov.bc.ca/jira/browse/TCVP-2882)
- Fixed the issue with returning empty list of disputeUpdateRequests through adding additional check for 'UNKNOWN' status type for which case sending the status as null to avoid any status filtering from ORDS.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
