### PR TITLE
Switch image streams to pull from artifactory

### DIFF
--- a/gitops/openshift/tools/image-streams/cassandra.yaml
+++ b/gitops/openshift/tools/image-streams/cassandra.yaml
@@ -12,8 +12,8 @@ spec:
     - name: '4.1.4-debian-12-r5'
       from:
         kind: DockerImage
-        name: 'docker.io/bitnami/cassandra:4.1.4-debian-12-r5'
-        imagePullSecret: 'pipeline-docker-hub-pull'
+        name: 'artifacts.developer.gov.bc.ca/docker-remote/bitnami/cassandra:4.1.4-debian-12-r5'
+        imagePullSecret: 'artifacts-default-gpffbq'
       importPolicy:
         scheduled: true
       referencePolicy:
@@ -21,8 +21,8 @@ spec:
     - name: '4.0.12-debian-12-r9'
       from:
         kind: DockerImage
-        name: 'docker.io/bitnami/cassandra:4.0.12-debian-12-r9'
-        imagePullSecret: 'pipeline-docker-hub-pull'
+        name: 'artifacts.developer.gov.bc.ca/docker-remote/bitnami/cassandra:4.0.12-debian-12-r9'
+        imagePullSecret: 'artifacts-default-gpffbq'
       importPolicy:
         scheduled: true
       referencePolicy:

--- a/gitops/openshift/tools/image-streams/common-object-management-service.yaml
+++ b/gitops/openshift/tools/image-streams/common-object-management-service.yaml
@@ -1,7 +1,7 @@
 kind: ImageStream
 apiVersion: image.openshift.io/v1
 metadata:
-  name: form-recognizer-custom-template-3.0
+  name: common-object-management-service
   namespace: 0198bb-tools
   labels:
     usage: runtime-image
@@ -9,10 +9,10 @@ spec:
   lookupPolicy:
     local: true
   tags:
-    - name: '2022-08-31'
+    - name: '0.4.2'
       from:
         kind: DockerImage
-        name: 'artifacts.developer.gov.bc.ca/microsoft-docker-remote/azure-cognitive-services/form-recognizer/custom-template-3.0:2022-08-31'
+        name: 'artifacts.developer.gov.bc.ca/docker-remote/bcgovimages/common-object-management-service:0.4.2'
         imagePullSecret: 'artifacts-default-gpffbq'
       importPolicy:
         scheduled: true

--- a/gitops/openshift/tools/image-streams/dotnet.yaml
+++ b/gitops/openshift/tools/image-streams/dotnet.yaml
@@ -12,8 +12,8 @@ spec:
     - name: '8.0'
       from:
         kind: DockerImage
-        name: 'mcr.microsoft.com/dotnet/sdk:8.0'
-        imagePullSecret: 'pipeline-docker-hub-pull'
+        name: 'artifacts.developer.gov.bc.ca/microsoft-docker-remote/dotnet/sdk:8.0'
+        imagePullSecret: 'artifacts-default-gpffbq'
       importPolicy:
         scheduled: true
       referencePolicy:
@@ -21,8 +21,8 @@ spec:
     - name: '7.0'
       from:
         kind: DockerImage
-        name: 'mcr.microsoft.com/dotnet/sdk:7.0'
-        imagePullSecret: 'pipeline-docker-hub-pull'
+        name: 'artifacts.developer.gov.bc.ca/microsoft-docker-remote/dotnet/sdk:7.0'
+        imagePullSecret: 'artifacts-default-gpffbq'
       importPolicy:
         scheduled: true
       referencePolicy:
@@ -42,7 +42,8 @@ spec:
     - name: 'latest'
       from:
         kind: DockerImage
-        name: 'registry.access.redhat.com/ubi8/dotnet-80-runtime:latest'
+        name: 'artifacts.developer.gov.bc.ca/redhat-access-docker-remote/ubi8/dotnet-80-runtime:latest'
+        imagePullSecret: 'artifacts-default-gpffbq'
       importPolicy:
         scheduled: true
       referencePolicy:
