### PR TITLE
TCVP-2563 Filter RSI search results to a specific FormNumber

### DIFF
--- a/src/backend/TrafficCourts/Citizen.Service/Controllers/TicketsController.cs
+++ b/src/backend/TrafficCourts/Citizen.Service/Controllers/TicketsController.cs
@@ -60,6 +60,13 @@ namespace TrafficCourts.Citizen.Service.Controllers
                 return NotFound();
             }
 
+            // no need to check if the dispute is submitted before if this ticket is invalid
+            InvalidTicketVersionException? exception = response.Result.Value as InvalidTicketVersionException;
+            if (exception is not null)
+            {
+                return BadRequest(exception.Message);
+            }
+
             try
             {
                 var check = await _ticketSearchService.IsDisputeSubmittedBefore(ticketNumber, cancellationToken);

--- a/src/backend/TrafficCourts/Citizen.Service/Features/Tickets/Search/Handler.cs
+++ b/src/backend/TrafficCourts/Citizen.Service/Features/Tickets/Search/Handler.cs
@@ -53,7 +53,12 @@ public class Handler : IRequestHandler<Request, Response>
         }
         catch (InvalidTicketVersionException exception)
         {
-            _logger.LogError(exception, "Could not return a ticket with invalid violation date and version (VT1)");
+            if (_logger.IsEnabled(LogLevel.Debug)) 
+            {
+                _logger.LogDebug("Tickets starting with 'S' must dated after April 9, 2024. This ticket is dated {ViolationDate}.",
+                    exception.ViolationDate);
+            }
+
             return new Response(exception);
         }
         catch (Exception exception)

--- a/src/backend/TrafficCourts/Test/Citizen.Service/Features/Tickets/SearchHandlerTest.cs
+++ b/src/backend/TrafficCourts/Test/Citizen.Service/Features/Tickets/SearchHandlerTest.cs
@@ -125,7 +125,8 @@ namespace TrafficCourts.Test.Citizen.Service.Features.Tickets
             Mock<ITicketInvoiceSearchService> _invoiceSearchService = new();
             Mock<ILogger<TicketSearchService>> _logger = new();
             TicketSearchService ticketSearchService = new(_bus.Object, _invoiceSearchService.Object, _logger.Object);
