### PR TITLE
TCVP-2889 Update scope name to have correct naming convention

### DIFF
--- a/src/backend/TrafficCourts/Staff.Service/Authentication/Scopes.cs
+++ b/src/backend/TrafficCourts/Staff.Service/Authentication/Scopes.cs
@@ -14,7 +14,7 @@ public static class Scopes
     public const string Cancel = "cancel";
     public const string Submit = "submit";
     public const string Review = "review";
-    public const string RequireCourtHearing = "require_court_hearing";
+    public const string RequireCourtHearing = "require-court-hearing";
 
     public const string Create = "create";
     public const string Read = "read";


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- TCVP-2889 fixes the scope name to be consistent
- Dev and Test Keycloak have been updated, duplicating the permission and scopes as a transitionary update
- Production Keycloak uses the new names
- Note: the `update_court_appearance`/`update-court-appearance` does not appear to be in use. No sure when/who added this.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [ ] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