@@ -62,7 +63,8 @@ spec:
     - name: 'latest'
       from:
         kind: DockerImage
-        name: 'registry.access.redhat.com/ubi8/dotnet-70-runtime:latest'
+        name: 'artifacts.developer.gov.bc.ca/redhat-access-docker-remote/ubi8/dotnet-70-runtime:latest'
+        imagePullSecret: 'artifacts-default-gpffbq'
       importPolicy:
         scheduled: true
       referencePolicy:

--- a/gitops/openshift/tools/image-streams/eclipse-temurin.yaml
+++ b/gitops/openshift/tools/image-streams/eclipse-temurin.yaml
@@ -12,8 +12,8 @@ spec:
     - name: '21'
       from:
         kind: DockerImage
-        name: 'docker.io/eclipse-temurin:21'
-        imagePullSecret: 'pipeline-docker-hub-pull'
+        name: 'artifacts.developer.gov.bc.ca/docker-remote/eclipse-temurin:21'
+        imagePullSecret: 'artifacts-default-gpffbq'
       importPolicy:
         scheduled: true
       referencePolicy:
@@ -21,8 +21,8 @@ spec:
     - name: '17'
       from:
         kind: DockerImage
-        name: 'docker.io/eclipse-temurin:17'
-        imagePullSecret: 'pipeline-docker-hub-pull'
+        name: 'artifacts.developer.gov.bc.ca/docker-remote/eclipse-temurin:17'
+        imagePullSecret: 'artifacts-default-gpffbq'
       importPolicy:
         scheduled: true
       referencePolicy:
@@ -30,8 +30,8 @@ spec:
     - name: '11'
       from:
         kind: DockerImage
-        name: 'docker.io/eclipse-temurin:11'
-        imagePullSecret: 'pipeline-docker-hub-pull'
+        name: 'artifacts.developer.gov.bc.ca/docker-remote/eclipse-temurin:11'
+        imagePullSecret: 'artifacts-default-gpffbq'
       importPolicy:
         scheduled: true
       referencePolicy:

--- a/gitops/openshift/tools/image-streams/form-recognizer-layout-3.0.yaml
+++ b/gitops/openshift/tools/image-streams/form-recognizer-layout-3.0.yaml
@@ -12,7 +12,8 @@ spec:
     - name: '2022-08-31'
       from:
         kind: DockerImage
-        name: 'mcr.microsoft.com/azure-cognitive-services/form-recognizer/layout-3.0:2022-08-31'
+        name: 'artifacts.developer.gov.bc.ca/microsoft-docker-remote/azure-cognitive-services/form-recognizer/layout-3.0:2022-08-31'
+        imagePullSecret: 'artifacts-default-gpffbq'
       importPolicy:
         scheduled: true
       referencePolicy:

--- a/gitops/openshift/tools/image-streams/jaeger.yaml
+++ b/gitops/openshift/tools/image-streams/jaeger.yaml
@@ -12,8 +12,8 @@ spec:
     - name: '1.55.0-debian-12-r0'
       from:
         kind: DockerImage
-        name: 'docker.io/bitnami/jaeger:1.55.0-debian-12-r0'
-        imagePullSecret: 'pipeline-docker-hub-pull'
+        name: 'artifacts.developer.gov.bc.ca/docker-remote/bitnami/jaeger:1.55.0-debian-12-r0'
+        imagePullSecret: 'artifacts-default-gpffbq'
       importPolicy:
         scheduled: true
       referencePolicy:

--- a/gitops/openshift/tools/image-streams/jaegertracing-all-in-one.yaml
+++ b/gitops/openshift/tools/image-streams/jaegertracing-all-in-one.yaml
@@ -12,8 +12,8 @@ spec:
     - name: '1.55.0'
       from:
         kind: DockerImage
-        name: 'docker.io/jaegertracing/all-in-one:1.55.0'
-        imagePullSecret: 'pipeline-docker-hub-pull'
+        name: 'artifacts.developer.gov.bc.ca/docker-remote/jaegertracing/all-in-one:1.55.0'
+        imagePullSecret: 'artifacts-default-gpffbq'
       importPolicy:
         scheduled: true
       referencePolicy:

