### PR TITLE
TCVP-2865 Print ticket validation view

### DIFF
--- a/src/backend/TrafficCourts/Staff.Service/Controllers/DisputeController.cs
+++ b/src/backend/TrafficCourts/Staff.Service/Controllers/DisputeController.cs
@@ -1,6 +1,8 @@
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using System.ComponentModel.DataAnnotations;
 using System.Net;
+using TrafficCourts.Cdogs.Client;
 using TrafficCourts.Common.Authorization;
 using TrafficCourts.Common.Errors;
 using TrafficCourts.Domain.Models;
@@ -9,24 +11,26 @@ using TrafficCourts.Staff.Service.Authentication;
 using TrafficCourts.Staff.Service.Models;
 using TrafficCourts.Staff.Service.Models.Disputes;
 using TrafficCourts.Staff.Service.Services;
-using X.PagedList;
 
 namespace TrafficCourts.Staff.Service.Controllers;
 
 public class DisputeController : StaffControllerBase
 {
     private readonly IDisputeService _disputeService;
+    private readonly IPrintDigitalCaseFileService _printService;
     private readonly ILogger<DisputeController> _logger;
 
     /// <summary>
     /// Default Constructor
     /// </summary>
     /// <param name="disputeService"></param>
+    /// <param name="printService"></param>
     /// <param name="logger"></param>
     /// <exception cref="ArgumentNullException"><paramref name="logger"/> is null.</exception>
-    public DisputeController(IDisputeService disputeService, ILogger<DisputeController> logger)
+    public DisputeController(IDisputeService disputeService, IPrintDigitalCaseFileService printService, ILogger<DisputeController> logger)
     {
         _disputeService = disputeService ?? throw new ArgumentNullException(nameof(disputeService));
+        _printService = printService ?? throw new ArgumentNullException(nameof(printService));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
@@ -620,6 +624,41 @@ public class DisputeController : StaffControllerBase
         catch (Exception e)
         {
             _logger.LogError(e, "Error retrieving Dispute update requests for a dispute from oracle-data-api");
+            return new HttpError(StatusCodes.Status500InternalServerError, e.Message);
+        }
+    }
+
+    /// <summary>
+    /// Returns generated document.
+    /// </summary>
+    /// <param name="disputeId">Dispute Id</param>
+    /// <param name="timeZone">The IANA timze zone id</param>
+    /// <param name="cancellationToken"></param>
+    /// <response code="200">Generated Document.</response>
+    /// <response code="400">The </response>
+    /// <response code="401">Request lacks valid authentication credentials.</response>
+    /// <response code="403">Forbidden.</response>
+    /// <response code="500">There was a server error that prevented the search from completing successfully or no data found.</response>
+    /// <returns>A generated document</returns>
+    [AllowAnonymous]
+    [HttpGet("{disputeId}/print")]
+    [ProducesResponseType(typeof(FileStreamResult), StatusCodes.Status200OK, "application/octet-stream")]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+    [KeycloakAuthorize(Resources.Dispute, Scopes.Read)]
+    public async Task<IActionResult> PrintDisputeAsync([Required] long disputeId, [Required] string timeZone, CancellationToken cancellationToken)
+    {
+        _logger.LogDebug("Rendering print version of ticket validation view for dispute {disputeId} in timezone {timeZone}.", disputeId, timeZone);
+
+        try
+        {
+            RenderedReport report = await _printService.PrintTicketValidationViewAsync(disputeId, timeZone, cancellationToken);
+            return File(report.Content, "application/pdf", report.ReportName);
+        }
+        catch (Exception e)
+        {
+            _logger.LogError(e, "Error when generating print version of dispute");
             return new HttpError(StatusCodes.Status500InternalServerError, e.Message);
         }
     }

--- a/src/backend/TrafficCourts/Staff.Service/Services/IPrintDigitalCaseFileService.cs
+++ b/src/backend/TrafficCourts/Staff.Service/Services/IPrintDigitalCaseFileService.cs
@@ -8,4 +8,13 @@ public interface IPrintDigitalCaseFileService
     /// Renders the digital case file for a given dispute based on ticket number. This really should be using the tco_dispute.dispute_id.
     /// </summary>
     Task<RenderedReport> PrintDigitalCaseFileAsync(string ticketNumber, string timeZoneId, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Renders the ticket validation view for a given OCCAM dispute data based on dispute id.
+    /// </summary>
+    /// <param name="disputeId"></param>
+    /// <param name="timeZoneId"></param>
+    /// <param name="cancellationToken"></param>
+    /// <returns></returns>
+    Task<RenderedReport> PrintTicketValidationViewAsync(long disputeId, string timeZoneId, CancellationToken cancellationToken);
 }

--- a/src/backend/TrafficCourts/TrafficCourts.OracleDataApi/TrafficCourts.OracleDataApi.csproj
+++ b/src/backend/TrafficCourts/TrafficCourts.OracleDataApi/TrafficCourts.OracleDataApi.csproj
@@ -25,6 +25,9 @@
 			<_Parameter1>TrafficCourts.OracleDataApi.Test</_Parameter1>
 		</AssemblyAttribute>
 		<AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+			<_Parameter1>TrafficCourts.Staff.Service.Test</_Parameter1>
+		</AssemblyAttribute>
+		<AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
 			<_Parameter1>DynamicProxyGenAssembly2</_Parameter1>
 		</AssemblyAttribute>
 	</ItemGroup>

--- a/src/backend/TrafficCourts/TrafficCourts.Staff.Service.Test/Controllers/DisputeControllerTest.cs
+++ b/src/backend/TrafficCourts/TrafficCourts.Staff.Service.Test/Controllers/DisputeControllerTest.cs
@@ -35,7 +35,8 @@ public class DisputeControllerTest
             .Setup(_ => _.GetAllDisputesAsync(It.IsAny<GetAllDisputesParameters>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(expected);
         var mockLogger = new Mock<ILogger<DisputeController>>();
-        DisputeController disputeController = new(disputeService.Object, mockLogger.Object);
+        var mockPrintDcf = new Mock<IPrintDigitalCaseFileService>();
+        DisputeController disputeController = new(disputeService.Object, mockPrintDcf.Object, mockLogger.Object);
 
         // Act
         GetAllDisputesParameters? parameters = null;
@@ -62,7 +63,8 @@ public class DisputeControllerTest
             .Setup(_ => _.GetDisputeAsync(It.Is<long>(v => v == id), true, It.IsAny<CancellationToken>()))
             .ReturnsAsync(dispute);
         var mockLogger = new Mock<ILogger<DisputeController>>();
-        DisputeController disputeController = new (disputeService.Object, mockLogger.Object);
+        var mockPrintDcf = new Mock<IPrintDigitalCaseFileService>();
+        DisputeController disputeController = new(disputeService.Object, mockPrintDcf.Object, mockLogger.Object);
 
         // Act
         IActionResult? result = await disputeController.GetDisputeAsync(id, CancellationToken.None);
@@ -86,7 +88,8 @@ public class DisputeControllerTest
             .Setup(_ => _.GetDisputeAsync(It.Is<long>(v => v == id), true, It.IsAny<CancellationToken>()))
             .Throws(new TrafficCourts.Exceptions.ApiException("msg", StatusCodes.Status400BadRequest, "rsp", null!, null));
         var mockLogger = new Mock<ILogger<DisputeController>>();
-        DisputeController disputeController = new(disputeService.Object, mockLogger.Object);
+        var mockPrintDcf = new Mock<IPrintDigitalCaseFileService>();
+        DisputeController disputeController = new(disputeService.Object, mockPrintDcf.Object, mockLogger.Object);
 
         // Act
         IActionResult? result = await disputeController.GetDisputeAsync(id, CancellationToken.None);
@@ -110,7 +113,8 @@ public class DisputeControllerTest
             .Setup(_ => _.GetDisputeAsync(It.Is<long>(v => v == id), true, It.IsAny<CancellationToken>()))
             .Throws(new TrafficCourts.Exceptions.ApiException("msg", StatusCodes.Status404NotFound, "rsp", null!, null));
         var mockLogger = new Mock<ILogger<DisputeController>>();
-        DisputeController disputeController = new(disputeService.Object, mockLogger.Object);
+        var mockPrintDcf = new Mock<IPrintDigitalCaseFileService>();
+        DisputeController disputeController = new(disputeService.Object, mockPrintDcf.Object, mockLogger.Object);
 
         // Act
         IActionResult? result = await disputeController.GetDisputeAsync(id, CancellationToken.None);
@@ -134,7 +138,8 @@ public class DisputeControllerTest
             .Setup(_ => _.UpdateDisputeAsync(It.Is<long>(v => v == id), It.IsAny<ClaimsPrincipal>(), It.IsAny<string>(), It.IsAny<Dispute>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(dispute);
         var mockLogger = new Mock<ILogger<DisputeController>>();
-        DisputeController disputeController = new(disputeService.Object, mockLogger.Object);
+        var mockPrintDcf = new Mock<IPrintDigitalCaseFileService>();
+        DisputeController disputeController = new(disputeService.Object, mockPrintDcf.Object, mockLogger.Object);
 
         // Act
         IActionResult? result = await disputeController.UpdateDisputeAsync(id, dispute, "test comment", CancellationToken.None);
@@ -158,7 +163,8 @@ public class DisputeControllerTest
             .Setup(_ => _.UpdateDisputeAsync(It.Is<long>(v => v == id), It.IsAny<ClaimsPrincipal>(), It.IsAny<string>(), It.IsAny<Dispute>(), It.IsAny<CancellationToken>()))
             .Throws(new TrafficCourts.Exceptions.ApiException("msg", StatusCodes.Status400BadRequest, "rsp", null!, null));
         var mockLogger = new Mock<ILogger<DisputeController>>();
-        DisputeController disputeController = new(disputeService.Object, mockLogger.Object);
+        var mockPrintDcf = new Mock<IPrintDigitalCaseFileService>();
+        DisputeController disputeController = new(disputeService.Object, mockPrintDcf.Object, mockLogger.Object);
 
         // Act
         IActionResult? result = await disputeController.UpdateDisputeAsync(id, dispute, "test comment", CancellationToken.None);
@@ -183,7 +189,8 @@ public class DisputeControllerTest
             .Setup(_ => _.UpdateDisputeAsync(It.Is<long>(v => v == updatedId), It.IsAny<ClaimsPrincipal>(), It.IsAny<string>(), It.IsAny<Dispute>(), It.IsAny<CancellationToken>()))
             .Throws(new TrafficCourts.Exceptions.ApiException("msg", StatusCodes.Status404NotFound, "rsp", null!, null));
         var mockLogger = new Mock<ILogger<DisputeController>>();
-        DisputeController disputeController = new(disputeService.Object, mockLogger.Object);
+        var mockPrintDcf = new Mock<IPrintDigitalCaseFileService>();
+        DisputeController disputeController = new(disputeService.Object, mockPrintDcf.Object, mockLogger.Object);
 
         // Act
         IActionResult? result = await disputeController.UpdateDisputeAsync(updatedId, dispute, "test comment", CancellationToken.None);
@@ -207,7 +214,8 @@ public class DisputeControllerTest
             .Setup(_ => _.ValidateDisputeAsync(It.Is<long>(v => v == id), null, It.IsAny<ClaimsPrincipal>(), It.IsAny<CancellationToken>()))
             .Verifiable();
         var mockLogger = new Mock<ILogger<DisputeController>>();
-        DisputeController disputeController = new(disputeService.Object, mockLogger.Object);
+        var mockPrintDcf = new Mock<IPrintDigitalCaseFileService>();
+        DisputeController disputeController = new(disputeService.Object, mockPrintDcf.Object, mockLogger.Object);
 
         // Act
         await disputeController.ValidateDisputeAsync(id, null, CancellationToken.None);
@@ -228,7 +236,8 @@ public class DisputeControllerTest
             .Setup(_ => _.ValidateDisputeAsync(It.Is<long>(v => v == id), dispute, It.IsAny<ClaimsPrincipal>(), It.IsAny<CancellationToken>()))
             .Verifiable();
         var mockLogger = new Mock<ILogger<DisputeController>>();
-        DisputeController disputeController = new(disputeService.Object, mockLogger.Object);
+        var mockPrintDcf = new Mock<IPrintDigitalCaseFileService>();
+        DisputeController disputeController = new(disputeService.Object, mockPrintDcf.Object, mockLogger.Object);
 
         // Act
         await disputeController.ValidateDisputeAsync(id, dispute, CancellationToken.None);
@@ -250,7 +259,8 @@ public class DisputeControllerTest
             .Setup(_ => _.AcceptDisputeUpdateRequestAsync(It.Is<long>(v => v == id), It.IsAny<ClaimsPrincipal>(), It.IsAny<CancellationToken>()))
             .Verifiable();
         var mockLogger = new Mock<ILogger<DisputeController>>();
-        DisputeController disputeController = new(disputeService.Object, mockLogger.Object);
+        var mockPrintDcf = new Mock<IPrintDigitalCaseFileService>();
+        DisputeController disputeController = new(disputeService.Object, mockPrintDcf.Object, mockLogger.Object);
 
         // Act
         await disputeController.AcceptDisputeUpdateRequestAsync(id, CancellationToken.None);
@@ -276,7 +286,8 @@ public class DisputeControllerTest
             .Setup(_ => _.GetAllDisputesWithPendingUpdateRequestsAsync(It.IsAny<CancellationToken>()))
             .ReturnsAsync(disputes);
         var mockLogger = new Mock<ILogger<DisputeController>>();
-        DisputeController disputeController = new(disputeService.Object, mockLogger.Object);
+        var mockPrintDcf = new Mock<IPrintDigitalCaseFileService>();
+        DisputeController disputeController = new(disputeService.Object, mockPrintDcf.Object, mockLogger.Object);
 
         // Act
         IActionResult? result = await disputeController.GetDisputesWithPendingUpdateRequestsAsync(CancellationToken.None);
@@ -309,7 +320,8 @@ public class DisputeControllerTest
             .Setup(_ => _.GetDisputeUpdateRequestsAsync(1, It.IsAny<CancellationToken>()))
             .ReturnsAsync(updateRequests);
         var mockLogger = new Mock<ILogger<DisputeController>>();
-        DisputeController disputeController = new(disputeService.Object, mockLogger.Object);
+        var mockPrintDcf = new Mock<IPrintDigitalCaseFileService>();
+        DisputeController disputeController = new(disputeService.Object, mockPrintDcf.Object, mockLogger.Object);
 
         // Act
         IActionResult? result = await disputeController.GetDisputeUpdateRequestsAsync(1, CancellationToken.None);
@@ -333,7 +345,8 @@ public class DisputeControllerTest
         dispute.DisputeId = id;
         var disputeService = new Mock<IDisputeService>();
         var mockLogger = new Mock<ILogger<DisputeController>>();
-        DisputeController disputeController = new(disputeService.Object, mockLogger.Object);
+        var mockPrintDcf = new Mock<IPrintDigitalCaseFileService>();
+        DisputeController disputeController = new(disputeService.Object, mockPrintDcf.Object, mockLogger.Object);
 
         disputeService
             .Setup(_ => _.GetDisputeAsync(It.Is<long>(v => v == id), true, It.IsAny<CancellationToken>()))

--- a/src/backend/TrafficCourts/TrafficCourts.Staff.Service.Test/Services/PrintDigialCaseFile/PrintDigitalCaseFileIntegrationTest.cs
+++ b/src/backend/TrafficCourts/TrafficCourts.Staff.Service.Test/Services/PrintDigialCaseFile/PrintDigitalCaseFileIntegrationTest.cs
@@ -1,76 +1,123 @@
-﻿//using MassTransit;
-//using Microsoft.Extensions.Configuration;
-//using Microsoft.Extensions.Logging;
-//using Moq;
-//using System.Collections.Generic;
-//using System.Net.Http;
-//using System.Threading;
-//using System.Threading.Tasks;
-//using TrafficCourts.Cdogs.Client;
-//using TrafficCourts.Common.Features.Lookups;
-//using TrafficCourts.Common.OpenAPIs.KeycloakAdminApi.v22_0;
-//using TrafficCourts.Common.OpenAPIs.OracleDataApi.v1_0;
-//using TrafficCourts.Staff.Service.Services;
-//using Xunit;
+﻿using AutoFixture;
+using AutoMapper;
+using MassTransit;
+using MediatR;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Moq;
+using NSubstitute;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using TrafficCourts.Cdogs.Client;
+using TrafficCourts.Common.Features.Lookups;
+using TrafficCourts.Common.OpenAPIs.KeycloakAdminApi.v22_0;
+using TrafficCourts.Coms.Client;
+using TrafficCourts.Domain.Models;
+using TrafficCourts.OracleDataApi;
+using TrafficCourts.Staff.Service.Services;
+using Xunit;
+using ZiggyCreatures.Caching.Fusion;
+using Oracle = TrafficCourts.OracleDataApi.Client.V1;
 
-//namespace TrafficCourts.Staff.Service.Test.Services.PrintDigialCaseFile
-//{
-//    public class PrintDigitalCaseFileIntegrationTest
-//    {
-//        private PrintDigitalCaseFileService _sut;
+namespace TrafficCourts.Staff.Service.Test.Services.PrintDigialCaseFile
+{
+    public class PrintDigitalCaseFileIntegrationTest
+    {
+        private PrintDigitalCaseFileService _sut;
+        private readonly Oracle.IOracleDataApiClient _client = Substitute.For<Oracle.IOracleDataApiClient>();
+        private readonly IMapper _mapper = Substitute.For<IMapper>();
+        private readonly IMediator _mediator = Substitute.For<IMediator>();
+        private readonly ILogger<OracleDataApiService> _logger = Substitute.For<ILogger<OracleDataApiService>>();
+        private readonly Fixture _fixture = new Fixture();
+
+        public PrintDigitalCaseFileIntegrationTest()
+        {
+            IConfiguration configuration = GetConfiguration();
+
+            OracleDataApiService oracleDataApi = new(_client, _mapper, _mediator, _logger);
+
+            var mock = new Mock<IStaffDocumentService>();
+            mock.Setup(_ => _.FindFilesAsync(It.IsAny<Domain.Models.DocumentProperties>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new List<TrafficCourts.Domain.Models.FileMetadata>());
+
+            var mockKeycloakService = new Mock<IKeycloakService>();
+            // Add setup for the methods within IKeycloakService that are called internally by GetDigitalCaseFileAsync.
+            mockKeycloakService.Setup(_ => _.UsersByIdirAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new List<UserRepresentation>());
+
+            IJJDisputeService jjDisputeService = new JJDisputeService(
+                oracleDataApi,
+                Mock.Of<IBus>(),
+                mock.Object,
+                Mock.Of<IKeycloakService>(),
+                Mock.Of<IStatuteLookupService>(),
+                Mock.Of<ILogger<JJDisputeService>>());
+
+            IDisputeService disputeService = new DisputeService(
+                oracleDataApi,
+                Mock.Of<IBus>(),
+                Mock.Of<IObjectManagementService>(),
+                Mock.Of<IAgencyLookupService>(),
+                Mock.Of<IProvinceLookupService>(),
+                mock.Object,
+                Mock.Of<IFusionCache>(),
+                Mock.Of<ILogger<DisputeService>>());
+
+            _sut = new PrintDigitalCaseFileService(
+                jjDisputeService,
+                oracleDataApi,
+                Mock.Of<IProvinceLookupService>(),
+                Mock.Of<ICountryLookupService>(),
+                Mock.Of<IDocumentGenerationService>(),
+                disputeService,
+                Mock.Of<ILogger<PrintDigitalCaseFileService>>());
+        }
+
+        [IntegrationTestFact]
+        public async Task Print()
+        {
+            // create oracle object that should be returned from the client
+            var oracle = _fixture.Create<Oracle.JJDispute>();
+            var jjDispute = _fixture.Create<JJDispute>();
+
+            _client.GetJJDisputeAsync(Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
+                .Returns(_ => Task.FromResult(oracle));
+
+            _mapper.Map<JJDispute>(oracle).Returns(jjDispute);
+
+            Models.DigitalCaseFiles.Print.DigitalCaseFile dcf = await _sut.GetDigitalCaseFileAsync("EA03148599", "Pacific Standard Time", CancellationToken.None);
+            var json = Newtonsoft.Json.JsonConvert.SerializeObject(dcf);
+
+            Assert.True(true);
+        }
+
+        [IntegrationTestFact]
+        public async Task PrintTicketValidationView()
+        {
+            // create oracle object that should be returned from the client
+            var oracle = _fixture.Create<Oracle.Dispute>();
+            var dispute = _fixture.Create<Dispute>();
+
+            _client.GetDisputeAsync(Arg.Any<long>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
+                .Returns(_ => Task.FromResult(oracle));
+
+            _mapper.Map<Dispute>(oracle).Returns(dispute);
+
+            Models.DigitalCaseFiles.Print.DigitalCaseFile dcf = await _sut.GetDigitalCaseFileAsync(3354, "Pacific Standard Time", CancellationToken.None);
+            var json = Newtonsoft.Json.JsonConvert.SerializeObject(dcf);
+
+            Assert.True(true);
+        }
 
 
-//        public PrintDigitalCaseFileIntegrationTest()
-//        {
-//            IConfiguration configuration = GetConfiguration();
+        private IConfiguration GetConfiguration()
+        {
+            IConfiguration configuration = new ConfigurationBuilder()
+                .AddUserSecrets<PrintDigitalCaseFileIntegrationTest>()
+                .Build();
 
-//            IOracleDataApiClient oracleDataApi = new OracleDataApiClient(new HttpClient
-//            {
-//                BaseAddress = configuration.GetValue<System.Uri>("OracleDataApi:BaseAddress")
-//            });
-
-//            var mock = new Mock<IStaffDocumentService>();
-//            mock.Setup(_ => _.FindFilesAsync(It.IsAny<Domain.Models.DocumentProperties>(), It.IsAny<CancellationToken>()))
-//                .ReturnsAsync(new List<TrafficCourts.Domain.Models.FileMetadata>());
-
-//            var mockKeycloakService = new Mock<IKeycloakService>();
-//            // Add setup for the methods within IKeycloakService that are called internally by GetDigitalCaseFileAsync.
-//            mockKeycloakService.Setup(_ => _.UsersByIdirAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
-//                .ReturnsAsync(new List<UserRepresentation>());
-
-//            IJJDisputeService disputeService = new JJDisputeService(
-//                oracleDataApi,
-//                Mock.Of<IBus>(),
-//                mock.Object,
-//                Mock.Of<IKeycloakService>(),
-//                Mock.Of<IStatuteLookupService>(),
-//                Mock.Of<ILogger<JJDisputeService>>());
-
-//            _sut = new PrintDigitalCaseFileService(
-//                disputeService,
-//                oracleDataApi,
-//                Mock.Of<IProvinceLookupService>(),
-//                Mock.Of<IDocumentGenerationService>(),
-//                Mock.Of<ILogger<PrintDigitalCaseFileService>>());
-//        }
-
-//        [IntegrationTestFact]
-//        public async Task Print()
-//        {
-//            Models.DigitalCaseFiles.Print.DigitalCaseFile dcf = await _sut.GetDigitalCaseFileAsync("EA03148599", "Pacific Standard Time", CancellationToken.None);
-//            var json = Newtonsoft.Json.JsonConvert.SerializeObject(dcf);
-
-//            Assert.True(true);
-//        }
-
-
-//        private IConfiguration GetConfiguration()
-//        {
-//            IConfiguration configuration = new ConfigurationBuilder()
-//                .AddUserSecrets<PrintDigitalCaseFileIntegrationTest>()
-//                .Build();
-
-//            return configuration;
-//        }
-//    }
-//}
+            return configuration;
+        }
+    }
+}

--- a/src/frontend/staff-portal/src/app/api/api/dispute.service.ts
+++ b/src/frontend/staff-portal/src/app/api/api/dispute.service.ts
@@ -338,6 +338,83 @@ export class DisputeService {
     }
 
     /**
+     * Returns generated document.
+     * @param disputeId Dispute Id
+     * @param timeZone The IANA timze zone id
+     * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
+     * @param reportProgress flag to report request and response progress.
+     */
+    public apiDisputeDisputeIdPrintGet(disputeId: number, timeZone: string, observe?: 'body', reportProgress?: boolean, options?: {httpHeaderAccept?: 'text/plain' | 'application/json' | 'text/json', context?: HttpContext}): Observable<any>;
+    public apiDisputeDisputeIdPrintGet(disputeId: number, timeZone: string, observe?: 'response', reportProgress?: boolean, options?: {httpHeaderAccept?: 'text/plain' | 'application/json' | 'text/json', context?: HttpContext}): Observable<HttpResponse<any>>;
+    public apiDisputeDisputeIdPrintGet(disputeId: number, timeZone: string, observe?: 'events', reportProgress?: boolean, options?: {httpHeaderAccept?: 'text/plain' | 'application/json' | 'text/json', context?: HttpContext}): Observable<HttpEvent<any>>;
+    public apiDisputeDisputeIdPrintGet(disputeId: number, timeZone: string, observe: any = 'body', reportProgress: boolean = false, options?: {httpHeaderAccept?: 'text/plain' | 'application/json' | 'text/json', context?: HttpContext}): Observable<any> {
+        if (disputeId === null || disputeId === undefined) {
+            throw new Error('Required parameter disputeId was null or undefined when calling apiDisputeDisputeIdPrintGet.');
+        }
+        if (timeZone === null || timeZone === undefined) {
+            throw new Error('Required parameter timeZone was null or undefined when calling apiDisputeDisputeIdPrintGet.');
+        }
+
+        let localVarQueryParameters = new HttpParams({encoder: this.encoder});
+        if (timeZone !== undefined && timeZone !== null) {
+          localVarQueryParameters = this.addToHttpParams(localVarQueryParameters,
+            <any>timeZone, 'timeZone');
+        }
+
+        let localVarHeaders = this.defaultHeaders;
+
+        let localVarCredential: string | undefined;
+        // authentication (Bearer) required
+        localVarCredential = this.configuration.lookupCredential('Bearer');
+        if (localVarCredential) {
+            localVarHeaders = localVarHeaders.set('Authorization', localVarCredential);
+        }
+
+        let localVarHttpHeaderAcceptSelected: string | undefined = options && options.httpHeaderAccept;
+        if (localVarHttpHeaderAcceptSelected === undefined) {
+            // to determine the Accept header
+            const httpHeaderAccepts: string[] = [
+                'text/plain',
+                'application/json',
+                'text/json'
+            ];
+            localVarHttpHeaderAcceptSelected = this.configuration.selectHeaderAccept(httpHeaderAccepts);
+        }
+        if (localVarHttpHeaderAcceptSelected !== undefined) {
+            localVarHeaders = localVarHeaders.set('Accept', localVarHttpHeaderAcceptSelected);
+        }
+
+        let localVarHttpContext: HttpContext | undefined = options && options.context;
+        if (localVarHttpContext === undefined) {
+            localVarHttpContext = new HttpContext();
+        }
+
+
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
+            }
+        }
+
+        return this.httpClient.get<any>(`${this.configuration.basePath}/api/dispute/${this.configuration.encodeParam({name: "disputeId", value: disputeId, in: "path", style: "simple", explode: false, dataType: "number", dataFormat: "int64"})}/print`,
+            {
+                context: localVarHttpContext,
+                params: localVarQueryParameters,
+                responseType: <any>responseType_,
+                withCredentials: this.configuration.withCredentials,
+                headers: localVarHeaders,
+                observe: observe,
+                reportProgress: reportProgress
+            }
+        );
+    }
+
+    /**
      * Updates a single Dispute through the Oracle Data Interface API based on unique dispute id and the dispute data being passed in the body.
      * @param disputeId Unique identifier for a specific Dispute record.
      * @param staffComment VTC staff\&#39;s comment for saving or updating a dispute in Ticket Validation

--- a/src/frontend/staff-portal/src/app/api/swagger.json
+++ b/src/frontend/staff-portal/src/app/api/swagger.json
@@ -1,456 +1,309 @@
 {
-    "openapi": "3.0.1",
-    "info": {
-      "title": "VTC Staff API",
-      "description": "Violation Ticket Centre Staff API",
-      "version": "v1"
-    },
-    "paths": {
-      "/api/dispute/disputes": {
-        "get": {
-          "tags": [
-            "Dispute"
-          ],
-          "summary": "Returns all Disputes from the Oracle Data API with given parameters.",
-          "parameters": [
-            {
-              "name": "excludeStatus",
-              "in": "query",
-              "description": "The status to exclude",
-              "schema": {
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/ExcludeStatus"
-                }
-              }
-            },
-            {
-              "name": "ticket",
-              "in": "query",
-              "description": "The optional ticket number to search on. The value will be searched using contains.",
-              "schema": {
-                "type": "string"
-              }
-            },
-            {
-              "name": "surname",
-              "in": "query",
-              "description": "The optional surname to search on. The value will be searched using contains.",
-              "schema": {
-                "type": "string"
-              }
-            },
-            {
-              "name": "status",
-              "in": "query",
-              "description": "The optional status to find.",
-              "schema": {
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/DisputeStatus"
-                }
-              }
-            },
-            {
-              "name": "from",
-              "in": "query",
-              "description": "The optional from date to search. The submitted date will be filtered where greater or equal to this value.",
-              "schema": {
-                "type": "string",
-                "format": "date-time"
-              }
-            },
-            {
-              "name": "thru",
-              "in": "query",
-              "description": "The optional thru date to search. The submitted date will be filtered where less than or equal to this value.",
-              "schema": {
-                "type": "string",
-                "format": "date-time"
-              }
-            },
-            {
-              "name": "courtHouse",
-              "in": "query",
-              "description": "The optional court house location to search. The value will be searched using contains.",
-              "schema": {
-                "type": "string"
-              }
-            },
-            {
-              "name": "sortBy",
-              "in": "query",
-              "description": "The optional sort by contains the attribute name to sort. The data is sorted on the attribute.",
-              "schema": {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                }
-              }
-            },
-            {
-              "name": "direction",
-              "in": "query",
-              "description": "The optional sort direction contains the asc or desc. The data is sorted by given direction.",
-              "schema": {
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/SortDirection"
-                }
-              }
-            },
-            {
-              "name": "DefaultPageSize",
-              "in": "query",
-              "description": "The default page size contains the default count of records.",
-              "schema": {
-                "type": "integer",
-                "format": "int32"
-              }
-            },
-            {
-              "name": "pageNumber",
-              "in": "query",
-              "description": "The optional page number gives the records from given page",
-              "schema": {
-                "type": "integer",
-                "format": "int32"
-              }
-            },
-            {
-              "name": "pageSize",
-              "in": "query",
-              "description": "The optional page size sets the record count",
-              "schema": {
-                "type": "integer",
-                "format": "int32"
+  "openapi": "3.0.1",
+  "info": {
+    "title": "VTC Staff API",
+    "description": "Violation Ticket Centre Staff API",
+    "version": "v1"
+  },
+  "paths": {
+    "/api/dispute/disputes": {
+      "get": {
+        "tags": [
+          "Dispute"
+        ],
+        "summary": "Returns all Disputes from the Oracle Data API with given parameters.",
+        "parameters": [
+          {
+            "name": "excludeStatus",
+            "in": "query",
+            "description": "The status to exclude",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/ExcludeStatus"
               }
             }
-          ],
-          "responses": {
-            "200": {
-              "description": "The Disputes were found.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/PagedDisputeListItemCollection"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/PagedDisputeListItemCollection"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/PagedDisputeListItemCollection"
-                  }
-                }
-              }
-            },
-            "401": {
-              "description": "Request lacks valid authentication credentials.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "403": {
-              "description": "Forbidden, requires dispute:read permission.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "500": {
-              "description": "There was a server error that prevented the search from completing successfully or no data found."
+          },
+          {
+            "name": "ticket",
+            "in": "query",
+            "description": "The optional ticket number to search on. The value will be searched using contains.",
+            "schema": {
+              "type": "string"
             }
-          }
-        }
-      },
-      "/api/dispute/disputes/count": {
-        "get": {
-          "tags": [
-            "Dispute"
-          ],
-          "summary": "Returns the count of disputes with the given status.",
-          "parameters": [
-            {
-              "name": "status",
-              "in": "query",
-              "description": "",
-              "schema": {
+          },
+          {
+            "name": "surname",
+            "in": "query",
+            "description": "The optional surname to search on. The value will be searched using contains.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "status",
+            "in": "query",
+            "description": "The optional status to find.",
+            "schema": {
+              "type": "array",
+              "items": {
                 "$ref": "#/components/schemas/DisputeStatus"
               }
             }
-          ],
-          "responses": {
-            "200": {
-              "description": "The Disputes were found.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/GetDisputeCountResponse"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/GetDisputeCountResponse"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/GetDisputeCountResponse"
-                  }
-                }
-              }
-            },
-            "401": {
-              "description": "Request lacks valid authentication credentials.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "403": {
-              "description": "Forbidden, requires dispute:read permission.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "500": {
-              "description": "There was a server error that prevented the search from completing successfully or no data found."
+          },
+          {
+            "name": "from",
+            "in": "query",
+            "description": "The optional from date to search. The submitted date will be filtered where greater or equal to this value.",
+            "schema": {
+              "type": "string",
+              "format": "date-time"
             }
-          }
-        }
-      },
-      "/api/dispute/{disputeId}": {
-        "get": {
-          "tags": [
-            "Dispute"
-          ],
-          "summary": "Returns a single Dispute with the given identifier from the Oracle Data API.",
-          "parameters": [
-            {
-              "name": "disputeId",
-              "in": "path",
-              "description": "Unique identifier for a specific Dispute record.",
-              "required": true,
-              "schema": {
-                "type": "integer",
-                "format": "int64"
-              }
+          },
+          {
+            "name": "thru",
+            "in": "query",
+            "description": "The optional thru date to search. The submitted date will be filtered where less than or equal to this value.",
+            "schema": {
+              "type": "string",
+              "format": "date-time"
             }
-          ],
-          "responses": {
-            "200": {
-              "description": "The Dispute was found.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/Dispute"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/Dispute"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/Dispute"
-                  }
-                }
-              }
-            },
-            "400": {
-              "description": "The request was not well formed. Check the parameters.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "401": {
-              "description": "Request lacks valid authentication credentials.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "403": {
-              "description": "Forbidden, requires dispute:read permission.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "404": {
-              "description": "The dispute was not found.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "409": {
-              "description": "The Dispute has already been assigned to a user. Dispute cannot be modified until assigned time expires.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "500": {
-              "description": "There was a server error that prevented the search from completing successfully or no data found."
+          },
+          {
+            "name": "courtHouse",
+            "in": "query",
+            "description": "The optional court house location to search. The value will be searched using contains.",
+            "schema": {
+              "type": "string"
             }
-          }
-        },
-        "put": {
-          "tags": [
-            "Dispute"
-          ],
-          "summary": "Updates a single Dispute through the Oracle Data Interface API based on unique dispute id and the dispute data being passed in the body.",
-          "parameters": [
-            {
-              "name": "disputeId",
-              "in": "path",
-              "description": "Unique identifier for a specific Dispute record.",
-              "required": true,
-              "schema": {
-                "type": "integer",
-                "format": "int64"
-              }
-            },
-            {
-              "name": "staffComment",
-              "in": "query",
-              "description": "VTC staff's comment for saving or updating a dispute in Ticket Validation",
-              "schema": {
-                "maxLength": 500,
-                "minLength": 0,
+          },
+          {
+            "name": "sortBy",
+            "in": "query",
+            "description": "The optional sort by contains the attribute name to sort. The data is sorted on the attribute.",
+            "schema": {
+              "type": "array",
+              "items": {
                 "type": "string"
               }
             }
-          ],
-          "requestBody": {
-            "description": "",
+          },
+          {
+            "name": "direction",
+            "in": "query",
+            "description": "The optional sort direction contains the asc or desc. The data is sorted by given direction.",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/SortDirection"
+              }
+            }
+          },
+          {
+            "name": "DefaultPageSize",
+            "in": "query",
+            "description": "The default page size contains the default count of records.",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "pageNumber",
+            "in": "query",
+            "description": "The optional page number gives the records from given page",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "pageSize",
+            "in": "query",
+            "description": "The optional page size sets the record count",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The Disputes were found.",
             "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/PagedDisputeListItemCollection"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PagedDisputeListItemCollection"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PagedDisputeListItemCollection"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Request lacks valid authentication credentials.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden, requires dispute:read permission.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "There was a server error that prevented the search from completing successfully or no data found."
+          }
+        }
+      }
+    },
+    "/api/dispute/disputes/count": {
+      "get": {
+        "tags": [
+          "Dispute"
+        ],
+        "summary": "Returns the count of disputes with the given status.",
+        "parameters": [
+          {
+            "name": "status",
+            "in": "query",
+            "description": "",
+            "schema": {
+              "$ref": "#/components/schemas/DisputeStatus"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The Disputes were found.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetDisputeCountResponse"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetDisputeCountResponse"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetDisputeCountResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Request lacks valid authentication credentials.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden, requires dispute:read permission.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "There was a server error that prevented the search from completing successfully or no data found."
+          }
+        }
+      }
+    },
+    "/api/dispute/{disputeId}": {
+      "get": {
+        "tags": [
+          "Dispute"
+        ],
+        "summary": "Returns a single Dispute with the given identifier from the Oracle Data API.",
+        "parameters": [
+          {
+            "name": "disputeId",
+            "in": "path",
+            "description": "Unique identifier for a specific Dispute record.",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The Dispute was found.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/Dispute"
+                }
+              },
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/Dispute"
@@ -460,4259 +313,4353 @@
                 "schema": {
                   "$ref": "#/components/schemas/Dispute"
                 }
+              }
+            }
+          },
+          "400": {
+            "description": "The request was not well formed. Check the parameters.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
               },
-              "application/*+json": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Request lacks valid authentication credentials.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden, requires dispute:read permission.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "The dispute was not found.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "The Dispute has already been assigned to a user. Dispute cannot be modified until assigned time expires.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "There was a server error that prevented the search from completing successfully or no data found."
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "Dispute"
+        ],
+        "summary": "Updates a single Dispute through the Oracle Data Interface API based on unique dispute id and the dispute data being passed in the body.",
+        "parameters": [
+          {
+            "name": "disputeId",
+            "in": "path",
+            "description": "Unique identifier for a specific Dispute record.",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          {
+            "name": "staffComment",
+            "in": "query",
+            "description": "VTC staff's comment for saving or updating a dispute in Ticket Validation",
+            "schema": {
+              "maxLength": 500,
+              "minLength": 0,
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Dispute"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Dispute"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Dispute"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The Dispute is updated.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/Dispute"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Dispute"
+                }
+              },
+              "text/json": {
                 "schema": {
                   "$ref": "#/components/schemas/Dispute"
                 }
               }
             }
           },
-          "responses": {
-            "200": {
-              "description": "The Dispute is updated.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/Dispute"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/Dispute"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/Dispute"
-                  }
+          "400": {
+            "description": "The request was not well formed. Check the parameters.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
                 }
               }
-            },
-            "400": {
-              "description": "The request was not well formed. Check the parameters.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "401": {
-              "description": "Request lacks valid authentication credentials.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "403": {
-              "description": "Forbidden, requires dispute:update permission.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "404": {
-              "description": "The Dispute to update was not found.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "409": {
-              "description": "The Dispute has already been assigned to a user. Dispute cannot be modified until assigned time expires.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "500": {
-              "description": "There was a server error that prevented the update from completing successfully."
             }
+          },
+          "401": {
+            "description": "Request lacks valid authentication credentials.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden, requires dispute:update permission.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "The Dispute to update was not found.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "The Dispute has already been assigned to a user. Dispute cannot be modified until assigned time expires.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "There was a server error that prevented the update from completing successfully."
           }
         }
-      },
-      "/api/dispute/{disputeId}/reject": {
-        "put": {
-          "tags": [
-            "Dispute"
-          ],
-          "summary": "Updates the status of a particular Dispute record to REJECTED.",
-          "parameters": [
-            {
-              "name": "disputeId",
-              "in": "path",
-              "description": "Unique identifier for a specific Dispute record to cancel.",
-              "required": true,
-              "schema": {
-                "type": "integer",
-                "format": "int64"
-              }
+      }
+    },
+    "/api/dispute/{disputeId}/reject": {
+      "put": {
+        "tags": [
+          "Dispute"
+        ],
+        "summary": "Updates the status of a particular Dispute record to REJECTED.",
+        "parameters": [
+          {
+            "name": "disputeId",
+            "in": "path",
+            "description": "Unique identifier for a specific Dispute record to cancel.",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
             }
-          ],
-          "requestBody": {
-            "content": {
-              "multipart/form-data": {
-                "schema": {
-                  "required": [
-                    "rejectedReason"
-                  ],
-                  "type": "object",
-                  "properties": {
-                    "rejectedReason": {
-                      "maxLength": 256,
-                      "minLength": 0,
-                      "type": "string"
-                    }
-                  }
-                },
-                "encoding": {
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "required": [
+                  "rejectedReason"
+                ],
+                "type": "object",
+                "properties": {
                   "rejectedReason": {
-                    "style": "form"
+                    "maxLength": 256,
+                    "minLength": 0,
+                    "type": "string"
                   }
                 }
-              }
-            }
-          },
-          "responses": {
-            "200": {
-              "description": "The Dispute is updated."
-            },
-            "400": {
-              "description": "The request was not well formed. Check the parameters.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
+              },
+              "encoding": {
+                "rejectedReason": {
+                  "style": "form"
                 }
               }
-            },
-            "401": {
-              "description": "Request lacks valid authentication credentials.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "403": {
-              "description": "Forbidden, requires dispute:reject permission.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "404": {
-              "description": "Dispute record not found. Update failed.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "405": {
-              "description": "A Dispute status can only be set to REJECTED iff status is NEW, CANCELLED, VALIDATED or REJECTED and the rejected reason must be <= 256 characters. Update failed.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "409": {
-              "description": "The Dispute has already been assigned to a different user. Dispute cannot be modified until assigned time expires.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "500": {
-              "description": "There was a server error that prevented the update from completing successfully."
             }
           }
-        }
-      },
-      "/api/dispute/{disputeId}/validate": {
-        "put": {
-          "tags": [
-            "Dispute"
-          ],
-          "summary": "Updates the status of a particular Dispute record to VALIDATED.",
-          "parameters": [
-            {
-              "name": "disputeId",
-              "in": "path",
-              "description": "Unique identifier for a specific Dispute record to validate.",
-              "required": true,
-              "schema": {
-                "type": "integer",
-                "format": "int64"
-              }
-            }
-          ],
-          "requestBody": {
-            "description": "Validated dispute data to update",
+        },
+        "responses": {
+          "200": {
+            "description": "The Dispute is updated."
+          },
+          "400": {
+            "description": "The request was not well formed. Check the parameters.",
             "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Dispute"
+                  "$ref": "#/components/schemas/ProblemDetails"
                 }
               },
               "text/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Dispute"
-                }
-              },
-              "application/*+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Dispute"
+                  "$ref": "#/components/schemas/ProblemDetails"
                 }
               }
             }
           },
-          "responses": {
-            "200": {
-              "description": "The Dispute is updated."
-            },
-            "400": {
-              "description": "The request was not well formed. Check the parameters.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
+          "401": {
+            "description": "Request lacks valid authentication credentials.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
                 }
               }
-            },
-            "401": {
-              "description": "Request lacks valid authentication credentials.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "403": {
-              "description": "Forbidden, requires dispute:validate permission.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "404": {
-              "description": "Dispute record not found. Update failed.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "405": {
-              "description": "A Dispute status can only be set to VALIDATED iff status is NEW. Update failed.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "409": {
-              "description": "The Dispute has already been assigned to a different user. Dispute cannot be modified until assigned time expires.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "500": {
-              "description": "There was a server error that prevented the update from completing successfully."
             }
+          },
+          "403": {
+            "description": "Forbidden, requires dispute:reject permission.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Dispute record not found. Update failed.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "A Dispute status can only be set to REJECTED iff status is NEW, CANCELLED, VALIDATED or REJECTED and the rejected reason must be \u003C= 256 characters. Update failed.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "The Dispute has already been assigned to a different user. Dispute cannot be modified until assigned time expires.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "There was a server error that prevented the update from completing successfully."
           }
         }
-      },
-      "/api/dispute/{disputeId}/cancel": {
-        "put": {
-          "tags": [
-            "Dispute"
-          ],
-          "summary": "Updates the status of a particular Dispute record to CANCELLED.",
-          "parameters": [
-            {
-              "name": "disputeId",
-              "in": "path",
-              "description": "Unique identifier for a specific Dispute record to cancel.",
-              "required": true,
+      }
+    },
+    "/api/dispute/{disputeId}/validate": {
+      "put": {
+        "tags": [
+          "Dispute"
+        ],
+        "summary": "Updates the status of a particular Dispute record to VALIDATED.",
+        "parameters": [
+          {
+            "name": "disputeId",
+            "in": "path",
+            "description": "Unique identifier for a specific Dispute record to validate.",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "Validated dispute data to update",
+          "content": {
+            "application/json": {
               "schema": {
-                "type": "integer",
-                "format": "int64"
+                "$ref": "#/components/schemas/Dispute"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Dispute"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Dispute"
               }
             }
-          ],
-          "requestBody": {
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The Dispute is updated."
+          },
+          "400": {
+            "description": "The request was not well formed. Check the parameters.",
             "content": {
-              "multipart/form-data": {
+              "text/plain": {
                 "schema": {
-                  "required": [
-                    "cancelledReason"
-                  ],
-                  "type": "object",
-                  "properties": {
-                    "cancelledReason": {
-                      "maxLength": 256,
-                      "minLength": 0,
-                      "type": "string"
-                    }
-                  }
-                },
-                "encoding": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Request lacks valid authentication credentials.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden, requires dispute:validate permission.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Dispute record not found. Update failed.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "A Dispute status can only be set to VALIDATED iff status is NEW. Update failed.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "The Dispute has already been assigned to a different user. Dispute cannot be modified until assigned time expires.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "There was a server error that prevented the update from completing successfully."
+          }
+        }
+      }
+    },
+    "/api/dispute/{disputeId}/cancel": {
+      "put": {
+        "tags": [
+          "Dispute"
+        ],
+        "summary": "Updates the status of a particular Dispute record to CANCELLED.",
+        "parameters": [
+          {
+            "name": "disputeId",
+            "in": "path",
+            "description": "Unique identifier for a specific Dispute record to cancel.",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "required": [
+                  "cancelledReason"
+                ],
+                "type": "object",
+                "properties": {
                   "cancelledReason": {
-                    "style": "form"
-                  }
-                }
-              }
-            }
-          },
-          "responses": {
-            "200": {
-              "description": "The Dispute is updated."
-            },
-            "400": {
-              "description": "The request was not well formed. Check the parameters.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "401": {
-              "description": "Request lacks valid authentication credentials.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "403": {
-              "description": "Forbidden, requires dispute:cancel permission.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "404": {
-              "description": "Dispute record not found. Update failed.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "405": {
-              "description": "A Dispute status can only be set to CANCELLED iff status is NEW, VALIDATED, REJECTED or PROCESSING.Update failed.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "409": {
-              "description": "The Dispute has already been assigned to a different user. Dispute cannot be modified until assigned time expires.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "500": {
-              "description": "There was a server error that prevented the update from completing successfully."
-            }
-          }
-        }
-      },
-      "/api/dispute/{disputeId}/resendemailverify": {
-        "put": {
-          "tags": [
-            "Dispute"
-          ],
-          "summary": "An endpoint for resending an email to a Disputant.",
-          "parameters": [
-            {
-              "name": "disputeId",
-              "in": "path",
-              "description": "",
-              "required": true,
-              "schema": {
-                "type": "integer",
-                "format": "int64"
-              }
-            }
-          ],
-          "responses": {
-            "200": {
-              "description": "Success",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "type": "string"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "type": "string"
-                  }
-                },
-                "text/json": {
-                  "schema": {
+                    "maxLength": 256,
+                    "minLength": 0,
                     "type": "string"
                   }
                 }
-              }
-            },
-            "400": {
-              "description": "Bad Request",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
+              },
+              "encoding": {
+                "cancelledReason": {
+                  "style": "form"
                 }
               }
-            },
-            "401": {
-              "description": "Unauthorized",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "403": {
-              "description": "Forbidden",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "500": {
-              "description": "Server Error"
-            }
-          }
-        }
-      },
-      "/api/dispute/{disputeId}/submit": {
-        "put": {
-          "tags": [
-            "Dispute"
-          ],
-          "summary": "Submits a Dispute record, setting it's status to PROCESSING",
-          "parameters": [
-            {
-              "name": "disputeId",
-              "in": "path",
-              "description": "Unique identifier for a specific Dispute record to submit.",
-              "required": true,
-              "schema": {
-                "type": "integer",
-                "format": "int64"
-              }
-            }
-          ],
-          "responses": {
-            "200": {
-              "description": "The Dispute is updated."
-            },
-            "400": {
-              "description": "The request was not well formed. Check the parameters.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "401": {
-              "description": "Request lacks valid authentication credentials.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "403": {
-              "description": "Forbidden, requires dispute:submit permission.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "404": {
-              "description": "Dispute record not found. Update failed.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "405": {
-              "description": "A Dispute can only be submitted if the status is NEW or is already set to PROCESSING. Update failed.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "409": {
-              "description": "The Dispute has already been assigned to a different user. Dispute cannot be modified until assigned time expires.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "500": {
-              "description": "There was a server error that prevented the update from completing successfully."
-            }
-          }
-        }
-      },
-      "/api/dispute/updaterequest/{updateStatusId}/accept": {
-        "put": {
-          "tags": [
-            "Dispute"
-          ],
-          "summary": "Approves a DisputeUpdateRequest record, setting it's status to ACCEPTED.",
-          "parameters": [
-            {
-              "name": "updateStatusId",
-              "in": "path",
-              "description": "Unique identifier for a specific DisputeUpdateRequest record to accept.",
-              "required": true,
-              "schema": {
-                "type": "integer",
-                "format": "int64"
-              }
-            }
-          ],
-          "responses": {
-            "200": {
-              "description": "Success"
-            },
-            "500": {
-              "description": "Server Error"
-            }
-          }
-        }
-      },
-      "/api/dispute/updaterequest/{updateStatusId}/reject": {
-        "put": {
-          "tags": [
-            "Dispute"
-          ],
-          "summary": "Rejects a DisputeUpdateRequest record, setting it's status to REJECTED.",
-          "parameters": [
-            {
-              "name": "updateStatusId",
-              "in": "path",
-              "description": "Unique identifier for a specific DisputeUpdateRequest record to reject.",
-              "required": true,
-              "schema": {
-                "type": "integer",
-                "format": "int64"
-              }
-            }
-          ],
-          "responses": {
-            "200": {
-              "description": "Success"
-            },
-            "500": {
-              "description": "Server Error"
-            }
-          }
-        }
-      },
-      "/api/dispute/disputeswithupdaterequests": {
-        "get": {
-          "tags": [
-            "Dispute"
-          ],
-          "summary": "Returns all Disputes that have pending update requests from the Oracle Data API",
-          "responses": {
-            "200": {
-              "description": "The Disputes were found.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "type": "array",
-                    "items": {
-                      "$ref": "#/components/schemas/DisputeWithUpdates"
-                    }
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "type": "array",
-                    "items": {
-                      "$ref": "#/components/schemas/DisputeWithUpdates"
-                    }
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "type": "array",
-                    "items": {
-                      "$ref": "#/components/schemas/DisputeWithUpdates"
-                    }
-                  }
-                }
-              }
-            },
-            "401": {
-              "description": "Request lacks valid authentication credentials.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "403": {
-              "description": "Forbidden, requires dispute:read permission.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "500": {
-              "description": "There was a server error that prevented the search from completing successfully or no data found."
-            }
-          }
-        }
-      },
-      "/api/dispute/{disputeId}/disputeupdaterequests": {
-        "get": {
-          "tags": [
-            "Dispute"
-          ],
-          "summary": "Returns all update requests for a specific dispute",
-          "parameters": [
-            {
-              "name": "disputeId",
-              "in": "path",
-              "description": "Dispute Id",
-              "required": true,
-              "schema": {
-                "type": "integer",
-                "format": "int64"
-              }
-            }
-          ],
-          "responses": {
-            "200": {
-              "description": "The Update requests were found.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "type": "array",
-                    "items": {
-                      "$ref": "#/components/schemas/DisputeUpdateRequest"
-                    }
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "type": "array",
-                    "items": {
-                      "$ref": "#/components/schemas/DisputeUpdateRequest"
-                    }
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "type": "array",
-                    "items": {
-                      "$ref": "#/components/schemas/DisputeUpdateRequest"
-                    }
-                  }
-                }
-              }
-            },
-            "401": {
-              "description": "Request lacks valid authentication credentials.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "403": {
-              "description": "Forbidden, requires dispute:read permission.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "500": {
-              "description": "There was a server error that prevented the search from completing successfully or no data found."
-            }
-          }
-        }
-      },
-      "/api/disputelock": {
-        "get": {
-          "tags": [
-            "DisputeLock"
-          ],
-          "summary": "Acquires a lock for a JJ Dispute.",
-          "parameters": [
-            {
-              "name": "ticketNumber",
-              "in": "query",
-              "description": "",
-              "schema": {
-                "type": "string"
-              }
-            },
-            {
-              "name": "username",
-              "in": "query",
-              "description": "",
-              "schema": {
-                "type": "string"
-              }
-            }
-          ],
-          "responses": {
-            "200": {
-              "description": "Success",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/Lock"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/Lock"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/Lock"
-                  }
-                }
-              }
-            },
-            "409": {
-              "description": "Conflict",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "500": {
-              "description": "Server Error"
-            }
-          }
-        }
-      },
-      "/api/disputelock/{lockId}": {
-        "put": {
-          "tags": [
-            "DisputeLock"
-          ],
-          "summary": "Refreshes the expiry time of a lock.",
-          "parameters": [
-            {
-              "name": "lockId",
-              "in": "path",
-              "description": "",
-              "required": true,
-              "schema": {
-                "type": "string"
-              }
-            }
-          ],
-          "responses": {
-            "200": {
-              "description": "Success",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "type": "string",
-                    "format": "date-time"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "type": "string",
-                    "format": "date-time"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "type": "string",
-                    "format": "date-time"
-                  }
-                }
-              }
-            },
-            "409": {
-              "description": "Conflict",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "500": {
-              "description": "Server Error"
             }
           }
         },
-        "delete": {
-          "tags": [
-            "DisputeLock"
-          ],
-          "summary": "Releases a lock.",
-          "parameters": [
-            {
-              "name": "lockId",
-              "in": "path",
-              "description": "",
-              "required": true,
-              "schema": {
-                "type": "string"
-              }
-            }
-          ],
-          "responses": {
-            "200": {
-              "description": "Success"
-            },
-            "404": {
-              "description": "Not Found",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "500": {
-              "description": "Server Error"
-            }
-          }
-        }
-      },
-      "/api/document": {
-        "post": {
-          "tags": [
-            "Document"
-          ],
-          "summary": "Creates a new file the document management service along with metadata.",
-          "parameters": [
-            {
-              "name": "disputeId",
-              "in": "header",
-              "description": "The TCO dispute id to associate document with.",
-              "schema": {
-                "maximum": 2147483647,
-                "minimum": 1,
-                "type": "integer",
-                "format": "int64"
-              }
-            },
-            {
-              "name": "noticeOfDisputeId",
-              "in": "header",
-              "description": "The occam dispute id to associate document with.",
-              "required": true,
-              "schema": {
-                "type": "string"
-              }
-            },
-            {
-              "name": "documentType",
-              "in": "header",
-              "description": "The document type to associate with this file.",
-              "required": true,
-              "schema": {
-                "type": "string"
-              }
-            }
-          ],
-          "requestBody": {
+        "responses": {
+          "200": {
+            "description": "The Dispute is updated."
+          },
+          "400": {
+            "description": "The request was not well formed. Check the parameters.",
             "content": {
-              "multipart/form-data": {
+              "text/plain": {
                 "schema": {
-                  "required": [
-                    "file"
-                  ],
-                  "type": "object",
-                  "properties": {
-                    "file": {
-                      "type": "string",
-                      "format": "binary"
-                    }
-                  }
-                },
-                "encoding": {
-                  "file": {
-                    "style": "form"
-                  }
+                  "$ref": "#/components/schemas/ProblemDetails"
                 }
-              }
-            }
-          },
-          "responses": {
-            "200": {
-              "description": "The document is successfully uploaded and saved.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "type": "string",
-                    "format": "uuid"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "type": "string",
-                    "format": "uuid"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "type": "string",
-                    "format": "uuid"
-                  }
-                }
-              }
-            },
-            "400": {
-              "description": "The request was not well formed. The file and ticket number are required",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "401": {
-              "description": "Unauthenticated.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "403": {
-              "description": "Forbidden, requires jjdispute:update permission.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "500": {
-              "description": "There was a server error that prevented the file upload from completing successfully."
-            }
-          }
-        },
-        "get": {
-          "tags": [
-            "Document"
-          ],
-          "summary": "Downloads a document for the given unique file ID if the virus scan staus is clean.",
-          "parameters": [
-            {
-              "name": "fileId",
-              "in": "query",
-              "description": "Unique identifier for a specific document.",
-              "schema": {
-                "type": "string",
-                "format": "uuid"
-              }
-            }
-          ],
-          "responses": {
-            "200": {
-              "description": "The document is successfully downloaded."
-            },
-            "400": {
-              "description": "The request was not well formed. Check the parameters.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "401": {
-              "description": "Unauthenticated.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "403": {
-              "description": "Forbidden, requires jjdispute:read permission.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "404": {
-              "description": "The file was not found.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "500": {
-              "description": "There was a server error that prevented the file to be downloaded successfully."
-            }
-          }
-        },
-        "delete": {
-          "tags": [
-            "Document"
-          ],
-          "summary": "Removes the specified document for the given unique file ID.",
-          "parameters": [
-            {
-              "name": "fileId",
-              "in": "query",
-              "description": "Unique identifier for a specific document.",
-              "schema": {
-                "type": "string",
-                "format": "uuid"
-              }
-            }
-          ],
-          "responses": {
-            "200": {
-              "description": "The document is successfully removed."
-            },
-            "400": {
-              "description": "The request was not well formed. Check the parameters.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "401": {
-              "description": "Unauthenticated.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "403": {
-              "description": "Forbidden, requires jjdispute:delete permission.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "500": {
-              "description": "There was a server error that prevented the file to be removed successfully."
-            }
-          }
-        }
-      },
-      "/api/emailhistory/emailhistory": {
-        "get": {
-          "tags": [
-            "EmailHistory"
-          ],
-          "summary": "Returns all File History Records from the Oracle Data API related to a specific ticket number.",
-          "parameters": [
-            {
-              "name": "ticketNumber",
-              "in": "query",
-              "description": "",
-              "schema": {
-                "type": "string"
-              }
-            }
-          ],
-          "responses": {
-            "200": {
-              "description": "The File history records were found.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "type": "array",
-                    "items": {
-                      "$ref": "#/components/schemas/EmailHistory"
-                    }
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "type": "array",
-                    "items": {
-                      "$ref": "#/components/schemas/EmailHistory"
-                    }
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "type": "array",
-                    "items": {
-                      "$ref": "#/components/schemas/EmailHistory"
-                    }
-                  }
-                }
-              }
-            },
-            "403": {
-              "description": "Forbidden, requires dispute:read permission.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "500": {
-              "description": "There was a server error that prevented the search from completing successfully or no data found."
-            },
-            "401": {
-              "description": "Unauthenticated."
-            }
-          }
-        }
-      },
-      "/api/filehistory/filehistory": {
-        "get": {
-          "tags": [
-            "FileHistory"
-          ],
-          "summary": "Returns all File History Records from the Oracle Data API related to a specific ticket number.",
-          "parameters": [
-            {
-              "name": "ticketNumber",
-              "in": "query",
-              "description": "",
-              "schema": {
-                "type": "string"
-              }
-            }
-          ],
-          "responses": {
-            "200": {
-              "description": "The File history records were found.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "type": "array",
-                    "items": {
-                      "$ref": "#/components/schemas/FileHistory"
-                    }
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "type": "array",
-                    "items": {
-                      "$ref": "#/components/schemas/FileHistory"
-                    }
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "type": "array",
-                    "items": {
-                      "$ref": "#/components/schemas/FileHistory"
-                    }
-                  }
-                }
-              }
-            },
-            "403": {
-              "description": "Forbidden, requires dispute:read permission.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "500": {
-              "description": "There was a server error that prevented the search from completing successfully or no data found."
-            },
-            "401": {
-              "description": "Unauthenticated."
-            }
-          }
-        }
-      },
-      "/api/jj/disputes": {
-        "get": {
-          "tags": [
-            "JJ"
-          ],
-          "summary": "Returns all JJ Disputes from the Oracle Data API",
-          "parameters": [
-            {
-              "name": "jjAssignedTo",
-              "in": "query",
-              "description": "If specified, will retrieve the records which are assigned to the specified jj staff",
-              "schema": {
-                "type": "string"
-              }
-            }
-          ],
-          "responses": {
-            "200": {
-              "description": "The JJ disputes were found.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "type": "array",
-                    "items": {
-                      "$ref": "#/components/schemas/JJDispute"
-                    }
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "type": "array",
-                    "items": {
-                      "$ref": "#/components/schemas/JJDispute"
-                    }
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "type": "array",
-                    "items": {
-                      "$ref": "#/components/schemas/JJDispute"
-                    }
-                  }
-                }
-              }
-            },
-            "401": {
-              "description": "Request lacks valid authentication credentials.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "403": {
-              "description": "Forbidden, requires jj-dispute:read permission.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "500": {
-              "description": "There was a server error that prevented the search from completing successfully or no data found."
-            }
-          }
-        }
-      },
-      "/api/jj/{jjDisputeId}": {
-        "get": {
-          "tags": [
-            "JJ"
-          ],
-          "summary": "Returns a single JJ Dispute with the given identifier from the Oracle Data API.",
-          "parameters": [
-            {
-              "name": "jjDisputeId",
-              "in": "path",
-              "description": "Unique identifier for a specific JJ dispute record.",
-              "required": true,
-              "schema": {
-                "type": "integer",
-                "format": "int64"
-              }
-            },
-            {
-              "name": "ticketNumber",
-              "in": "query",
-              "description": "Ticket number for a specific JJ dispute record.",
-              "schema": {
-                "type": "string"
-              }
-            },
-            {
-              "name": "assignVTC",
-              "in": "query",
-              "description": "boolean to indicate need to assign VTC.",
-              "schema": {
-                "type": "boolean"
-              }
-            }
-          ],
-          "responses": {
-            "200": {
-              "description": "The JJ dispute was found.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/JJDispute"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/JJDispute"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/JJDispute"
-                  }
-                }
-              }
-            },
-            "400": {
-              "description": "The request was not well formed. Check the parameters.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "401": {
-              "description": "Request lacks valid authentication credentials.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "403": {
-              "description": "Forbidden, requires jj-dispute:read permission.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "404": {
-              "description": "Not Found",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "409": {
-              "description": "The JJDispute has already been assigned to a user. JJDispute cannot be modified until assigned time expires.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "500": {
-              "description": "There was a server error that prevented the search from completing successfully or no data found."
-            }
-          }
-        }
-      },
-      "/api/jj/ticketimage/{ticketNumber}/{documentType}": {
-        "get": {
-          "tags": [
-            "JJ"
-          ],
-          "summary": "Returns a single Justin Document for a given ticket number and docment type.",
-          "parameters": [
-            {
-              "name": "ticketNumber",
-              "in": "path",
-              "description": "Ticket number for a specific JJ dispute record.",
-              "required": true,
-              "schema": {
-                "type": "string"
-              }
-            },
-            {
-              "name": "documentType",
-              "in": "path",
-              "description": "indicates document type.",
-              "required": true,
-              "schema": {
-                "$ref": "#/components/schemas/DocumentType"
-              }
-            }
-          ],
-          "responses": {
-            "200": {
-              "description": "The document was found.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/TicketImageDataJustinDocument"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/TicketImageDataJustinDocument"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/TicketImageDataJustinDocument"
-                  }
-                }
-              }
-            },
-            "400": {
-              "description": "The request was not well formed. Check the parameters.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "401": {
-              "description": "Request lacks valid authentication credentials.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "403": {
-              "description": "Forbidden, requires jj-dispute:read permission.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "404": {
-              "description": "Not Found",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "500": {
-              "description": "There was a server error that prevented the search from completing successfully or no data found."
-            }
-          }
-        }
-      },
-      "/api/jj/{ticketNumber}/cascade": {
-        "put": {
-          "tags": [
-            "JJ"
-          ],
-          "summary": "Updates a single JJ Dispute and related Dispute data.\r\nMust have update-admin permission on the JJDispute resource to use this endpoint.",
-          "parameters": [
-            {
-              "name": "ticketNumber",
-              "in": "path",
-              "description": "Unique identifier for a specific JJ Dispute record.",
-              "required": true,
-              "schema": {
-                "type": "string"
-              }
-            }
-          ],
-          "requestBody": {
-            "description": "",
-            "content": {
+              },
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/JJDispute"
+                  "$ref": "#/components/schemas/ProblemDetails"
                 }
               },
               "text/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/JJDispute"
-                }
-              },
-              "application/*+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/JJDispute"
+                  "$ref": "#/components/schemas/ProblemDetails"
                 }
               }
             }
           },
-          "responses": {
-            "200": {
-              "description": "The JJ Dispute is updated.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/JJDispute"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/JJDispute"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/JJDispute"
-                  }
-                }
-              }
-            },
-            "400": {
-              "description": "The request was not well formed. Check the parameters.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "401": {
-              "description": "Request lacks valid authentication credentials.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "403": {
-              "description": "Forbidden, requires jj-dispute:update permission.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "404": {
-              "description": "The JJ Dispute to update was not found.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "405": {
-              "description": "An invalid JJ Dispute status is provided. Update failed.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "409": {
-              "description": "Conflict",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "500": {
-              "description": "There was a server error that prevented the update from completing successfully."
-            }
-          }
-        }
-      },
-      "/api/jj/{ticketNumber}": {
-        "put": {
-          "tags": [
-            "JJ"
-          ],
-          "summary": "Updates a single JJ Dispute through the Oracle Data Interface API based on unique violation ticket number and the jj dispute data being passed in the body.",
-          "parameters": [
-            {
-              "name": "ticketNumber",
-              "in": "path",
-              "description": "Unique identifier for a specific JJ Dispute record.",
-              "required": true,
-              "schema": {
-                "type": "string"
-              }
-            },
-            {
-              "name": "jjDisputeId",
-              "in": "query",
-              "description": "Unique identifier for a specific JJ Dispute record.",
-              "schema": {
-                "type": "integer",
-                "format": "int64"
-              }
-            },
-            {
-              "name": "checkVTC",
-              "in": "query",
-              "description": "boolean to indicate need to check VTC assigned.",
-              "schema": {
-                "type": "boolean"
-              }
-            }
-          ],
-          "requestBody": {
-            "description": "",
+          "401": {
+            "description": "Request lacks valid authentication credentials.",
             "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/JJDispute"
+                  "$ref": "#/components/schemas/ProblemDetails"
                 }
               },
               "text/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/JJDispute"
-                }
-              },
-              "application/*+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/JJDispute"
+                  "$ref": "#/components/schemas/ProblemDetails"
                 }
               }
             }
           },
-          "responses": {
-            "200": {
-              "description": "Admin resolution is submitted. The JJ Dispute is updated.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/JJDispute"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/JJDispute"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/JJDispute"
-                  }
+          "403": {
+            "description": "Forbidden, requires dispute:cancel permission.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
                 }
               }
-            },
-            "400": {
-              "description": "The request was not well formed. Check the parameters.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "401": {
-              "description": "Request lacks valid authentication credentials.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "403": {
-              "description": "Forbidden, requires jj-dispute:update permission.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "404": {
-              "description": "The JJ Dispute to update was not found.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "405": {
-              "description": "An invalid JJ Dispute status is provided. Update failed.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "409": {
-              "description": "Conflict",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "500": {
-              "description": "There was a server error that prevented the update from completing successfully."
             }
+          },
+          "404": {
+            "description": "Dispute record not found. Update failed.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "A Dispute status can only be set to CANCELLED iff status is NEW, VALIDATED, REJECTED or PROCESSING.Update failed.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "The Dispute has already been assigned to a different user. Dispute cannot be modified until assigned time expires.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "There was a server error that prevented the update from completing successfully."
           }
         }
-      },
-      "/api/jj/assign": {
-        "put": {
-          "tags": [
-            "JJ"
-          ],
-          "summary": "Updates each JJ Dispute based on the passed in IDs (ticket number) to assign them to a specific JJ or unassign them if JJ not specified.",
-          "parameters": [
-            {
-              "name": "ticketNumbers",
-              "in": "query",
-              "description": "List of Unique identifiers for JJ Dispute records to be assigend/unassigned.",
-              "required": true,
-              "schema": {
-                "type": "array",
-                "items": {
+      }
+    },
+    "/api/dispute/{disputeId}/resendemailverify": {
+      "put": {
+        "tags": [
+          "Dispute"
+        ],
+        "summary": "An endpoint for resending an email to a Disputant.",
+        "parameters": [
+          {
+            "name": "disputeId",
+            "in": "path",
+            "description": "",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "text/json": {
+                "schema": {
                   "type": "string"
                 }
               }
-            },
-            {
-              "name": "username",
-              "in": "query",
-              "description": "IDIR username of the JJ that JJ Dispute(s) will be assigned to, if specified. Otherwise JJ Disputes will be unassigned.",
-              "schema": {
-                "type": "string"
-              }
             }
-          ],
-          "responses": {
-            "200": {
-              "description": "JJ Disputes are assigned/unassigned to/from a JJ successfully. The JJ Disputes are updated."
-            },
-            "400": {
-              "description": "The request was not well formed. Check the parameters.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "401": {
-              "description": "Request lacks valid authentication credentials.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "403": {
-              "description": "Forbidden, requires jj-dispute:assign permission.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "404": {
-              "description": "The JJ Dispute(s) to update was not found.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "405": {
-              "description": "Method Not Allowed",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "500": {
-              "description": "There was a server error that prevented the update from completing successfully."
-            }
-          }
-        }
-      },
-      "/api/jj/{ticketNumber}/recall": {
-        "put": {
-          "tags": [
-            "JJ"
-          ],
-          "summary": "Updates the status of a particular JJDispute record to REVIEW when JJ wants to recall and open an ACCEPTED, CONFIRMED or CONCLUDED dispute.",
-          "parameters": [
-            {
-              "name": "ticketNumber",
-              "in": "path",
-              "description": "Unique identifier for a specific JJ Dispute record.",
-              "required": true,
-              "schema": {
-                "type": "string"
-              }
-            },
-            {
-              "name": "checkVTC",
-              "in": "query",
-              "description": "boolean to indicate need to check VTC assigned.",
-              "schema": {
-                "type": "boolean"
-              }
-            }
-          ],
-          "responses": {
-            "200": {
-              "description": "The JJDispute is updated."
-            },
-            "400": {
-              "description": "The request was not well formed. Check the parameters.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "401": {
-              "description": "Request lacks valid authentication credentials.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "403": {
-              "description": "Forbidden, requires jjdispute:review permission.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "404": {
-              "description": "JJDispute record not found. Update failed.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "405": {
-              "description": "A JJDispute status can only be set to REVIEW if status is CONFIRMED and the remark must be less than 256 characters OR if the status ACCEPTED, CONFIRMED or CONCLUDED and DCF's current hearing date = today's date. Update failed",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "409": {
-              "description": "The JJDispute has already been assigned to a different user. JJDispute cannot be modified until assigned time expires.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "500": {
-              "description": "There was a server error that prevented the update from completing successfully."
-            }
-          }
-        }
-      },
-      "/api/jj/{ticketNumber}/review": {
-        "put": {
-          "tags": [
-            "JJ"
-          ],
-          "summary": "Updates the status of a particular JJDispute record to REVIEW as well as adds an optional remark that explaining why the status was set to REVIEW.",
-          "parameters": [
-            {
-              "name": "ticketNumber",
-              "in": "path",
-              "description": "Unique identifier for a specific JJ Dispute record.",
-              "required": true,
-              "schema": {
-                "type": "string"
-              }
-            },
-            {
-              "name": "checkVTC",
-              "in": "query",
-              "description": "boolean to indicate need to check VTC assigned.",
-              "schema": {
-                "type": "boolean"
-              }
-            }
-          ],
-          "requestBody": {
+          },
+          "400": {
+            "description": "Bad Request",
             "content": {
-              "multipart/form-data": {
+              "text/plain": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "remark": {
-                      "maxLength": 256,
-                      "minLength": 0,
-                      "type": "string"
-                    }
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server Error"
+          }
+        }
+      }
+    },
+    "/api/dispute/{disputeId}/submit": {
+      "put": {
+        "tags": [
+          "Dispute"
+        ],
+        "summary": "Submits a Dispute record, setting it's status to PROCESSING",
+        "parameters": [
+          {
+            "name": "disputeId",
+            "in": "path",
+            "description": "Unique identifier for a specific Dispute record to submit.",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The Dispute is updated."
+          },
+          "400": {
+            "description": "The request was not well formed. Check the parameters.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Request lacks valid authentication credentials.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden, requires dispute:submit permission.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Dispute record not found. Update failed.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "A Dispute can only be submitted if the status is NEW or is already set to PROCESSING. Update failed.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "The Dispute has already been assigned to a different user. Dispute cannot be modified until assigned time expires.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "There was a server error that prevented the update from completing successfully."
+          }
+        }
+      }
+    },
+    "/api/dispute/updaterequest/{updateStatusId}/accept": {
+      "put": {
+        "tags": [
+          "Dispute"
+        ],
+        "summary": "Approves a DisputeUpdateRequest record, setting it's status to ACCEPTED.",
+        "parameters": [
+          {
+            "name": "updateStatusId",
+            "in": "path",
+            "description": "Unique identifier for a specific DisputeUpdateRequest record to accept.",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "500": {
+            "description": "Server Error"
+          }
+        }
+      }
+    },
+    "/api/dispute/updaterequest/{updateStatusId}/reject": {
+      "put": {
+        "tags": [
+          "Dispute"
+        ],
+        "summary": "Rejects a DisputeUpdateRequest record, setting it's status to REJECTED.",
+        "parameters": [
+          {
+            "name": "updateStatusId",
+            "in": "path",
+            "description": "Unique identifier for a specific DisputeUpdateRequest record to reject.",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "500": {
+            "description": "Server Error"
+          }
+        }
+      }
+    },
+    "/api/dispute/disputeswithupdaterequests": {
+      "get": {
+        "tags": [
+          "Dispute"
+        ],
+        "summary": "Returns all Disputes that have pending update requests from the Oracle Data API",
+        "responses": {
+          "200": {
+            "description": "The Disputes were found.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/DisputeWithUpdates"
                   }
-                },
-                "encoding": {
-                  "remark": {
-                    "style": "form"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/DisputeWithUpdates"
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/DisputeWithUpdates"
                   }
                 }
               }
             }
           },
-          "responses": {
-            "200": {
-              "description": "The JJDispute is updated."
-            },
-            "400": {
-              "description": "The request was not well formed. Check the parameters.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
+          "401": {
+            "description": "Request lacks valid authentication credentials.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
                 }
               }
-            },
-            "401": {
-              "description": "Request lacks valid authentication credentials.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "403": {
-              "description": "Forbidden, requires jjdispute:review permission.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "404": {
-              "description": "JJDispute record not found. Update failed.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "405": {
-              "description": "A JJDispute status can only be set to REVIEW if status is CONFIRMED and the remark must be less than 256 characters OR if the status ACCEPTED, CONFIRMED or CONCLUDED and DCF's current hearing date = today's date. Update failed",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "409": {
-              "description": "The JJDispute has already been assigned to a different user. JJDispute cannot be modified until assigned time expires.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "500": {
-              "description": "There was a server error that prevented the update from completing successfully."
             }
+          },
+          "403": {
+            "description": "Forbidden, requires dispute:read permission.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "There was a server error that prevented the search from completing successfully or no data found."
           }
         }
-      },
-      "/api/jj/{ticketNumber}/requirecourthearing": {
-        "put": {
-          "tags": [
-            "JJ"
-          ],
-          "summary": "Updates the status of a particular JJDispute record to REQUIRE_COURT_HEARING, hearing type to COURT_APPEARANCE as well as adds an optional remark that explaining why the status was set.",
-          "parameters": [
-            {
-              "name": "ticketNumber",
-              "in": "path",
-              "description": "Unique identifier for a specific JJ Dispute record.",
-              "required": true,
-              "schema": {
-                "type": "string"
-              }
+      }
+    },
+    "/api/dispute/{disputeId}/disputeupdaterequests": {
+      "get": {
+        "tags": [
+          "Dispute"
+        ],
+        "summary": "Returns all update requests for a specific dispute",
+        "parameters": [
+          {
+            "name": "disputeId",
+            "in": "path",
+            "description": "Dispute Id",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
             }
-          ],
-          "requestBody": {
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The Update requests were found.",
             "content": {
-              "multipart/form-data": {
+              "text/plain": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "remark": {
-                      "maxLength": 256,
-                      "minLength": 0,
-                      "type": "string"
-                    }
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/DisputeUpdateRequest"
                   }
-                },
-                "encoding": {
-                  "remark": {
-                    "style": "form"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/DisputeUpdateRequest"
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/DisputeUpdateRequest"
                   }
                 }
               }
             }
           },
-          "responses": {
-            "200": {
-              "description": "The JJDispute is updated."
-            },
-            "400": {
-              "description": "The request was not well formed. Check the parameters.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
+          "401": {
+            "description": "Request lacks valid authentication credentials.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
                 }
               }
-            },
-            "401": {
-              "description": "Request lacks valid authentication credentials.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "403": {
-              "description": "Forbidden, requires jjdispute:require_court_hearing permission.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "404": {
-              "description": "JJDispute record not found. Update failed.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "405": {
-              "description": "A JJDispute status can only be set to REQUIRE_COURT_HEARING iff status is one of the following: NEW, IN_PROGRESS, REVIEW, REQUIRE_COURT_HEARING and the remark must be less than or equal to 256 characters. Update failed.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "409": {
-              "description": "The JJDispute has already been assigned to a different user. JJDispute cannot be modified until assigned time expires.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "500": {
-              "description": "There was a server error that prevented the update from completing successfully."
             }
+          },
+          "403": {
+            "description": "Forbidden, requires dispute:read permission.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "There was a server error that prevented the search from completing successfully or no data found."
+          }
+        }
+      }
+    },
+    "/api/dispute/{disputeId}/print": {
+      "get": {
+        "tags": [
+          "Dispute"
+        ],
+        "summary": "Returns generated document.",
+        "parameters": [
+          {
+            "name": "disputeId",
+            "in": "path",
+            "description": "Dispute Id",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          {
+            "name": "timeZone",
+            "in": "query",
+            "description": "The IANA timze zone id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Generated Document."
+          },
+          "401": {
+            "description": "Request lacks valid authentication credentials.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "There was a server error that prevented the search from completing successfully or no data found."
+          },
+          "400": {
+            "description": "The"
+          }
+        }
+      }
+    },
+    "/api/disputelock": {
+      "get": {
+        "tags": [
+          "DisputeLock"
+        ],
+        "summary": "Acquires a lock for a JJ Dispute.",
+        "parameters": [
+          {
+            "name": "ticketNumber",
+            "in": "query",
+            "description": "",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "username",
+            "in": "query",
+            "description": "",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/Lock"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Lock"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Lock"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server Error"
+          }
+        }
+      }
+    },
+    "/api/disputelock/{lockId}": {
+      "put": {
+        "tags": [
+          "DisputeLock"
+        ],
+        "summary": "Refreshes the expiry time of a lock.",
+        "parameters": [
+          {
+            "name": "lockId",
+            "in": "path",
+            "description": "",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string",
+                  "format": "date-time"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "string",
+                  "format": "date-time"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "string",
+                  "format": "date-time"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server Error"
           }
         }
       },
-      "/api/jj/{ticketNumber}/accept": {
-        "put": {
-          "tags": [
-            "JJ"
-          ],
-          "summary": "Updates the status of a particular JJDispute record to ACCEPTED.",
-          "parameters": [
-            {
-              "name": "ticketNumber",
-              "in": "path",
-              "description": "Ticket number for a specific JJ Dispute record.",
-              "required": true,
+      "delete": {
+        "tags": [
+          "DisputeLock"
+        ],
+        "summary": "Releases a lock.",
+        "parameters": [
+          {
+            "name": "lockId",
+            "in": "path",
+            "description": "",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server Error"
+          }
+        }
+      }
+    },
+    "/api/document": {
+      "post": {
+        "tags": [
+          "Document"
+        ],
+        "summary": "Creates a new file the document management service along with metadata.",
+        "parameters": [
+          {
+            "name": "disputeId",
+            "in": "header",
+            "description": "The TCO dispute id to associate document with.",
+            "schema": {
+              "maximum": 2147483647,
+              "minimum": 1,
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          {
+            "name": "noticeOfDisputeId",
+            "in": "header",
+            "description": "The occam dispute id to associate document with.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "documentType",
+            "in": "header",
+            "description": "The document type to associate with this file.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
               "schema": {
+                "required": [
+                  "file"
+                ],
+                "type": "object",
+                "properties": {
+                  "file": {
+                    "type": "string",
+                    "format": "binary"
+                  }
+                }
+              },
+              "encoding": {
+                "file": {
+                  "style": "form"
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The document is successfully uploaded and saved.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string",
+                  "format": "uuid"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "string",
+                  "format": "uuid"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "string",
+                  "format": "uuid"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "The request was not well formed. The file and ticket number are required",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthenticated.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden, requires jjdispute:update permission.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "There was a server error that prevented the file upload from completing successfully."
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "Document"
+        ],
+        "summary": "Downloads a document for the given unique file ID if the virus scan staus is clean.",
+        "parameters": [
+          {
+            "name": "fileId",
+            "in": "query",
+            "description": "Unique identifier for a specific document.",
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The document is successfully downloaded."
+          },
+          "400": {
+            "description": "The request was not well formed. Check the parameters.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthenticated.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden, requires jjdispute:read permission.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "The file was not found.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "There was a server error that prevented the file to be downloaded successfully."
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Document"
+        ],
+        "summary": "Removes the specified document for the given unique file ID.",
+        "parameters": [
+          {
+            "name": "fileId",
+            "in": "query",
+            "description": "Unique identifier for a specific document.",
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The document is successfully removed."
+          },
+          "400": {
+            "description": "The request was not well formed. Check the parameters.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthenticated.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden, requires jjdispute:delete permission.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "There was a server error that prevented the file to be removed successfully."
+          }
+        }
+      }
+    },
+    "/api/emailhistory/emailhistory": {
+      "get": {
+        "tags": [
+          "EmailHistory"
+        ],
+        "summary": "Returns all File History Records from the Oracle Data API related to a specific ticket number.",
+        "parameters": [
+          {
+            "name": "ticketNumber",
+            "in": "query",
+            "description": "",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The File history records were found.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/EmailHistory"
+                  }
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/EmailHistory"
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/EmailHistory"
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden, requires dispute:read permission.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "There was a server error that prevented the search from completing successfully or no data found."
+          },
+          "401": {
+            "description": "Unauthenticated."
+          }
+        }
+      }
+    },
+    "/api/filehistory/filehistory": {
+      "get": {
+        "tags": [
+          "FileHistory"
+        ],
+        "summary": "Returns all File History Records from the Oracle Data API related to a specific ticket number.",
+        "parameters": [
+          {
+            "name": "ticketNumber",
+            "in": "query",
+            "description": "",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The File history records were found.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/FileHistory"
+                  }
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/FileHistory"
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/FileHistory"
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden, requires dispute:read permission.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "There was a server error that prevented the search from completing successfully or no data found."
+          },
+          "401": {
+            "description": "Unauthenticated."
+          }
+        }
+      }
+    },
+    "/api/jj/disputes": {
+      "get": {
+        "tags": [
+          "JJ"
+        ],
+        "summary": "Returns all JJ Disputes from the Oracle Data API",
+        "parameters": [
+          {
+            "name": "jjAssignedTo",
+            "in": "query",
+            "description": "If specified, will retrieve the records which are assigned to the specified jj staff",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The JJ disputes were found.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/JJDispute"
+                  }
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/JJDispute"
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/JJDispute"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Request lacks valid authentication credentials.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden, requires jj-dispute:read permission.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "There was a server error that prevented the search from completing successfully or no data found."
+          }
+        }
+      }
+    },
+    "/api/jj/{jjDisputeId}": {
+      "get": {
+        "tags": [
+          "JJ"
+        ],
+        "summary": "Returns a single JJ Dispute with the given identifier from the Oracle Data API.",
+        "parameters": [
+          {
+            "name": "jjDisputeId",
+            "in": "path",
+            "description": "Unique identifier for a specific JJ dispute record.",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          {
+            "name": "ticketNumber",
+            "in": "query",
+            "description": "Ticket number for a specific JJ dispute record.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "assignVTC",
+            "in": "query",
+            "description": "boolean to indicate need to assign VTC.",
+            "schema": {
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The JJ dispute was found.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/JJDispute"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JJDispute"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JJDispute"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "The request was not well formed. Check the parameters.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Request lacks valid authentication credentials.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden, requires jj-dispute:read permission.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "The JJDispute has already been assigned to a user. JJDispute cannot be modified until assigned time expires.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "There was a server error that prevented the search from completing successfully or no data found."
+          }
+        }
+      }
+    },
+    "/api/jj/ticketimage/{ticketNumber}/{documentType}": {
+      "get": {
+        "tags": [
+          "JJ"
+        ],
+        "summary": "Returns a single Justin Document for a given ticket number and docment type.",
+        "parameters": [
+          {
+            "name": "ticketNumber",
+            "in": "path",
+            "description": "Ticket number for a specific JJ dispute record.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "documentType",
+            "in": "path",
+            "description": "indicates document type.",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/DocumentType"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The document was found.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/TicketImageDataJustinDocument"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TicketImageDataJustinDocument"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TicketImageDataJustinDocument"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "The request was not well formed. Check the parameters.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Request lacks valid authentication credentials.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden, requires jj-dispute:read permission.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "There was a server error that prevented the search from completing successfully or no data found."
+          }
+        }
+      }
+    },
+    "/api/jj/{ticketNumber}/cascade": {
+      "put": {
+        "tags": [
+          "JJ"
+        ],
+        "summary": "Updates a single JJ Dispute and related Dispute data.\r\nMust have update-admin permission on the JJDispute resource to use this endpoint.",
+        "parameters": [
+          {
+            "name": "ticketNumber",
+            "in": "path",
+            "description": "Unique identifier for a specific JJ Dispute record.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/JJDispute"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/JJDispute"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/JJDispute"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The JJ Dispute is updated.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/JJDispute"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JJDispute"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JJDispute"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "The request was not well formed. Check the parameters.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Request lacks valid authentication credentials.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden, requires jj-dispute:update permission.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "The JJ Dispute to update was not found.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "An invalid JJ Dispute status is provided. Update failed.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "There was a server error that prevented the update from completing successfully."
+          }
+        }
+      }
+    },
+    "/api/jj/{ticketNumber}": {
+      "put": {
+        "tags": [
+          "JJ"
+        ],
+        "summary": "Updates a single JJ Dispute through the Oracle Data Interface API based on unique violation ticket number and the jj dispute data being passed in the body.",
+        "parameters": [
+          {
+            "name": "ticketNumber",
+            "in": "path",
+            "description": "Unique identifier for a specific JJ Dispute record.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "jjDisputeId",
+            "in": "query",
+            "description": "Unique identifier for a specific JJ Dispute record.",
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          {
+            "name": "checkVTC",
+            "in": "query",
+            "description": "boolean to indicate need to check VTC assigned.",
+            "schema": {
+              "type": "boolean"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/JJDispute"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/JJDispute"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/JJDispute"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Admin resolution is submitted. The JJ Dispute is updated.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/JJDispute"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JJDispute"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JJDispute"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "The request was not well formed. Check the parameters.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Request lacks valid authentication credentials.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden, requires jj-dispute:update permission.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "The JJ Dispute to update was not found.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "An invalid JJ Dispute status is provided. Update failed.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "There was a server error that prevented the update from completing successfully."
+          }
+        }
+      }
+    },
+    "/api/jj/assign": {
+      "put": {
+        "tags": [
+          "JJ"
+        ],
+        "summary": "Updates each JJ Dispute based on the passed in IDs (ticket number) to assign them to a specific JJ or unassign them if JJ not specified.",
+        "parameters": [
+          {
+            "name": "ticketNumbers",
+            "in": "query",
+            "description": "List of Unique identifiers for JJ Dispute records to be assigend/unassigned.",
+            "required": true,
+            "schema": {
+              "type": "array",
+              "items": {
                 "type": "string"
               }
-            },
-            {
-              "name": "checkVTC",
-              "in": "query",
-              "description": "boolean to indicate need to check VTC assigned.",
-              "schema": {
-                "type": "boolean"
-              }
             }
-          ],
-          "responses": {
-            "200": {
-              "description": "The JJDispute is updated."
-            },
-            "400": {
-              "description": "The request was not well formed. Check the parameters.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "401": {
-              "description": "Request lacks valid authentication credentials.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "403": {
-              "description": "Forbidden, requires jjdispute:accept permission.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "404": {
-              "description": "JJDispute record not found. Update failed.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "405": {
-              "description": "A JJDispute status can only be set to ACCEPTED iff status is CONFIRMED. Update failed.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "409": {
-              "description": "The JJDispute has already been assigned to a different user. JJDispute cannot be modified until assigned time expires.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "500": {
-              "description": "There was a server error that prevented the update from completing successfully."
+          },
+          {
+            "name": "username",
+            "in": "query",
+            "description": "IDIR username of the JJ that JJ Dispute(s) will be assigned to, if specified. Otherwise JJ Disputes will be unassigned.",
+            "schema": {
+              "type": "string"
             }
           }
-        }
-      },
-      "/api/jj/{ticketNumber}/conclude": {
-        "put": {
-          "tags": [
-            "JJ"
-          ],
-          "summary": "Updates the status of a particular JJDispute record to CONCLUDED.",
-          "parameters": [
-            {
-              "name": "ticketNumber",
-              "in": "path",
-              "description": "Ticket number for a specific JJ Dispute record.",
-              "required": true,
-              "schema": {
-                "type": "string"
-              }
-            },
-            {
-              "name": "checkVTC",
-              "in": "query",
-              "description": "boolean to indicate need to check VTC assigned.",
-              "schema": {
-                "type": "boolean"
+        ],
+        "responses": {
+          "200": {
+            "description": "JJ Disputes are assigned/unassigned to/from a JJ successfully. The JJ Disputes are updated."
+          },
+          "400": {
+            "description": "The request was not well formed. Check the parameters.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
               }
             }
-          ],
-          "responses": {
-            "200": {
-              "description": "The JJDispute is updated."
-            },
-            "400": {
-              "description": "The request was not well formed. Check the parameters.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
+          },
+          "401": {
+            "description": "Request lacks valid authentication credentials.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
                 }
               }
-            },
-            "401": {
-              "description": "Request lacks valid authentication credentials.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "403": {
-              "description": "Forbidden, requires jjdispute:accept permission.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "404": {
-              "description": "JJDispute record not found. Update failed.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "409": {
-              "description": "The JJDispute has already been assigned to a different user. JJDispute cannot be modified until assigned time expires.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "500": {
-              "description": "There was a server error that prevented the update from completing successfully."
             }
+          },
+          "403": {
+            "description": "Forbidden, requires jj-dispute:assign permission.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "The JJ Dispute(s) to update was not found.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method Not Allowed",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "There was a server error that prevented the update from completing successfully."
           }
         }
-      },
-      "/api/jj/{ticketNumber}/cancel": {
-        "put": {
-          "tags": [
-            "JJ"
-          ],
-          "summary": "Updates the status of a particular JJDispute record to CANCELLED.",
-          "parameters": [
-            {
-              "name": "ticketNumber",
-              "in": "path",
-              "description": "Ticket number for a specific JJ Dispute record.",
-              "required": true,
-              "schema": {
-                "type": "string"
-              }
-            },
-            {
-              "name": "checkVTC",
-              "in": "query",
-              "description": "boolean to indicate need to check VTC assigned.",
-              "schema": {
-                "type": "boolean"
-              }
+      }
+    },
+    "/api/jj/{ticketNumber}/recall": {
+      "put": {
+        "tags": [
+          "JJ"
+        ],
+        "summary": "Updates the status of a particular JJDispute record to REVIEW when JJ wants to recall and open an ACCEPTED, CONFIRMED or CONCLUDED dispute.",
+        "parameters": [
+          {
+            "name": "ticketNumber",
+            "in": "path",
+            "description": "Unique identifier for a specific JJ Dispute record.",
+            "required": true,
+            "schema": {
+              "type": "string"
             }
-          ],
-          "responses": {
-            "200": {
-              "description": "The JJDispute is updated."
-            },
-            "400": {
-              "description": "The request was not well formed. Check the parameters.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "401": {
-              "description": "Request lacks valid authentication credentials.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "403": {
-              "description": "Forbidden, requires jjdispute:accept permission.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "404": {
-              "description": "JJDispute record not found. Update failed.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "409": {
-              "description": "The JJDispute has already been assigned to a different user. JJDispute cannot be modified until assigned time expires.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "500": {
-              "description": "There was a server error that prevented the update from completing successfully."
+          },
+          {
+            "name": "checkVTC",
+            "in": "query",
+            "description": "boolean to indicate need to check VTC assigned.",
+            "schema": {
+              "type": "boolean"
             }
           }
-        }
-      },
-      "/api/jj/{ticketNumber}/updatecourtappearance/requirecourthearing": {
-        "put": {
-          "tags": [
-            "JJ"
-          ],
-          "summary": "Updates court appearance record as well as the status of a particular JJDispute record to REQUIRE_COURT_HEARING, hearing type to COURT_APPEARANCE.",
-          "parameters": [
-            {
-              "name": "ticketNumber",
-              "in": "path",
-              "description": "Ticket number for a specific JJ Dispute record.",
-              "required": true,
-              "schema": {
-                "type": "string"
+        ],
+        "responses": {
+          "200": {
+            "description": "The JJDispute is updated."
+          },
+          "400": {
+            "description": "The request was not well formed. Check the parameters.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
               }
             }
-          ],
-          "responses": {
-            "200": {
-              "description": "The court appearance and JJDispute status are updated."
-            },
-            "400": {
-              "description": "The request was not well formed. Check the parameters.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
+          },
+          "401": {
+            "description": "Request lacks valid authentication credentials.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
                 }
               }
-            },
-            "401": {
-              "description": "Request lacks valid authentication credentials.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "403": {
-              "description": "Forbidden, requires jjdispute:update permission.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "404": {
-              "description": "JJDispute record not found. Update failed.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "405": {
-              "description": "A JJDispute status can only be set to REQUIRE_COURT_HEARING iff status is one of the following: NEW, IN_PROGRESS, REVIEW, REQUIRE_COURT_HEARING. Update failed.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "409": {
-              "description": "Conflict",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "500": {
-              "description": "There was a server error that prevented the update from completing successfully."
             }
+          },
+          "403": {
+            "description": "Forbidden, requires jjdispute:review permission.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "JJDispute record not found. Update failed.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "A JJDispute status can only be set to REVIEW if status is CONFIRMED and the remark must be less than 256 characters OR if the status ACCEPTED, CONFIRMED or CONCLUDED and DCF's current hearing date = today's date. Update failed",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "The JJDispute has already been assigned to a different user. JJDispute cannot be modified until assigned time expires.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "There was a server error that prevented the update from completing successfully."
           }
         }
-      },
-      "/api/jj/{ticketNumber}/updatecourtappearance/confirm": {
-        "put": {
-          "tags": [
-            "JJ"
-          ],
-          "summary": "Updates court appearance record as well as the status of a particular JJDispute record to CONFIRMED.",
-          "parameters": [
-            {
-              "name": "ticketNumber",
-              "in": "path",
-              "description": "Ticket number for a specific JJ Dispute record.",
-              "required": true,
-              "schema": {
-                "type": "string"
-              }
+      }
+    },
+    "/api/jj/{ticketNumber}/review": {
+      "put": {
+        "tags": [
+          "JJ"
+        ],
+        "summary": "Updates the status of a particular JJDispute record to REVIEW as well as adds an optional remark that explaining why the status was set to REVIEW.",
+        "parameters": [
+          {
+            "name": "ticketNumber",
+            "in": "path",
+            "description": "Unique identifier for a specific JJ Dispute record.",
+            "required": true,
+            "schema": {
+              "type": "string"
             }
-          ],
-          "responses": {
-            "200": {
-              "description": "The court appearance and JJDispute status are updated."
-            },
-            "400": {
-              "description": "The request was not well formed. Check the parameters.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "401": {
-              "description": "Request lacks valid authentication credentials.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "403": {
-              "description": "Forbidden, requires jjdispute:update permission.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "404": {
-              "description": "JJDispute record not found. Update failed.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "405": {
-              "description": "A JJDispute status can only be set to CONFIRMED iff status is one of the following: REVIEW, NEW, HEARING_SCHEDULED, IN_PROGRESS, CONFIRMED. Update failed.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "409": {
-              "description": "Conflict",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "500": {
-              "description": "There was a server error that prevented the update from completing successfully."
+          },
+          {
+            "name": "checkVTC",
+            "in": "query",
+            "description": "boolean to indicate need to check VTC assigned.",
+            "schema": {
+              "type": "boolean"
             }
           }
-        }
-      },
-      "/api/jj/{ticketNumber}/print": {
-        "get": {
-          "tags": [
-            "JJ"
-          ],
-          "summary": "Returns generated document. This really should be using the tco_dispute.dispute_id.",
-          "parameters": [
-            {
-              "name": "ticketNumber",
-              "in": "path",
-              "description": "The ticket number to print. This really should be using the tco_dispute.dispute_id",
-              "required": true,
+        ],
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
               "schema": {
-                "type": "string"
-              }
-            },
-            {
-              "name": "timeZone",
-              "in": "query",
-              "description": "The IANA timze zone id",
-              "required": true,
-              "schema": {
-                "type": "string"
-              }
-            }
-          ],
-          "responses": {
-            "200": {
-              "description": "Generated Document."
-            },
-            "401": {
-              "description": "Request lacks valid authentication credentials.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
+                "type": "object",
+                "properties": {
+                  "remark": {
+                    "maxLength": 256,
+                    "minLength": 0,
+                    "type": "string"
                   }
                 }
-              }
-            },
-            "403": {
-              "description": "Forbidden.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "500": {
-              "description": "There was a server error that prevented the search from completing successfully or no data found."
-            },
-            "400": {
-              "description": "The"
-            }
-          }
-        }
-      },
-      "/api/keycloak/{groupName}/users": {
-        "get": {
-          "tags": [
-            "Keycloak"
-          ],
-          "summary": "Returns all Users with the given group name.",
-          "parameters": [
-            {
-              "name": "groupName",
-              "in": "path",
-              "description": "A unique group name to query.",
-              "required": true,
-              "schema": {
-                "type": "string"
-              }
-            }
-          ],
-          "responses": {
-            "200": {
-              "description": "Success",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "type": "array",
-                    "items": {
-                      "$ref": "#/components/schemas/UserRepresentation"
-                    }
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "type": "array",
-                    "items": {
-                      "$ref": "#/components/schemas/UserRepresentation"
-                    }
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "type": "array",
-                    "items": {
-                      "$ref": "#/components/schemas/UserRepresentation"
-                    }
-                  }
-                }
-              }
-            },
-            "401": {
-              "description": "Request lacks valid authentication credentials.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "500": {
-              "description": "Server Error"
-            }
-          }
-        }
-      },
-      "/api/lookup/statutes": {
-        "get": {
-          "tags": [
-            "Lookup"
-          ],
-          "summary": "Returns a list of Violation Ticket Statutes filtered by given section text (if provided).",
-          "parameters": [
-            {
-              "name": "section",
-              "in": "query",
-              "description": "Motor vehicle act Section text to query by, ie \"13(1)(a)\" returns \"Motor Vehicle or Trailer without Licence\" contravention, or blank for no filter.",
-              "schema": {
-                "type": "string"
-              }
-            }
-          ],
-          "responses": {
-            "200": {
-              "description": "OK",
-              "content": {
-                "application/json": {
-                  "schema": {
-                    "type": "array",
-                    "items": {
-                      "$ref": "#/components/schemas/Statute"
-                    }
-                  }
-                }
-              }
-            },
-            "401": {
-              "description": "Request lacks valid authentication credentials.",
-              "content": {
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
+              },
+              "encoding": {
+                "remark": {
+                  "style": "form"
                 }
               }
             }
           }
-        }
-      },
-      "/api/lookup/languages": {
-        "get": {
-          "tags": [
-            "Lookup"
-          ],
-          "summary": "Returns a list of Languages.",
-          "responses": {
-            "200": {
-              "description": "OK",
-              "content": {
-                "application/json": {
-                  "schema": {
-                    "type": "array",
-                    "items": {
-                      "$ref": "#/components/schemas/Language"
-                    }
-                  }
+        },
+        "responses": {
+          "200": {
+            "description": "The JJDispute is updated."
+          },
+          "400": {
+            "description": "The request was not well formed. Check the parameters.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
                 }
               }
-            },
-            "401": {
-              "description": "Request lacks valid authentication credentials.",
-              "content": {
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
+            }
+          },
+          "401": {
+            "description": "Request lacks valid authentication credentials.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden, requires jjdispute:review permission.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "JJDispute record not found. Update failed.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "A JJDispute status can only be set to REVIEW if status is CONFIRMED and the remark must be less than 256 characters OR if the status ACCEPTED, CONFIRMED or CONCLUDED and DCF's current hearing date = today's date. Update failed",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "The JJDispute has already been assigned to a different user. JJDispute cannot be modified until assigned time expires.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "There was a server error that prevented the update from completing successfully."
+          }
+        }
+      }
+    },
+    "/api/jj/{ticketNumber}/requirecourthearing": {
+      "put": {
+        "tags": [
+          "JJ"
+        ],
+        "summary": "Updates the status of a particular JJDispute record to REQUIRE_COURT_HEARING, hearing type to COURT_APPEARANCE as well as adds an optional remark that explaining why the status was set.",
+        "parameters": [
+          {
+            "name": "ticketNumber",
+            "in": "path",
+            "description": "Unique identifier for a specific JJ Dispute record.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "remark": {
+                    "maxLength": 256,
+                    "minLength": 0,
+                    "type": "string"
                   }
+                }
+              },
+              "encoding": {
+                "remark": {
+                  "style": "form"
                 }
               }
             }
           }
-        }
-      },
-      "/api/lookup/agencies": {
-        "get": {
-          "tags": [
-            "Lookup"
-          ],
-          "summary": "Returns a list of agencies.",
-          "responses": {
-            "200": {
-              "description": "OK",
-              "content": {
-                "application/json": {
-                  "schema": {
-                    "type": "array",
-                    "items": {
-                      "$ref": "#/components/schemas/Agency"
-                    }
-                  }
+        },
+        "responses": {
+          "200": {
+            "description": "The JJDispute is updated."
+          },
+          "400": {
+            "description": "The request was not well formed. Check the parameters.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
                 }
               }
-            },
-            "401": {
-              "description": "Request lacks valid authentication credentials.",
-              "content": {
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
+            }
+          },
+          "401": {
+            "description": "Request lacks valid authentication credentials.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden, requires jjdispute:require_court_hearing permission.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "JJDispute record not found. Update failed.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "A JJDispute status can only be set to REQUIRE_COURT_HEARING iff status is one of the following: NEW, IN_PROGRESS, REVIEW, REQUIRE_COURT_HEARING and the remark must be less than or equal to 256 characters. Update failed.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "The JJDispute has already been assigned to a different user. JJDispute cannot be modified until assigned time expires.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "There was a server error that prevented the update from completing successfully."
+          }
+        }
+      }
+    },
+    "/api/jj/{ticketNumber}/accept": {
+      "put": {
+        "tags": [
+          "JJ"
+        ],
+        "summary": "Updates the status of a particular JJDispute record to ACCEPTED.",
+        "parameters": [
+          {
+            "name": "ticketNumber",
+            "in": "path",
+            "description": "Ticket number for a specific JJ Dispute record.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "checkVTC",
+            "in": "query",
+            "description": "boolean to indicate need to check VTC assigned.",
+            "schema": {
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The JJDispute is updated."
+          },
+          "400": {
+            "description": "The request was not well formed. Check the parameters.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Request lacks valid authentication credentials.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden, requires jjdispute:accept permission.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "JJDispute record not found. Update failed.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "A JJDispute status can only be set to ACCEPTED iff status is CONFIRMED. Update failed.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "The JJDispute has already been assigned to a different user. JJDispute cannot be modified until assigned time expires.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "There was a server error that prevented the update from completing successfully."
+          }
+        }
+      }
+    },
+    "/api/jj/{ticketNumber}/conclude": {
+      "put": {
+        "tags": [
+          "JJ"
+        ],
+        "summary": "Updates the status of a particular JJDispute record to CONCLUDED.",
+        "parameters": [
+          {
+            "name": "ticketNumber",
+            "in": "path",
+            "description": "Ticket number for a specific JJ Dispute record.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "checkVTC",
+            "in": "query",
+            "description": "boolean to indicate need to check VTC assigned.",
+            "schema": {
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The JJDispute is updated."
+          },
+          "400": {
+            "description": "The request was not well formed. Check the parameters.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Request lacks valid authentication credentials.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden, requires jjdispute:accept permission.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "JJDispute record not found. Update failed.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "The JJDispute has already been assigned to a different user. JJDispute cannot be modified until assigned time expires.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "There was a server error that prevented the update from completing successfully."
+          }
+        }
+      }
+    },
+    "/api/jj/{ticketNumber}/cancel": {
+      "put": {
+        "tags": [
+          "JJ"
+        ],
+        "summary": "Updates the status of a particular JJDispute record to CANCELLED.",
+        "parameters": [
+          {
+            "name": "ticketNumber",
+            "in": "path",
+            "description": "Ticket number for a specific JJ Dispute record.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "checkVTC",
+            "in": "query",
+            "description": "boolean to indicate need to check VTC assigned.",
+            "schema": {
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The JJDispute is updated."
+          },
+          "400": {
+            "description": "The request was not well formed. Check the parameters.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Request lacks valid authentication credentials.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden, requires jjdispute:accept permission.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "JJDispute record not found. Update failed.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "The JJDispute has already been assigned to a different user. JJDispute cannot be modified until assigned time expires.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "There was a server error that prevented the update from completing successfully."
+          }
+        }
+      }
+    },
+    "/api/jj/{ticketNumber}/updatecourtappearance/requirecourthearing": {
+      "put": {
+        "tags": [
+          "JJ"
+        ],
+        "summary": "Updates court appearance record as well as the status of a particular JJDispute record to REQUIRE_COURT_HEARING, hearing type to COURT_APPEARANCE.",
+        "parameters": [
+          {
+            "name": "ticketNumber",
+            "in": "path",
+            "description": "Ticket number for a specific JJ Dispute record.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The court appearance and JJDispute status are updated."
+          },
+          "400": {
+            "description": "The request was not well formed. Check the parameters.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Request lacks valid authentication credentials.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden, requires jjdispute:update permission.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "JJDispute record not found. Update failed.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "A JJDispute status can only be set to REQUIRE_COURT_HEARING iff status is one of the following: NEW, IN_PROGRESS, REVIEW, REQUIRE_COURT_HEARING. Update failed.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "There was a server error that prevented the update from completing successfully."
+          }
+        }
+      }
+    },
+    "/api/jj/{ticketNumber}/updatecourtappearance/confirm": {
+      "put": {
+        "tags": [
+          "JJ"
+        ],
+        "summary": "Updates court appearance record as well as the status of a particular JJDispute record to CONFIRMED.",
+        "parameters": [
+          {
+            "name": "ticketNumber",
+            "in": "path",
+            "description": "Ticket number for a specific JJ Dispute record.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The court appearance and JJDispute status are updated."
+          },
+          "400": {
+            "description": "The request was not well formed. Check the parameters.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Request lacks valid authentication credentials.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden, requires jjdispute:update permission.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "JJDispute record not found. Update failed.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "A JJDispute status can only be set to CONFIRMED iff status is one of the following: REVIEW, NEW, HEARING_SCHEDULED, IN_PROGRESS, CONFIRMED. Update failed.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "There was a server error that prevented the update from completing successfully."
+          }
+        }
+      }
+    },
+    "/api/jj/{ticketNumber}/print": {
+      "get": {
+        "tags": [
+          "JJ"
+        ],
+        "summary": "Returns generated document. This really should be using the tco_dispute.dispute_id.",
+        "parameters": [
+          {
+            "name": "ticketNumber",
+            "in": "path",
+            "description": "The ticket number to print. This really should be using the tco_dispute.dispute_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "timeZone",
+            "in": "query",
+            "description": "The IANA timze zone id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Generated Document."
+          },
+          "401": {
+            "description": "Request lacks valid authentication credentials.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "There was a server error that prevented the search from completing successfully or no data found."
+          },
+          "400": {
+            "description": "The"
+          }
+        }
+      }
+    },
+    "/api/keycloak/{groupName}/users": {
+      "get": {
+        "tags": [
+          "Keycloak"
+        ],
+        "summary": "Returns all Users with the given group name.",
+        "parameters": [
+          {
+            "name": "groupName",
+            "in": "path",
+            "description": "A unique group name to query.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/UserRepresentation"
+                  }
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/UserRepresentation"
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/UserRepresentation"
                   }
                 }
               }
             }
-          }
-        }
-      },
-      "/api/lookup/province": {
-        "get": {
-          "tags": [
-            "Lookup"
-          ],
-          "summary": "Returns a list of provinces.",
-          "responses": {
-            "200": {
-              "description": "OK",
-              "content": {
-                "application/json": {
-                  "schema": {
-                    "type": "array",
-                    "items": {
-                      "$ref": "#/components/schemas/Province"
-                    }
-                  }
+          },
+          "401": {
+            "description": "Request lacks valid authentication credentials.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
                 }
               }
-            },
-            "401": {
-              "description": "Request lacks valid authentication credentials.",
-              "content": {
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
+            }
+          },
+          "500": {
+            "description": "Server Error"
+          }
+        }
+      }
+    },
+    "/api/lookup/statutes": {
+      "get": {
+        "tags": [
+          "Lookup"
+        ],
+        "summary": "Returns a list of Violation Ticket Statutes filtered by given section text (if provided).",
+        "parameters": [
+          {
+            "name": "section",
+            "in": "query",
+            "description": "Motor vehicle act Section text to query by, ie \"13(1)(a)\" returns \"Motor Vehicle or Trailer without Licence\" contravention, or blank for no filter.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Statute"
                   }
                 }
               }
             }
-          }
-        }
-      },
-      "/api/lookup/country": {
-        "get": {
-          "tags": [
-            "Lookup"
-          ],
-          "summary": "Returns a list of countries.",
-          "responses": {
-            "200": {
-              "description": "OK",
-              "content": {
-                "application/json": {
-                  "schema": {
-                    "type": "array",
-                    "items": {
-                      "$ref": "#/components/schemas/Country"
-                    }
-                  }
-                }
-              }
-            },
-            "401": {
-              "description": "Request lacks valid authentication credentials.",
-              "content": {
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
+          },
+          "401": {
+            "description": "Request lacks valid authentication credentials.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
                 }
               }
             }
@@ -4720,2960 +4667,3133 @@
         }
       }
     },
-    "components": {
-      "schemas": {
-        "Agency": {
-          "type": "object",
-          "properties": {
-            "id": {
-              "type": "string",
-              "nullable": true
-            },
-            "name": {
-              "type": "string",
-              "nullable": true
-            },
-            "typeCode": {
-              "type": "string",
-              "nullable": true
-            }
-          },
-          "additionalProperties": false
-        },
-        "BoundingBox": {
-          "type": "object",
-          "properties": {
-            "points": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/Point"
-              },
-              "nullable": true
-            }
-          },
-          "additionalProperties": false
-        },
-        "Country": {
-          "type": "object",
-          "properties": {
-            "ctryId": {
-              "type": "string",
-              "nullable": true
-            },
-            "ctryLongNm": {
-              "type": "string",
-              "nullable": true
-            }
-          },
-          "additionalProperties": false
-        },
-        "CredentialRepresentation": {
-          "type": "object",
-          "properties": {
-            "id": {
-              "type": "string",
-              "nullable": true
-            },
-            "type": {
-              "type": "string",
-              "nullable": true
-            },
-            "userLabel": {
-              "type": "string",
-              "nullable": true
-            },
-            "secretData": {
-              "type": "string",
-              "nullable": true
-            },
-            "credentialData": {
-              "type": "string",
-              "nullable": true
-            },
-            "priority": {
-              "type": "integer",
-              "format": "int32"
-            },
-            "createdDate": {
-              "type": "integer",
-              "format": "int64"
-            },
-            "value": {
-              "type": "string",
-              "nullable": true
-            },
-            "temporary": {
-              "type": "boolean"
-            },
-            "device": {
-              "type": "string",
-              "nullable": true
-            },
-            "hashedSaltedValue": {
-              "type": "string",
-              "nullable": true
-            },
-            "salt": {
-              "type": "string",
-              "nullable": true
-            },
-            "hashIterations": {
-              "type": "integer",
-              "format": "int32"
-            },
-            "counter": {
-              "type": "integer",
-              "format": "int32"
-            },
-            "algorithm": {
-              "type": "string",
-              "nullable": true
-            },
-            "digits": {
-              "type": "integer",
-              "format": "int32"
-            },
-            "period": {
-              "type": "integer",
-              "format": "int32"
-            },
-            "config": {
-              "type": "object",
-              "additionalProperties": {
-                "type": "array",
-                "items": {
-                  "type": "string"
+    "/api/lookup/languages": {
+      "get": {
+        "tags": [
+          "Lookup"
+        ],
+        "summary": "Returns a list of Languages.",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Language"
+                  }
                 }
-              },
-              "nullable": true
-            },
-            "additionalProperties": {
-              "type": "object",
-              "additionalProperties": { },
-              "nullable": true
+              }
             }
           },
-          "additionalProperties": false
+          "401": {
+            "description": "Request lacks valid authentication credentials.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/lookup/agencies": {
+      "get": {
+        "tags": [
+          "Lookup"
+        ],
+        "summary": "Returns a list of agencies.",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Agency"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Request lacks valid authentication credentials.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/lookup/province": {
+      "get": {
+        "tags": [
+          "Lookup"
+        ],
+        "summary": "Returns a list of provinces.",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Province"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Request lacks valid authentication credentials.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/lookup/country": {
+      "get": {
+        "tags": [
+          "Lookup"
+        ],
+        "summary": "Returns a list of countries.",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Country"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Request lacks valid authentication credentials.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Agency": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "nullable": true
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "typeCode": {
+            "type": "string",
+            "nullable": true
+          }
         },
-        "Dispute": {
-          "type": "object",
-          "properties": {
-            "fileData": {
+        "additionalProperties": false
+      },
+      "BoundingBox": {
+        "type": "object",
+        "properties": {
+          "points": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Point"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "Country": {
+        "type": "object",
+        "properties": {
+          "ctryId": {
+            "type": "string",
+            "nullable": true
+          },
+          "ctryLongNm": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "CredentialRepresentation": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "nullable": true
+          },
+          "type": {
+            "type": "string",
+            "nullable": true
+          },
+          "userLabel": {
+            "type": "string",
+            "nullable": true
+          },
+          "secretData": {
+            "type": "string",
+            "nullable": true
+          },
+          "credentialData": {
+            "type": "string",
+            "nullable": true
+          },
+          "priority": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "createdDate": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "value": {
+            "type": "string",
+            "nullable": true
+          },
+          "temporary": {
+            "type": "boolean"
+          },
+          "device": {
+            "type": "string",
+            "nullable": true
+          },
+          "hashedSaltedValue": {
+            "type": "string",
+            "nullable": true
+          },
+          "salt": {
+            "type": "string",
+            "nullable": true
+          },
+          "hashIterations": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "counter": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "algorithm": {
+            "type": "string",
+            "nullable": true
+          },
+          "digits": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "period": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "config": {
+            "type": "object",
+            "additionalProperties": {
               "type": "array",
               "items": {
-                "$ref": "#/components/schemas/FileMetadata"
-              },
-              "nullable": true
+                "type": "string"
+              }
             },
-            "createdBy": {
-              "type": "string",
-              "nullable": true
-            },
-            "createdTs": {
-              "type": "string",
-              "format": "date-time"
-            },
-            "modifiedBy": {
-              "type": "string",
-              "nullable": true
-            },
-            "modifiedTs": {
-              "type": "string",
-              "format": "date-time",
-              "nullable": true
-            },
-            "disputeId": {
-              "type": "integer",
-              "format": "int64"
-            },
-            "noticeOfDisputeGuid": {
-              "type": "string",
-              "nullable": true
-            },
-            "ticketNumber": {
-              "type": "string",
-              "nullable": true
-            },
-            "issuedTs": {
-              "type": "string",
-              "format": "date-time",
-              "nullable": true
-            },
-            "submittedTs": {
-              "type": "string",
-              "format": "date-time",
-              "nullable": true
-            },
-            "disputantSurname": {
-              "type": "string",
-              "nullable": true
-            },
-            "disputantGivenName1": {
-              "type": "string",
-              "nullable": true
-            },
-            "disputantGivenName2": {
-              "type": "string",
-              "nullable": true
-            },
-            "disputantGivenName3": {
-              "type": "string",
-              "nullable": true
-            },
-            "disputantBirthdate": {
-              "type": "string",
-              "format": "date-time",
-              "nullable": true
-            },
-            "driversLicenceNumber": {
-              "maxLength": 30,
-              "minLength": 0,
-              "type": "string",
-              "nullable": true
-            },
-            "disputantOrganization": {
-              "type": "string",
-              "nullable": true
-            },
-            "disputantClientId": {
-              "type": "string",
-              "nullable": true
-            },
-            "driversLicenceIssuedCountryId": {
-              "type": "integer",
-              "format": "int32",
-              "nullable": true
-            },
-            "driversLicenceIssuedProvinceSeqNo": {
-              "type": "integer",
-              "format": "int32",
-              "nullable": true
-            },
-            "driversLicenceProvince": {
-              "maxLength": 30,
-              "minLength": 0,
-              "type": "string",
-              "nullable": true
-            },
-            "status": {
-              "$ref": "#/components/schemas/DisputeStatus"
-            },
-            "addressLine1": {
-              "type": "string",
-              "nullable": true
-            },
-            "addressLine2": {
-              "type": "string",
-              "nullable": true
-            },
-            "addressLine3": {
-              "type": "string",
-              "nullable": true
-            },
-            "addressCity": {
-              "maxLength": 30,
-              "minLength": 0,
-              "type": "string",
-              "nullable": true
-            },
-            "addressProvince": {
-              "maxLength": 30,
-              "minLength": 0,
-              "type": "string",
-              "nullable": true
-            },
-            "addressProvinceCountryId": {
-              "type": "integer",
-              "format": "int32",
-              "nullable": true
-            },
-            "addressProvinceSeqNo": {
-              "type": "integer",
-              "format": "int32",
-              "nullable": true
-            },
-            "addressCountryId": {
-              "type": "integer",
-              "format": "int32",
-              "nullable": true
-            },
-            "postalCode": {
-              "maxLength": 10,
-              "minLength": 0,
-              "type": "string",
-              "nullable": true
-            },
-            "homePhoneNumber": {
-              "type": "string",
-              "nullable": true
-            },
-            "workPhoneNumber": {
-              "type": "string",
-              "nullable": true
-            },
-            "emailAddress": {
-              "type": "string",
-              "nullable": true
-            },
-            "emailAddressVerified": {
-              "type": "boolean"
-            },
-            "filingDate": {
-              "type": "string",
-              "format": "date-time",
-              "nullable": true
-            },
-            "representedByLawyer": {
-              "$ref": "#/components/schemas/DisputeRepresentedByLawyer"
-            },
-            "lawFirmName": {
-              "type": "string",
-              "nullable": true
-            },
-            "lawyerSurname": {
-              "type": "string",
-              "nullable": true
-            },
-            "lawyerGivenName1": {
-              "type": "string",
-              "nullable": true
-            },
-            "lawyerGivenName2": {
-              "type": "string",
-              "nullable": true
-            },
-            "lawyerGivenName3": {
-              "type": "string",
-              "nullable": true
-            },
-            "lawyerAddress": {
-              "maxLength": 300,
-              "minLength": 0,
-              "type": "string",
-              "nullable": true
-            },
-            "lawyerPhoneNumber": {
-              "type": "string",
-              "nullable": true
-            },
-            "lawyerEmail": {
-              "maxLength": 100,
-              "minLength": 0,
-              "type": "string",
-              "nullable": true
-            },
-            "officerPin": {
-              "type": "string",
-              "nullable": true
-            },
-            "contactTypeCd": {
-              "$ref": "#/components/schemas/DisputeContactTypeCd"
-            },
-            "requestCourtAppearanceYn": {
-              "$ref": "#/components/schemas/DisputeRequestCourtAppearanceYn"
-            },
-            "contactLawFirmNm": {
-              "type": "string",
-              "nullable": true
-            },
-            "contactGiven1Nm": {
-              "type": "string",
-              "nullable": true
-            },
-            "contactGiven2Nm": {
-              "type": "string",
-              "nullable": true
-            },
-            "contactGiven3Nm": {
-              "type": "string",
-              "nullable": true
-            },
-            "contactSurnameNm": {
-              "type": "string",
-              "nullable": true
-            },
-            "appearanceDtm": {
-              "type": "string",
-              "format": "date-time",
-              "nullable": true
-            },
-            "appearanceLessThan14DaysYn": {
-              "$ref": "#/components/schemas/DisputeAppearanceLessThan14DaysYn"
-            },
-            "detachmentLocation": {
-              "type": "string",
-              "nullable": true
-            },
-            "courtAgenId": {
-              "type": "string",
-              "nullable": true
-            },
-            "interpreterLanguageCd": {
-              "maxLength": 3,
-              "minLength": 0,
-              "type": "string",
-              "nullable": true
-            },
-            "interpreterRequired": {
-              "$ref": "#/components/schemas/DisputeInterpreterRequired"
-            },
-            "witnessNo": {
-              "type": "integer",
-              "format": "int32",
-              "nullable": true
-            },
-            "fineReductionReason": {
-              "type": "string",
-              "nullable": true
-            },
-            "timeToPayReason": {
-              "type": "string",
-              "nullable": true
-            },
-            "disputantComment": {
-              "type": "string",
-              "nullable": true
-            },
-            "rejectedReason": {
-              "type": "string",
-              "nullable": true
-            },
-            "userAssignedTo": {
-              "type": "string",
-              "nullable": true
-            },
-            "userAssignedTs": {
-              "type": "string",
-              "format": "date-time",
-              "nullable": true
-            },
-            "disputantDetectedOcrIssues": {
-              "$ref": "#/components/schemas/DisputeDisputantDetectedOcrIssues"
-            },
-            "disputantOcrIssues": {
-              "type": "string",
-              "nullable": true
-            },
-            "systemDetectedOcrIssues": {
-              "$ref": "#/components/schemas/DisputeSystemDetectedOcrIssues"
-            },
-            "ocrTicketFilename": {
-              "maxLength": 100,
-              "minLength": 0,
-              "type": "string",
-              "nullable": true
-            },
-            "signatoryType": {
-              "$ref": "#/components/schemas/DisputeSignatoryType"
-            },
-            "signatoryName": {
-              "maxLength": 100,
-              "minLength": 0,
-              "type": "string",
-              "nullable": true
-            },
-            "violationTicket": {
-              "$ref": "#/components/schemas/ViolationTicket"
-            },
-            "disputeCounts": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/DisputeCount"
-              },
-              "nullable": true
-            },
-            "additionalProperties": {
-              "type": "object",
-              "additionalProperties": { },
-              "nullable": true
-            }
+            "nullable": true
           },
-          "additionalProperties": false
-        },
-        "DisputeAppearanceLessThan14DaysYn": {
-          "enum": [
-            "UNKNOWN",
-            "Y",
-            "N"
-          ],
-          "type": "string"
-        },
-        "DisputeContactTypeCd": {
-          "enum": [
-            "UNKNOWN",
-            "INDIVIDUAL",
-            "LAWYER",
-            "OTHER"
-          ],
-          "type": "string"
-        },
-        "DisputeCount": {
-          "type": "object",
-          "properties": {
-            "createdBy": {
-              "type": "string",
-              "nullable": true
-            },
-            "createdTs": {
-              "type": "string",
-              "format": "date-time"
-            },
-            "modifiedBy": {
-              "type": "string",
-              "nullable": true
-            },
-            "modifiedTs": {
-              "type": "string",
-              "format": "date-time",
-              "nullable": true
-            },
-            "countNo": {
-              "maximum": 3,
-              "minimum": 1,
-              "type": "integer",
-              "format": "int32"
-            },
-            "pleaCode": {
-              "$ref": "#/components/schemas/DisputeCountPleaCode"
-            },
-            "requestTimeToPay": {
-              "$ref": "#/components/schemas/DisputeCountRequestTimeToPay"
-            },
-            "requestReduction": {
-              "$ref": "#/components/schemas/DisputeCountRequestReduction"
-            },
-            "requestCourtAppearance": {
-              "$ref": "#/components/schemas/DisputeCountRequestCourtAppearance"
-            },
+          "additionalProperties": {
+            "type": "object",
             "additionalProperties": {
-              "type": "object",
-              "additionalProperties": { },
-              "nullable": true
-            }
+
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "Dispute": {
+        "type": "object",
+        "properties": {
+          "fileData": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FileMetadata"
+            },
+            "nullable": true
           },
-          "additionalProperties": false
-        },
-        "DisputeCountPleaCode": {
-          "enum": [
-            "UNKNOWN",
-            "G",
-            "N"
-          ],
-          "type": "string"
-        },
-        "DisputeCountRequestCourtAppearance": {
-          "enum": [
-            "UNKNOWN",
-            "Y",
-            "N"
-          ],
-          "type": "string"
-        },
-        "DisputeCountRequestReduction": {
-          "enum": [
-            "UNKNOWN",
-            "Y",
-            "N"
-          ],
-          "type": "string"
-        },
-        "DisputeCountRequestTimeToPay": {
-          "enum": [
-            "UNKNOWN",
-            "Y",
-            "N"
-          ],
-          "type": "string"
-        },
-        "DisputeDisputantDetectedOcrIssues": {
-          "enum": [
-            "UNKNOWN",
-            "Y",
-            "N"
-          ],
-          "type": "string"
-        },
-        "DisputeInterpreterRequired": {
-          "enum": [
-            "UNKNOWN",
-            "Y",
-            "N"
-          ],
-          "type": "string"
-        },
-        "DisputeListItem": {
-          "type": "object",
-          "properties": {
-            "disputeId": {
-              "type": "integer",
-              "format": "int64"
+          "createdBy": {
+            "type": "string",
+            "nullable": true
+          },
+          "createdTs": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "modifiedBy": {
+            "type": "string",
+            "nullable": true
+          },
+          "modifiedTs": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "disputeId": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "noticeOfDisputeGuid": {
+            "type": "string",
+            "nullable": true
+          },
+          "ticketNumber": {
+            "type": "string",
+            "nullable": true
+          },
+          "issuedTs": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "submittedTs": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "disputantSurname": {
+            "type": "string",
+            "nullable": true
+          },
+          "disputantGivenName1": {
+            "type": "string",
+            "nullable": true
+          },
+          "disputantGivenName2": {
+            "type": "string",
+            "nullable": true
+          },
+          "disputantGivenName3": {
+            "type": "string",
+            "nullable": true
+          },
+          "disputantBirthdate": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "driversLicenceNumber": {
+            "maxLength": 30,
+            "minLength": 0,
+            "type": "string",
+            "nullable": true
+          },
+          "disputantOrganization": {
+            "type": "string",
+            "nullable": true
+          },
+          "disputantClientId": {
+            "type": "string",
+            "nullable": true
+          },
+          "driversLicenceIssuedCountryId": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "driversLicenceIssuedProvinceSeqNo": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "driversLicenceProvince": {
+            "maxLength": 30,
+            "minLength": 0,
+            "type": "string",
+            "nullable": true
+          },
+          "status": {
+            "$ref": "#/components/schemas/DisputeStatus"
+          },
+          "addressLine1": {
+            "type": "string",
+            "nullable": true
+          },
+          "addressLine2": {
+            "type": "string",
+            "nullable": true
+          },
+          "addressLine3": {
+            "type": "string",
+            "nullable": true
+          },
+          "addressCity": {
+            "maxLength": 30,
+            "minLength": 0,
+            "type": "string",
+            "nullable": true
+          },
+          "addressProvince": {
+            "maxLength": 30,
+            "minLength": 0,
+            "type": "string",
+            "nullable": true
+          },
+          "addressProvinceCountryId": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "addressProvinceSeqNo": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "addressCountryId": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "postalCode": {
+            "maxLength": 10,
+            "minLength": 0,
+            "type": "string",
+            "nullable": true
+          },
+          "homePhoneNumber": {
+            "type": "string",
+            "nullable": true
+          },
+          "workPhoneNumber": {
+            "type": "string",
+            "nullable": true
+          },
+          "emailAddress": {
+            "type": "string",
+            "nullable": true
+          },
+          "emailAddressVerified": {
+            "type": "boolean"
+          },
+          "filingDate": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "representedByLawyer": {
+            "$ref": "#/components/schemas/DisputeRepresentedByLawyer"
+          },
+          "lawFirmName": {
+            "type": "string",
+            "nullable": true
+          },
+          "lawyerSurname": {
+            "type": "string",
+            "nullable": true
+          },
+          "lawyerGivenName1": {
+            "type": "string",
+            "nullable": true
+          },
+          "lawyerGivenName2": {
+            "type": "string",
+            "nullable": true
+          },
+          "lawyerGivenName3": {
+            "type": "string",
+            "nullable": true
+          },
+          "lawyerAddress": {
+            "maxLength": 300,
+            "minLength": 0,
+            "type": "string",
+            "nullable": true
+          },
+          "lawyerPhoneNumber": {
+            "type": "string",
+            "nullable": true
+          },
+          "lawyerEmail": {
+            "maxLength": 100,
+            "minLength": 0,
+            "type": "string",
+            "nullable": true
+          },
+          "officerPin": {
+            "type": "string",
+            "nullable": true
+          },
+          "contactTypeCd": {
+            "$ref": "#/components/schemas/DisputeContactTypeCd"
+          },
+          "requestCourtAppearanceYn": {
+            "$ref": "#/components/schemas/DisputeRequestCourtAppearanceYn"
+          },
+          "contactLawFirmNm": {
+            "type": "string",
+            "nullable": true
+          },
+          "contactGiven1Nm": {
+            "type": "string",
+            "nullable": true
+          },
+          "contactGiven2Nm": {
+            "type": "string",
+            "nullable": true
+          },
+          "contactGiven3Nm": {
+            "type": "string",
+            "nullable": true
+          },
+          "contactSurnameNm": {
+            "type": "string",
+            "nullable": true
+          },
+          "appearanceDtm": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "appearanceLessThan14DaysYn": {
+            "$ref": "#/components/schemas/DisputeAppearanceLessThan14DaysYn"
+          },
+          "detachmentLocation": {
+            "type": "string",
+            "nullable": true
+          },
+          "courtAgenId": {
+            "type": "string",
+            "nullable": true
+          },
+          "interpreterLanguageCd": {
+            "maxLength": 3,
+            "minLength": 0,
+            "type": "string",
+            "nullable": true
+          },
+          "interpreterRequired": {
+            "$ref": "#/components/schemas/DisputeInterpreterRequired"
+          },
+          "witnessNo": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "fineReductionReason": {
+            "type": "string",
+            "nullable": true
+          },
+          "timeToPayReason": {
+            "type": "string",
+            "nullable": true
+          },
+          "disputantComment": {
+            "type": "string",
+            "nullable": true
+          },
+          "rejectedReason": {
+            "type": "string",
+            "nullable": true
+          },
+          "userAssignedTo": {
+            "type": "string",
+            "nullable": true
+          },
+          "userAssignedTs": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "disputantDetectedOcrIssues": {
+            "$ref": "#/components/schemas/DisputeDisputantDetectedOcrIssues"
+          },
+          "disputantOcrIssues": {
+            "type": "string",
+            "nullable": true
+          },
+          "systemDetectedOcrIssues": {
+            "$ref": "#/components/schemas/DisputeSystemDetectedOcrIssues"
+          },
+          "ocrTicketFilename": {
+            "maxLength": 100,
+            "minLength": 0,
+            "type": "string",
+            "nullable": true
+          },
+          "signatoryType": {
+            "$ref": "#/components/schemas/DisputeSignatoryType"
+          },
+          "signatoryName": {
+            "maxLength": 100,
+            "minLength": 0,
+            "type": "string",
+            "nullable": true
+          },
+          "violationTicket": {
+            "$ref": "#/components/schemas/ViolationTicket"
+          },
+          "disputeCounts": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DisputeCount"
             },
-            "ticketNumber": {
-              "type": "string",
-              "nullable": true
-            },
-            "submittedTs": {
-              "type": "string",
-              "format": "date-time",
-              "nullable": true
-            },
-            "disputantSurname": {
-              "type": "string",
-              "nullable": true
-            },
-            "disputantGivenName1": {
-              "type": "string",
-              "nullable": true
-            },
-            "disputantGivenName2": {
-              "type": "string",
-              "nullable": true
-            },
-            "disputantGivenName3": {
-              "type": "string",
-              "nullable": true
-            },
-            "status": {
-              "$ref": "#/components/schemas/DisputeListItemStatus"
-            },
-            "emailAddress": {
-              "type": "string",
-              "nullable": true
-            },
-            "emailAddressVerified": {
-              "type": "boolean"
-            },
-            "filingDate": {
-              "type": "string",
-              "format": "date-time",
-              "nullable": true
-            },
-            "requestCourtAppearanceYn": {
-              "$ref": "#/components/schemas/DisputeListItemRequestCourtAppearanceYn"
-            },
-            "userAssignedTo": {
-              "type": "string",
-              "nullable": true
-            },
-            "userAssignedTs": {
-              "type": "string",
-              "format": "date-time",
-              "nullable": true
-            },
-            "disputantDetectedOcrIssues": {
-              "$ref": "#/components/schemas/DisputeListItemDisputantDetectedOcrIssues"
-            },
-            "systemDetectedOcrIssues": {
-              "$ref": "#/components/schemas/DisputeListItemSystemDetectedOcrIssues"
-            },
-            "violationDate": {
-              "type": "string",
-              "format": "date-time",
-              "nullable": true
-            },
-            "jjDisputeStatus": {
-              "$ref": "#/components/schemas/DisputeListItemJjDisputeStatus"
-            },
-            "jjAssignedTo": {
-              "type": "string",
-              "nullable": true
-            },
-            "jjDecisionDate": {
-              "type": "string",
-              "format": "date-time",
-              "nullable": true
-            },
-            "courtAgenId": {
-              "type": "string",
-              "nullable": true
-            },
+            "nullable": true
+          },
+          "additionalProperties": {
+            "type": "object",
             "additionalProperties": {
-              "type": "object",
-              "additionalProperties": { },
-              "nullable": true
-            }
+
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "DisputeAppearanceLessThan14DaysYn": {
+        "enum": [
+          "UNKNOWN",
+          "Y",
+          "N"
+        ],
+        "type": "string"
+      },
+      "DisputeContactTypeCd": {
+        "enum": [
+          "UNKNOWN",
+          "INDIVIDUAL",
+          "LAWYER",
+          "OTHER"
+        ],
+        "type": "string"
+      },
+      "DisputeCount": {
+        "type": "object",
+        "properties": {
+          "createdBy": {
+            "type": "string",
+            "nullable": true
           },
-          "additionalProperties": false
-        },
-        "DisputeListItemDisputantDetectedOcrIssues": {
-          "enum": [
-            "UNKNOWN",
-            "Y",
-            "N"
-          ],
-          "type": "string"
-        },
-        "DisputeListItemJjDisputeStatus": {
-          "enum": [
-            "UNKNOWN",
-            "NEW",
-            "IN_PROGRESS",
-            "DATA_UPDATE",
-            "CONFIRMED",
-            "REQUIRE_COURT_HEARING",
-            "REQUIRE_MORE_INFO",
-            "ACCEPTED",
-            "REVIEW",
-            "CONCLUDED",
-            "CANCELLED",
-            "HEARING_SCHEDULED"
-          ],
-          "type": "string"
-        },
-        "DisputeListItemRequestCourtAppearanceYn": {
-          "enum": [
-            "UNKNOWN",
-            "Y",
-            "N"
-          ],
-          "type": "string"
-        },
-        "DisputeListItemStatus": {
-          "enum": [
-            "UNKNOWN",
-            "NEW",
-            "VALIDATED",
-            "PROCESSING",
-            "REJECTED",
-            "CANCELLED",
-            "CONCLUDED"
-          ],
-          "type": "string"
-        },
-        "DisputeListItemSystemDetectedOcrIssues": {
-          "enum": [
-            "UNKNOWN",
-            "Y",
-            "N"
-          ],
-          "type": "string"
-        },
-        "DisputeRepresentedByLawyer": {
-          "enum": [
-            "UNKNOWN",
-            "Y",
-            "N"
-          ],
-          "type": "string"
-        },
-        "DisputeRequestCourtAppearanceYn": {
-          "enum": [
-            "UNKNOWN",
-            "Y",
-            "N"
-          ],
-          "type": "string"
-        },
-        "DisputeSignatoryType": {
-          "enum": [
-            "U",
-            "D",
-            "A"
-          ],
-          "type": "string"
-        },
-        "DisputeStatus": {
-          "enum": [
-            "UNKNOWN",
-            "NEW",
-            "VALIDATED",
-            "PROCESSING",
-            "REJECTED",
-            "CANCELLED",
-            "CONCLUDED"
-          ],
-          "type": "string"
-        },
-        "DisputeSystemDetectedOcrIssues": {
-          "enum": [
-            "UNKNOWN",
-            "Y",
-            "N"
-          ],
-          "type": "string"
-        },
-        "DisputeUpdateRequest": {
-          "required": [
-            "status",
-            "updateJson",
-            "updateType"
-          ],
-          "type": "object",
-          "properties": {
-            "createdBy": {
-              "type": "string",
-              "nullable": true
+          "createdTs": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "modifiedBy": {
+            "type": "string",
+            "nullable": true
+          },
+          "modifiedTs": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "countNo": {
+            "maximum": 3,
+            "minimum": 1,
+            "type": "integer",
+            "format": "int32"
+          },
+          "pleaCode": {
+            "$ref": "#/components/schemas/DisputeCountPleaCode"
+          },
+          "requestTimeToPay": {
+            "$ref": "#/components/schemas/DisputeCountRequestTimeToPay"
+          },
+          "requestReduction": {
+            "$ref": "#/components/schemas/DisputeCountRequestReduction"
+          },
+          "requestCourtAppearance": {
+            "$ref": "#/components/schemas/DisputeCountRequestCourtAppearance"
+          },
+          "additionalProperties": {
+            "type": "object",
+            "additionalProperties": {
+
             },
-            "createdTs": {
-              "type": "string",
-              "format": "date-time"
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "DisputeCountPleaCode": {
+        "enum": [
+          "UNKNOWN",
+          "G",
+          "N"
+        ],
+        "type": "string"
+      },
+      "DisputeCountRequestCourtAppearance": {
+        "enum": [
+          "UNKNOWN",
+          "Y",
+          "N"
+        ],
+        "type": "string"
+      },
+      "DisputeCountRequestReduction": {
+        "enum": [
+          "UNKNOWN",
+          "Y",
+          "N"
+        ],
+        "type": "string"
+      },
+      "DisputeCountRequestTimeToPay": {
+        "enum": [
+          "UNKNOWN",
+          "Y",
+          "N"
+        ],
+        "type": "string"
+      },
+      "DisputeDisputantDetectedOcrIssues": {
+        "enum": [
+          "UNKNOWN",
+          "Y",
+          "N"
+        ],
+        "type": "string"
+      },
+      "DisputeInterpreterRequired": {
+        "enum": [
+          "UNKNOWN",
+          "Y",
+          "N"
+        ],
+        "type": "string"
+      },
+      "DisputeListItem": {
+        "type": "object",
+        "properties": {
+          "disputeId": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "ticketNumber": {
+            "type": "string",
+            "nullable": true
+          },
+          "submittedTs": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "disputantSurname": {
+            "type": "string",
+            "nullable": true
+          },
+          "disputantGivenName1": {
+            "type": "string",
+            "nullable": true
+          },
+          "disputantGivenName2": {
+            "type": "string",
+            "nullable": true
+          },
+          "disputantGivenName3": {
+            "type": "string",
+            "nullable": true
+          },
+          "status": {
+            "$ref": "#/components/schemas/DisputeListItemStatus"
+          },
+          "emailAddress": {
+            "type": "string",
+            "nullable": true
+          },
+          "emailAddressVerified": {
+            "type": "boolean"
+          },
+          "filingDate": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "requestCourtAppearanceYn": {
+            "$ref": "#/components/schemas/DisputeListItemRequestCourtAppearanceYn"
+          },
+          "userAssignedTo": {
+            "type": "string",
+            "nullable": true
+          },
+          "userAssignedTs": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "disputantDetectedOcrIssues": {
+            "$ref": "#/components/schemas/DisputeListItemDisputantDetectedOcrIssues"
+          },
+          "systemDetectedOcrIssues": {
+            "$ref": "#/components/schemas/DisputeListItemSystemDetectedOcrIssues"
+          },
+          "violationDate": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "jjDisputeStatus": {
+            "$ref": "#/components/schemas/DisputeListItemJjDisputeStatus"
+          },
+          "jjAssignedTo": {
+            "type": "string",
+            "nullable": true
+          },
+          "jjDecisionDate": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "courtAgenId": {
+            "type": "string",
+            "nullable": true
+          },
+          "additionalProperties": {
+            "type": "object",
+            "additionalProperties": {
+
             },
-            "modifiedBy": {
-              "type": "string",
-              "nullable": true
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "DisputeListItemDisputantDetectedOcrIssues": {
+        "enum": [
+          "UNKNOWN",
+          "Y",
+          "N"
+        ],
+        "type": "string"
+      },
+      "DisputeListItemJjDisputeStatus": {
+        "enum": [
+          "UNKNOWN",
+          "NEW",
+          "IN_PROGRESS",
+          "DATA_UPDATE",
+          "CONFIRMED",
+          "REQUIRE_COURT_HEARING",
+          "REQUIRE_MORE_INFO",
+          "ACCEPTED",
+          "REVIEW",
+          "CONCLUDED",
+          "CANCELLED",
+          "HEARING_SCHEDULED"
+        ],
+        "type": "string"
+      },
+      "DisputeListItemRequestCourtAppearanceYn": {
+        "enum": [
+          "UNKNOWN",
+          "Y",
+          "N"
+        ],
+        "type": "string"
+      },
+      "DisputeListItemStatus": {
+        "enum": [
+          "UNKNOWN",
+          "NEW",
+          "VALIDATED",
+          "PROCESSING",
+          "REJECTED",
+          "CANCELLED",
+          "CONCLUDED"
+        ],
+        "type": "string"
+      },
+      "DisputeListItemSystemDetectedOcrIssues": {
+        "enum": [
+          "UNKNOWN",
+          "Y",
+          "N"
+        ],
+        "type": "string"
+      },
+      "DisputeRepresentedByLawyer": {
+        "enum": [
+          "UNKNOWN",
+          "Y",
+          "N"
+        ],
+        "type": "string"
+      },
+      "DisputeRequestCourtAppearanceYn": {
+        "enum": [
+          "UNKNOWN",
+          "Y",
+          "N"
+        ],
+        "type": "string"
+      },
+      "DisputeSignatoryType": {
+        "enum": [
+          "U",
+          "D",
+          "A"
+        ],
+        "type": "string"
+      },
+      "DisputeStatus": {
+        "enum": [
+          "UNKNOWN",
+          "NEW",
+          "VALIDATED",
+          "PROCESSING",
+          "REJECTED",
+          "CANCELLED",
+          "CONCLUDED"
+        ],
+        "type": "string"
+      },
+      "DisputeSystemDetectedOcrIssues": {
+        "enum": [
+          "UNKNOWN",
+          "Y",
+          "N"
+        ],
+        "type": "string"
+      },
+      "DisputeUpdateRequest": {
+        "required": [
+          "status",
+          "updateJson",
+          "updateType"
+        ],
+        "type": "object",
+        "properties": {
+          "createdBy": {
+            "type": "string",
+            "nullable": true
+          },
+          "createdTs": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "modifiedBy": {
+            "type": "string",
+            "nullable": true
+          },
+          "modifiedTs": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "disputeUpdateRequestId": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "disputeId": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "status": {
+            "$ref": "#/components/schemas/DisputeUpdateRequestStatus2"
+          },
+          "updateType": {
+            "$ref": "#/components/schemas/DisputeUpdateRequestUpdateType"
+          },
+          "updateJson": {
+            "maxLength": 4000,
+            "minLength": 3,
+            "type": "string"
+          },
+          "currentJson": {
+            "maxLength": 4000,
+            "minLength": 0,
+            "type": "string",
+            "nullable": true
+          },
+          "statusUpdateTs": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "additionalProperties": {
+            "type": "object",
+            "additionalProperties": {
+
             },
-            "modifiedTs": {
-              "type": "string",
-              "format": "date-time",
-              "nullable": true
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "DisputeUpdateRequestStatus2": {
+        "enum": [
+          "UNKNOWN",
+          "ACCEPTED",
+          "PENDING",
+          "REJECTED"
+        ],
+        "type": "string"
+      },
+      "DisputeUpdateRequestUpdateType": {
+        "enum": [
+          "UNKNOWN",
+          "DISPUTANT_ADDRESS",
+          "DISPUTANT_PHONE",
+          "DISPUTANT_NAME",
+          "COUNT",
+          "DISPUTANT_EMAIL",
+          "DISPUTANT_DOCUMENT",
+          "COURT_OPTIONS"
+        ],
+        "type": "string"
+      },
+      "DisputeWithUpdates": {
+        "type": "object",
+        "properties": {
+          "disputeId": {
+            "type": "integer",
+            "description": "ID",
+            "format": "int64"
+          },
+          "ticketNumber": {
+            "type": "string",
+            "description": "Ticket Number",
+            "nullable": true
+          },
+          "submittedTs": {
+            "type": "string",
+            "description": "Timestamp that disputant submitted the notice of dispute",
+            "format": "date-time",
+            "nullable": true
+          },
+          "disputantSurname": {
+            "type": "string",
+            "description": "Disputant Surname",
+            "nullable": true
+          },
+          "disputantGivenName1": {
+            "type": "string",
+            "description": "Disputant Given Name 1",
+            "nullable": true
+          },
+          "disputantGivenName2": {
+            "type": "string",
+            "description": "Disputant Given Name 2",
+            "nullable": true
+          },
+          "disputantGivenName3": {
+            "type": "string",
+            "description": "Disputant Given Name 3",
+            "nullable": true
+          },
+          "status": {
+            "$ref": "#/components/schemas/DisputeStatus"
+          },
+          "userAssignedTo": {
+            "type": "string",
+            "description": "VTC Staff assigned to dispute",
+            "nullable": true
+          },
+          "userAssignedTs": {
+            "type": "string",
+            "description": "Timestamp that VTC Staff was assigned to dispute",
+            "format": "date-time",
+            "nullable": true
+          },
+          "adjournmentDocument": {
+            "type": "boolean",
+            "description": "Whether or Not there is a pending request for an adjournment from the Disputant",
+            "nullable": true
+          },
+          "changeOfPlea": {
+            "type": "boolean",
+            "description": "Whether or not there is a pending request for a change of Plea from the Disputant",
+            "nullable": true
+          },
+          "hearingDate": {
+            "type": "string",
+            "description": "Date of next upcoming hearing (if there is one)",
+            "format": "date-time",
+            "nullable": true
+          },
+          "emailAddress": {
+            "type": "string",
+            "description": "Email address",
+            "nullable": true
+          },
+          "emailAddressVerified": {
+            "type": "boolean",
+            "description": "Email address verified",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "Represents a violation ticket notice of dispute."
+      },
+      "DocumentSource": {
+        "enum": [
+          "Citizen",
+          "Staff"
+        ],
+        "type": "string"
+      },
+      "DocumentType": {
+        "enum": [
+          "UNKNOWN",
+          "NOTICE_OF_DISPUTE",
+          "TICKET_IMAGE"
+        ],
+        "type": "string"
+      },
+      "EmailHistory": {
+        "type": "object",
+        "properties": {
+          "createdBy": {
+            "type": "string",
+            "nullable": true
+          },
+          "createdTs": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "modifiedBy": {
+            "type": "string",
+            "nullable": true
+          },
+          "modifiedTs": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "emailHistoryId": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "emailSentTs": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "fromEmailAddress": {
+            "maxLength": 100,
+            "minLength": 0,
+            "type": "string",
+            "nullable": true
+          },
+          "toEmailAddress": {
+            "maxLength": 4000,
+            "minLength": 0,
+            "type": "string",
+            "nullable": true
+          },
+          "ccEmailAddress": {
+            "maxLength": 4000,
+            "minLength": 0,
+            "type": "string",
+            "nullable": true
+          },
+          "bccEmailAddress": {
+            "maxLength": 4000,
+            "minLength": 0,
+            "type": "string",
+            "nullable": true
+          },
+          "subject": {
+            "maxLength": 1000,
+            "minLength": 0,
+            "type": "string",
+            "nullable": true
+          },
+          "htmlContent": {
+            "maxLength": 4000,
+            "minLength": 0,
+            "type": "string",
+            "nullable": true
+          },
+          "plainTextContent": {
+            "maxLength": 4000,
+            "minLength": 0,
+            "type": "string",
+            "nullable": true
+          },
+          "successfullySent": {
+            "$ref": "#/components/schemas/EmailHistorySuccessfullySent"
+          },
+          "occamDisputeId": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "additionalProperties": {
+            "type": "object",
+            "additionalProperties": {
+
             },
-            "disputeUpdateRequestId": {
-              "type": "integer",
-              "format": "int64"
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "EmailHistorySuccessfullySent": {
+        "enum": [
+          "UNKNOWN",
+          "Y",
+          "N"
+        ],
+        "type": "string"
+      },
+      "ExcludeStatus": {
+        "enum": [
+          "UNKNOWN",
+          "NEW",
+          "VALIDATED",
+          "PROCESSING",
+          "REJECTED",
+          "CANCELLED",
+          "CONCLUDED"
+        ],
+        "type": "string"
+      },
+      "FederatedIdentityRepresentation": {
+        "type": "object",
+        "properties": {
+          "identityProvider": {
+            "type": "string",
+            "nullable": true
+          },
+          "userId": {
+            "type": "string",
+            "nullable": true
+          },
+          "userName": {
+            "type": "string",
+            "nullable": true
+          },
+          "additionalProperties": {
+            "type": "object",
+            "additionalProperties": {
+
             },
-            "disputeId": {
-              "type": "integer",
-              "format": "int64"
-            },
-            "status": {
-              "$ref": "#/components/schemas/DisputeUpdateRequestStatus2"
-            },
-            "updateType": {
-              "$ref": "#/components/schemas/DisputeUpdateRequestUpdateType"
-            },
-            "updateJson": {
-              "maxLength": 4000,
-              "minLength": 3,
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "Field": {
+        "type": "object",
+        "properties": {
+          "value": {
+            "type": "string",
+            "nullable": true
+          },
+          "fieldConfidence": {
+            "type": "number",
+            "format": "float",
+            "nullable": true
+          },
+          "validationErrors": {
+            "type": "array",
+            "items": {
               "type": "string"
             },
-            "currentJson": {
-              "maxLength": 4000,
-              "minLength": 0,
-              "type": "string",
-              "nullable": true
-            },
-            "statusUpdateTs": {
-              "type": "string",
-              "format": "date-time",
-              "nullable": true
-            },
-            "additionalProperties": {
-              "type": "object",
-              "additionalProperties": { },
-              "nullable": true
-            }
+            "nullable": true
           },
-          "additionalProperties": false
-        },
-        "DisputeUpdateRequestStatus2": {
-          "enum": [
-            "UNKNOWN",
-            "ACCEPTED",
-            "PENDING",
-            "REJECTED"
-          ],
-          "type": "string"
-        },
-        "DisputeUpdateRequestUpdateType": {
-          "enum": [
-            "UNKNOWN",
-            "DISPUTANT_ADDRESS",
-            "DISPUTANT_PHONE",
-            "DISPUTANT_NAME",
-            "COUNT",
-            "DISPUTANT_EMAIL",
-            "DISPUTANT_DOCUMENT",
-            "COURT_OPTIONS"
-          ],
-          "type": "string"
-        },
-        "DisputeWithUpdates": {
-          "type": "object",
-          "properties": {
-            "disputeId": {
-              "type": "integer",
-              "description": "ID",
-              "format": "int64"
-            },
-            "ticketNumber": {
-              "type": "string",
-              "description": "Ticket Number",
-              "nullable": true
-            },
-            "submittedTs": {
-              "type": "string",
-              "description": "Timestamp that disputant submitted the notice of dispute",
-              "format": "date-time",
-              "nullable": true
-            },
-            "disputantSurname": {
-              "type": "string",
-              "description": "Disputant Surname",
-              "nullable": true
-            },
-            "disputantGivenName1": {
-              "type": "string",
-              "description": "Disputant Given Name 1",
-              "nullable": true
-            },
-            "disputantGivenName2": {
-              "type": "string",
-              "description": "Disputant Given Name 2",
-              "nullable": true
-            },
-            "disputantGivenName3": {
-              "type": "string",
-              "description": "Disputant Given Name 3",
-              "nullable": true
-            },
-            "status": {
-              "$ref": "#/components/schemas/DisputeStatus"
-            },
-            "userAssignedTo": {
-              "type": "string",
-              "description": "VTC Staff assigned to dispute",
-              "nullable": true
-            },
-            "userAssignedTs": {
-              "type": "string",
-              "description": "Timestamp that VTC Staff was assigned to dispute",
-              "format": "date-time",
-              "nullable": true
-            },
-            "adjournmentDocument": {
-              "type": "boolean",
-              "description": "Whether or Not there is a pending request for an adjournment from the Disputant",
-              "nullable": true
-            },
-            "changeOfPlea": {
-              "type": "boolean",
-              "description": "Whether or not there is a pending request for a change of Plea from the Disputant",
-              "nullable": true
-            },
-            "hearingDate": {
-              "type": "string",
-              "description": "Date of next upcoming hearing (if there is one)",
-              "format": "date-time",
-              "nullable": true
-            },
-            "emailAddress": {
-              "type": "string",
-              "description": "Email address",
-              "nullable": true
-            },
-            "emailAddressVerified": {
-              "type": "boolean",
-              "description": "Email address verified",
-              "nullable": true
-            }
+          "type": {
+            "type": "string",
+            "nullable": true
           },
-          "additionalProperties": false,
-          "description": "Represents a violation ticket notice of dispute."
-        },
-        "DocumentSource": {
-          "enum": [
-            "Citizen",
-            "Staff"
-          ],
-          "type": "string"
-        },
-        "DocumentType": {
-          "enum": [
-            "UNKNOWN",
-            "NOTICE_OF_DISPUTE",
-            "TICKET_IMAGE"
-          ],
-          "type": "string"
-        },
-        "EmailHistory": {
-          "type": "object",
-          "properties": {
-            "createdBy": {
-              "type": "string",
-              "nullable": true
-            },
-            "createdTs": {
-              "type": "string",
-              "format": "date-time"
-            },
-            "modifiedBy": {
-              "type": "string",
-              "nullable": true
-            },
-            "modifiedTs": {
-              "type": "string",
-              "format": "date-time",
-              "nullable": true
-            },
-            "emailHistoryId": {
-              "type": "integer",
-              "format": "int64"
-            },
-            "emailSentTs": {
-              "type": "string",
-              "format": "date-time"
-            },
-            "fromEmailAddress": {
-              "maxLength": 100,
-              "minLength": 0,
-              "type": "string",
-              "nullable": true
-            },
-            "toEmailAddress": {
-              "maxLength": 4000,
-              "minLength": 0,
-              "type": "string",
-              "nullable": true
-            },
-            "ccEmailAddress": {
-              "maxLength": 4000,
-              "minLength": 0,
-              "type": "string",
-              "nullable": true
-            },
-            "bccEmailAddress": {
-              "maxLength": 4000,
-              "minLength": 0,
-              "type": "string",
-              "nullable": true
-            },
-            "subject": {
-              "maxLength": 1000,
-              "minLength": 0,
-              "type": "string",
-              "nullable": true
-            },
-            "htmlContent": {
-              "maxLength": 4000,
-              "minLength": 0,
-              "type": "string",
-              "nullable": true
-            },
-            "plainTextContent": {
-              "maxLength": 4000,
-              "minLength": 0,
-              "type": "string",
-              "nullable": true
-            },
-            "successfullySent": {
-              "$ref": "#/components/schemas/EmailHistorySuccessfullySent"
-            },
-            "occamDisputeId": {
-              "type": "integer",
-              "format": "int64"
-            },
-            "additionalProperties": {
-              "type": "object",
-              "additionalProperties": { },
-              "nullable": true
-            }
-          },
-          "additionalProperties": false
-        },
-        "EmailHistorySuccessfullySent": {
-          "enum": [
-            "UNKNOWN",
-            "Y",
-            "N"
-          ],
-          "type": "string"
-        },
-        "ExcludeStatus": {
-          "enum": [
-            "UNKNOWN",
-            "NEW",
-            "VALIDATED",
-            "PROCESSING",
-            "REJECTED",
-            "CANCELLED",
-            "CONCLUDED"
-          ],
-          "type": "string"
-        },
-        "FederatedIdentityRepresentation": {
-          "type": "object",
-          "properties": {
-            "identityProvider": {
-              "type": "string",
-              "nullable": true
-            },
-            "userId": {
-              "type": "string",
-              "nullable": true
-            },
-            "userName": {
-              "type": "string",
-              "nullable": true
-            },
-            "additionalProperties": {
-              "type": "object",
-              "additionalProperties": { },
-              "nullable": true
-            }
-          },
-          "additionalProperties": false
-        },
-        "Field": {
-          "type": "object",
-          "properties": {
-            "value": {
-              "type": "string",
-              "nullable": true
-            },
-            "fieldConfidence": {
-              "type": "number",
-              "format": "float",
-              "nullable": true
-            },
-            "validationErrors": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              },
-              "nullable": true
-            },
-            "type": {
-              "type": "string",
-              "nullable": true
-            },
-            "boundingBoxes": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/BoundingBox"
-              },
-              "nullable": true
-            }
-          },
-          "additionalProperties": false
-        },
-        "FileHistory": {
-          "required": [
-            "auditLogEntryType"
-          ],
-          "type": "object",
-          "properties": {
-            "createdBy": {
-              "type": "string",
-              "nullable": true
-            },
-            "createdTs": {
-              "type": "string",
-              "format": "date-time"
-            },
-            "modifiedBy": {
-              "type": "string",
-              "nullable": true
-            },
-            "modifiedTs": {
-              "type": "string",
-              "format": "date-time",
-              "nullable": true
-            },
-            "fileHistoryId": {
-              "type": "integer",
-              "format": "int64"
-            },
-            "disputeId": {
-              "type": "integer",
-              "format": "int64"
-            },
-            "auditLogEntryType": {
-              "$ref": "#/components/schemas/FileHistoryAuditLogEntryType"
-            },
-            "description": {
-              "type": "string",
-              "nullable": true
-            },
-            "comment": {
-              "type": "string",
-              "nullable": true
-            },
-            "actionByApplicationUser": {
-              "type": "string",
-              "nullable": true
-            },
-            "additionalProperties": {
-              "type": "object",
-              "additionalProperties": { },
-              "nullable": true
-            }
-          },
-          "additionalProperties": false
-        },
-        "FileHistoryAuditLogEntryType": {
-          "enum": [
-            "UNKNOWN",
-            "ARFL",
-            "CAIN",
-            "CAWT",
-            "CCAN",
-            "CCON",
-            "CCWR",
-            "CLEG",
-            "CUEM",
-            "CUEV",
-            "CUIN",
-            "CULG",
-            "CUPD",
-            "CUWR",
-            "CUWT",
-            "DURA",
-            "DURR",
-            "EMCA",
-            "EMCF",
-            "EMCR",
-            "EMDC",
-            "EMFD",
-            "EMPR",
-            "EMRJ",
-            "EMRV",
-            "EMST",
-            "EMUP",
-            "EMVF",
-            "ESUR",
-            "FDLD",
-            "FDLS",
-            "FUPD",
-            "FUPS",
-            "FRMK",
-            "INIT",
-            "JASG",
-            "JCNF",
-            "JDIV",
-            "JPRG",
-            "OCNT",
-            "RCLD",
-            "RECN",
-            "SADM",
-            "SCAN",
-            "SPRC",
-            "SREJ",
-            "SUB",
-            "SUPL",
-            "SVAL",
-            "URSR",
-            "VREV",
-            "VSUB"
-          ],
-          "type": "string"
-        },
-        "FileMetadata": {
-          "type": "object",
-          "properties": {
-            "fileId": {
-              "type": "string",
-              "format": "uuid",
-              "nullable": true
-            },
-            "fileName": {
-              "type": "string",
-              "nullable": true
-            },
-            "noticeOfDisputeGuid": {
-              "type": "string",
-              "nullable": true
-            },
-            "documentSource": {
-              "$ref": "#/components/schemas/DocumentSource"
-            },
-            "documentType": {
-              "type": "string",
-              "nullable": true
-            },
-            "virusScanStatus": {
-              "type": "string",
-              "nullable": true
-            },
-            "documentStatus": {
-              "type": "string",
-              "nullable": true
-            },
-            "ticketNumber": {
-              "type": "string",
-              "nullable": true
-            },
-            "disputeId": {
-              "type": "integer",
-              "format": "int64",
-              "nullable": true
-            },
-            "pendingFileStream": {
-              "type": "string",
-              "nullable": true
-            },
-            "deleteRequested": {
-              "type": "boolean",
-              "nullable": true
-            }
-          },
-          "additionalProperties": false
-        },
-        "GetDisputeCountResponse": {
-          "type": "object",
-          "properties": {
-            "status": {
-              "$ref": "#/components/schemas/DisputeStatus"
-            },
-            "count": {
-              "type": "integer",
-              "format": "int32"
-            }
-          },
-          "additionalProperties": false
-        },
-        "JJDispute": {
-          "type": "object",
-          "properties": {
-            "fileData": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/FileMetadata"
-              },
-              "nullable": true
-            },
-            "lockId": {
-              "type": "string",
-              "nullable": true
-            },
-            "lockedBy": {
-              "type": "string",
-              "nullable": true
-            },
-            "lockExpiresAtUtc": {
-              "type": "string",
-              "format": "date-time",
-              "nullable": true
-            },
-            "createdBy": {
-              "type": "string",
-              "nullable": true
-            },
-            "createdTs": {
-              "type": "string",
-              "format": "date-time"
-            },
-            "modifiedBy": {
-              "type": "string",
-              "nullable": true
-            },
-            "modifiedTs": {
-              "type": "string",
-              "format": "date-time",
-              "nullable": true
-            },
-            "id": {
-              "type": "integer",
-              "format": "int64"
-            },
-            "ticketNumber": {
-              "type": "string",
-              "nullable": true
-            },
-            "accidentYn": {
-              "$ref": "#/components/schemas/JJDisputeAccidentYn"
-            },
-            "addressLine1": {
-              "type": "string",
-              "nullable": true
-            },
-            "addressLine2": {
-              "type": "string",
-              "nullable": true
-            },
-            "addressLine3": {
-              "type": "string",
-              "nullable": true
-            },
-            "addressCity": {
-              "type": "string",
-              "nullable": true
-            },
-            "addressProvince": {
-              "type": "string",
-              "nullable": true
-            },
-            "addressCountry": {
-              "type": "string",
-              "nullable": true
-            },
-            "addressPostalCode": {
-              "type": "string",
-              "nullable": true
-            },
-            "disputantBirthdate": {
-              "type": "string",
-              "format": "date-time",
-              "nullable": true
-            },
-            "driversLicenceNumber": {
-              "type": "string",
-              "nullable": true
-            },
-            "drvLicIssuedProvSeqNo": {
-              "type": "string",
-              "nullable": true
-            },
-            "drvLicIssuedCtryId": {
-              "type": "string",
-              "nullable": true
-            },
-            "emailAddress": {
-              "type": "string",
-              "nullable": true
-            },
-            "status": {
-              "$ref": "#/components/schemas/JJDisputeStatus"
-            },
-            "hearingType": {
-              "$ref": "#/components/schemas/JJDisputeHearingType"
-            },
-            "multipleOfficersYn": {
-              "$ref": "#/components/schemas/JJDisputeMultipleOfficersYn"
-            },
-            "noticeOfDisputeGuid": {
-              "type": "string",
-              "nullable": true
-            },
-            "noticeOfHearingYn": {
-              "$ref": "#/components/schemas/JJDisputeNoticeOfHearingYn"
-            },
-            "occamDisputantGiven1Nm": {
-              "type": "string",
-              "nullable": true
-            },
-            "occamDisputantGiven2Nm": {
-              "type": "string",
-              "nullable": true
-            },
-            "occamDisputantGiven3Nm": {
-              "type": "string",
-              "nullable": true
-            },
-            "occamDisputantSurnameNm": {
-              "type": "string",
-              "nullable": true
-            },
-            "occamDisputeId": {
-              "type": "integer",
-              "format": "int64"
-            },
-            "occamViolationTicketUpldId": {
-              "type": "string",
-              "nullable": true
-            },
-            "submittedTs": {
-              "type": "string",
-              "format": "date-time",
-              "nullable": true
-            },
-            "issuedTs": {
-              "type": "string",
-              "format": "date-time",
-              "nullable": true
-            },
-            "violationDate": {
-              "type": "string",
-              "format": "date-time",
-              "nullable": true
-            },
-            "icbcReceivedDate": {
-              "type": "string",
-              "format": "date-time",
-              "nullable": true
-            },
-            "enforcementOfficer": {
-              "type": "string",
-              "nullable": true
-            },
-            "electronicTicketYn": {
-              "$ref": "#/components/schemas/JJDisputeElectronicTicketYn"
-            },
-            "policeDetachment": {
-              "type": "string",
-              "nullable": true
-            },
-            "courthouseLocation": {
-              "type": "string",
-              "nullable": true
-            },
-            "offenceLocation": {
-              "type": "string",
-              "nullable": true
-            },
-            "jjAssignedTo": {
-              "type": "string",
-              "nullable": true
-            },
-            "jjDecisionDate": {
-              "type": "string",
-              "format": "date-time",
-              "nullable": true
-            },
-            "vtcAssignedTo": {
-              "type": "string",
-              "nullable": true
-            },
-            "vtcAssignedTs": {
-              "type": "string",
-              "format": "date-time",
-              "nullable": true
-            },
-            "fineReductionReason": {
-              "type": "string",
-              "nullable": true
-            },
-            "timeToPayReason": {
-              "type": "string",
-              "nullable": true
-            },
-            "contactLawFirmName": {
-              "type": "string",
-              "nullable": true
-            },
-            "contactGivenName1": {
-              "type": "string",
-              "nullable": true
-            },
-            "contactGivenName2": {
-              "type": "string",
-              "nullable": true
-            },
-            "contactGivenName3": {
-              "type": "string",
-              "nullable": true
-            },
-            "contactSurname": {
-              "type": "string",
-              "nullable": true
-            },
-            "contactType": {
-              "$ref": "#/components/schemas/JJDisputeContactType"
-            },
-            "appearInCourt": {
-              "$ref": "#/components/schemas/JJDisputeAppearInCourt"
-            },
-            "courtAgenId": {
-              "type": "string",
-              "nullable": true
-            },
-            "recalled": {
-              "type": "boolean",
-              "nullable": true
-            },
-            "lawFirmName": {
-              "type": "string",
-              "nullable": true
-            },
-            "lawyerSurname": {
-              "type": "string",
-              "nullable": true
-            },
-            "lawyerGivenName1": {
-              "type": "string",
-              "nullable": true
-            },
-            "lawyerGivenName2": {
-              "type": "string",
-              "nullable": true
-            },
-            "lawyerGivenName3": {
-              "type": "string",
-              "nullable": true
-            },
-            "justinRccId": {
-              "type": "string",
-              "nullable": true
-            },
-            "interpreterLanguageCd": {
-              "type": "string",
-              "nullable": true
-            },
-            "witnessNo": {
-              "type": "integer",
-              "format": "int32",
-              "nullable": true
-            },
-            "disputantAttendanceType": {
-              "$ref": "#/components/schemas/JJDisputeDisputantAttendanceType"
-            },
-            "signatoryType": {
-              "$ref": "#/components/schemas/JJDisputeSignatoryType"
-            },
-            "signatoryName": {
-              "maxLength": 100,
-              "minLength": 0,
-              "type": "string",
-              "nullable": true
-            },
-            "remarks": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/JJDisputeRemark"
-              },
-              "nullable": true
-            },
-            "jjDisputedCounts": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/JJDisputedCount"
-              },
-              "nullable": true
-            },
-            "jjDisputeCourtAppearanceRoPs": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/JJDisputeCourtAppearanceRoP"
-              },
-              "nullable": true
-            },
-            "additionalProperties": {
-              "type": "object",
-              "additionalProperties": { },
-              "nullable": true
-            }
-          },
-          "additionalProperties": false
-        },
-        "JJDisputeAccidentYn": {
-          "enum": [
-            "UNKNOWN",
-            "Y",
-            "N"
-          ],
-          "type": "string"
-        },
-        "JJDisputeAppearInCourt": {
-          "enum": [
-            "UNKNOWN",
-            "Y",
-            "N"
-          ],
-          "type": "string"
-        },
-        "JJDisputeContactType": {
-          "enum": [
-            "UNKNOWN",
-            "INDIVIDUAL",
-            "LAWYER",
-            "OTHER"
-          ],
-          "type": "string"
-        },
-        "JJDisputeCourtAppearanceRoP": {
-          "type": "object",
-          "properties": {
-            "justinAppearanceId": {
-              "type": "string",
-              "nullable": true
-            },
-            "id": {
-              "type": "integer",
-              "format": "int64",
-              "nullable": true
-            },
-            "appearanceTs": {
-              "type": "string",
-              "format": "date-time",
-              "nullable": true
-            },
-            "room": {
-              "type": "string",
-              "nullable": true
-            },
-            "duration": {
-              "type": "integer",
-              "format": "int32",
-              "nullable": true
-            },
-            "reason": {
-              "type": "string",
-              "nullable": true
-            },
-            "appCd": {
-              "$ref": "#/components/schemas/JJDisputeCourtAppearanceRoPAppCd"
-            },
-            "noAppTs": {
-              "type": "string",
-              "format": "date-time",
-              "nullable": true
-            },
-            "clerkRecord": {
-              "type": "string",
-              "nullable": true
-            },
-            "defenceCounsel": {
-              "type": "string",
-              "nullable": true
-            },
-            "dattCd": {
-              "$ref": "#/components/schemas/JJDisputeCourtAppearanceRoPDattCd"
-            },
-            "crown": {
-              "$ref": "#/components/schemas/JJDisputeCourtAppearanceRoPCrown"
-            },
-            "jjSeized": {
-              "$ref": "#/components/schemas/JJDisputeCourtAppearanceRoPJjSeized"
-            },
-            "adjudicator": {
-              "type": "string",
-              "nullable": true
-            },
-            "comments": {
-              "maxLength": 4000,
-              "minLength": 0,
-              "type": "string",
-              "nullable": true
-            },
-            "additionalProperties": {
-              "type": "object",
-              "additionalProperties": { },
-              "nullable": true
-            }
-          },
-          "additionalProperties": false
-        },
-        "JJDisputeCourtAppearanceRoPAppCd": {
-          "enum": [
-            "UNKNOWN",
-            "A",
-            "P",
-            "N"
-          ],
-          "type": "string"
-        },
-        "JJDisputeCourtAppearanceRoPCrown": {
-          "enum": [
-            "UNKNOWN",
-            "P",
-            "N"
-          ],
-          "type": "string"
-        },
-        "JJDisputeCourtAppearanceRoPDattCd": {
-          "enum": [
-            "UNKNOWN",
-            "A",
-            "C",
-            "N"
-          ],
-          "type": "string"
-        },
-        "JJDisputeCourtAppearanceRoPJjSeized": {
-          "enum": [
-            "UNKNOWN",
-            "Y",
-            "N"
-          ],
-          "type": "string"
-        },
-        "JJDisputeDisputantAttendanceType": {
-          "enum": [
-            "UNKNOWN",
-            "WRITTEN_REASONS",
-            "VIDEO_CONFERENCE",
-            "TELEPHONE_CONFERENCE",
-            "MSTEAMS_AUDIO",
-            "MSTEAMS_VIDEO",
-            "IN_PERSON"
-          ],
-          "type": "string"
-        },
-        "JJDisputeElectronicTicketYn": {
-          "enum": [
-            "UNKNOWN",
-            "Y",
-            "N"
-          ],
-          "type": "string"
-        },
-        "JJDisputeHearingType": {
-          "enum": [
-            "UNKNOWN",
-            "COURT_APPEARANCE",
-            "WRITTEN_REASONS"
-          ],
-          "type": "string"
-        },
-        "JJDisputeMultipleOfficersYn": {
-          "enum": [
-            "UNKNOWN",
-            "Y",
-            "N"
-          ],
-          "type": "string"
-        },
-        "JJDisputeNoticeOfHearingYn": {
-          "enum": [
-            "UNKNOWN",
-            "Y",
-            "N"
-          ],
-          "type": "string"
-        },
-        "JJDisputeRemark": {
-          "type": "object",
-          "properties": {
-            "createdBy": {
-              "type": "string",
-              "nullable": true
-            },
-            "createdTs": {
-              "type": "string",
-              "format": "date-time"
-            },
-            "modifiedBy": {
-              "type": "string",
-              "nullable": true
-            },
-            "modifiedTs": {
-              "type": "string",
-              "format": "date-time",
-              "nullable": true
-            },
-            "id": {
-              "type": "integer",
-              "format": "int64"
-            },
-            "userFullName": {
-              "type": "string",
-              "nullable": true
-            },
-            "note": {
-              "maxLength": 4000,
-              "minLength": 0,
-              "type": "string",
-              "nullable": true
-            },
-            "remarksMadeTs": {
-              "type": "string",
-              "format": "date-time"
-            },
-            "additionalProperties": {
-              "type": "object",
-              "additionalProperties": { },
-              "nullable": true
-            }
-          },
-          "additionalProperties": false
-        },
-        "JJDisputeSignatoryType": {
-          "enum": [
-            "U",
-            "D",
-            "A"
-          ],
-          "type": "string"
-        },
-        "JJDisputeStatus": {
-          "enum": [
-            "UNKNOWN",
-            "NEW",
-            "IN_PROGRESS",
-            "DATA_UPDATE",
-            "CONFIRMED",
-            "REQUIRE_COURT_HEARING",
-            "REQUIRE_MORE_INFO",
-            "ACCEPTED",
-            "REVIEW",
-            "CONCLUDED",
-            "CANCELLED",
-            "HEARING_SCHEDULED"
-          ],
-          "type": "string"
-        },
-        "JJDisputedCount": {
-          "type": "object",
-          "properties": {
-            "createdBy": {
-              "type": "string",
-              "nullable": true
-            },
-            "createdTs": {
-              "type": "string",
-              "format": "date-time"
-            },
-            "modifiedBy": {
-              "type": "string",
-              "nullable": true
-            },
-            "modifiedTs": {
-              "type": "string",
-              "format": "date-time",
-              "nullable": true
-            },
-            "id": {
-              "type": "integer",
-              "format": "int64"
-            },
-            "plea": {
-              "$ref": "#/components/schemas/JJDisputedCountPlea"
-            },
-            "count": {
-              "maximum": 3,
-              "minimum": 1,
-              "type": "integer",
-              "format": "int32"
-            },
-            "requestTimeToPay": {
-              "$ref": "#/components/schemas/JJDisputedCountRequestTimeToPay"
-            },
-            "requestReduction": {
-              "$ref": "#/components/schemas/JJDisputedCountRequestReduction"
-            },
-            "appearInCourt": {
-              "$ref": "#/components/schemas/JJDisputedCountAppearInCourt"
-            },
-            "description": {
-              "type": "string",
-              "nullable": true
-            },
-            "dueDate": {
-              "type": "string",
-              "format": "date-time",
-              "nullable": true
-            },
-            "ticketedFineAmount": {
-              "type": "number",
-              "format": "float",
-              "nullable": true
-            },
-            "lesserOrGreaterAmount": {
-              "type": "number",
-              "format": "float",
-              "nullable": true
-            },
-            "includesSurcharge": {
-              "$ref": "#/components/schemas/JJDisputedCountIncludesSurcharge"
-            },
-            "revisedDueDate": {
-              "type": "string",
-              "format": "date-time",
-              "nullable": true
-            },
-            "totalFineAmount": {
-              "type": "number",
-              "format": "float",
-              "nullable": true
-            },
-            "violationDate": {
-              "type": "string",
-              "format": "date-time",
-              "nullable": true
-            },
-            "comments": {
-              "maxLength": 4000,
-              "minLength": 0,
-              "type": "string",
-              "nullable": true
-            },
-            "latestPlea": {
-              "$ref": "#/components/schemas/JJDisputedCountLatestPlea"
-            },
-            "latestPleaUpdateTs": {
-              "type": "string",
-              "format": "date-time",
-              "nullable": true
-            },
-            "jjDisputedCountRoP": {
-              "$ref": "#/components/schemas/JJDisputedCountRoP"
-            },
-            "additionalProperties": {
-              "type": "object",
-              "additionalProperties": { },
-              "nullable": true
-            }
-          },
-          "additionalProperties": false
-        },
-        "JJDisputedCountAppearInCourt": {
-          "enum": [
-            "UNKNOWN",
-            "Y",
-            "N"
-          ],
-          "type": "string"
-        },
-        "JJDisputedCountIncludesSurcharge": {
-          "enum": [
-            "UNKNOWN",
-            "Y",
-            "N"
-          ],
-          "type": "string"
-        },
-        "JJDisputedCountLatestPlea": {
-          "enum": [
-            "UNKNOWN",
-            "G",
-            "N"
-          ],
-          "type": "string"
-        },
-        "JJDisputedCountPlea": {
-          "enum": [
-            "UNKNOWN",
-            "G",
-            "N"
-          ],
-          "type": "string"
-        },
-        "JJDisputedCountRequestReduction": {
-          "enum": [
-            "UNKNOWN",
-            "Y",
-            "N"
-          ],
-          "type": "string"
-        },
-        "JJDisputedCountRequestTimeToPay": {
-          "enum": [
-            "UNKNOWN",
-            "Y",
-            "N"
-          ],
-          "type": "string"
-        },
-        "JJDisputedCountRoP": {
-          "type": "object",
-          "properties": {
-            "createdBy": {
-              "type": "string",
-              "nullable": true
-            },
-            "createdTs": {
-              "type": "string",
-              "format": "date-time"
-            },
-            "modifiedBy": {
-              "type": "string",
-              "nullable": true
-            },
-            "modifiedTs": {
-              "type": "string",
-              "format": "date-time",
-              "nullable": true
-            },
-            "id": {
-              "type": "integer",
-              "format": "int64"
-            },
-            "finding": {
-              "$ref": "#/components/schemas/JJDisputedCountRoPFinding"
-            },
-            "lesserDescription": {
-              "type": "string",
-              "nullable": true
-            },
-            "ssProbationDuration": {
-              "type": "string",
-              "nullable": true
-            },
-            "ssProbationConditions": {
-              "type": "string",
-              "nullable": true
-            },
-            "jailDuration": {
-              "type": "string",
-              "nullable": true
-            },
-            "jailIntermittent": {
-              "$ref": "#/components/schemas/JJDisputedCountRoPJailIntermittent"
-            },
-            "probationDuration": {
-              "type": "string",
-              "nullable": true
-            },
-            "probationConditions": {
-              "type": "string",
-              "nullable": true
-            },
-            "drivingProhibition": {
-              "type": "string",
-              "nullable": true
-            },
-            "drivingProhibitionMVASection": {
-              "type": "string",
-              "nullable": true
-            },
-            "dismissed": {
-              "$ref": "#/components/schemas/JJDisputedCountRoPDismissed"
-            },
-            "forWantOfProsecution": {
-              "$ref": "#/components/schemas/JJDisputedCountRoPForWantOfProsecution"
-            },
-            "withdrawn": {
-              "$ref": "#/components/schemas/JJDisputedCountRoPWithdrawn"
-            },
-            "abatement": {
-              "$ref": "#/components/schemas/JJDisputedCountRoPAbatement"
-            },
-            "stayOfProceedingsBy": {
-              "type": "string",
-              "nullable": true
-            },
-            "other": {
-              "type": "string",
-              "nullable": true
-            },
-            "additionalProperties": {
-              "type": "object",
-              "additionalProperties": { },
-              "nullable": true
-            }
-          },
-          "additionalProperties": false
-        },
-        "JJDisputedCountRoPAbatement": {
-          "enum": [
-            "UNKNOWN",
-            "Y",
-            "N"
-          ],
-          "type": "string"
-        },
-        "JJDisputedCountRoPDismissed": {
-          "enum": [
-            "UNKNOWN",
-            "Y",
-            "N"
-          ],
-          "type": "string"
-        },
-        "JJDisputedCountRoPFinding": {
-          "enum": [
-            "UNKNOWN",
-            "GUILTY",
-            "NOT_GUILTY",
-            "CANCELLED",
-            "PAID_PRIOR_TO_APPEARANCE",
-            "GUILTY_LESSER"
-          ],
-          "type": "string"
-        },
-        "JJDisputedCountRoPForWantOfProsecution": {
-          "enum": [
-            "UNKNOWN",
-            "Y",
-            "N"
-          ],
-          "type": "string"
-        },
-        "JJDisputedCountRoPJailIntermittent": {
-          "enum": [
-            "UNKNOWN",
-            "Y",
-            "N"
-          ],
-          "type": "string"
-        },
-        "JJDisputedCountRoPWithdrawn": {
-          "enum": [
-            "UNKNOWN",
-            "Y",
-            "N"
-          ],
-          "type": "string"
-        },
-        "Language": {
-          "type": "object",
-          "properties": {
-            "code": {
-              "type": "string",
-              "nullable": true
-            },
-            "description": {
-              "type": "string",
-              "nullable": true
-            }
-          },
-          "additionalProperties": false
-        },
-        "Lock": {
-          "type": "object",
-          "properties": {
-            "lockId": {
-              "type": "string",
-              "description": "Lock ID",
-              "nullable": true
-            },
-            "ticketNumber": {
-              "type": "string",
-              "description": "The ticket number associated with the dispute.",
-              "nullable": true
-            },
-            "username": {
-              "type": "string",
-              "description": "Username of the person who acquired the lock.",
-              "nullable": true
-            },
-            "expiryTimeUtc": {
-              "type": "string",
-              "description": "The time in UTC when the acquired lock expires.",
-              "format": "date-time"
-            },
-            "createdAtUtc": {
-              "type": "string",
-              "description": "The time in UTC when the lock was created.",
-              "format": "date-time"
-            }
-          },
-          "additionalProperties": false
-        },
-        "OcrViolationTicket": {
-          "type": "object",
-          "properties": {
-            "ticketVersion": {
-              "$ref": "#/components/schemas/ViolationTicketVersion"
-            },
-            "imageFilename": {
-              "type": "string",
-              "nullable": true
-            },
-            "globalConfidence": {
-              "type": "number",
-              "format": "float"
-            },
-            "fields": {
-              "type": "object",
-              "additionalProperties": {
-                "$ref": "#/components/schemas/Field"
-              },
-              "nullable": true
-            }
-          },
-          "additionalProperties": false
-        },
-        "PagedDisputeListItemCollection": {
-          "type": "object",
-          "properties": {
+          "boundingBoxes": {
+            "type": "array",
             "items": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/DisputeListItem"
-              },
-              "nullable": true
+              "$ref": "#/components/schemas/BoundingBox"
             },
-            "pageNumber": {
-              "type": "integer",
-              "format": "int32",
-              "readOnly": true
-            },
-            "pageSize": {
-              "type": "integer",
-              "format": "int32",
-              "readOnly": true
-            },
-            "pageCount": {
-              "type": "integer",
-              "format": "int32",
-              "readOnly": true
-            },
-            "totalItemCount": {
-              "type": "integer",
-              "format": "int32",
-              "readOnly": true
-            },
-            "hasPreviousPage": {
-              "type": "boolean",
-              "readOnly": true
-            },
-            "hasNextPage": {
-              "type": "boolean",
-              "readOnly": true
-            },
-            "isFirstPage": {
-              "type": "boolean",
-              "readOnly": true
-            },
-            "isLastPage": {
-              "type": "boolean",
-              "readOnly": true
-            }
-          },
-          "additionalProperties": false
+            "nullable": true
+          }
         },
-        "Point": {
-          "type": "object",
-          "properties": {
-            "x": {
-              "type": "number",
-              "format": "float"
-            },
-            "y": {
-              "type": "number",
-              "format": "float"
-            }
+        "additionalProperties": false
+      },
+      "FileHistory": {
+        "required": [
+          "auditLogEntryType"
+        ],
+        "type": "object",
+        "properties": {
+          "createdBy": {
+            "type": "string",
+            "nullable": true
           },
-          "additionalProperties": false
-        },
-        "ProblemDetails": {
-          "type": "object",
-          "properties": {
-            "type": {
-              "type": "string",
-              "nullable": true
-            },
-            "title": {
-              "type": "string",
-              "nullable": true
-            },
-            "status": {
-              "type": "integer",
-              "format": "int32",
-              "nullable": true
-            },
-            "detail": {
-              "type": "string",
-              "nullable": true
-            },
-            "instance": {
-              "type": "string",
-              "nullable": true
-            }
+          "createdTs": {
+            "type": "string",
+            "format": "date-time"
           },
-          "additionalProperties": { }
-        },
-        "Province": {
-          "type": "object",
-          "properties": {
-            "ctryId": {
-              "type": "string",
-              "nullable": true
-            },
-            "provSeqNo": {
-              "type": "string",
-              "nullable": true
-            },
-            "provNm": {
-              "type": "string",
-              "nullable": true
-            },
-            "provAbbreviationCd": {
-              "type": "string",
-              "nullable": true
-            }
+          "modifiedBy": {
+            "type": "string",
+            "nullable": true
           },
-          "additionalProperties": false
-        },
-        "SocialLinkRepresentation": {
-          "type": "object",
-          "properties": {
-            "socialProvider": {
-              "type": "string",
-              "nullable": true
-            },
-            "socialUserId": {
-              "type": "string",
-              "nullable": true
-            },
-            "socialUsername": {
-              "type": "string",
-              "nullable": true
-            },
+          "modifiedTs": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "fileHistoryId": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "disputeId": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "auditLogEntryType": {
+            "$ref": "#/components/schemas/FileHistoryAuditLogEntryType"
+          },
+          "description": {
+            "type": "string",
+            "nullable": true
+          },
+          "comment": {
+            "type": "string",
+            "nullable": true
+          },
+          "actionByApplicationUser": {
+            "type": "string",
+            "nullable": true
+          },
+          "additionalProperties": {
+            "type": "object",
             "additionalProperties": {
-              "type": "object",
-              "additionalProperties": { },
-              "nullable": true
-            }
+
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "FileHistoryAuditLogEntryType": {
+        "enum": [
+          "UNKNOWN",
+          "ARFL",
+          "CAIN",
+          "CAWT",
+          "CCAN",
+          "CCON",
+          "CCWR",
+          "CLEG",
+          "CUEM",
+          "CUEV",
+          "CUIN",
+          "CULG",
+          "CUPD",
+          "CUWR",
+          "CUWT",
+          "DURA",
+          "DURR",
+          "EMCA",
+          "EMCF",
+          "EMCR",
+          "EMDC",
+          "EMFD",
+          "EMPR",
+          "EMRJ",
+          "EMRV",
+          "EMST",
+          "EMUP",
+          "EMVF",
+          "ESUR",
+          "FDLD",
+          "FDLS",
+          "FUPD",
+          "FUPS",
+          "FRMK",
+          "INIT",
+          "JASG",
+          "JCNF",
+          "JDIV",
+          "JPRG",
+          "OCNT",
+          "RCLD",
+          "RECN",
+          "SADM",
+          "SCAN",
+          "SPRC",
+          "SREJ",
+          "SUB",
+          "SUPL",
+          "SVAL",
+          "URSR",
+          "VREV",
+          "VSUB"
+        ],
+        "type": "string"
+      },
+      "FileMetadata": {
+        "type": "object",
+        "properties": {
+          "fileId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
           },
-          "additionalProperties": false
-        },
-        "SortDirection": {
-          "enum": [
-            "asc",
-            "desc"
-          ],
-          "type": "string"
-        },
-        "Statute": {
-          "type": "object",
-          "properties": {
-            "id": {
-              "type": "string",
-              "nullable": true
-            },
-            "actCode": {
-              "type": "string",
-              "nullable": true
-            },
-            "sectionText": {
-              "type": "string",
-              "nullable": true
-            },
-            "subsectionText": {
-              "type": "string",
-              "nullable": true
-            },
-            "paragraphText": {
-              "type": "string",
-              "nullable": true
-            },
-            "subparagraphText": {
-              "type": "string",
-              "nullable": true
-            },
-            "code": {
-              "type": "string",
-              "nullable": true
-            },
-            "shortDescriptionText": {
-              "type": "string",
-              "nullable": true
-            },
-            "descriptionText": {
-              "type": "string",
-              "nullable": true
-            }
+          "fileName": {
+            "type": "string",
+            "nullable": true
           },
-          "additionalProperties": false
+          "noticeOfDisputeGuid": {
+            "type": "string",
+            "nullable": true
+          },
+          "documentSource": {
+            "$ref": "#/components/schemas/DocumentSource"
+          },
+          "documentType": {
+            "type": "string",
+            "nullable": true
+          },
+          "virusScanStatus": {
+            "type": "string",
+            "nullable": true
+          },
+          "documentStatus": {
+            "type": "string",
+            "nullable": true
+          },
+          "ticketNumber": {
+            "type": "string",
+            "nullable": true
+          },
+          "disputeId": {
+            "type": "integer",
+            "format": "int64",
+            "nullable": true
+          },
+          "pendingFileStream": {
+            "type": "string",
+            "nullable": true
+          },
+          "deleteRequested": {
+            "type": "boolean",
+            "nullable": true
+          }
         },
-        "TicketImageDataJustinDocument": {
-          "type": "object",
-          "properties": {
-            "reportType": {
-              "$ref": "#/components/schemas/TicketImageDataJustinDocumentReportType"
+        "additionalProperties": false
+      },
+      "GetDisputeCountResponse": {
+        "type": "object",
+        "properties": {
+          "status": {
+            "$ref": "#/components/schemas/DisputeStatus"
+          },
+          "count": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "additionalProperties": false
+      },
+      "JJDispute": {
+        "type": "object",
+        "properties": {
+          "fileData": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FileMetadata"
             },
-            "reportFormat": {
-              "type": "string",
-              "nullable": true
+            "nullable": true
+          },
+          "lockId": {
+            "type": "string",
+            "nullable": true
+          },
+          "lockedBy": {
+            "type": "string",
+            "nullable": true
+          },
+          "lockExpiresAtUtc": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "createdBy": {
+            "type": "string",
+            "nullable": true
+          },
+          "createdTs": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "modifiedBy": {
+            "type": "string",
+            "nullable": true
+          },
+          "modifiedTs": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "ticketNumber": {
+            "type": "string",
+            "nullable": true
+          },
+          "accidentYn": {
+            "$ref": "#/components/schemas/JJDisputeAccidentYn"
+          },
+          "addressLine1": {
+            "type": "string",
+            "nullable": true
+          },
+          "addressLine2": {
+            "type": "string",
+            "nullable": true
+          },
+          "addressLine3": {
+            "type": "string",
+            "nullable": true
+          },
+          "addressCity": {
+            "type": "string",
+            "nullable": true
+          },
+          "addressProvince": {
+            "type": "string",
+            "nullable": true
+          },
+          "addressCountry": {
+            "type": "string",
+            "nullable": true
+          },
+          "addressPostalCode": {
+            "type": "string",
+            "nullable": true
+          },
+          "disputantBirthdate": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "driversLicenceNumber": {
+            "type": "string",
+            "nullable": true
+          },
+          "drvLicIssuedProvSeqNo": {
+            "type": "string",
+            "nullable": true
+          },
+          "drvLicIssuedCtryId": {
+            "type": "string",
+            "nullable": true
+          },
+          "emailAddress": {
+            "type": "string",
+            "nullable": true
+          },
+          "status": {
+            "$ref": "#/components/schemas/JJDisputeStatus"
+          },
+          "hearingType": {
+            "$ref": "#/components/schemas/JJDisputeHearingType"
+          },
+          "multipleOfficersYn": {
+            "$ref": "#/components/schemas/JJDisputeMultipleOfficersYn"
+          },
+          "noticeOfDisputeGuid": {
+            "type": "string",
+            "nullable": true
+          },
+          "noticeOfHearingYn": {
+            "$ref": "#/components/schemas/JJDisputeNoticeOfHearingYn"
+          },
+          "occamDisputantGiven1Nm": {
+            "type": "string",
+            "nullable": true
+          },
+          "occamDisputantGiven2Nm": {
+            "type": "string",
+            "nullable": true
+          },
+          "occamDisputantGiven3Nm": {
+            "type": "string",
+            "nullable": true
+          },
+          "occamDisputantSurnameNm": {
+            "type": "string",
+            "nullable": true
+          },
+          "occamDisputeId": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "occamViolationTicketUpldId": {
+            "type": "string",
+            "nullable": true
+          },
+          "submittedTs": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "issuedTs": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "violationDate": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "icbcReceivedDate": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "enforcementOfficer": {
+            "type": "string",
+            "nullable": true
+          },
+          "electronicTicketYn": {
+            "$ref": "#/components/schemas/JJDisputeElectronicTicketYn"
+          },
+          "policeDetachment": {
+            "type": "string",
+            "nullable": true
+          },
+          "courthouseLocation": {
+            "type": "string",
+            "nullable": true
+          },
+          "offenceLocation": {
+            "type": "string",
+            "nullable": true
+          },
+          "jjAssignedTo": {
+            "type": "string",
+            "nullable": true
+          },
+          "jjDecisionDate": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "vtcAssignedTo": {
+            "type": "string",
+            "nullable": true
+          },
+          "vtcAssignedTs": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "fineReductionReason": {
+            "type": "string",
+            "nullable": true
+          },
+          "timeToPayReason": {
+            "type": "string",
+            "nullable": true
+          },
+          "contactLawFirmName": {
+            "type": "string",
+            "nullable": true
+          },
+          "contactGivenName1": {
+            "type": "string",
+            "nullable": true
+          },
+          "contactGivenName2": {
+            "type": "string",
+            "nullable": true
+          },
+          "contactGivenName3": {
+            "type": "string",
+            "nullable": true
+          },
+          "contactSurname": {
+            "type": "string",
+            "nullable": true
+          },
+          "contactType": {
+            "$ref": "#/components/schemas/JJDisputeContactType"
+          },
+          "appearInCourt": {
+            "$ref": "#/components/schemas/JJDisputeAppearInCourt"
+          },
+          "courtAgenId": {
+            "type": "string",
+            "nullable": true
+          },
+          "recalled": {
+            "type": "boolean",
+            "nullable": true
+          },
+          "lawFirmName": {
+            "type": "string",
+            "nullable": true
+          },
+          "lawyerSurname": {
+            "type": "string",
+            "nullable": true
+          },
+          "lawyerGivenName1": {
+            "type": "string",
+            "nullable": true
+          },
+          "lawyerGivenName2": {
+            "type": "string",
+            "nullable": true
+          },
+          "lawyerGivenName3": {
+            "type": "string",
+            "nullable": true
+          },
+          "justinRccId": {
+            "type": "string",
+            "nullable": true
+          },
+          "interpreterLanguageCd": {
+            "type": "string",
+            "nullable": true
+          },
+          "witnessNo": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "disputantAttendanceType": {
+            "$ref": "#/components/schemas/JJDisputeDisputantAttendanceType"
+          },
+          "signatoryType": {
+            "$ref": "#/components/schemas/JJDisputeSignatoryType"
+          },
+          "signatoryName": {
+            "maxLength": 100,
+            "minLength": 0,
+            "type": "string",
+            "nullable": true
+          },
+          "remarks": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/JJDisputeRemark"
             },
-            "partId": {
-              "type": "string",
-              "nullable": true
+            "nullable": true
+          },
+          "jjDisputedCounts": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/JJDisputedCount"
             },
-            "participantName": {
-              "type": "string",
-              "nullable": true
+            "nullable": true
+          },
+          "jjDisputeCourtAppearanceRoPs": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/JJDisputeCourtAppearanceRoP"
             },
-            "index": {
-              "type": "string",
-              "nullable": true
-            },
-            "fileData": {
-              "type": "string",
-              "nullable": true
-            },
+            "nullable": true
+          },
+          "additionalProperties": {
+            "type": "object",
             "additionalProperties": {
-              "type": "object",
-              "additionalProperties": { },
-              "nullable": true
-            }
+
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "JJDisputeAccidentYn": {
+        "enum": [
+          "UNKNOWN",
+          "Y",
+          "N"
+        ],
+        "type": "string"
+      },
+      "JJDisputeAppearInCourt": {
+        "enum": [
+          "UNKNOWN",
+          "Y",
+          "N"
+        ],
+        "type": "string"
+      },
+      "JJDisputeContactType": {
+        "enum": [
+          "UNKNOWN",
+          "INDIVIDUAL",
+          "LAWYER",
+          "OTHER"
+        ],
+        "type": "string"
+      },
+      "JJDisputeCourtAppearanceRoP": {
+        "type": "object",
+        "properties": {
+          "justinAppearanceId": {
+            "type": "string",
+            "nullable": true
           },
-          "additionalProperties": false
-        },
-        "TicketImageDataJustinDocumentReportType": {
-          "enum": [
-            "UNKNOWN",
-            "NOTICE_OF_DISPUTE",
-            "TICKET_IMAGE"
-          ],
-          "type": "string"
-        },
-        "UserConsentRepresentation": {
-          "type": "object",
-          "properties": {
-            "clientId": {
-              "type": "string",
-              "nullable": true
-            },
-            "grantedClientScopes": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              },
-              "nullable": true
-            },
-            "createdDate": {
-              "type": "integer",
-              "format": "int64"
-            },
-            "lastUpdatedDate": {
-              "type": "integer",
-              "format": "int64"
-            },
-            "grantedRealmRoles": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              },
-              "nullable": true
-            },
+          "id": {
+            "type": "integer",
+            "format": "int64",
+            "nullable": true
+          },
+          "appearanceTs": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "room": {
+            "type": "string",
+            "nullable": true
+          },
+          "duration": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "reason": {
+            "type": "string",
+            "nullable": true
+          },
+          "appCd": {
+            "$ref": "#/components/schemas/JJDisputeCourtAppearanceRoPAppCd"
+          },
+          "noAppTs": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "clerkRecord": {
+            "type": "string",
+            "nullable": true
+          },
+          "defenceCounsel": {
+            "type": "string",
+            "nullable": true
+          },
+          "dattCd": {
+            "$ref": "#/components/schemas/JJDisputeCourtAppearanceRoPDattCd"
+          },
+          "crown": {
+            "$ref": "#/components/schemas/JJDisputeCourtAppearanceRoPCrown"
+          },
+          "jjSeized": {
+            "$ref": "#/components/schemas/JJDisputeCourtAppearanceRoPJjSeized"
+          },
+          "adjudicator": {
+            "type": "string",
+            "nullable": true
+          },
+          "comments": {
+            "maxLength": 4000,
+            "minLength": 0,
+            "type": "string",
+            "nullable": true
+          },
+          "additionalProperties": {
+            "type": "object",
             "additionalProperties": {
-              "type": "object",
-              "additionalProperties": { },
-              "nullable": true
-            }
-          },
-          "additionalProperties": false
+
+            },
+            "nullable": true
+          }
         },
-        "UserRepresentation": {
-          "type": "object",
-          "properties": {
-            "self": {
-              "type": "string",
-              "nullable": true
-            },
-            "id": {
-              "type": "string",
-              "nullable": true
-            },
-            "createdTimestamp": {
-              "type": "integer",
-              "format": "int64"
-            },
-            "firstName": {
-              "type": "string",
-              "nullable": true
-            },
-            "lastName": {
-              "type": "string",
-              "nullable": true
-            },
-            "email": {
-              "type": "string",
-              "nullable": true
-            },
-            "username": {
-              "type": "string",
-              "nullable": true
-            },
-            "enabled": {
-              "type": "boolean"
-            },
-            "totp": {
-              "type": "boolean"
-            },
-            "emailVerified": {
-              "type": "boolean"
-            },
-            "attributes": {
-              "type": "object",
-              "additionalProperties": {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                }
-              },
-              "nullable": true
-            },
-            "credentials": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/CredentialRepresentation"
-              },
-              "nullable": true
-            },
-            "requiredActions": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              },
-              "nullable": true
-            },
-            "federatedIdentities": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/FederatedIdentityRepresentation"
-              },
-              "nullable": true
-            },
-            "socialLinks": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/SocialLinkRepresentation"
-              },
-              "nullable": true
-            },
-            "realmRoles": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              },
-              "nullable": true
-            },
-            "clientRoles": {
-              "type": "object",
-              "additionalProperties": {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                }
-              },
-              "nullable": true
-            },
-            "clientConsents": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/UserConsentRepresentation"
-              },
-              "nullable": true
-            },
-            "notBefore": {
-              "type": "integer",
-              "format": "int32"
-            },
-            "applicationRoles": {
-              "type": "object",
-              "additionalProperties": {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                }
-              },
-              "nullable": true
-            },
-            "federationLink": {
-              "type": "string",
-              "nullable": true
-            },
-            "serviceAccountClientId": {
-              "type": "string",
-              "nullable": true
-            },
-            "groups": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              },
-              "nullable": true
-            },
-            "origin": {
-              "type": "string",
-              "nullable": true
-            },
-            "disableableCredentialTypes": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              },
-              "nullable": true
-            },
-            "access": {
-              "type": "object",
-              "additionalProperties": {
-                "type": "boolean"
-              },
-              "nullable": true
-            },
+        "additionalProperties": false
+      },
+      "JJDisputeCourtAppearanceRoPAppCd": {
+        "enum": [
+          "UNKNOWN",
+          "A",
+          "P",
+          "N"
+        ],
+        "type": "string"
+      },
+      "JJDisputeCourtAppearanceRoPCrown": {
+        "enum": [
+          "UNKNOWN",
+          "P",
+          "N"
+        ],
+        "type": "string"
+      },
+      "JJDisputeCourtAppearanceRoPDattCd": {
+        "enum": [
+          "UNKNOWN",
+          "A",
+          "C",
+          "N"
+        ],
+        "type": "string"
+      },
+      "JJDisputeCourtAppearanceRoPJjSeized": {
+        "enum": [
+          "UNKNOWN",
+          "Y",
+          "N"
+        ],
+        "type": "string"
+      },
+      "JJDisputeDisputantAttendanceType": {
+        "enum": [
+          "UNKNOWN",
+          "WRITTEN_REASONS",
+          "VIDEO_CONFERENCE",
+          "TELEPHONE_CONFERENCE",
+          "MSTEAMS_AUDIO",
+          "MSTEAMS_VIDEO",
+          "IN_PERSON"
+        ],
+        "type": "string"
+      },
+      "JJDisputeElectronicTicketYn": {
+        "enum": [
+          "UNKNOWN",
+          "Y",
+          "N"
+        ],
+        "type": "string"
+      },
+      "JJDisputeHearingType": {
+        "enum": [
+          "UNKNOWN",
+          "COURT_APPEARANCE",
+          "WRITTEN_REASONS"
+        ],
+        "type": "string"
+      },
+      "JJDisputeMultipleOfficersYn": {
+        "enum": [
+          "UNKNOWN",
+          "Y",
+          "N"
+        ],
+        "type": "string"
+      },
+      "JJDisputeNoticeOfHearingYn": {
+        "enum": [
+          "UNKNOWN",
+          "Y",
+          "N"
+        ],
+        "type": "string"
+      },
+      "JJDisputeRemark": {
+        "type": "object",
+        "properties": {
+          "createdBy": {
+            "type": "string",
+            "nullable": true
+          },
+          "createdTs": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "modifiedBy": {
+            "type": "string",
+            "nullable": true
+          },
+          "modifiedTs": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "userFullName": {
+            "type": "string",
+            "nullable": true
+          },
+          "note": {
+            "maxLength": 4000,
+            "minLength": 0,
+            "type": "string",
+            "nullable": true
+          },
+          "remarksMadeTs": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "additionalProperties": {
+            "type": "object",
             "additionalProperties": {
-              "type": "object",
-              "additionalProperties": { },
-              "nullable": true
-            }
-          },
-          "additionalProperties": false
+
+            },
+            "nullable": true
+          }
         },
-        "ViolationTicket": {
-          "type": "object",
-          "properties": {
-            "createdBy": {
-              "type": "string",
-              "nullable": true
-            },
-            "createdTs": {
-              "type": "string",
-              "format": "date-time"
-            },
-            "modifiedBy": {
-              "type": "string",
-              "nullable": true
-            },
-            "modifiedTs": {
-              "type": "string",
-              "format": "date-time",
-              "nullable": true
-            },
-            "violationTicketId": {
-              "type": "integer",
-              "format": "int64"
-            },
-            "ticketNumber": {
-              "type": "string",
-              "nullable": true
-            },
-            "disputantOrganizationName": {
-              "type": "string",
-              "nullable": true
-            },
-            "disputantSurname": {
-              "type": "string",
-              "nullable": true
-            },
-            "disputantGivenNames": {
-              "type": "string",
-              "nullable": true
-            },
-            "isYoungPerson": {
-              "$ref": "#/components/schemas/ViolationTicketIsYoungPerson"
-            },
-            "disputantDriversLicenceNumber": {
-              "maxLength": 30,
-              "minLength": 7,
-              "type": "string",
-              "nullable": true
-            },
-            "disputantClientNumber": {
-              "type": "string",
-              "nullable": true
-            },
-            "driversLicenceProvince": {
-              "maxLength": 100,
-              "minLength": 0,
-              "type": "string",
-              "nullable": true
-            },
-            "driversLicenceCountry": {
-              "maxLength": 100,
-              "minLength": 0,
-              "type": "string",
-              "nullable": true
-            },
-            "driversLicenceIssuedYear": {
-              "type": "integer",
-              "format": "int32",
-              "nullable": true
-            },
-            "driversLicenceExpiryYear": {
-              "type": "integer",
-              "format": "int32",
-              "nullable": true
-            },
-            "disputantBirthdate": {
-              "type": "string",
-              "format": "date-time",
-              "nullable": true
-            },
-            "address": {
-              "maxLength": 100,
-              "minLength": 0,
-              "type": "string",
-              "nullable": true
-            },
-            "addressCity": {
-              "type": "string",
-              "nullable": true
-            },
-            "addressProvince": {
-              "type": "string",
-              "nullable": true
-            },
-            "addressPostalCode": {
-              "type": "string",
-              "nullable": true
-            },
-            "addressCountry": {
-              "type": "string",
-              "nullable": true
-            },
-            "officerPin": {
-              "type": "string",
-              "nullable": true
-            },
-            "detachmentLocation": {
-              "type": "string",
-              "nullable": true
-            },
-            "issuedTs": {
-              "type": "string",
-              "format": "date-time",
-              "nullable": true
-            },
-            "issuedOnRoadOrHighway": {
-              "type": "string",
-              "nullable": true
-            },
-            "issuedAtOrNearCity": {
-              "type": "string",
-              "nullable": true
-            },
-            "isChangeOfAddress": {
-              "$ref": "#/components/schemas/ViolationTicketIsChangeOfAddress"
-            },
-            "isDriver": {
-              "$ref": "#/components/schemas/ViolationTicketIsDriver"
-            },
-            "isOwner": {
-              "$ref": "#/components/schemas/ViolationTicketIsOwner"
-            },
-            "courtLocation": {
-              "type": "string",
-              "nullable": true
-            },
-            "violationTicketCounts": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/ViolationTicketCount"
-              },
-              "nullable": true
-            },
+        "additionalProperties": false
+      },
+      "JJDisputeSignatoryType": {
+        "enum": [
+          "U",
+          "D",
+          "A"
+        ],
+        "type": "string"
+      },
+      "JJDisputeStatus": {
+        "enum": [
+          "UNKNOWN",
+          "NEW",
+          "IN_PROGRESS",
+          "DATA_UPDATE",
+          "CONFIRMED",
+          "REQUIRE_COURT_HEARING",
+          "REQUIRE_MORE_INFO",
+          "ACCEPTED",
+          "REVIEW",
+          "CONCLUDED",
+          "CANCELLED",
+          "HEARING_SCHEDULED"
+        ],
+        "type": "string"
+      },
+      "JJDisputedCount": {
+        "type": "object",
+        "properties": {
+          "createdBy": {
+            "type": "string",
+            "nullable": true
+          },
+          "createdTs": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "modifiedBy": {
+            "type": "string",
+            "nullable": true
+          },
+          "modifiedTs": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "plea": {
+            "$ref": "#/components/schemas/JJDisputedCountPlea"
+          },
+          "count": {
+            "maximum": 3,
+            "minimum": 1,
+            "type": "integer",
+            "format": "int32"
+          },
+          "requestTimeToPay": {
+            "$ref": "#/components/schemas/JJDisputedCountRequestTimeToPay"
+          },
+          "requestReduction": {
+            "$ref": "#/components/schemas/JJDisputedCountRequestReduction"
+          },
+          "appearInCourt": {
+            "$ref": "#/components/schemas/JJDisputedCountAppearInCourt"
+          },
+          "description": {
+            "type": "string",
+            "nullable": true
+          },
+          "dueDate": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "ticketedFineAmount": {
+            "type": "number",
+            "format": "float",
+            "nullable": true
+          },
+          "lesserOrGreaterAmount": {
+            "type": "number",
+            "format": "float",
+            "nullable": true
+          },
+          "includesSurcharge": {
+            "$ref": "#/components/schemas/JJDisputedCountIncludesSurcharge"
+          },
+          "revisedDueDate": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "totalFineAmount": {
+            "type": "number",
+            "format": "float",
+            "nullable": true
+          },
+          "violationDate": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "comments": {
+            "maxLength": 4000,
+            "minLength": 0,
+            "type": "string",
+            "nullable": true
+          },
+          "latestPlea": {
+            "$ref": "#/components/schemas/JJDisputedCountLatestPlea"
+          },
+          "latestPleaUpdateTs": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "jjDisputedCountRoP": {
+            "$ref": "#/components/schemas/JJDisputedCountRoP"
+          },
+          "additionalProperties": {
+            "type": "object",
             "additionalProperties": {
-              "type": "object",
-              "additionalProperties": { },
-              "nullable": true
+
             },
-            "violationTicketImage": {
-              "$ref": "#/components/schemas/ViolationTicketImage"
-            },
-            "ocrViolationTicket": {
-              "$ref": "#/components/schemas/OcrViolationTicket"
-            }
-          },
-          "additionalProperties": false
+            "nullable": true
+          }
         },
-        "ViolationTicketCount": {
-          "type": "object",
-          "properties": {
-            "createdBy": {
-              "type": "string",
-              "nullable": true
-            },
-            "createdTs": {
-              "type": "string",
-              "format": "date-time"
-            },
-            "modifiedBy": {
-              "type": "string",
-              "nullable": true
-            },
-            "modifiedTs": {
-              "type": "string",
-              "format": "date-time",
-              "nullable": true
-            },
-            "violationTicketCountId": {
-              "type": "integer",
-              "format": "int64"
-            },
-            "countNo": {
-              "maximum": 3,
-              "minimum": 1,
-              "type": "integer",
-              "format": "int32"
-            },
-            "description": {
-              "type": "string",
-              "nullable": true
-            },
-            "actOrRegulationNameCode": {
-              "type": "string",
-              "nullable": true
-            },
-            "isAct": {
-              "$ref": "#/components/schemas/ViolationTicketCountIsAct"
-            },
-            "isRegulation": {
-              "$ref": "#/components/schemas/ViolationTicketCountIsRegulation"
-            },
-            "section": {
-              "maxLength": 10,
-              "minLength": 0,
-              "type": "string",
-              "nullable": true
-            },
-            "subsection": {
-              "maxLength": 4,
-              "minLength": 0,
-              "type": "string",
-              "nullable": true
-            },
-            "paragraph": {
-              "maxLength": 3,
-              "minLength": 0,
-              "type": "string",
-              "nullable": true
-            },
-            "subparagraph": {
-              "maxLength": 5,
-              "minLength": 0,
-              "type": "string",
-              "nullable": true
-            },
-            "ticketedAmount": {
-              "type": "number",
-              "format": "float",
-              "nullable": true
-            },
+        "additionalProperties": false
+      },
+      "JJDisputedCountAppearInCourt": {
+        "enum": [
+          "UNKNOWN",
+          "Y",
+          "N"
+        ],
+        "type": "string"
+      },
+      "JJDisputedCountIncludesSurcharge": {
+        "enum": [
+          "UNKNOWN",
+          "Y",
+          "N"
+        ],
+        "type": "string"
+      },
+      "JJDisputedCountLatestPlea": {
+        "enum": [
+          "UNKNOWN",
+          "G",
+          "N"
+        ],
+        "type": "string"
+      },
+      "JJDisputedCountPlea": {
+        "enum": [
+          "UNKNOWN",
+          "G",
+          "N"
+        ],
+        "type": "string"
+      },
+      "JJDisputedCountRequestReduction": {
+        "enum": [
+          "UNKNOWN",
+          "Y",
+          "N"
+        ],
+        "type": "string"
+      },
+      "JJDisputedCountRequestTimeToPay": {
+        "enum": [
+          "UNKNOWN",
+          "Y",
+          "N"
+        ],
+        "type": "string"
+      },
+      "JJDisputedCountRoP": {
+        "type": "object",
+        "properties": {
+          "createdBy": {
+            "type": "string",
+            "nullable": true
+          },
+          "createdTs": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "modifiedBy": {
+            "type": "string",
+            "nullable": true
+          },
+          "modifiedTs": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "finding": {
+            "$ref": "#/components/schemas/JJDisputedCountRoPFinding"
+          },
+          "lesserDescription": {
+            "type": "string",
+            "nullable": true
+          },
+          "ssProbationDuration": {
+            "type": "string",
+            "nullable": true
+          },
+          "ssProbationConditions": {
+            "type": "string",
+            "nullable": true
+          },
+          "jailDuration": {
+            "type": "string",
+            "nullable": true
+          },
+          "jailIntermittent": {
+            "$ref": "#/components/schemas/JJDisputedCountRoPJailIntermittent"
+          },
+          "probationDuration": {
+            "type": "string",
+            "nullable": true
+          },
+          "probationConditions": {
+            "type": "string",
+            "nullable": true
+          },
+          "drivingProhibition": {
+            "type": "string",
+            "nullable": true
+          },
+          "drivingProhibitionMVASection": {
+            "type": "string",
+            "nullable": true
+          },
+          "dismissed": {
+            "$ref": "#/components/schemas/JJDisputedCountRoPDismissed"
+          },
+          "forWantOfProsecution": {
+            "$ref": "#/components/schemas/JJDisputedCountRoPForWantOfProsecution"
+          },
+          "withdrawn": {
+            "$ref": "#/components/schemas/JJDisputedCountRoPWithdrawn"
+          },
+          "abatement": {
+            "$ref": "#/components/schemas/JJDisputedCountRoPAbatement"
+          },
+          "stayOfProceedingsBy": {
+            "type": "string",
+            "nullable": true
+          },
+          "other": {
+            "type": "string",
+            "nullable": true
+          },
+          "additionalProperties": {
+            "type": "object",
             "additionalProperties": {
-              "type": "object",
-              "additionalProperties": { },
-              "nullable": true
-            }
-          },
-          "additionalProperties": false
-        },
-        "ViolationTicketCountIsAct": {
-          "enum": [
-            "UNKNOWN",
-            "Y",
-            "N"
-          ],
-          "type": "string"
-        },
-        "ViolationTicketCountIsRegulation": {
-          "enum": [
-            "UNKNOWN",
-            "Y",
-            "N"
-          ],
-          "type": "string"
-        },
-        "ViolationTicketImage": {
-          "type": "object",
-          "properties": {
-            "image": {
-              "type": "string",
-              "format": "byte",
-              "nullable": true
+
             },
-            "mimeType": {
-              "type": "string",
-              "nullable": true
-            }
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "JJDisputedCountRoPAbatement": {
+        "enum": [
+          "UNKNOWN",
+          "Y",
+          "N"
+        ],
+        "type": "string"
+      },
+      "JJDisputedCountRoPDismissed": {
+        "enum": [
+          "UNKNOWN",
+          "Y",
+          "N"
+        ],
+        "type": "string"
+      },
+      "JJDisputedCountRoPFinding": {
+        "enum": [
+          "UNKNOWN",
+          "GUILTY",
+          "NOT_GUILTY",
+          "CANCELLED",
+          "PAID_PRIOR_TO_APPEARANCE",
+          "GUILTY_LESSER"
+        ],
+        "type": "string"
+      },
+      "JJDisputedCountRoPForWantOfProsecution": {
+        "enum": [
+          "UNKNOWN",
+          "Y",
+          "N"
+        ],
+        "type": "string"
+      },
+      "JJDisputedCountRoPJailIntermittent": {
+        "enum": [
+          "UNKNOWN",
+          "Y",
+          "N"
+        ],
+        "type": "string"
+      },
+      "JJDisputedCountRoPWithdrawn": {
+        "enum": [
+          "UNKNOWN",
+          "Y",
+          "N"
+        ],
+        "type": "string"
+      },
+      "Language": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string",
+            "nullable": true
           },
-          "additionalProperties": false
+          "description": {
+            "type": "string",
+            "nullable": true
+          }
         },
-        "ViolationTicketIsChangeOfAddress": {
-          "enum": [
-            "UNKNOWN",
-            "Y",
-            "N"
-          ],
-          "type": "string"
+        "additionalProperties": false
+      },
+      "Lock": {
+        "type": "object",
+        "properties": {
+          "lockId": {
+            "type": "string",
+            "description": "Lock ID",
+            "nullable": true
+          },
+          "ticketNumber": {
+            "type": "string",
+            "description": "The ticket number associated with the dispute.",
+            "nullable": true
+          },
+          "username": {
+            "type": "string",
+            "description": "Username of the person who acquired the lock.",
+            "nullable": true
+          },
+          "expiryTimeUtc": {
+            "type": "string",
+            "description": "The time in UTC when the acquired lock expires.",
+            "format": "date-time"
+          },
+          "createdAtUtc": {
+            "type": "string",
+            "description": "The time in UTC when the lock was created.",
+            "format": "date-time"
+          }
         },
-        "ViolationTicketIsDriver": {
-          "enum": [
-            "UNKNOWN",
-            "Y",
-            "N"
-          ],
-          "type": "string"
+        "additionalProperties": false
+      },
+      "OcrViolationTicket": {
+        "type": "object",
+        "properties": {
+          "ticketVersion": {
+            "$ref": "#/components/schemas/ViolationTicketVersion"
+          },
+          "imageFilename": {
+            "type": "string",
+            "nullable": true
+          },
+          "globalConfidence": {
+            "type": "number",
+            "format": "float"
+          },
+          "fields": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/Field"
+            },
+            "nullable": true
+          }
         },
-        "ViolationTicketIsOwner": {
-          "enum": [
-            "UNKNOWN",
-            "Y",
-            "N"
-          ],
-          "type": "string"
+        "additionalProperties": false
+      },
+      "PagedDisputeListItemCollection": {
+        "type": "object",
+        "properties": {
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DisputeListItem"
+            },
+            "nullable": true
+          },
+          "pageNumber": {
+            "type": "integer",
+            "format": "int32",
+            "readOnly": true
+          },
+          "pageSize": {
+            "type": "integer",
+            "format": "int32",
+            "readOnly": true
+          },
+          "pageCount": {
+            "type": "integer",
+            "format": "int32",
+            "readOnly": true
+          },
+          "totalItemCount": {
+            "type": "integer",
+            "format": "int32",
+            "readOnly": true
+          },
+          "hasPreviousPage": {
+            "type": "boolean",
+            "readOnly": true
+          },
+          "hasNextPage": {
+            "type": "boolean",
+            "readOnly": true
+          },
+          "isFirstPage": {
+            "type": "boolean",
+            "readOnly": true
+          },
+          "isLastPage": {
+            "type": "boolean",
+            "readOnly": true
+          }
         },
-        "ViolationTicketIsYoungPerson": {
-          "enum": [
-            "UNKNOWN",
-            "Y",
-            "N"
-          ],
-          "type": "string"
+        "additionalProperties": false
+      },
+      "Point": {
+        "type": "object",
+        "properties": {
+          "x": {
+            "type": "number",
+            "format": "float"
+          },
+          "y": {
+            "type": "number",
+            "format": "float"
+          }
         },
-        "ViolationTicketVersion": {
-          "enum": [
-            "VT1",
-            "VT2"
-          ],
-          "type": "string"
+        "additionalProperties": false
+      },
+      "ProblemDetails": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "nullable": true
+          },
+          "title": {
+            "type": "string",
+            "nullable": true
+          },
+          "status": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "detail": {
+            "type": "string",
+            "nullable": true
+          },
+          "instance": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": {
+
         }
       },
-      "securitySchemes": {
-        "Bearer": {
-          "type": "apiKey",
-          "description": "JWT Authorization header using the Bearer scheme. Example: \"Authorization: Bearer {token}\"",
-          "name": "Authorization",
-          "in": "header"
-        }
+      "Province": {
+        "type": "object",
+        "properties": {
+          "ctryId": {
+            "type": "string",
+            "nullable": true
+          },
+          "provSeqNo": {
+            "type": "string",
+            "nullable": true
+          },
+          "provNm": {
+            "type": "string",
+            "nullable": true
+          },
+          "provAbbreviationCd": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "SocialLinkRepresentation": {
+        "type": "object",
+        "properties": {
+          "socialProvider": {
+            "type": "string",
+            "nullable": true
+          },
+          "socialUserId": {
+            "type": "string",
+            "nullable": true
+          },
+          "socialUsername": {
+            "type": "string",
+            "nullable": true
+          },
+          "additionalProperties": {
+            "type": "object",
+            "additionalProperties": {
+
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "SortDirection": {
+        "enum": [
+          "asc",
+          "desc"
+        ],
+        "type": "string"
+      },
+      "Statute": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "nullable": true
+          },
+          "actCode": {
+            "type": "string",
+            "nullable": true
+          },
+          "sectionText": {
+            "type": "string",
+            "nullable": true
+          },
+          "subsectionText": {
+            "type": "string",
+            "nullable": true
+          },
+          "paragraphText": {
+            "type": "string",
+            "nullable": true
+          },
+          "subparagraphText": {
+            "type": "string",
+            "nullable": true
+          },
+          "code": {
+            "type": "string",
+            "nullable": true
+          },
+          "shortDescriptionText": {
+            "type": "string",
+            "nullable": true
+          },
+          "descriptionText": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "TicketImageDataJustinDocument": {
+        "type": "object",
+        "properties": {
+          "reportType": {
+            "$ref": "#/components/schemas/TicketImageDataJustinDocumentReportType"
+          },
+          "reportFormat": {
+            "type": "string",
+            "nullable": true
+          },
+          "partId": {
+            "type": "string",
+            "nullable": true
+          },
+          "participantName": {
+            "type": "string",
+            "nullable": true
+          },
+          "index": {
+            "type": "string",
+            "nullable": true
+          },
+          "fileData": {
+            "type": "string",
+            "nullable": true
+          },
+          "additionalProperties": {
+            "type": "object",
+            "additionalProperties": {
+
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "TicketImageDataJustinDocumentReportType": {
+        "enum": [
+          "UNKNOWN",
+          "NOTICE_OF_DISPUTE",
+          "TICKET_IMAGE"
+        ],
+        "type": "string"
+      },
+      "UserConsentRepresentation": {
+        "type": "object",
+        "properties": {
+          "clientId": {
+            "type": "string",
+            "nullable": true
+          },
+          "grantedClientScopes": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true
+          },
+          "createdDate": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "lastUpdatedDate": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "grantedRealmRoles": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true
+          },
+          "additionalProperties": {
+            "type": "object",
+            "additionalProperties": {
+
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "UserRepresentation": {
+        "type": "object",
+        "properties": {
+          "self": {
+            "type": "string",
+            "nullable": true
+          },
+          "id": {
+            "type": "string",
+            "nullable": true
+          },
+          "createdTimestamp": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "firstName": {
+            "type": "string",
+            "nullable": true
+          },
+          "lastName": {
+            "type": "string",
+            "nullable": true
+          },
+          "email": {
+            "type": "string",
+            "nullable": true
+          },
+          "username": {
+            "type": "string",
+            "nullable": true
+          },
+          "enabled": {
+            "type": "boolean"
+          },
+          "totp": {
+            "type": "boolean"
+          },
+          "emailVerified": {
+            "type": "boolean"
+          },
+          "attributes": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "nullable": true
+          },
+          "credentials": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CredentialRepresentation"
+            },
+            "nullable": true
+          },
+          "requiredActions": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true
+          },
+          "federatedIdentities": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FederatedIdentityRepresentation"
+            },
+            "nullable": true
+          },
+          "socialLinks": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SocialLinkRepresentation"
+            },
+            "nullable": true
+          },
+          "realmRoles": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true
+          },
+          "clientRoles": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "nullable": true
+          },
+          "clientConsents": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/UserConsentRepresentation"
+            },
+            "nullable": true
+          },
+          "notBefore": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "applicationRoles": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "nullable": true
+          },
+          "federationLink": {
+            "type": "string",
+            "nullable": true
+          },
+          "serviceAccountClientId": {
+            "type": "string",
+            "nullable": true
+          },
+          "groups": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true
+          },
+          "origin": {
+            "type": "string",
+            "nullable": true
+          },
+          "disableableCredentialTypes": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true
+          },
+          "access": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "boolean"
+            },
+            "nullable": true
+          },
+          "additionalProperties": {
+            "type": "object",
+            "additionalProperties": {
+
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "ViolationTicket": {
+        "type": "object",
+        "properties": {
+          "createdBy": {
+            "type": "string",
+            "nullable": true
+          },
+          "createdTs": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "modifiedBy": {
+            "type": "string",
+            "nullable": true
+          },
+          "modifiedTs": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "violationTicketId": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "ticketNumber": {
+            "type": "string",
+            "nullable": true
+          },
+          "disputantOrganizationName": {
+            "type": "string",
+            "nullable": true
+          },
+          "disputantSurname": {
+            "type": "string",
+            "nullable": true
+          },
+          "disputantGivenNames": {
+            "type": "string",
+            "nullable": true
+          },
+          "isYoungPerson": {
+            "$ref": "#/components/schemas/ViolationTicketIsYoungPerson"
+          },
+          "disputantDriversLicenceNumber": {
+            "maxLength": 30,
+            "minLength": 7,
+            "type": "string",
+            "nullable": true
+          },
+          "disputantClientNumber": {
+            "type": "string",
+            "nullable": true
+          },
+          "driversLicenceProvince": {
+            "maxLength": 100,
+            "minLength": 0,
+            "type": "string",
+            "nullable": true
+          },
+          "driversLicenceCountry": {
+            "maxLength": 100,
+            "minLength": 0,
+            "type": "string",
+            "nullable": true
+          },
+          "driversLicenceIssuedYear": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "driversLicenceExpiryYear": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "disputantBirthdate": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "address": {
+            "maxLength": 100,
+            "minLength": 0,
+            "type": "string",
+            "nullable": true
+          },
+          "addressCity": {
+            "type": "string",
+            "nullable": true
+          },
+          "addressProvince": {
+            "type": "string",
+            "nullable": true
+          },
+          "addressPostalCode": {
+            "type": "string",
+            "nullable": true
+          },
+          "addressCountry": {
+            "type": "string",
+            "nullable": true
+          },
+          "officerPin": {
+            "type": "string",
+            "nullable": true
+          },
+          "detachmentLocation": {
+            "type": "string",
+            "nullable": true
+          },
+          "issuedTs": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "issuedOnRoadOrHighway": {
+            "type": "string",
+            "nullable": true
+          },
+          "issuedAtOrNearCity": {
+            "type": "string",
+            "nullable": true
+          },
+          "isChangeOfAddress": {
+            "$ref": "#/components/schemas/ViolationTicketIsChangeOfAddress"
+          },
+          "isDriver": {
+            "$ref": "#/components/schemas/ViolationTicketIsDriver"
+          },
+          "isOwner": {
+            "$ref": "#/components/schemas/ViolationTicketIsOwner"
+          },
+          "courtLocation": {
+            "type": "string",
+            "nullable": true
+          },
+          "violationTicketCounts": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ViolationTicketCount"
+            },
+            "nullable": true
+          },
+          "additionalProperties": {
+            "type": "object",
+            "additionalProperties": {
+
+            },
+            "nullable": true
+          },
+          "violationTicketImage": {
+            "$ref": "#/components/schemas/ViolationTicketImage"
+          },
+          "ocrViolationTicket": {
+            "$ref": "#/components/schemas/OcrViolationTicket"
+          }
+        },
+        "additionalProperties": false
+      },
+      "ViolationTicketCount": {
+        "type": "object",
+        "properties": {
+          "createdBy": {
+            "type": "string",
+            "nullable": true
+          },
+          "createdTs": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "modifiedBy": {
+            "type": "string",
+            "nullable": true
+          },
+          "modifiedTs": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "violationTicketCountId": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "countNo": {
+            "maximum": 3,
+            "minimum": 1,
+            "type": "integer",
+            "format": "int32"
+          },
+          "description": {
+            "type": "string",
+            "nullable": true
+          },
+          "actOrRegulationNameCode": {
+            "type": "string",
+            "nullable": true
+          },
+          "isAct": {
+            "$ref": "#/components/schemas/ViolationTicketCountIsAct"
+          },
+          "isRegulation": {
+            "$ref": "#/components/schemas/ViolationTicketCountIsRegulation"
+          },
+          "section": {
+            "maxLength": 10,
+            "minLength": 0,
+            "type": "string",
+            "nullable": true
+          },
+          "subsection": {
+            "maxLength": 4,
+            "minLength": 0,
+            "type": "string",
+            "nullable": true
+          },
+          "paragraph": {
+            "maxLength": 3,
+            "minLength": 0,
+            "type": "string",
+            "nullable": true
+          },
+          "subparagraph": {
+            "maxLength": 5,
+            "minLength": 0,
+            "type": "string",
+            "nullable": true
+          },
+          "ticketedAmount": {
+            "type": "number",
+            "format": "float",
+            "nullable": true
+          },
+          "additionalProperties": {
+            "type": "object",
+            "additionalProperties": {
+
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "ViolationTicketCountIsAct": {
+        "enum": [
+          "UNKNOWN",
+          "Y",
+          "N"
+        ],
+        "type": "string"
+      },
+      "ViolationTicketCountIsRegulation": {
+        "enum": [
+          "UNKNOWN",
+          "Y",
+          "N"
+        ],
+        "type": "string"
+      },
+      "ViolationTicketImage": {
+        "type": "object",
+        "properties": {
+          "image": {
+            "type": "string",
+            "format": "byte",
+            "nullable": true
+          },
+          "mimeType": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "ViolationTicketIsChangeOfAddress": {
+        "enum": [
+          "UNKNOWN",
+          "Y",
+          "N"
+        ],
+        "type": "string"
+      },
+      "ViolationTicketIsDriver": {
+        "enum": [
+          "UNKNOWN",
+          "Y",
+          "N"
+        ],
+        "type": "string"
+      },
+      "ViolationTicketIsOwner": {
+        "enum": [
+          "UNKNOWN",
+          "Y",
+          "N"
+        ],
+        "type": "string"
+      },
+      "ViolationTicketIsYoungPerson": {
+        "enum": [
+          "UNKNOWN",
+          "Y",
+          "N"
+        ],
+        "type": "string"
+      },
+      "ViolationTicketVersion": {
+        "enum": [
+          "VT1",
+          "VT2"
+        ],
+        "type": "string"
       }
     },
-    "security": [
-      {
-        "Bearer": [ ]
+    "securitySchemes": {
+      "Bearer": {
+        "type": "apiKey",
+        "description": "JWT Authorization header using the Bearer scheme. Example: \"Authorization: Bearer {token}\"",
+        "name": "Authorization",
+        "in": "header"
       }
-    ]
-  }
+    }
+  },
+  "security": [
+    {
+      "Bearer": []
+    }
+  ]
+}

--- a/src/frontend/staff-portal/src/app/components/staff-workbench/contact-info/contact-info.component.html
+++ b/src/frontend/staff-portal/src/app/components/staff-workbench/contact-info/contact-info.component.html
@@ -1,8 +1,17 @@
 <app-page>
+  <ng-container stickyToolBar>
+    <div class="app-width" style="padding-top: 1.5vh; padding-bottom: 1.5vh;" fxLayout="row">
+      <div fxFlex>
+        <a (click)="onBack()" style="color: #48afe5">
+          <mat-icon inline="true">arrow_back</mat-icon> Back to TRM home
+        </a>
+      </div>
+      <div>
+        <button mat-raised-button (click)="onPrint()">Print</button>
+      </div>
+    </div>
+  </ng-container>
   <div class="contact-info">
-    <a (click)="onBack()" style="color: #48afe5">
-      <mat-icon inline="true">arrow_back</mat-icon> Back to TRM home
-    </a>
     <app-ticket-status [dispute]="lastUpdatedDispute" *ngIf="lastUpdatedDispute"></app-ticket-status>
     <div *ngIf="conflict === true">
       <span>

--- a/src/frontend/staff-portal/src/app/components/staff-workbench/contact-info/contact-info.component.ts
+++ b/src/frontend/staff-portal/src/app/components/staff-workbench/contact-info/contact-info.component.ts
@@ -377,4 +377,15 @@ export class ContactInfoComponent implements OnInit {
   public handleCollapse(name: string) {
     this.collapseObj[name] = !this.collapseObj[name]
   }
+
+  onPrint() {
+    this.disputeService.apiTicketValidationPrintGet(this.lastUpdatedDispute.disputeId).subscribe(result => {
+      if (result) {
+        var url = URL.createObjectURL(result);
+        window.open(url);
+      } else {
+        alert("File contents not found");
+      }
+    });
+  }
 }

--- a/src/frontend/staff-portal/src/app/components/staff-workbench/ticket-info/ticket-info.component.html
+++ b/src/frontend/staff-portal/src/app/components/staff-workbench/ticket-info/ticket-info.component.html
@@ -1,8 +1,17 @@
 <app-page>
+  <ng-container stickyToolBar>
+    <div class="app-width" style="padding-top: 1.5vh; padding-bottom: 1.5vh;" fxLayout="row">
+      <div fxFlex>
+        <a (click)="onBack()" style="color: #48afe5">
+          <mat-icon inline="true">arrow_back</mat-icon> Back to TRM home
+        </a>
+      </div>
+      <div>
+        <button mat-raised-button (click)="onPrint()">Print</button>
+      </div>
+    </div>
+  </ng-container>
   <div class="ticket-info">
-    <a (click)="onBack()" style="color: #48afe5">
-      <mat-icon inline="true">arrow_back</mat-icon> Back to TRM home
-    </a>
     <app-ticket-status [dispute]="lastUpdatedDispute" *ngIf="lastUpdatedDispute"></app-ticket-status>
     <div *ngIf="conflict === true">
       <span>

--- a/src/frontend/staff-portal/src/app/components/staff-workbench/ticket-info/ticket-info.component.ts
+++ b/src/frontend/staff-portal/src/app/components/staff-workbench/ticket-info/ticket-info.component.ts
@@ -893,4 +893,15 @@ export class TicketInfoComponent implements OnInit {
   public onValidateClick(): void {
     this.validateClicked = true;
   }
+
+  onPrint() {
+    this.disputeService.apiTicketValidationPrintGet(this.lastUpdatedDispute.disputeId).subscribe(result => {
+      if (result) {
+        var url = URL.createObjectURL(result);
+        window.open(url);
+      } else {
+        alert("File contents not found");
+      }
+    });
+  }
 }

--- a/src/frontend/staff-portal/src/app/services/dispute.service.ts
+++ b/src/frontend/staff-portal/src/app/services/dispute.service.ts
@@ -6,6 +6,8 @@ import { Observable, BehaviorSubject } from 'rxjs';
 import { catchError, map } from 'rxjs/operators';
 import { EventEmitter, Injectable } from '@angular/core';
 import { TableFilter } from '@shared/models/table-filter-options.model';
+import { HttpClient, HttpContext, HttpHeaders, HttpResponse } from '@angular/common/http';
+import { AuthService } from './auth.service';
 
 export interface IDisputeService {
   disputes$: Observable<Dispute[]>;
@@ -30,7 +32,9 @@ export class DisputeService implements IDisputeService {
     private toastService: ToastService,
     private logger: LoggerService,
     private configService: ConfigService,
-    private disputeApiService: DisputeApiService
+    private disputeApiService: DisputeApiService,
+    private http: HttpClient,
+    private authService: AuthService
   ) {
     this._disputes = new BehaviorSubject<Dispute[]>(null);
   }
@@ -369,10 +373,10 @@ export class DisputeService implements IDisputeService {
   }
 
   /**
-* Accept the dispute update request
-*
-* @param disputeId
-*/
+  * Accept the dispute update request
+  *
+  * @param disputeId
+  */
   public rejectDisputeUpdateRequest(updateStatusId: number): Observable<any> {
 
     return this.disputeApiService.apiDisputeUpdaterequestUpdateStatusIdRejectPut(updateStatusId)
@@ -517,6 +521,25 @@ export class DisputeService implements IDisputeService {
     if (dispute.addressLine3) dispute.address = dispute.address + "," + dispute.addressLine3;
 
     return dispute;
+  }
+
+  public apiTicketValidationPrintGet(disputeId: number, timeZone: string = Intl.DateTimeFormat().resolvedOptions().timeZone): Observable<any> {
+    return this.http
+    .get(`/api/dispute/${disputeId}/print?timeZone=${timeZone}`, {
+      observe: 'response',
+      responseType: 'blob',
+      context: new HttpContext(),
+      withCredentials: true,
+      headers: new HttpHeaders(
+        {
+          'Authorization': 'Bearer ' + this.authService.token,
+          'Accept': '*/*',
+          'Access-Control-Allow-Origin': ''
+        }),
+    }).pipe(
+      map((result: HttpResponse<Blob>) => {
+        return result.body;
+      }));
   }
 }
 


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- [TCVP-2865](https://jag.gov.bc.ca/jira/browse/TCVP-2865)
- Added functionality to print occam version of dcf for ticket validation view by creating a new PrintDigitalCaseFileService method to process occam dispute fields to render them in existing dcf template, and a new controller endpoint to return generated document. 
- Fixed existing DisputeController unit tests. Re-enabled integration test for print dcf by fixing the dependencies and added a new Xunit integration test for print ticket validation view.
- Added a sticky tool bar to the top of ticket validation page with a 'Print' button to trigger downloading generated pdf through calling the new endpoint to print ticket validation page.

![print-bar](https://github.com/bcgov/jag-traffic-courts-online/assets/98848668/1c31609a-13d8-4a4f-aefc-bf7b17b4ce2e)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
