### PR TITLE
Clean up trace and metric registration. Exclude Fusion Cache backplane

### DIFF
--- a/src/backend/TrafficCourts/Citizen.Service/Instrumentation/MeterProviderBuilderExtensions.cs
+++ b/src/backend/TrafficCourts/Citizen.Service/Instrumentation/MeterProviderBuilderExtensions.cs
@@ -1,0 +1,13 @@
+﻿namespace OpenTelemetry.Metrics;
+
+/// <summary>
+/// Contains extension methods to <see cref="MeterProviderBuilder"/> for enabling Citizen Service metrics instrumentation.
+/// </summary>
+public static class MeterProviderBuilderExtensions
+{
+    public static MeterProviderBuilder AddCitizenServiceInstrumentation(this MeterProviderBuilder builder)
+    {
+        builder.AddMeter("CitizenService");
+        return builder;
+    }
+}

--- a/src/backend/TrafficCourts/Citizen.Service/Instrumentation/TracerProviderBuilderExtensions.cs
+++ b/src/backend/TrafficCourts/Citizen.Service/Instrumentation/TracerProviderBuilderExtensions.cs
@@ -1,0 +1,12 @@
+﻿namespace OpenTelemetry.Trace;
+
+/// <summary>
+/// Contains extension methods to <see cref="TracerProviderBuilder"/> for enabling Citizen Service traces instrumentation.
+/// </summary>
+public static class TracerProviderBuilderExtensions
+{
+    public static TracerProviderBuilder AddCitizenServiceInstrumentation(this TracerProviderBuilder builder)
+    {
+        return builder;
+    }
+}

--- a/src/backend/TrafficCourts/Citizen.Service/Startup.cs
+++ b/src/backend/TrafficCourts/Citizen.Service/Startup.cs
@@ -42,15 +42,24 @@ public static class Startup
         builder.AddOpenTelemetry(Diagnostics.Source, logger, options =>
         {
             options
-                .AddFusionCacheInstrumentation()
-                .AddSource(MassTransit.Logging.DiagnosticHeaders.DefaultListenerName)
-                .AddSource(Coms.Client.Monitoring.Diagnostics.Source.Name);
+                .AddFusionCacheInstrumentation(options =>
+                {
+                    // TODO: allow setting from config, useful in dev but not test/prod
+                    options.IncludeMemoryLevel = false;
+                    options.IncludeDistributedLevel = false;
+                    options.IncludeBackplane = false;
+                })
+                .AddCitizenServiceInstrumentation()
+                .AddComsClientInstrumentation()
+                .AddMassTransitInstrumentation();
         },
             options =>
             {
                 options
                     .AddFusionCacheInstrumentation()
-                    .AddMeter("MassTransit", "ComsClient", "CitizenService");
+                    .AddCitizenServiceInstrumentation()
+                    .AddComsClientInstrumentation()
+                    .AddMassTransitInstrumentation();
             }
         );
 

--- a/src/backend/TrafficCourts/Common/Configuration/Extensions.cs
+++ b/src/backend/TrafficCourts/Common/Configuration/Extensions.cs
@@ -117,7 +117,8 @@ public static class Extensions
             loggerConfiguration
                 .ReadFrom.Configuration(builder.Configuration)
                 .Enrich.WithExceptionDetails(destructurers)
-                .Enrich.With<TrafficCourts.Logging.Enrichers.HostNameEnricher>();
+                .Enrich.With<TrafficCourts.Logging.Enrichers.HostNameEnricher>()
+                .Enrich.With<TrafficCourts.Logging.Enrichers.ActivityEnricher>();
         });
     }
 

--- a/src/backend/TrafficCourts/Messaging/MeterProviderBuilderExtensions.cs
+++ b/src/backend/TrafficCourts/Messaging/MeterProviderBuilderExtensions.cs
@@ -1,0 +1,13 @@
+﻿namespace OpenTelemetry.Metrics;
+
+/// <summary>
+/// Contains extension methods to <see cref="MeterProviderBuilder"/> for enabling MassTransit metrics instrumentation.
+/// </summary>
+public static class MeterProviderBuilderExtensions
+{
+    public static MeterProviderBuilder AddMassTransitInstrumentation(this MeterProviderBuilder builder)
+    {
+        builder.AddMeter("MassTransit");
+        return builder;
+    }
+}