-            Invoice invoice = new() {
+            Invoice invoice = new()
+            {
                 InvoiceNumber = "EA000000001",
                 PbcRefNumber = "n/a",
                 PartyNumber = "n/a",
@@ -141,19 +142,19 @@ namespace TrafficCourts.Test.Citizen.Service.Features.Tickets
                 Act = "DTM",
                 Section = "45(a)"
             };
-            IList<Invoice> invoices = [ invoice ];
+            IList<Invoice> invoices = [invoice];
 
             // When
             _invoiceSearchService
                 .Setup(_ => _.SearchAsync(It.IsAny<string>(), It.IsAny<TimeOnly>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(invoices));
-            
+
             // Then
             // Invoice.Act does not match MVA or MVAR and so results should be null
             var actual = await ticketSearchService.SearchAsync(ticketNumber, TimeOnly.MinValue, CancellationToken.None);
             Assert.Null(actual);
         }
-        
+
 
         [Fact]
         public async Task search_includes_MVA_tickets()
@@ -165,7 +166,8 @@ namespace TrafficCourts.Test.Citizen.Service.Features.Tickets
             Mock<ITicketInvoiceSearchService> _invoiceSearchService = new();
             Mock<ILogger<TicketSearchService>> _logger = new();
             TicketSearchService ticketSearchService = new(_bus.Object, _invoiceSearchService.Object, _logger.Object);
-            Invoice invoice = new() {
+            Invoice invoice = new()
+            {
                 InvoiceNumber = "EA000000001",
                 PbcRefNumber = "n/a",
                 PartyNumber = "n/a",
@@ -179,22 +181,23 @@ namespace TrafficCourts.Test.Citizen.Service.Features.Tickets
                 OffenceDescription = "Speed against area sign",
                 ViolationDate = "2023-04-09",
                 Act = "MVA",
-                Section = "45(a)"
+                Section = "45(a)",
+                FormNumber = "MV6000E (040924)"
             };
-            IList<Invoice> invoices = [ invoice ];
+            IList<Invoice> invoices = [invoice];
 
             // When
             _invoiceSearchService
                 .Setup(_ => _.SearchAsync(It.IsAny<string>(), It.IsAny<TimeOnly>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(invoices));
-            
+
             // Then
             // Invoice.Act should match MVA
             var actual = await ticketSearchService.SearchAsync(ticketNumber, TimeOnly.MinValue, CancellationToken.None);
             Assert.NotNull(actual);
             Assert.Equal("EA00000000", actual.TicketNumber);
         }
-        
+
 
         [Fact]
         public async Task search_includes_MVAR_tickets()
@@ -206,7 +209,8 @@ namespace TrafficCourts.Test.Citizen.Service.Features.Tickets
             Mock<ITicketInvoiceSearchService> _invoiceSearchService = new();
             Mock<ILogger<TicketSearchService>> _logger = new();
             TicketSearchService ticketSearchService = new(_bus.Object, _invoiceSearchService.Object, _logger.Object);
-            Invoice invoice = new() {
+            Invoice invoice = new()
+            {
                 InvoiceNumber = "EA000000001",
                 PbcRefNumber = "n/a",
                 PartyNumber = "n/a",
@@ -220,20 +224,187 @@ namespace TrafficCourts.Test.Citizen.Service.Features.Tickets
                 OffenceDescription = "Speed against area sign",
                 ViolationDate = "2023-04-09",
                 Act = "MVAR",
-                Section = "45(a)"
+                Section = "45(a)",
+                FormNumber = "MV6000E (040924)"
             };
-            IList<Invoice> invoices = [ invoice ];
+            IList<Invoice> invoices = [invoice];
 
             // When
             _invoiceSearchService
                 .Setup(_ => _.SearchAsync(It.IsAny<string>(), It.IsAny<TimeOnly>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(invoices));
-            
+
             // Then
             // Invoice.Act should match MVAR 
             var actual = await ticketSearchService.SearchAsync(ticketNumber, TimeOnly.MinValue, CancellationToken.None);
             Assert.NotNull(actual);
             Assert.Equal("EA00000000", actual.TicketNumber);
+        }
+
+        // test that asserts that the ticketSearchService includes Invoices with a FormNumber == "MV6000E (040924)"
+        [Fact]
+        public async Task search_includes_FormNumber_tickets()
+        {
+            // Given
+            string ticketNumber = "EA00000000";
+            string ticketTime = "00:00";
+            Mock<IBus> _bus = new();
+            Mock<ITicketInvoiceSearchService> _invoiceSearchService = new();
+            Mock<ILogger<TicketSearchService>> _logger = new();
+            TicketSearchService ticketSearchService = new(_bus.Object, _invoiceSearchService.Object, _logger.Object);
+            Invoice invoice = new()
+            {
+                InvoiceNumber = "EA000000001",
+                PbcRefNumber = "n/a",
+                PartyNumber = "n/a",
+                PartyName = "n/a",
+                AccountNumber = "n/a",
+                SiteNumber = "n/a",
+                InvoiceType = "Traffic Violation Ticket",
+                ViolationDateTime = "2023-04-09T" + ticketTime,
+                TicketedAmount = 100.00M,
+                AmountDue = 100.00M,
+                OffenceDescription = "Speed against area sign",
+                ViolationDate = "2023-04-09",
+                Act = "MVAR",
+                Section = "45(a)",
+                FormNumber = "MV6000E (040924)"
+            };
+            IList<Invoice> invoices = [invoice];
+
+            // When
+            _invoiceSearchService
+                .Setup(_ => _.SearchAsync(It.IsAny<string>(), It.IsAny<TimeOnly>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.FromResult(invoices));
+
+            // Then
+            var actual = await ticketSearchService.SearchAsync(ticketNumber, TimeOnly.MinValue, CancellationToken.None);
+            Assert.NotNull(actual);
+            Assert.Equal("EA00000000", actual.TicketNumber);
+        }
+
+        // test that asserts that the ticketSearchService includes Invoices with a FormNumber == "MV6000E(040924)"
+        [Fact]
+        public async Task search_includes_FormNumber_tickets_wo_spaces()
+        {
+            // Given
+            string ticketNumber = "EA00000000";
+            string ticketTime = "00:00";
+            Mock<IBus> _bus = new();
+            Mock<ITicketInvoiceSearchService> _invoiceSearchService = new();
+            Mock<ILogger<TicketSearchService>> _logger = new();
+            TicketSearchService ticketSearchService = new(_bus.Object, _invoiceSearchService.Object, _logger.Object);
+            Invoice invoice = new()
+            {
+                InvoiceNumber = "EA000000001",
+                PbcRefNumber = "n/a",
+                PartyNumber = "n/a",
+                PartyName = "n/a",
+                AccountNumber = "n/a",
+                SiteNumber = "n/a",
+                InvoiceType = "Traffic Violation Ticket",
+                ViolationDateTime = "2023-04-09T" + ticketTime,
+                TicketedAmount = 100.00M,
+                AmountDue = 100.00M,
+                OffenceDescription = "Speed against area sign",
+                ViolationDate = "2023-04-09",
+                Act = "MVAR",
+                Section = "45(a)",
+                FormNumber = "MV6000E(040924)"
+            };
+            IList<Invoice> invoices = [invoice];
+
+            // When
+            _invoiceSearchService
+                .Setup(_ => _.SearchAsync(It.IsAny<string>(), It.IsAny<TimeOnly>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.FromResult(invoices));
+
+            // Then
+            var actual = await ticketSearchService.SearchAsync(ticketNumber, TimeOnly.MinValue, CancellationToken.None);
+            Assert.NotNull(actual);
+            Assert.Equal("EA00000000", actual.TicketNumber);
+        }
+
+        // test that asserts that the ticketSearchService excludes Invoices with a FormNumber != "MV6000E (040924)"
+        [Fact]
+        public async Task search_excludes_FormNumber_tickets()
+        {
+            // Given
+            string ticketNumber = "EA00000000";
+            string ticketTime = "00:00";
+            Mock<IBus> _bus = new();
+            Mock<ITicketInvoiceSearchService> _invoiceSearchService = new();
+            Mock<ILogger<TicketSearchService>> _logger = new();
+            TicketSearchService ticketSearchService = new(_bus.Object, _invoiceSearchService.Object, _logger.Object);
+            Invoice invoice = new()
+            {
+                InvoiceNumber = "EA000000001",
+                PbcRefNumber = "n/a",
+                PartyNumber = "n/a",
+                PartyName = "n/a",
+                AccountNumber = "n/a",
+                SiteNumber = "n/a",
+                InvoiceType = "Traffic Violation Ticket",
+                ViolationDateTime = "2023-04-09T" + ticketTime,
+                TicketedAmount = 100.00M,
+                AmountDue = 100.00M,
+                OffenceDescription = "Speed against area sign",
+                ViolationDate = "2023-04-09",
+                Act = "MVAR",
+                Section = "45(a)",
+                FormNumber = "MV7000E (040924)"
+            };
+            IList<Invoice> invoices = [invoice];
+
+            // When
+            _invoiceSearchService
+                .Setup(_ => _.SearchAsync(It.IsAny<string>(), It.IsAny<TimeOnly>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.FromResult(invoices));
+
+            // Then
+            var actual = await ticketSearchService.SearchAsync(ticketNumber, TimeOnly.MinValue, CancellationToken.None);
+            Assert.Null(actual);
+        }
+
+        // test that asserts that the ticketSearchService excludes Invoices with a FormNumber != "MV6000E(040924)"
+        [Fact]
+        public async Task search_excludes_FormNumber_wo_spaces_tickets()
+        {
+            // Given
+            string ticketNumber = "EA00000000";
+            string ticketTime = "00:00";
+            Mock<IBus> _bus = new();
+            Mock<ITicketInvoiceSearchService> _invoiceSearchService = new();
+            Mock<ILogger<TicketSearchService>> _logger = new();
+            TicketSearchService ticketSearchService = new(_bus.Object, _invoiceSearchService.Object, _logger.Object);
+            Invoice invoice = new()
+            {
+                InvoiceNumber = "EA000000001",
+                PbcRefNumber = "n/a",
+                PartyNumber = "n/a",
+                PartyName = "n/a",
+                AccountNumber = "n/a",
+                SiteNumber = "n/a",
+                InvoiceType = "Traffic Violation Ticket",
+                ViolationDateTime = "2023-04-09T" + ticketTime,
+                TicketedAmount = 100.00M,
+                AmountDue = 100.00M,
+                OffenceDescription = "Speed against area sign",
+                ViolationDate = "2023-04-09",
+                Act = "MVAR",
+                Section = "45(a)",
+                FormNumber = "MV7000E(040924)"
+            };
+            IList<Invoice> invoices = [invoice];
+
+            // When
+            _invoiceSearchService
+                .Setup(_ => _.SearchAsync(It.IsAny<string>(), It.IsAny<TimeOnly>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.FromResult(invoices));
+
+            // Then
+            var actual = await ticketSearchService.SearchAsync(ticketNumber, TimeOnly.MinValue, CancellationToken.None);
+            Assert.Null(actual);
         }
     }
 }


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- TCVP-2563 exclude all RSI search results that do not match "MV6000E (040924)" or "MV6000E(040924)"
- If ticket is invalid VT2, skips the check if the ticket already disputed.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Add new tests confirm the pattern matching

## Does the change impact or break the Docker build?

- [ ] Yes
- [ ] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
