### PR TITLE
TCVP-2921 update readinessProbe allowing retry

### DIFF
--- a/gitops/charts/jaeger/jaeger-aio/templates/deployment.yaml
+++ b/gitops/charts/jaeger/jaeger-aio/templates/deployment.yaml
@@ -66,6 +66,10 @@ spec:
               path: /
               port: 14269
             initialDelaySeconds: 5
+            periodSeconds: 15
+            timeoutSeconds: 10
+            successThreshold: 1
+            failureThreshold: 10
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- Adds failure threshold parameters to avoid restarting pod if a probe fails

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [ ] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