--- a/gitops/openshift/tools/image-streams/keycloak.yaml
+++ b/gitops/openshift/tools/image-streams/keycloak.yaml
@@ -12,8 +12,8 @@ spec:
     - name: '23.0.7-debian-12-r4'
       from:
         kind: DockerImage
-        name: 'docker.io/bitnami/keycloak:23.0.7-debian-12-r4'
-        imagePullSecret: 'pipeline-docker-hub-pull'
+        name: 'artifacts.developer.gov.bc.ca/docker-remote/bitnami/keycloak:23.0.7-debian-12-r4'
+        imagePullSecret: 'artifacts-default-gpffbq'
       importPolicy:
         scheduled: true
       referencePolicy:
@@ -21,8 +21,8 @@ spec:
     - name: '22.0.5-debian-11-r7'
       from:
         kind: DockerImage
-        name: 'docker.io/bitnami/keycloak:22.0.5-debian-11-r7'
-        imagePullSecret: 'pipeline-docker-hub-pull'
+        name: 'artifacts.developer.gov.bc.ca/docker-remote/bitnami/keycloak:22.0.5-debian-11-r7'
+        imagePullSecret: 'artifacts-default-gpffbq'
       importPolicy:
         scheduled: true
       referencePolicy:
@@ -30,8 +30,8 @@ spec:
     - name: '22.0.4-debian-11-r2'
       from:
         kind: DockerImage
-        name: 'docker.io/bitnami/keycloak:22.0.4-debian-11-r2'
-        imagePullSecret: 'pipeline-docker-hub-pull'
+        name: 'artifacts.developer.gov.bc.ca/docker-remote/bitnami/keycloak:22.0.4-debian-11-r2'
+        imagePullSecret: 'artifacts-default-gpffbq'
       importPolicy:
         scheduled: true
       referencePolicy:

--- a/gitops/openshift/tools/image-streams/maven.yaml
+++ b/gitops/openshift/tools/image-streams/maven.yaml
@@ -12,8 +12,8 @@ spec:
     - name: '3.8.6-jdk-11'
       from:
         kind: DockerImage
-        name: 'docker.io/maven:3.8.6-jdk-11'
-        imagePullSecret: 'pipeline-docker-hub-pull'
+        name: 'artifacts.developer.gov.bc.ca/docker-remote/maven:3.8.6-jdk-11'
+        imagePullSecret: 'artifacts-default-gpffbq'
       importPolicy:
         scheduled: true
       referencePolicy:

--- a/gitops/openshift/tools/image-streams/nginx-120.yaml
+++ b/gitops/openshift/tools/image-streams/nginx-120.yaml
@@ -12,7 +12,8 @@ spec:
     - name: 'latest'
       from:
         kind: DockerImage
-        name: 'registry.access.redhat.com/ubi8/nginx-120:latest'
+        name: 'artifacts.developer.gov.bc.ca/redhat-access-docker-remote/ubi8/nginx-120:latest'
+        imagePullSecret: 'artifacts-default-gpffbq'
       importPolicy:
         scheduled: true
       referencePolicy:
@@ -20,7 +21,8 @@ spec:
     - name: '1-127'
       from:
         kind: DockerImage
-        name: 'registry.access.redhat.com/ubi8/nginx-120:1-127.1698060561'
+        name: 'artifacts.developer.gov.bc.ca/redhat-access-docker-remote/ubi8/nginx-120:1-127.1698060561'
+        imagePullSecret: 'artifacts-default-gpffbq'
       importPolicy:
         scheduled: true
       referencePolicy:
@@ -28,7 +30,8 @@ spec:
     - name: '1-92'
       from:
         kind: DockerImage
-        name: 'registry.access.redhat.com/ubi8/nginx-120:1-92'
+        name: 'artifacts.developer.gov.bc.ca/redhat-access-docker-remote/ubi8/nginx-120:1-92'
+        imagePullSecret: 'artifacts-default-gpffbq'
       importPolicy:
         scheduled: true
       referencePolicy:
