### PR TITLE
TCVP-2887 Return bad request response for inconsistent ticket number from the request

### DIFF
--- a/src/backend/TrafficCourts/Citizen.Service/Controllers/DisputesController.cs
+++ b/src/backend/TrafficCourts/Citizen.Service/Controllers/DisputesController.cs
@@ -73,6 +73,13 @@ public class DisputesController : ControllerBase
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     public async Task<IActionResult> CreateAsync([FromBody] Models.Disputes.NoticeOfDispute dispute, CancellationToken cancellationToken)
     {
+        if (dispute.TicketNumber is not null && dispute.ViolationTicket is not null && dispute.ViolationTicket.TicketNumber is not null 
+            && dispute.TicketNumber != dispute.ViolationTicket.TicketNumber)
+        {
+            _logger.LogDebug("TicketNumber of the Dispute: {DisputeTicketNumber} and ViolationTicket: {ViolationTicketNumber} are different.", dispute.TicketNumber, dispute.ViolationTicket.TicketNumber);
+            return BadRequest("Violation Ticket Number must match Ticket Number");
+        }
+
         Create.Request request = new Create.Request(dispute);
 
         // Part of the 'send' here is to add the scanned in image of a ticket(if there is one) to COMS and remove from REDIS cache

--- a/src/backend/TrafficCourts/Test/Citizen.Service/Controllers/DisputesControllerTest.cs
+++ b/src/backend/TrafficCourts/Test/Citizen.Service/Controllers/DisputesControllerTest.cs
@@ -188,5 +188,35 @@ namespace TrafficCourts.Test.Citizen.Service.Controllers
             // Assert
             var okResult = Assert.IsType<OkObjectResult>(result);
         }
+
+        [Fact]
+        public void CreateAsync_TicketNumbersDoNotMatch_ReturnsBadRequest()
+        {
+            // Arrange
+            var mockMediator = new Mock<IMediator>();
+            var mockLogger = new Mock<ILogger<DisputesController>>();
+            var mockBus = new Mock<IBus>();
+            var mockHashids = new Mock<IHashids>();
+            var mockMapper = new Mock<IMapper>();
+            var mockComsService = new Mock<ICitizenDocumentService>();
+            var tokenEncoder = Mock.Of<IDisputeEmailVerificationTokenEncoder>();
+            var controller = new DisputesController(mockBus.Object, mockMediator.Object, mockLogger.Object, mockHashids.Object, tokenEncoder, mockMapper.Object, mockComsService.Object);
+            var dispute = new NoticeOfDispute
+            {
+                TicketNumber = "EB02000004",
+                ViolationTicket = new TrafficCourts.Citizen.Service.Models.Tickets.ViolationTicket
+                {
+                    TicketNumber = "EB02000099"
+                }
+            };
+
+            // Act
+            var result = controller.CreateAsync(dispute, CancellationToken.None);
+
+            // Assert
+            Assert.NotNull(result);
+            var errorResult = Assert.IsType<BadRequestObjectResult>(result?.Result);
+            Assert.Equal("Violation Ticket Number must match Ticket Number", errorResult.Value);
+        }
     }
 }


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- [TCVP-2887](https://justice.gov.bc.ca/jira/browse/TCVP-2887)
- Added validation for submitted dispute to check if the Violation Ticket Number matches Dispute's ticket number and if they don't return bad request response.
- Added Xunit test.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