--- a/src/backend/TrafficCourts/Messaging/TracerProviderBuilderExtensions.cs
+++ b/src/backend/TrafficCourts/Messaging/TracerProviderBuilderExtensions.cs
@@ -1,0 +1,13 @@
+﻿namespace OpenTelemetry.Trace;
+
+/// <summary>
+/// Contains extension methods to <see cref="TracerProviderBuilder"/> for enabling MassTransit traces instrumentation.
+/// </summary>
+public static class TracerProviderBuilderExtensions
+{
+    public static TracerProviderBuilder AddMassTransitInstrumentation(this TracerProviderBuilder builder)
+    {
+        builder.AddSource(MassTransit.Logging.DiagnosticHeaders.DefaultListenerName);
+        return builder;
+    }
+}

--- a/src/backend/TrafficCourts/Staff.Service/Startup.cs
+++ b/src/backend/TrafficCourts/Staff.Service/Startup.cs
@@ -29,16 +29,25 @@ public static class Startup
         builder.AddOpenTelemetry(Diagnostics.Source, logger, options =>
         {
             options
-                .AddSource(MassTransit.Logging.DiagnosticHeaders.DefaultListenerName)
-                .AddSource(Coms.Client.Monitoring.Diagnostics.Source.Name)
-                .AddFusionCacheInstrumentation()
+                .AddComsClientInstrumentation()
+                .AddFusionCacheInstrumentation(options =>
+                {
+                    // TODO: allow setting from config, useful in dev but not test/prod
+                    options.IncludeMemoryLevel = false;
+                    options.IncludeDistributedLevel = false;
+                    options.IncludeBackplane = false;
+                })
+                .AddMassTransitInstrumentation()
+                .AddOracleDataApiInstrumentation()
                 .AddRedisInstrumentation();
         },
         options => 
         {
             options
+                .AddComsClientInstrumentation()
                 .AddFusionCacheInstrumentation()
-                .AddMeter("MassTransit", "ComsClient", "OracleDataApi");
+                .AddMassTransitInstrumentation()
+                .AddOracleDataApiInstrumentation();
         });
 
         var redisConnectionString = builder.AddRedis();

--- a/src/backend/TrafficCourts/TrafficCourts.Coms.Client/Monitoring/Diagnostics.cs
+++ b/src/backend/TrafficCourts/TrafficCourts.Coms.Client/Monitoring/Diagnostics.cs
@@ -1,9 +1,8 @@
 ﻿using System.Diagnostics;
 
-namespace TrafficCourts.Coms.Client.Monitoring
+namespace TrafficCourts.Coms.Client.Monitoring;
+
+internal static class Diagnostics
 {
-    public static class Diagnostics
-    {
-        public static readonly ActivitySource Source = new ActivitySource("coms");
-    }
+    public static readonly ActivitySource Source = new ActivitySource("coms");
 }

--- a/src/backend/TrafficCourts/TrafficCourts.Coms.Client/Monitoring/MeterProviderBuilderExtensions.cs
+++ b/src/backend/TrafficCourts/TrafficCourts.Coms.Client/Monitoring/MeterProviderBuilderExtensions.cs
@@ -1,0 +1,15 @@
+﻿using TrafficCourts.Coms.Client.Monitoring;
+
+namespace OpenTelemetry.Metrics;
+
+/// <summary>
+/// Contains extension methods to <see cref="MeterProviderBuilder"/> for enabling Coms Client metrics instrumentation.
+/// </summary>
+public static class MeterProviderBuilderExtensions
+{
+    public static MeterProviderBuilder AddComsClientInstrumentation(this MeterProviderBuilder builder)
+    {
+        builder.AddMeter(Instrumentation.MeterName);
+        return builder;
+    }
+}

--- a/src/backend/TrafficCourts/TrafficCourts.Coms.Client/Monitoring/TracerProviderBuilderExtensions.cs
+++ b/src/backend/TrafficCourts/TrafficCourts.Coms.Client/Monitoring/TracerProviderBuilderExtensions.cs
@@ -1,0 +1,13 @@
+﻿namespace OpenTelemetry.Trace;
+
+/// <summary>
+/// Contains extension methods to <see cref="TracerProviderBuilder"/> for enabling Coms Client traces instrumentation.
+/// </summary>
+public static class TracerProviderBuilderExtensions
+{
+    public static TracerProviderBuilder AddComsClientInstrumentation(this TracerProviderBuilder builder)
+    {
+        builder.AddSource(TrafficCourts.Coms.Client.Monitoring.Diagnostics.Source.Name);
+        return builder;
+    }
+}

