### PR TITLE
TCVP-2864 Add date of birth to DCF

### DIFF
--- a/src/frontend/staff-portal/src/app/components/jj-dispute-info/jj-dispute/jj-dispute.component.html
+++ b/src/frontend/staff-portal/src/app/components/jj-dispute-info/jj-dispute/jj-dispute.component.html
@@ -108,6 +108,10 @@
               </mat-form-field>
             </span>
             <span class="section-grid-cell">
+              <p class="section-grid-header">Date of Birth</p>
+              <p class="section-grid-text">{{ lastUpdatedJJDispute.disputantBirthdate | date: "dd-MMM-yyyy" : "UTC" }}</p>
+            </span>
+            <span class="section-grid-cell">
               <p class="section-grid-header">Location of Offence</p>
               <p class="section-grid-text"> {{ lastUpdatedJJDispute.offenceLocation }}</p>
             </span>


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- [TCVP-2864](https://justice.gov.bc.ca/jira/browse/TCVP-2864)
- Added read only 'date of birth' field to display disputant's date of birth on DCF page.

![dateOfBirthDCF_2](https://github.com/bcgov/jag-traffic-courts-online/assets/98848668/4dd1f5c6-16ca-43a5-be5f-b5c767738877)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
