### PR TITLE
TCVP-2885 Updated liveliness/readiness probe timeouts for oracle-data-api

### DIFF
--- a/gitops/charts/traffic-court-online/charts/oracle-data-api/templates/deployment.yaml
+++ b/gitops/charts/traffic-court-online/charts/oracle-data-api/templates/deployment.yaml
@@ -54,3 +54,23 @@ spec:
               protocol: TCP
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+          livenessProbe:
+            httpGet:
+              path: "/actuator/health"
+              port: 8080
+              scheme: HTTP
+            initialDelaySeconds: 30
+            timeoutSeconds: 60
+            periodSeconds: 10
+            successThreshold: 1
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: "/actuator/health"
+              port: 8080
+              scheme: HTTP
+            initialDelaySeconds: 10
+            timeoutSeconds: 60
+            periodSeconds: 10
+            successThreshold: 1
+            failureThreshold: 3

--- a/gitops/charts/traffic-court-online/charts/oracle-data-api/templates/deployment.yaml
+++ b/gitops/charts/traffic-court-online/charts/oracle-data-api/templates/deployment.yaml
@@ -59,18 +59,18 @@ spec:
               path: "/actuator/health"
               port: 8080
               scheme: HTTP
-            initialDelaySeconds: 30
+            initialDelaySeconds: 120
             timeoutSeconds: 60
             periodSeconds: 10
             successThreshold: 1
-            failureThreshold: 3
+            failureThreshold: 6
           readinessProbe:
             httpGet:
               path: "/actuator/health"
               port: 8080
               scheme: HTTP
-            initialDelaySeconds: 10
+            initialDelaySeconds: 120
             timeoutSeconds: 60
             periodSeconds: 10
             successThreshold: 1
-            failureThreshold: 3
+            failureThreshold: 6


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

Updated liveliness/readiness probe timeouts for oracle-data-api.
Given the container's limited CPU utilization (0.25m), it takes 120 seconds to start up. If we the container had more CPU, this could drop to 25 seconds for 1 CPU or 12 seconds for 2 CPUs.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [ ] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
