### PR TITLE
Move traffic court online image streams from gitops repos

### DIFF
--- a/gitops/openshift/tools/image-streams/arc-dispute-api-imagestream.yaml
+++ b/gitops/openshift/tools/image-streams/arc-dispute-api-imagestream.yaml
@@ -1,0 +1,10 @@
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  labels:
+    build: arc-dispute-api
+    usage: runtime-image
+  name: arc-dispute-api
+spec:
+  lookupPolicy:
+    local: false

--- a/gitops/openshift/tools/image-streams/citizen-api-imagestream.yaml
+++ b/gitops/openshift/tools/image-streams/citizen-api-imagestream.yaml
@@ -1,0 +1,10 @@
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  labels:
+    build: citizen-api
+    usage: runtime-image
+  name: citizen-api
+spec:
+  lookupPolicy:
+    local: false

--- a/gitops/openshift/tools/image-streams/citizen-web-imagestream.yaml
+++ b/gitops/openshift/tools/image-streams/citizen-web-imagestream.yaml
@@ -1,0 +1,10 @@
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  labels:
+    build: citizen-web
+    usage: runtime-image
+  name: citizen-web
+spec:
+  lookupPolicy:
+    local: false

--- a/gitops/openshift/tools/image-streams/oracle-data-api-imagestream.yaml
+++ b/gitops/openshift/tools/image-streams/oracle-data-api-imagestream.yaml
@@ -1,0 +1,10 @@
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  labels:
+    build: oracle-data-api    
+    usage: runtime-image
+  name: oracle-data-api
+spec:
+  lookupPolicy:
+    local: false

--- a/gitops/openshift/tools/image-streams/staff-api-imagestream.yaml
+++ b/gitops/openshift/tools/image-streams/staff-api-imagestream.yaml
@@ -1,0 +1,10 @@
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  labels:
+    build: staff-api
+    usage: runtime-image
+  name: staff-api
+spec:
+  lookupPolicy:
+    local: false

--- a/gitops/openshift/tools/image-streams/staff-web-imagestream.yaml
+++ b/gitops/openshift/tools/image-streams/staff-web-imagestream.yaml
@@ -1,0 +1,10 @@
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  labels:
+    build: staff-web
+    usage: runtime-image
+  name: staff-web
+spec:
+  lookupPolicy:
+    local: false

--- a/gitops/openshift/tools/image-streams/workflow-service-imagestream.yaml
+++ b/gitops/openshift/tools/image-streams/workflow-service-imagestream.yaml
@@ -1,0 +1,10 @@
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  labels:
+    build: workflow-service
+    usage: runtime-image
+  name: workflow-service
+spec:
+  lookupPolicy:
+    local: false


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- The image streams for traffic court online were stored in the gitops repo. When working on argocd for the pipelines, I uninstalled the app and recreated it. Because the pipelines were part of the argocd pipeline they got delete and thus our production tag 2.0.3. I recreated the release to ensure 2.0.3 tag was available in the image stream. This PR moves the image stream definitions to this repo to avoid them being deleted again.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [ ] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
