### PR TITLE
TCVP-2977: Populate ARC File with Violation Ticket Disputant Name from RSI Ticket Search

### DIFF
--- a/.docker/docker-compose.jaeger.yml
+++ b/.docker/docker-compose.jaeger.yml
@@ -1,5 +1,4 @@
 # Use Jaeger tracing for services
-version: "3.9"
 
 services:
   #############################################################################################
@@ -18,16 +17,21 @@ services:
       - "14268:14268"
       - "14269:14269"
       - "9411:9411"
+      - "4317:4317"
 
   citizen-api:
     environment:
-      OTEL_EXPORTER_JAEGER_ENDPOINT: http://jaeger:14268/api/traces
-      OTEL_EXPORTER_JAEGER_PROTOCOL: http/thrift.binary
+      OTEL_EXPORTER_OTLP_TRACES_ENDPOINT: http://jaeger:4317
     depends_on: [jaeger]
 
   oracle-data-api:
     environment:
       OTEL_EXPORTER_JAEGER_ENDPOINT: ${OTEL_EXPORTER_JAEGER_ENDPOINT:-http://jaeger:14250}
       SPRING_SLEUTH_ENABLED: ${SPRING_SLEUTH_ENABLED:-true}
+    depends_on: [jaeger]
+
+  staff-api:
+    environment:
+      OTEL_EXPORTER_OTLP_TRACES_ENDPOINT: http://jaeger:4317
     depends_on: [jaeger]
 

--- a/.env.template
+++ b/.env.template
@@ -11,6 +11,10 @@ OAUTH__CLIENTSECRET=xxxxxxxxxxxxxxxxxxxxxxxxxxxx
 CDOGS__CLIENTID=
 CDOGS__CLIENTSECRET=
 
+# Required only when TICKETSEARCH__SEARCHTYPE is 'RoadSafety'
+TICKETSEARCH__CLIENTID=
+TICKETSEARCH__CLIENTSECRET=
+
 # --------------------------------------
 # .NET based project default logging level
 Logging__LogLevel__Default=Information
@@ -27,3 +31,8 @@ ORDS_API_OCCAM_PASSWORD=
 ORDS_API_TCO_URL=
 ORDS_API_TCO_USERNAME=
 ORDS_API_TCO_PASSWORD=
+
+# Citizen API
+# Required only when TICKETSEARCH__SEARCHTYPE is 'RoadSafety'
+TICKETSEARCH__CLIENTID=
+TICKETSEARCH__CLIENTSECRET=

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,6 +32,11 @@ services:
       RABBITMQ__PASSWORD: ${RABBITMQ__PASSWORD:-guest}
       REDIS__CONNECTIONSTRING: ${REDIS__CONNECTIONSTRING:-redis:6379,password=password}
       TICKETSEARCH__SEARCHTYPE: ${TICKETSEARCH__SEARCHTYPE:-Mock}
+      TICKETSEARCH__CLIENTID: ${TICKETSEARCH__CLIENTID:-}
+      TICKETSEARCH__CLIENTSECRET: ${TICKETSEARCH__CLIENTSECRET:-}
+      TICKETSEARCH__TOKENENDPOINT: ${TICKETSEARCH__TOKENENDPOINT:-https://wsgw.test.jag.gov.bc.ca/auth/oauth/v2/token}
+      TICKETSEARCH__RESOURCEURL: ${TICKETSEARCH__RESOURCEURL:-https://wsgw.test.jag.gov.bc.ca/ride/paybc/paymentsvc}
+      TICKETSEARCH__BASEADDRESS: ${TICKETSEARCH__BASEADDRESS:-https://wsgw.test.jag.gov.bc.ca}
       JWT__AUTHORITY: ${JWT__AUTHORITY:-https://idtest.gov.bc.ca/login}     
       JWT__AUDIENCE: ${JWT__AUDIENCE:-ca.bc.gov.ag.tco.dev}
       OAuth__USERINFOENDPOINT: ${OAuth__USERINFOENDPOINT:-https://idtest.gov.bc.ca/oauth2/userinfo}
@@ -89,6 +94,11 @@ services:
       SERILOG__WRITETO__0__NAME: Console
       SERILOG__MINIMUMLEVEL__DEFAULT: ${SERILOG__MINIMUMLEVEL__DEFAULT:-Information} 
       TICKETSEARCH__SEARCHTYPE: ${TICKETSEARCH__SEARCHTYPE:-Mock}
+      TICKETSEARCH__CLIENTID: ${TICKETSEARCH__CLIENTID:-}
+      TICKETSEARCH__CLIENTSECRET: ${TICKETSEARCH__CLIENTSECRET:-}
+      TICKETSEARCH__TOKENENDPOINT: ${TICKETSEARCH__TOKENENDPOINT:-https://wsgw.test.jag.gov.bc.ca/auth/oauth/v2/token}
+      TICKETSEARCH__RESOURCEURL: ${TICKETSEARCH__RESOURCEURL:-https://wsgw.test.jag.gov.bc.ca/ride/paybc/paymentsvc}
+      TICKETSEARCH__BASEADDRESS: ${TICKETSEARCH__BASEADDRESS:-https://wsgw.test.jag.gov.bc.ca}
       CDOGS__CLIENTID: ${CDOGS__CLIENTID:-cdogs}
       CDOGS__CLIENTSECRET: ${CDOGS__CLIENTSECRET:-}
       CDOGS__ENDPOINT: ${CDOGS__ENDPOINT:-https://cdogs-dev.api.gov.bc.ca/api}

--- a/src/backend/TrafficCourts/Staff.Service/Mappers/Mapper.cs
+++ b/src/backend/TrafficCourts/Staff.Service/Mappers/Mapper.cs
@@ -17,17 +17,33 @@ public class Mapper
             target.NoticeOfDisputeGuid = new Guid(dispute.NoticeOfDisputeGuid);
         }
 
-        target.Surname = dispute.ViolationTicket?.DisputantSurname ?? dispute.DisputantSurname;
-        var (givenName1, givenName2, givenName3) = SplitGivenNames(dispute.ViolationTicket?.DisputantGivenNames);
-        if (givenName1 is null)
+        if (dispute.IcbcName is not null)
         {
-            target.GivenName1 = dispute.DisputantGivenName1;
-            target.GivenName2 = dispute.DisputantGivenName2;
-            target.GivenName3 = dispute.DisputantGivenName3;
+            target.Surname = dispute.IcbcName.Surname ?? dispute.DisputantSurname;
+            if (dispute.IcbcName.FirstGivenName is not null)
+            {
+                target.GivenName1 = dispute.IcbcName?.FirstGivenName;
+                target.GivenName2 = dispute.IcbcName?.SecondGivenName;
+            } else {
+                target.GivenName1 = dispute.DisputantGivenName1;
+                target.GivenName2 = dispute.DisputantGivenName2;
+                target.GivenName3 = dispute.DisputantGivenName3;
+            }
+            target.GivenName1 = dispute.IcbcName?.FirstGivenName;
+            target.GivenName2 = dispute.IcbcName?.SecondGivenName;
         } else {
-            target.GivenName1 = givenName1;
-            target.GivenName2 = givenName2;
-            target.GivenName3 = givenName3;
+            target.Surname = dispute.ViolationTicket?.DisputantSurname ?? dispute.DisputantSurname;
+            var (givenName1, givenName2, givenName3) = SplitGivenNames(dispute.ViolationTicket?.DisputantGivenNames);
+            if (givenName1 is null)
+            {
+                target.GivenName1 = dispute.DisputantGivenName1;
+                target.GivenName2 = dispute.DisputantGivenName2;
+                target.GivenName3 = dispute.DisputantGivenName3;
+            } else {
+                target.GivenName1 = givenName1;
+                target.GivenName2 = givenName2;
+                target.GivenName3 = givenName3;
+            }
         }
 
         target.TicketIssuanceDate = dispute.IssuedTs?.DateTime;

--- a/src/backend/TrafficCourts/Staff.Service/Mappers/Mapper.cs
+++ b/src/backend/TrafficCourts/Staff.Service/Mappers/Mapper.cs
@@ -17,16 +17,25 @@ public class Mapper
             target.NoticeOfDisputeGuid = new Guid(dispute.NoticeOfDisputeGuid);
         }
 
-        target.Surname = dispute.DisputantSurname;
-        target.GivenName1 = dispute.DisputantGivenName1;
-        target.GivenName2 = dispute.DisputantGivenName2;
-        target.GivenName3 = dispute.DisputantGivenName3;
+        target.Surname = dispute.ViolationTicket?.DisputantSurname ?? dispute.DisputantSurname;
+        var (givenName1, givenName2, givenName3) = SplitGivenNames(dispute.ViolationTicket?.DisputantGivenNames);
+        if (givenName1 is null)
+        {
+            target.GivenName1 = dispute.DisputantGivenName1;
+            target.GivenName2 = dispute.DisputantGivenName2;
+            target.GivenName3 = dispute.DisputantGivenName3;
+        } else {
+            target.GivenName1 = givenName1;
+            target.GivenName2 = givenName2;
+            target.GivenName3 = givenName3;
+        }
+
         target.TicketIssuanceDate = dispute.IssuedTs?.DateTime;
         target.TicketFileNumber = dispute.TicketNumber;
 
         // TCVP-2793 - issuing organziation should always be police (POL) and issuing location is the detachment location
         target.IssuingOrganization = "POL";
-        target.IssuingLocation = dispute.ViolationTicket.DetachmentLocation;
+        target.IssuingLocation = dispute.ViolationTicket?.DetachmentLocation ?? String.Empty;
 
         // If DL Province is out of province, do not send drivers licence
         if (dispute.DriversLicenceNumber is not null && dispute.DriversLicenceIssuedProvinceSeqNo == 1 && dispute.DriversLicenceIssuedCountryId == 1)
@@ -34,7 +43,7 @@ public class Mapper
         else target.DriversLicence = "";
 
         target.DisputeCounts = Map(dispute.DisputeCounts);
-        target.ViolationTicketCounts = Map(dispute.ViolationTicket.ViolationTicketCounts);
+        target.ViolationTicketCounts = Map(dispute.ViolationTicket?.ViolationTicketCounts);
 
         // TODO: Lookup address province seq no and country id and set addressprovince to abbreviation code
         if (dispute.AddressProvinceSeqNo is not null) target.Province = dispute.AddressProvince;
@@ -144,6 +153,26 @@ public class Mapper
         Append(dispute.AddressLine3);
 
         return buffer.ToString();
+    }
+
+    /// <summary>
+    /// Splits a full name into three given names.
+    /// </summary>
+    /// <param name="fullName">The full name to be split.</param>
+    /// <returns>A tuple containing three given names. If the full name is null or empty, all given names will be null.</returns>
+    private static (string? GivenName1, string? GivenName2, string? GivenName3) SplitGivenNames(string? fullName)
+    {
+        if (string.IsNullOrWhiteSpace(fullName))
+        {
+            return (null, null, null);
+        }
+
+        string[] parts = fullName.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+        string? givenName1 = parts.Length > 0 ? parts[0] : null;
+        string? givenName2 = parts.Length > 1 ? parts[1] : null;
+        string? givenName3 = parts.Length > 2 ? parts[2] : null;
+
+        return (givenName1, givenName2, givenName3);
     }
 
     public static DisputeRejected ToDisputeRejected(Dispute dispute)

--- a/src/backend/TrafficCourts/Staff.Service/Services/DisputeService.cs
+++ b/src/backend/TrafficCourts/Staff.Service/Services/DisputeService.cs
@@ -250,6 +250,10 @@ public class DisputeService : IDisputeService,
         // Status to PROCESSING
         dispute = await _oracleDataApi.SubmitDisputeAsync(disputeId, cancellationToken);
 
+        // TCVP-2977: Get disputant name data from ICBC RSI ticket search and update dispute's IcbcNameDetail
+        GetDisputeOptions options = new() {  DisputeId = disputeId, Assign = false, GetNameFromIcbc = true };
+        await GetIcbcTicketInformation(dispute, options, cancellationToken);
+
         // set AddressProvince to 2 character abbreviation code if prov seq no & ctry id present
         if (dispute.AddressProvinceSeqNo != null)
         {

--- a/src/backend/TrafficCourts/TrafficCourts.OracleDataApi/OracleDataApiService.cs
+++ b/src/backend/TrafficCourts/TrafficCourts.OracleDataApi/OracleDataApiService.cs
@@ -699,6 +699,17 @@ internal partial class OracleDataApiService : IOracleDataApiService
     {
         try
         {
+            // TCVP-2977: If the dispute has an IcbcName, update the Violation Ticket's DisputantSurname and DisputantGivenNames
+            if (body.IcbcName is { Surname: not null, FirstGivenName: not null })
+            {
+                body.ViolationTicket.DisputantSurname = body.IcbcName.Surname;
+                body.ViolationTicket.DisputantGivenNames = body.IcbcName.FirstGivenName;
+            
+                if (body.IcbcName.SecondGivenName is not null)
+                {
+                    body.ViolationTicket.DisputantGivenNames = $"{body.ViolationTicket.DisputantGivenNames} {body.IcbcName.SecondGivenName}";
+                }
+            }
             Oracle.Dispute oracleBody = _mapper.Map<Oracle.Dispute>(body);
 
             Oracle.Dispute oracle = await _client.UpdateDisputeAsync(id, oracleBody, cancellationToken);

--- a/src/backend/TrafficCourts/TrafficCourts.Staff.Service.Test/Mappers/MapperTest.cs
+++ b/src/backend/TrafficCourts/TrafficCourts.Staff.Service.Test/Mappers/MapperTest.cs
@@ -92,10 +92,10 @@ namespace TrafficCourts.Staff.Service.Test.Mappers
             var actual = Mapper.ToDisputeApproved(_expected);
             Assert.NotNull(actual);
 
-            Assert.Equal(_expected.DisputantSurname, actual.Surname);
-            Assert.Equal(_expected.DisputantGivenName1, actual.GivenName1);
-            Assert.Equal(_expected.DisputantGivenName2, actual.GivenName2);
-            Assert.Equal(_expected.DisputantGivenName3, actual.GivenName3);
+            Assert.Equal(_expected.IcbcName?.Surname, actual.Surname);
+            Assert.Equal(_expected.IcbcName?.FirstGivenName, actual.GivenName1);
+            Assert.Equal(_expected.IcbcName?.SecondGivenName, actual.GivenName2);
+            Assert.Equal(null!, actual.GivenName3);
         }
 
         [Fact]


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- [TCVP-2977](https://jag.gov.bc.ca/jira/browse/TCVP-2977)
- This fixes the issue mentioned in the ticket TCVP-2977 by pulling the disputant name from RSI ticket search before submitting to ARC and if it's not available through ticket search, it falls back to default disputant name from violation ticket data and disputant entered data respectively in the database.
- Updated mapper for submit dispute approved message to map icbc name if provided or the name on violation ticket for disputant name to submit to ARC.
- Updated XUnit test for the mapper.
- Updated docker compose file for jaeger to enable tracing for citizen-api, staff-api and oracle-data-api.
- Updated docker-compose.yml file to add necessary parameters to enable RSI ticket search and updated .env.template accordingly.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Tested locally by approving an e-ticket that was added through RSI search and confirmed ARC file has the disputant name from ticket search.

## Does the change impact or break the Docker build?

- [x] Yes
- [ ] No

If Yes: Has Docker been updated accordingly?

- [x] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