--- a/src/backend/TrafficCourts/TrafficCourts.Coms.Client/TrafficCourts.Coms.Client.csproj
+++ b/src/backend/TrafficCourts/TrafficCourts.Coms.Client/TrafficCourts.Coms.Client.csproj
@@ -13,6 +13,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
+    <PackageReference Include="OpenTelemetry.Api" Version="1.7.0" />
   </ItemGroup>
 
 	<ItemGroup>

--- a/src/backend/TrafficCourts/TrafficCourts.Core.Test/Logging/Enrichers/ActivityEnricherTest.cs
+++ b/src/backend/TrafficCourts/TrafficCourts.Core.Test/Logging/Enrichers/ActivityEnricherTest.cs
@@ -1,0 +1,53 @@
+﻿using NSubstitute;
+using Serilog.Core;
+using Serilog.Events;
+using Serilog.Parsing;
+using System.Diagnostics;
+using TrafficCourts.Logging.Enrichers;
+
+namespace TrafficCourts.Core.Test.Logging.Enrichers;
+
+public class ActivityEnricherTest : IDisposable
+{
+    private ActivityListener _listener;
+    private readonly List<Activity> activities = new List<Activity>();
+    private ActivitySource _activitySource = new ActivitySource(nameof(ActivityEnricherTest));
+
+    public ActivityEnricherTest()
+    {
+        // setup the activity listener
+
+        _listener = new ActivityListener();
+        _listener.ShouldListenTo = s => s.Name == nameof(ActivityEnricherTest);
+        _listener.Sample = (ref ActivityCreationOptions<ActivityContext> options) => ActivitySamplingResult.AllData;
+        _listener.ActivityStopped += a => activities.Add(a);
+        ActivitySource.AddActivityListener(_listener);
+    }
+
+    [Fact]
+    public void adds_TraceId_property()
+    {
+        using var activity = _activitySource.StartActivity("testing");
+
+        ActivityEnricher sut = new ActivityEnricher();
+
+        // create our log event
+        LogEvent logEvent = new LogEvent(
+            DateTimeOffset.UtcNow,
+            LogEventLevel.Information,
+            null,
+            new MessageTemplate([]),
+            []);
+
+        Assert.False(logEvent.Properties.ContainsKey("TraceId"));
+        
+        sut.Enrich(logEvent, Substitute.For<ILogEventPropertyFactory>());
+
+        Assert.True(logEvent.Properties.ContainsKey("TraceId"));
+    }
+
+    public void Dispose()
+    {
+        _listener?.Dispose();
+    }
+}

