### PR TITLE
Increase PVC storage for jaeger for test and prod

### DIFF
--- a/gitops/charts/jaeger/values-prod.yaml
+++ b/gitops/charts/jaeger/values-prod.yaml
@@ -47,7 +47,7 @@ storage:
    ephemeral: false
   #
   pvc:
-    size: 1Gi
+    size: 5Gi
     storageClassName: ""
 
 resources:

--- a/gitops/charts/jaeger/values-test.yaml
+++ b/gitops/charts/jaeger/values-test.yaml
@@ -47,7 +47,7 @@ storage:
    ephemeral: false
   #
   pvc:
-    size: 1Gi
+    size: 2Gi
     storageClassName: ""
 
 resources:


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- since setting up jaeger in test, the PVC has grown to 650 MB / 1GB. The default configuration should only keep 3 days worth of traces. Increased the PVC in test to 2GB and 5GB for prod.