@@ -36,7 +39,8 @@ spec:
     - name: '1-74'
       from:
         kind: DockerImage
-        name: 'registry.access.redhat.com/ubi8/nginx-120:1-74'
+        name: 'artifacts.developer.gov.bc.ca/redhat-access-docker-remote/ubi8/nginx-120:1-74'
+        imagePullSecret: 'artifacts-default-gpffbq'
       importPolicy:
         scheduled: true
       referencePolicy:
@@ -44,7 +48,8 @@ spec:
     - name: '1-54'
       from:
         kind: DockerImage
-        name: 'registry.access.redhat.com/ubi8/nginx-120:1-54'
+        name: 'artifacts.developer.gov.bc.ca/redhat-access-docker-remote/ubi8/nginx-120:1-54'
+        imagePullSecret: 'artifacts-default-gpffbq'
       importPolicy:
         scheduled: true
       referencePolicy:

--- a/gitops/openshift/tools/image-streams/node.yaml
+++ b/gitops/openshift/tools/image-streams/node.yaml
@@ -12,8 +12,8 @@ spec:
     - name: '18.12.1'
       from:
         kind: DockerImage
-        name: 'docker.io/node:18.12.1'
-        imagePullSecret: 'pipeline-docker-hub-pull'
+        name: 'artifacts.developer.gov.bc.ca/docker-remote/node:18.12.1'
+        imagePullSecret: 'artifacts-default-gpffbq'
       importPolicy:
         scheduled: true
       referencePolicy:
@@ -21,8 +21,8 @@ spec:
     - name: '18.12'
       from:
         kind: DockerImage
-        name: 'docker.io/node:18.12'
-        imagePullSecret: 'pipeline-docker-hub-pull'
+        name: 'artifacts.developer.gov.bc.ca/docker-remote/node:18.12'
+        imagePullSecret: 'artifacts-default-gpffbq'
       importPolicy:
         scheduled: true
       referencePolicy:
@@ -30,8 +30,8 @@ spec:
     - name: '16.18.1'
       from:
         kind: DockerImage
-        name: 'docker.io/node:16.18.1'
-        imagePullSecret: 'pipeline-docker-hub-pull'
+        name: 'artifacts.developer.gov.bc.ca/docker-remote/node:16.18.1'
+        imagePullSecret: 'artifacts-default-gpffbq'
       importPolicy:
         scheduled: true
       referencePolicy:

--- a/gitops/openshift/tools/image-streams/rabbitmq.yaml
+++ b/gitops/openshift/tools/image-streams/rabbitmq.yaml
@@ -12,8 +12,8 @@ spec:
     - name: '3.12.13-debian-12-r2'
       from:
         kind: DockerImage
-        name: 'docker.io/bitnami/rabbitmq:3.12.13-debian-12-r2'
-        imagePullSecret: 'pipeline-docker-hub-pull'
+        name: 'artifacts.developer.gov.bc.ca/docker-remote/bitnami/rabbitmq:3.12.13-debian-12-r2'
+        imagePullSecret: 'artifacts-default-gpffbq'
       importPolicy:
         scheduled: true
       referencePolicy:
@@ -21,8 +21,8 @@ spec:
     - name: '3.12-debian-11'
       from:
         kind: DockerImage
-        name: 'docker.io/bitnami/rabbitmq:3.12-debian-11'
-        imagePullSecret: 'pipeline-docker-hub-pull'
+        name: 'artifacts.developer.gov.bc.ca/docker-remote/bitnami/rabbitmq:3.12-debian-11'
+        imagePullSecret: 'artifacts-default-gpffbq'
       importPolicy:
         scheduled: true
       referencePolicy:
@@ -30,8 +30,8 @@ spec:
     - name: '3.12.6-debian-11-r11'
       from:
         kind: DockerImage
