### PR TITLE
TCVP-2950 make adjustments to fix possible memory leak

### DIFF
--- a/gitops/charts/traffic-court-online/charts/arc-dispute-api/templates/deployment.yaml
+++ b/gitops/charts/traffic-court-online/charts/arc-dispute-api/templates/deployment.yaml
@@ -50,6 +50,9 @@ spec:
             value: America/Vancouver
           - name: ASPNETCORE_URLS
             value: http://*:8080;http://*:9090
+          # use workstation garbage collector
+          - name: DOTNET_gcServer
+            value: 0
           name: {{ .Chart.Name }}
           image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}

--- a/src/backend/TrafficCourts/TrafficCourts.Arc.Dispute.Service/Configuration/SftpConnectionOptions.cs
+++ b/src/backend/TrafficCourts/TrafficCourts.Arc.Dispute.Service/Configuration/SftpConnectionOptions.cs
@@ -82,8 +82,7 @@ namespace TrafficCourts.Arc.Dispute.Service.Configuration
             if (!string.IsNullOrEmpty(SshPrivateKey))
             {
                 var bytes = Encoding.ASCII.GetBytes(SshPrivateKey);
-                MemoryStream stream = new MemoryStream(bytes);
-
+                using MemoryStream stream = new(bytes);
                 PrivateKeyFile privateKey = new(stream); // throws SshException if the private key is not well formed
                 return privateKey;
             }

--- a/src/backend/TrafficCourts/TrafficCourts.Arc.Dispute.Service/Services/SftpService.cs
+++ b/src/backend/TrafficCourts/TrafficCourts.Arc.Dispute.Service/Services/SftpService.cs
@@ -8,6 +8,7 @@ public class SftpService : ISftpService
 {
     private readonly ILogger<SftpService> _logger;
     private readonly SftpClient _client;
+    private bool _disposed;
 
     public SftpService(ILogger<SftpService> logger, SftpClient client)
     {
@@ -17,7 +18,21 @@ public class SftpService : ISftpService
 
     public void Dispose()
     {
-        _client.Dispose();
+        Dispose(true);
+        GC.SuppressFinalize(this);
+    }
+
+    protected virtual void Dispose(bool disposing)
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        if (disposing)
+        {
+            _client.Dispose();
+        }
     }
 
     public void UploadFile(MemoryStream data, string path, string filename)


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- Sets to use [Workstation GC instead of Server GC](https://learn.microsoft.com/en-us/dotnet/core/runtime-config/garbage-collector#workstation-vs-server)  `DOTNET_gcServer=0` in Helm chart
- Ensure MemoryStream is disposed after reading the private key from configuration
- Change Dispose method to implement dispose pattern [correctly](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1063#pseudo-code-example)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [ ] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