--- a/src/backend/TrafficCourts/TrafficCourts.Core.Test/TrafficCourts.Core.Test.csproj
+++ b/src/backend/TrafficCourts/TrafficCourts.Core.Test/TrafficCourts.Core.Test.csproj
@@ -13,6 +13,7 @@
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.Testing" Version="8.1.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="xunit" Version="2.7.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.7">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/backend/TrafficCourts/TrafficCourts.Core/Logging/Enrichers/ActivityEnricher.cs
+++ b/src/backend/TrafficCourts/TrafficCourts.Core/Logging/Enrichers/ActivityEnricher.cs
@@ -1,0 +1,83 @@
+﻿using Serilog.Core;
+using Serilog.Events;
+using System.Diagnostics;
+
+namespace TrafficCourts.Logging.Enrichers;
+
+public sealed class ActivityEnricher : ILogEventEnricher
+{
+    private readonly ActivityEnricherOptions _options;
+
+    public ActivityEnricher() : this(new ActivityEnricherOptions(true, false, false))
+    {
+    }
+
+    public ActivityEnricher(ActivityEnricherOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        _options = options;
+    }
+
+    public void Enrich(LogEvent logEvent, ILogEventPropertyFactory propertyFactory)
+    {
+        var activity = Activity.Current;
+        if (activity is null)
+        {
+            return;
+        }
+
+        if (_options.LogTraceId) AddPropertyIfAbsent(logEvent, activity, "TraceId", GetTraceId);
+        if (_options.LogSpanId) AddPropertyIfAbsent(logEvent, activity, "SpanId", GetSpanId);
+        if (_options.LogParentId) AddPropertyIfAbsent(logEvent, activity, "ParentId", GetParentId);
+    }
+
+    private void AddPropertyIfAbsent(LogEvent logEvent, Activity activity, string propertyName, Func<Activity, string?> valueFactory)
+    {
+        string? propertyValue = valueFactory(activity);
+        if (propertyValue is not null)
+        {
+            logEvent.AddPropertyIfAbsent(new LogEventProperty(propertyName, new ScalarValue(propertyValue)));
+        }
+    }
+
+    private static string? GetTraceId(Activity activity)
+    {
+        ArgumentNullException.ThrowIfNull(activity);
+
+        var traceId = activity.IdFormat switch
+        {
+            ActivityIdFormat.Hierarchical => activity.RootId,
+            ActivityIdFormat.W3C => activity.TraceId.ToHexString(),
+            ActivityIdFormat.Unknown => null,
+            _ => null,
+        };
+
+        return traceId;
+    }
+
+    private static string? GetSpanId(Activity activity)
+    {
+        var spanId = activity.IdFormat switch
+        {
+            ActivityIdFormat.Hierarchical => activity.Id,
+            ActivityIdFormat.W3C => activity.SpanId.ToHexString(),
+            ActivityIdFormat.Unknown => null,
+            _ => null,
+        };
+
+        return spanId;
+    }
+
+    private static string? GetParentId(Activity activity)
+    {
+        var parentId = activity.IdFormat switch
+        {
+            ActivityIdFormat.Hierarchical => activity.ParentId,
+            ActivityIdFormat.W3C => activity.ParentSpanId.ToHexString(),
+            ActivityIdFormat.Unknown => null,
+            _ => null,
+        };
+
+        return parentId;
+    }
+}

--- a/src/backend/TrafficCourts/TrafficCourts.Core/Logging/Enrichers/ActivityEnricherOptions.cs
+++ b/src/backend/TrafficCourts/TrafficCourts.Core/Logging/Enrichers/ActivityEnricherOptions.cs
@@ -1,0 +1,3 @@
+﻿namespace TrafficCourts.Logging.Enrichers;
+
+public sealed record ActivityEnricherOptions(bool LogTraceId, bool LogSpanId, bool LogParentId);

--- a/src/backend/TrafficCourts/TrafficCourts.OracleDataApi/MeterProviderBuilderExtensions.cs
+++ b/src/backend/TrafficCourts/TrafficCourts.OracleDataApi/MeterProviderBuilderExtensions.cs
@@ -1,0 +1,13 @@
+﻿namespace OpenTelemetry.Metrics;
+
+/// <summary>
+/// Contains extension methods to <see cref="MeterProviderBuilder"/> for enabling Oracle Data API metrics instrumentation.
+/// </summary>
+public static class MeterProviderBuilderExtensions
+{
+    public static MeterProviderBuilder AddOracleDataApiInstrumentation(this MeterProviderBuilder builder)
+    {
+        builder.AddMeter(TrafficCourts.OracleDataApi.OracleDataApiOperationMetrics.MeterName);
+        return builder;
+    }
+}

--- a/src/backend/TrafficCourts/TrafficCourts.OracleDataApi/TracerProviderBuilderExtensions.cs
+++ b/src/backend/TrafficCourts/TrafficCourts.OracleDataApi/TracerProviderBuilderExtensions.cs
@@ -1,0 +1,13 @@
+﻿namespace OpenTelemetry.Trace;
+
+/// <summary>
+/// Contains extension methods to <see cref="TracerProviderBuilder"/> for enabling Oracle Data API traces instrumentation.
+/// </summary>
+public static class TracerProviderBuilderExtensions
+{
+    public static TracerProviderBuilder AddOracleDataApiInstrumentation(this TracerProviderBuilder builder)
+    {
+        //builder.AddSource("...");
+        return builder;
+    }
+}


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- Fixes TCVP-2888 - filter out "receive from backplane" traces
- Cleans up the setup of trace and metrics by providing extension methods

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [ ] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