-        name: 'docker.io/bitnami/rabbitmq:3.12.6-debian-11-r11'
-        imagePullSecret: 'pipeline-docker-hub-pull'
+        name: 'artifacts.developer.gov.bc.ca/docker-remote/bitnami/rabbitmq:3.12.6-debian-11-r11'
+        imagePullSecret: 'artifacts-default-gpffbq'
       importPolicy:
         scheduled: true
       referencePolicy:
@@ -39,8 +39,8 @@ spec:
     - name: '3.12.0-debian-11-r0'
       from:
         kind: DockerImage
-        name: 'docker.io/bitnami/rabbitmq:3.12.0-debian-11-r0'
-        imagePullSecret: 'pipeline-docker-hub-pull'
+        name: 'artifacts.developer.gov.bc.ca/docker-remote/bitnami/rabbitmq:3.12.0-debian-11-r0'
+        imagePullSecret: 'artifacts-default-gpffbq'
       importPolicy:
         scheduled: true
       referencePolicy:
@@ -48,8 +48,8 @@ spec:
     - name: '3.11.9-debian-11-r2'
       from:
         kind: DockerImage
-        name: 'docker.io/bitnami/rabbitmq:3.11.9-debian-11-r2'
-        imagePullSecret: 'pipeline-docker-hub-pull'
+        name: 'artifacts.developer.gov.bc.ca/docker-remote/bitnami/rabbitmq:3.11.9-debian-11-r2'
+        imagePullSecret: 'artifacts-default-gpffbq'
       importPolicy:
         scheduled: true
       referencePolicy:

--- a/gitops/openshift/tools/image-streams/redis-cluster.yaml
+++ b/gitops/openshift/tools/image-streams/redis-cluster.yaml
@@ -12,8 +12,8 @@ spec:
     - name: '7.2.4-debian-12-r9'
       from:
         kind: DockerImage
-        name: 'docker.io/bitnami/redis-cluster:7.2.4-debian-12-r9'
-        imagePullSecret: 'pipeline-docker-hub-pull'
+        name: 'artifacts.developer.gov.bc.ca/docker-remote/bitnami/redis-cluster:7.2.4-debian-12-r9'
+        imagePullSecret: 'artifacts-default-gpffbq'
       importPolicy:
         scheduled: true
       referencePolicy:

--- a/gitops/openshift/tools/image-streams/redis-exporter.yaml
+++ b/gitops/openshift/tools/image-streams/redis-exporter.yaml
@@ -12,8 +12,8 @@ spec:
     - name: '1.58.0-debian-12-r3'
       from:
         kind: DockerImage
-        name: 'docker.io/bitnami/redis-exporter:1.58.0-debian-12-r3'
-        imagePullSecret: 'pipeline-docker-hub-pull'
+        name: 'artifacts.developer.gov.bc.ca/docker-remote/bitnami/redis-exporter:1.58.0-debian-12-r3'
+        imagePullSecret: 'artifacts-default-gpffbq'
       importPolicy:
         scheduled: true
       referencePolicy:
@@ -21,8 +21,8 @@ spec:
     - name: '1.55.0-debian-11-r0'
       from:
         kind: DockerImage
-        name: 'docker.io/bitnami/redis-exporter:1.55.0-debian-11-r0'
-        imagePullSecret: 'pipeline-docker-hub-pull'
+        name: 'artifacts.developer.gov.bc.ca/docker-remote/bitnami/redis-exporter:1.55.0-debian-11-r0'
+        imagePullSecret: 'artifacts-default-gpffbq'
       importPolicy:
         scheduled: true
       referencePolicy:
@@ -30,8 +30,8 @@ spec:
     - name: '1.54.0-debian-11-r25'
       from:
         kind: DockerImage
-        name: 'docker.io/bitnami/redis-exporter:1.54.0-debian-11-r25'
-        imagePullSecret: 'pipeline-docker-hub-pull'
+        name: 'artifacts.developer.gov.bc.ca/docker-remote/bitnami/redis-exporter:1.54.0-debian-11-r25'
+        imagePullSecret: 'artifacts-default-gpffbq'
       importPolicy:
         scheduled: true
       referencePolicy:
@@ -39,8 +39,8 @@ spec:
     - name: '1.50.0-debian-11-r13'
       from:
         kind: DockerImage
