### PR TITLE
TCVP-2914 Sanitized whitespace characters on some OCR fields

### DIFF
--- a/src/backend/TrafficCourts/Citizen.Service/Validators/FormRecognizerValidator.cs
+++ b/src/backend/TrafficCourts/Citizen.Service/Validators/FormRecognizerValidator.cs
@@ -130,10 +130,13 @@ public class FormRecognizerValidator : IFormRecognizerValidator
             if (violationTicket.Fields.TryGetValue(sectionKey, out var field))
             {
                 var titleValue = field.Value ?? "";
-                field.Value = Regex.Replace(titleValue, @"\s", " "); // replace all whitespace characters with a space
+                field.Value = Regex.Replace(titleValue, @"[\s\0\b\a]+", " "); // replace all whitespace characters with a space
             }
         }
 
+        // TCVP-2914 replace newline characters from location
+        SanitizeWhiteSpace(OcrViolationTicket.DetachmentLocation);
+        SanitizeWhiteSpace(OcrViolationTicket.HearingLocation);
         SanitizeWhiteSpace(OcrViolationTicket.ViolationTicketTitle);
 
         SanitizeCount(OcrViolationTicket.Count1Section, OcrViolationTicket.Count1ActRegs, OcrViolationTicket.Count1Description, OcrViolationTicket.Count1TicketAmount);

--- a/src/backend/TrafficCourts/Test/Citizen.Service/Validators/FormRecognizerValidatorTest.cs
+++ b/src/backend/TrafficCourts/Test/Citizen.Service/Validators/FormRecognizerValidatorTest.cs
@@ -175,5 +175,26 @@ public class FormRecognizerValidatorTest
         Assert.True(string.IsNullOrEmpty(violationTicket.Fields[OcrViolationTicket.Count3Description].Value));
     }
 
+    [Fact]
+    public async void TestSanitize_WhitespaceRemoved()
+    {
+        // Given
+        var _statuteLookupService = new Mock<IStatuteLookupService>();
+        var _logger = new Mock<ILogger<FormRecognizerValidator>>();
+        FormRecognizerValidator formRecognizerValidator = new(_statuteLookupService.Object, _logger.Object);
 
+        OcrViolationTicket violationTicket = new();
+        violationTicket.Fields.Add(OcrViolationTicket.DetachmentLocation, new Field(" \t \n some_text \t "));
+        violationTicket.Fields.Add(OcrViolationTicket.HearingLocation, new Field(" \t \r\n some_text \t "));
+        violationTicket.Fields.Add(OcrViolationTicket.ViolationTicketTitle, new Field(" \t \n some_text \t "));
+
+        // When
+        await formRecognizerValidator.SanitizeAsync(violationTicket);
+
+        // Then
+        Assert.Equal(" some_text ", violationTicket.Fields[OcrViolationTicket.DetachmentLocation].Value);
+        Assert.Equal(" some_text ", violationTicket.Fields[OcrViolationTicket.HearingLocation].Value);
+        Assert.Equal(" some_text ", violationTicket.Fields[OcrViolationTicket.ViolationTicketTitle].Value);
+    }    
+    
 }


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

TCVP-2914 

Added DetachmentLocation and HearingLocation to the list of fields we sanitize (replace whitespace characters with spaces).
Added Xunit test

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [ ] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
