### PR TITLE
Increase Prod Citizen Portal request timeout to 60 sec

### DIFF
--- a/gitops/openshift/prod/citizen-web-for-justice-proxy.yaml
+++ b/gitops/openshift/prod/citizen-web-for-justice-proxy.yaml
@@ -9,6 +9,7 @@ metadata:
   annotations:
     haproxy.router.openshift.io/ip_whitelist: 142.34.133.73 142.34.133.81
     haproxy.router.openshift.io/disable_cookies: "true"
+    haproxy.router.openshift.io/timeout: 60s
 spec:
   host: citizen-web-for-justice-proxy-0198bb-prod.apps.silver.devops.gov.bc.ca
   to:


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- Changes the default 30 second request timeout to 60 seconds to resolve OCR slowness

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [ ] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
