### PR TITLE
TCVP-3037: Refresh Oracle Data Api Connection on Redis Restart

### DIFF
--- a/src/backend/oracle-data-api/pom.xml
+++ b/src/backend/oracle-data-api/pom.xml
@@ -86,6 +86,10 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-data-redis</artifactId>
 		</dependency>
+		<dependency>
+		    <groupId>io.lettuce</groupId>
+		    <artifactId>lettuce-core</artifactId>
+		</dependency>
 
 		<!-- JPA dependencies -->
 		<dependency>


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- [TCVP-3037](https://jag.gov.bc.ca/jira/browse/TCVP-3037)
- Added functionality to enable adaptive topology refreshing for Redis through 'ClusterTopologyRefreshOptions' in Lettuce to configure topology refreshing based on certain triggers such as 'moved redirect' and 'cannot reconnect'.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
