### PR TITLE
TCVP-2895 add minReadySeconds until we can add health checks

### DIFF
--- a/gitops/charts/traffic-court-online/charts/arc-dispute-api/templates/deployment.yaml
+++ b/gitops/charts/traffic-court-online/charts/arc-dispute-api/templates/deployment.yaml
@@ -6,6 +6,7 @@ metadata:
     app.openshift.io/runtime: dotnet
     {{- include "arc-dispute-api.labels" . | nindent 4 }}
 spec:
+  minReadySeconds: 30
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
   {{- end }}

--- a/gitops/charts/traffic-court-online/charts/citizen-api/templates/deployment.yaml
+++ b/gitops/charts/traffic-court-online/charts/citizen-api/templates/deployment.yaml
@@ -6,6 +6,7 @@ metadata:
     app.openshift.io/runtime: dotnet
     {{- include "citizen-api.labels" . | nindent 4 }}
 spec:
+  minReadySeconds: 30
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
   {{- end }}

--- a/gitops/charts/traffic-court-online/charts/citizen-web/templates/deployment.yaml
+++ b/gitops/charts/traffic-court-online/charts/citizen-web/templates/deployment.yaml
@@ -15,6 +15,7 @@ metadata:
   annotations:
     app.openshift.io/connects-to: '[{{ include "tco.connectsTo" . | fromYaml | toJson }}]'
 spec:
+  minReadySeconds: 15
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
   {{- end }}

--- a/gitops/charts/traffic-court-online/charts/staff-api/templates/deployment.yaml
+++ b/gitops/charts/traffic-court-online/charts/staff-api/templates/deployment.yaml
@@ -6,6 +6,7 @@ metadata:
     app.openshift.io/runtime: dotnet
     {{- include "staff-api.labels" . | nindent 4 }}
 spec:
+  minReadySeconds: 30
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
   {{- end }}

--- a/gitops/charts/traffic-court-online/charts/staff-web/templates/deployment.yaml
+++ b/gitops/charts/traffic-court-online/charts/staff-web/templates/deployment.yaml
@@ -6,6 +6,7 @@ metadata:
     app.openshift.io/runtime: nginx
     {{- include "staff-web.labels" . | nindent 4 }}
 spec:
+  minReadySeconds: 15
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
   {{- end }}

--- a/gitops/charts/traffic-court-online/charts/workflow-service/templates/deployment.yaml
+++ b/gitops/charts/traffic-court-online/charts/workflow-service/templates/deployment.yaml
@@ -6,6 +6,7 @@ metadata:
     app.openshift.io/runtime: dotnet
     {{- include "workflow-service.labels" . | nindent 4 }}
 spec:
+  minReadySeconds: 30
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
   {{- end }}

--- a/gitops/charts/virus-scan/templates/deployment.yaml
+++ b/gitops/charts/virus-scan/templates/deployment.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
     {{- include "virusScan.labels" . | nindent 4 }}
 spec:
+  minReadySeconds: 30
   replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- adds minReadySeconds to deployments as an interim step before health checks can be implemented

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [ ] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
