### PR TITLE
TCVP-3052: Do not require OCR MVA/MVR check

### DIFF
--- a/src/backend/TrafficCourts/Citizen.Service/Validators/FormRecognizerValidator.cs
+++ b/src/backend/TrafficCourts/Citizen.Service/Validators/FormRecognizerValidator.cs
@@ -359,11 +359,12 @@ public class FormRecognizerValidator : IFormRecognizerValidator
         }
         rules.Add(new DateOfServiceLT30Rule(violationTicket.Fields[OcrViolationTicket.DateOfService]));
 
-        // LRAFED-2650 Only tickets that have MVA or MVAR checked are permitted.
+        // TCVP-3052 OCR process no longer requires rejecting images when it cannot determine if the MVA or MVR check boxes are checked.
+        /* // LRAFED-2650 Only tickets that have MVA or MVAR checked are permitted.
         if (ViolationTicketVersion.VT2.Equals(violationTicket.TicketVersion))
         {
             rules.Add(new DidCommitIsMVA(violationTicket.Fields[OcrViolationTicket.OffenceIsMVA], violationTicket));
-        }
+        } */
 
         // Run each rule and aggregate the results
         foreach (var rule in rules)


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- [TCVP-3052](https://jag.gov.bc.ca/jira/browse/TCVP-3052)
- Adjusted OCR rules not to require rejecting images when it cannot determine if the MVA or MVR check boxes are checked.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