-        name: 'docker.io/bitnami/redis-exporter:1.50.0-debian-11-r13'
-        imagePullSecret: 'pipeline-docker-hub-pull'
+        name: 'artifacts.developer.gov.bc.ca/docker-remote/bitnami/redis-exporter:1.50.0-debian-11-r13'
+        imagePullSecret: 'artifacts-default-gpffbq'
       importPolicy:
         scheduled: true
       referencePolicy:
@@ -48,8 +48,8 @@ spec:
     - name: '1.46.0-debian-11-r7'
       from:
         kind: DockerImage
-        name: 'docker.io/bitnami/redis-exporter:1.46.0-debian-11-r7'
-        imagePullSecret: 'pipeline-docker-hub-pull'
+        name: 'artifacts.developer.gov.bc.ca/docker-remote/bitnami/redis-exporter:1.46.0-debian-11-r7'
+        imagePullSecret: 'artifacts-default-gpffbq'
       importPolicy:
         scheduled: true
       referencePolicy:
@@ -57,8 +57,8 @@ spec:
     - name: '1.36.0-debian-10-r5'
       from:
         kind: DockerImage
-        name: 'docker.io/bitnami/redis-exporter:1.36.0-debian-10-r5'
-        imagePullSecret: 'pipeline-docker-hub-pull'
+        name: 'artifacts.developer.gov.bc.ca/docker-remote/bitnami/redis-exporter:1.36.0-debian-10-r5'
+        imagePullSecret: 'artifacts-default-gpffbq'
       importPolicy:
         scheduled: true
       referencePolicy:

--- a/gitops/openshift/tools/image-streams/redis.yaml
+++ b/gitops/openshift/tools/image-streams/redis.yaml
@@ -12,8 +12,8 @@ spec:
     - name: '7.2.4-debian-12-r10'
       from:
         kind: DockerImage
-        name: 'docker.io/bitnami/redis:7.2.4-debian-12-r10'
-        imagePullSecret: 'pipeline-docker-hub-pull'
+        name: 'artifacts.developer.gov.bc.ca/docker-remote/bitnami/redis:7.2.4-debian-12-r10'
+        imagePullSecret: 'artifacts-default-gpffbq'
       importPolicy:
         scheduled: true
       referencePolicy:
@@ -21,8 +21,8 @@ spec:
     - name: '7.2.1-debian-11-r24'
       from:
         kind: DockerImage
-        name: 'docker.io/bitnami/redis:7.2.1-debian-11-r24'
-        imagePullSecret: 'pipeline-docker-hub-pull'
+        name: 'artifacts.developer.gov.bc.ca/docker-remote/bitnami/redis:7.2.1-debian-11-r24'
+        imagePullSecret: 'artifacts-default-gpffbq'
       importPolicy:
         scheduled: true
       referencePolicy:
@@ -30,8 +30,8 @@ spec:
     - name: '7.0.8-debian-11-r13'
       from:
         kind: DockerImage
-        name: 'docker.io/bitnami/redis:7.0.8-debian-11-r13'
-        imagePullSecret: 'pipeline-docker-hub-pull'
+        name: 'artifacts.developer.gov.bc.ca/docker-remote/bitnami/redis:7.0.8-debian-11-r13'
+        imagePullSecret: 'artifacts-default-gpffbq'
       importPolicy:
         scheduled: true
       referencePolicy:
@@ -39,8 +39,8 @@ spec:
     - name: '7.0.5-debian-11-r23'
       from:
         kind: DockerImage
-        name: 'docker.io/bitnami/redis:7.0.5-debian-11-r23'
-        imagePullSecret: 'pipeline-docker-hub-pull'
+        name: 'artifacts.developer.gov.bc.ca/docker-remote/bitnami/redis:7.0.5-debian-11-r23'
+        imagePullSecret: 'artifacts-default-gpffbq'
       importPolicy:
         scheduled: true
       referencePolicy:


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- Changes image streams to pull thru BC Gov Artifactory instead of various registries directly.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [ ] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
