### PR TITLE
TCVP-2932 Adjust from address to avoid spam delivery

### DIFF
--- a/src/backend/TrafficCourts/Workflow.Service/Services/EmailTemplates/EmailTemplate.cs
+++ b/src/backend/TrafficCourts/Workflow.Service/Services/EmailTemplates/EmailTemplate.cs
@@ -11,7 +11,7 @@ public abstract class EmailTemplate<T> : IEmailTemplate<T>
     /// <summary>
     /// Provides sender email address.
     /// </summary>
-    protected const string Sender = "DoNotReply@tickets.gov.bc.ca";
+    protected const string Sender = "donotreply_courts.tco@gov.bc.ca";
 
     /// <summary>
     /// Provides the common help text.


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- TCVP-2932 using `@tickets.gov.bc.ca` is probably causing messages to go to the spam folder. This PR changes the from email address to `donotreply_courts.tco@gov.bc.ca` as per the [email best practices](https://raw.githubusercontent.com/wiki/bcgov/common-hosted-email-service/assets/bulk_email_best_practices.pdf) document

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [ ] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
