### PR TITLE
TCVP-2812 Display Courthouse Location on Print DCF

### DIFF
--- a/src/backend/TrafficCourts/Common/Features/Lookups/AgencyLookupService.cs
+++ b/src/backend/TrafficCourts/Common/Features/Lookups/AgencyLookupService.cs
@@ -11,4 +11,32 @@ public class AgencyLookupService : CachedLookupService<Agency>, IAgencyLookupSer
         : base("Agencies", redis, cache, TimeSpan.FromHours(1), logger)
     {
     }
+
+    public async Task<Agency?> GetByIdAsync(string agencyId)
+    {
+        if (string.IsNullOrEmpty(agencyId))
+        {
+            return null;
+        }
+
+        var agencies = await GetAgenciesAsync(agency => agency.Id == agencyId);
+        if (agencies.Count == 0)
+        {
+            return null;
+        }
+
+        if (agencies.Count > 1)
+        {
+            _logger.LogInformation("{Count} agencies were returned matching {Id}, returning first value", agencies.Count, agencyId);
+        }
+
+        return agencies[0];
+    }
+
+    private async Task<List<Agency>> GetAgenciesAsync(Func<Agency, bool> predicate)
+    {
+        var values = await GetListAsync();
+        var sections = values.Where(predicate).ToList();
+        return sections;
+    }
 }

--- a/src/backend/TrafficCourts/Common/Features/Lookups/IAgencyLookupService.cs
+++ b/src/backend/TrafficCourts/Common/Features/Lookups/IAgencyLookupService.cs
@@ -4,4 +4,10 @@ namespace TrafficCourts.Common.Features.Lookups;
 
 public interface IAgencyLookupService : ICachedLookupService<Agency>
 {
+    /// <summary>
+    /// Returns a specific Agency from the Redis Cache based on the agency id
+    /// </summary>
+    /// <param name="agencyId"></param>
+    /// <returns></returns>
+    Task<Agency?> GetByIdAsync(string agencyId);
 }

--- a/src/backend/TrafficCourts/Staff.Service/Services/PrintDigitalCaseFileService.cs
+++ b/src/backend/TrafficCourts/Staff.Service/Services/PrintDigitalCaseFileService.cs
@@ -13,6 +13,7 @@ public class PrintDigitalCaseFileService : IPrintDigitalCaseFileService
     private readonly IJJDisputeService _disputeService;
     private readonly IOracleDataApiService _oracleDataApi;
     private readonly IProvinceLookupService _provinceLookupService;
+    private readonly IAgencyLookupService _agencyLookupService;
     private readonly IDocumentGenerationService _documentGeneration;
     private readonly ILogger<PrintDigitalCaseFileService> _logger;
 
@@ -20,12 +21,14 @@ public class PrintDigitalCaseFileService : IPrintDigitalCaseFileService
         IJJDisputeService disputeService,
         IOracleDataApiService oracleDataApi,
         IProvinceLookupService provinceLookupService,
+        IAgencyLookupService agencyLookupService,
         IDocumentGenerationService documentGeneration,
         ILogger<PrintDigitalCaseFileService> logger)
     {
         _disputeService = disputeService ?? throw new ArgumentNullException(nameof(disputeService));
         _oracleDataApi = oracleDataApi ?? throw new ArgumentNullException(nameof(oracleDataApi));
         _provinceLookupService = provinceLookupService ?? throw new ArgumentNullException(nameof(provinceLookupService));
+        _agencyLookupService = agencyLookupService ?? throw new ArgumentNullException(nameof(agencyLookupService));
         _documentGeneration = documentGeneration ?? throw new ArgumentNullException(nameof(documentGeneration));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
@@ -89,6 +92,22 @@ public class PrintDigitalCaseFileService : IPrintDigitalCaseFileService
     }
 
     /// <summary>
+    /// Returns Agency (Courthouse Location) based on the provided agencyId through agencyLookupService.
+    /// </summary>
+    /// <param name="agencyId"></param>
+    /// <returns></returns>
+    private async Task<Agency?> GetCourthouseLocationAsync(string agencyId)
+    {
+        Domain.Models.Agency? courthouseLocation = null;
+        if (agencyId is not null)
+        {
+            courthouseLocation = await _agencyLookupService.GetByIdAsync(agencyId);
+        }
+
+        return courthouseLocation;
+    }
+
+    /// <summary>
     /// Fetches the <see cref="DigitalCaseFile"/> based on ticket number. This really should be using the tco_dispute.dispute_id.
     /// </summary>
     internal async Task<DigitalCaseFile> GetDigitalCaseFileAsync(string ticketNumber, string timeZoneId, CancellationToken cancellationToken)
@@ -105,6 +124,9 @@ public class PrintDigitalCaseFileService : IPrintDigitalCaseFileService
         Domain.Models.Province? driversLicenceProvince = await GetDriversLicenceProvinceAsync(dispute.DrvLicIssuedProvSeqNo, dispute.DrvLicIssuedCtryId);
         var fileHistory = await _oracleDataApi.GetFileHistoryByTicketNumberAsync(dispute.TicketNumber, cancellationToken);
 
+        // Get courthouse location data from the courthouse location lookup service based on CourtAgenId provided from the dispute
+        Agency? courthouseLocation = await GetCourthouseLocationAsync(dispute.CourtAgenId);
+
         var digitalCaseFile = new DigitalCaseFile();
 
         // fill in each section, the sections and fields are populated in order matching the template
@@ -120,7 +142,7 @@ public class PrintDigitalCaseFileService : IPrintDigitalCaseFileService
         ticket.Submitted = new FormattedDateOnly(dispute.SubmittedTs);
         ticket.IcbcReceived = new FormattedDateOnly(dispute.IcbcReceivedDate);
         ticket.CourtAgenyId = dispute.CourtAgenId;
-        ticket.CourtHouse = dispute.CourthouseLocation;
+        ticket.CourtHouse = courthouseLocation?.Name ?? string.Empty;
 
         // set the contact information
         var contact = digitalCaseFile.Contact;


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- TCVP-2812
-  Added a method to return a specific Agency from the Redis Cache based on the agency id provided in Staff Service.
- Updated print DCF service to lookup courthouse location through agency lookup service based on 'CourtAgenId' provided from the dispute in order to display its name on the printed version of DCF.

![courthouse - print dcf](https://github.com/bcgov/jag-traffic-courts-online/assets/98848668/6349d0b6-14fb-4a31-8c37-ad0add6512a5)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
