### PR TITLE
TCVP-3060: Fix Print DCF does not match DCF view on Staff Portal

### DIFF
--- a/src/backend/TrafficCourts/Staff.Service/Services/PrintDigitalCaseFileService.cs
+++ b/src/backend/TrafficCourts/Staff.Service/Services/PrintDigitalCaseFileService.cs
@@ -94,10 +94,13 @@ public class PrintDigitalCaseFileService : IPrintDigitalCaseFileService
         ticket.Number = dispute.ViolationTicket.TicketNumber;
         ticket.Surname = dispute.ViolationTicket.DisputantSurname;
         ticket.GivenNames = dispute.ViolationTicket.DisputantGivenNames;
-        ticket.DateOfBirth = new FormattedDateOnly(dispute.DisputantBirthdate);
+        ticket.DateOfBirth = dispute.ViolationTicket.DisputantBirthdate?.ToString("yyyy-MM-ddTHH:mm:ss.fffK") == "0001-01-01T08:00:00.000+00:00" ? FormattedDateOnly.Empty : new FormattedDateOnly(dispute.DisputantBirthdate);
         ticket.PoliceDetachment = dispute.ViolationTicket.DetachmentLocation;
         ticket.Issued = new FormattedDateTime(dispute.ViolationTicket.IssuedTs);
-        ticket.Submitted = new FormattedDateOnly(dispute.SubmittedTs);
+        if (dispute.SubmittedTs.HasValue)
+        {
+            ticket.Submitted = ConvertToFormattedLocalDateTime(dispute.SubmittedTs.Value);
+        }
         ticket.CourtAgenyId = dispute.CourtAgenId;
         ticket.CourtHouse = dispute.ViolationTicket.CourtLocation;
 
@@ -141,9 +144,9 @@ public class PrintDigitalCaseFileService : IPrintDigitalCaseFileService
                 break;
         }
         writtenReasons.Signature = dispute.SignatoryName;
-        if (dispute.SignatoryName != null)
+        if (dispute.SignatoryName != null && dispute.SubmittedTs.HasValue)
         {
-            writtenReasons.SubmissionTs = new FormattedDateTime(dispute.SubmittedTs);
+            writtenReasons.SubmissionTs = ConvertToFormattedLocalDateTime(dispute.SubmittedTs.Value);
         }
 
         // set the counts
@@ -289,11 +292,14 @@ public class PrintDigitalCaseFileService : IPrintDigitalCaseFileService
         ticket.Number = dispute.TicketNumber;
         ticket.Surname = dispute.DisputantSurname;
         ticket.GivenNames = ConcatenateWithSpaces(dispute.DisputantGivenName1, dispute.DisputantGivenName2, dispute.DisputantGivenName3);
-        ticket.DateOfBirth = new FormattedDateOnly(dispute.DisputantBirthdate);
+        ticket.DateOfBirth = dispute.DisputantBirthdate?.ToString("yyyy-MM-ddTHH:mm:ss.fffK") == "0001-01-01T08:00:00.000+00:00" ? FormattedDateOnly.Empty : new FormattedDateOnly(dispute.DisputantBirthdate);
         ticket.OffenceLocation = dispute.OffenceLocation;
         ticket.PoliceDetachment = dispute.PoliceDetachment;
         ticket.Issued = new FormattedDateTime(dispute.IssuedTs);
-        ticket.Submitted = new FormattedDateOnly(dispute.SubmittedTs);
+        if (dispute.SubmittedTs.HasValue)
+        {
+            ticket.Submitted = ConvertToFormattedLocalDateTime(dispute.SubmittedTs.Value);
+        }   
         ticket.IcbcReceived = new FormattedDateOnly(dispute.IcbcReceivedDate);
         ticket.CourtAgenyId = dispute.CourtAgenId;
         ticket.CourtHouse = courthouseLocation?.Name ?? string.Empty;
@@ -301,12 +307,7 @@ public class PrintDigitalCaseFileService : IPrintDigitalCaseFileService
         // set the contact information
         var contact = digitalCaseFile.Contact;
         contact.ContactType = ToString(dispute.ContactType);
-        contact.Surname = dispute.ContactSurname ?? ticket.Surname;
-        contact.GivenNames = ConcatenateWithSpaces(dispute.ContactGivenName1, dispute.ContactGivenName2, dispute.ContactGivenName3);
-        if (string.IsNullOrEmpty(contact.GivenNames))
-        {
-            contact.GivenNames = ticket.GivenNames;
-        }
+        SetContactNames(dispute, contact);
         contact.Address = FormatAddress(dispute);
         contact.DriversLicence.Province = driversLicenceProvince?.ProvAbbreviationCd ?? string.Empty;
         contact.DriversLicence.Number = dispute.DriversLicenceNumber;
@@ -352,9 +353,9 @@ public class PrintDigitalCaseFileService : IPrintDigitalCaseFileService
                 break;
         }
         writtenReasons.Signature = dispute.SignatoryName;
-        if (dispute.SignatoryName != null)
+        if (dispute.SignatoryName != null && dispute.SubmittedTs.HasValue)
         {
-            writtenReasons.SubmissionTs = new FormattedDateTime(dispute.SubmittedTs);
+            writtenReasons.SubmissionTs = ConvertToFormattedLocalDateTime(dispute.SubmittedTs.Value);
         }
 
         // set the counts
@@ -397,17 +398,8 @@ public class PrintDigitalCaseFileService : IPrintDigitalCaseFileService
                 {
                     // Assuming disputedCount.LatestPleaUpdateTs is in UTC
                     DateTimeOffset utcDateTimeOffset = disputedCount.LatestPleaUpdateTs.Value;
-                    // Retrieve the local time zone
-                    TimeZoneInfo localTimeZone = TimeZoneInfo.Local;
-                    // Check if the local time zone is UTC
-                    if (localTimeZone.BaseUtcOffset == TimeSpan.Zero)
-                    {
-                        // Fall back to a specific time zone if local time zone is UTC
-                        localTimeZone = TimeZoneInfo.FindSystemTimeZoneById("Pacific Standard Time");
-                    }
                     // Convert the UTC DateTimeOffset to the local DateTimeOffset
-                    DateTimeOffset localDateTimeOffset = TimeZoneInfo.ConvertTime(utcDateTimeOffset, localTimeZone);
-                    offenseCount.LatestPleaUpdate = new FormattedDateTime(localDateTimeOffset);
+                    offenseCount.LatestPleaUpdate = ConvertToFormattedLocalDateTime(utcDateTimeOffset);
                 }
                 if (disputedCount.JjDisputedCountRoP is not null) {
                     offenseCount.LesserDescription = disputedCount.JjDisputedCountRoP.LesserDescription ?? string.Empty;
@@ -974,6 +966,45 @@ public class PrintDigitalCaseFileService : IPrintDigitalCaseFileService
         {
             return null;
         }
+    }
+
+    private void SetContactNames(JJDispute dispute, ContactInformation contact)
+    {
+        switch (dispute.ContactType)
+        {
+            case JJDisputeContactType.INDIVIDUAL:
+                contact.Surname = dispute.OccamDisputantSurnameNm;
+                contact.GivenNames = ConcatenateWithSpaces(dispute.OccamDisputantGiven1Nm, dispute.OccamDisputantGiven2Nm, dispute.OccamDisputantGiven3Nm);
+                break;
+            case JJDisputeContactType.LAWYER:
+                contact.Surname = dispute.LawyerSurname;
+                contact.GivenNames = ConcatenateWithSpaces(dispute.LawyerGivenName1, dispute.LawyerGivenName2, dispute.LawyerGivenName3);
+                break;
+            // Other contact name
+            default:
+                contact.Surname = dispute.ContactSurname;
+                contact.GivenNames = ConcatenateWithSpaces(dispute.ContactGivenName1, dispute.ContactGivenName2, dispute.ContactGivenName3);
+                break;
+        }   
+    }
+
+    private static FormattedDateTime ConvertToFormattedLocalDateTime(DateTimeOffset utcDateTimeOffset, string fallbackTimeZoneId = "Pacific Standard Time")
+    {
+        // Retrieve the local time zone
+        TimeZoneInfo localTimeZone = TimeZoneInfo.Local;
+
+        // Check if the local time zone is UTC
+        if (localTimeZone.BaseUtcOffset == TimeSpan.Zero)
+        {
+            // Fall back to a specific time zone if local time zone is UTC
+            localTimeZone = TimeZoneInfo.FindSystemTimeZoneById(fallbackTimeZoneId);
+        }
+
+        // Convert the UTC DateTimeOffset to the local DateTimeOffset
+        DateTimeOffset localDateTimeOffset = TimeZoneInfo.ConvertTime(utcDateTimeOffset, localTimeZone);
+
+        // Return the FormattedDateTime object
+        return new FormattedDateTime(localDateTimeOffset);
     }
 
 }

--- a/src/backend/TrafficCourts/Staff.Service/Services/PrintDigitalCaseFileService.cs
+++ b/src/backend/TrafficCourts/Staff.Service/Services/PrintDigitalCaseFileService.cs
@@ -99,7 +99,7 @@ public class PrintDigitalCaseFileService : IPrintDigitalCaseFileService
         ticket.Issued = new FormattedDateTime(dispute.ViolationTicket.IssuedTs);
         if (dispute.SubmittedTs.HasValue)
         {
-            ticket.Submitted = ConvertToFormattedLocalDateTime(dispute.SubmittedTs.Value);
+            ticket.Submitted = ConvertToFormattedLocalDateTime(dispute.SubmittedTs.Value, timeZone.Id);
         }
         ticket.CourtAgenyId = dispute.CourtAgenId;
         ticket.CourtHouse = dispute.ViolationTicket.CourtLocation;
@@ -146,7 +146,7 @@ public class PrintDigitalCaseFileService : IPrintDigitalCaseFileService
         writtenReasons.Signature = dispute.SignatoryName;
         if (dispute.SignatoryName != null && dispute.SubmittedTs.HasValue)
         {
-            writtenReasons.SubmissionTs = ConvertToFormattedLocalDateTime(dispute.SubmittedTs.Value);
+            writtenReasons.SubmissionTs = ConvertToFormattedLocalDateTime(dispute.SubmittedTs.Value, timeZone.Id);
         }
 
         // set the counts
@@ -298,7 +298,7 @@ public class PrintDigitalCaseFileService : IPrintDigitalCaseFileService
         ticket.Issued = new FormattedDateTime(dispute.IssuedTs);
         if (dispute.SubmittedTs.HasValue)
         {
-            ticket.Submitted = ConvertToFormattedLocalDateTime(dispute.SubmittedTs.Value);
+            ticket.Submitted = ConvertToFormattedLocalDateTime(dispute.SubmittedTs.Value, timeZone.Id);
         }   
         ticket.IcbcReceived = new FormattedDateOnly(dispute.IcbcReceivedDate);
         ticket.CourtAgenyId = dispute.CourtAgenId;
@@ -355,7 +355,7 @@ public class PrintDigitalCaseFileService : IPrintDigitalCaseFileService
         writtenReasons.Signature = dispute.SignatoryName;
         if (dispute.SignatoryName != null && dispute.SubmittedTs.HasValue)
         {
-            writtenReasons.SubmissionTs = ConvertToFormattedLocalDateTime(dispute.SubmittedTs.Value);
+            writtenReasons.SubmissionTs = ConvertToFormattedLocalDateTime(dispute.SubmittedTs.Value, timeZone.Id);
         }
 
         // set the counts
@@ -399,7 +399,7 @@ public class PrintDigitalCaseFileService : IPrintDigitalCaseFileService
                     // Assuming disputedCount.LatestPleaUpdateTs is in UTC
                     DateTimeOffset utcDateTimeOffset = disputedCount.LatestPleaUpdateTs.Value;
                     // Convert the UTC DateTimeOffset to the local DateTimeOffset
-                    offenseCount.LatestPleaUpdate = ConvertToFormattedLocalDateTime(utcDateTimeOffset);
+                    offenseCount.LatestPleaUpdate = ConvertToFormattedLocalDateTime(utcDateTimeOffset, timeZone.Id);
                 }
                 if (disputedCount.JjDisputedCountRoP is not null) {
                     offenseCount.LesserDescription = disputedCount.JjDisputedCountRoP.LesserDescription ?? string.Empty;

--- a/src/frontend/staff-portal/src/app/components/jj-dispute-info/jj-dispute-court-appearances/jj-dispute-court-appearances.component.html
+++ b/src/frontend/staff-portal/src/app/components/jj-dispute-info/jj-dispute-court-appearances/jj-dispute-court-appearances.component.html
@@ -5,7 +5,7 @@
       Appearance Date/Time
     </th>
     <td mat-cell *matCellDef="let element">
-      <span>{{ element.appearanceTs | date: "dd-MMM-yyyy HH:mm" }}</span>
+      <span>{{ element.appearanceTs | date: "dd-MMM-yyyy HH:mm" : "UTC" }}</span>
     </td>
   </ng-container>
 

--- a/src/frontend/staff-portal/src/app/components/jj-dispute-info/jj-dispute/jj-dispute.component.html
+++ b/src/frontend/staff-portal/src/app/components/jj-dispute-info/jj-dispute/jj-dispute.component.html
@@ -294,7 +294,7 @@
             <span class="section-grid-cell">
               <p class="section-grid-header">Appearance Date/Time</p>
               <p class="section-grid-text">
-                {{ lastUpdatedJJDispute.mostRecentCourtAppearance?.appearanceTs | date: "dd-MMM-yyyy HH:mm" }}
+                {{ lastUpdatedJJDispute.mostRecentCourtAppearance?.appearanceTs | date: "dd-MMM-yyyy HH:mm" : "UTC" }}
               </p>
             </span>
             <span class="section-grid-cell">

--- a/src/frontend/staff-portal/src/app/components/staff-workbench/contact-info/contact-info.component.html
+++ b/src/frontend/staff-portal/src/app/components/staff-workbench/contact-info/contact-info.component.html
@@ -54,10 +54,10 @@
               lastUpdatedDispute.ticketNumber.substring(0,1) === 'E' ? "Electronic Ticket" : "Intersection safety camera ticket" }}</span>
           </div>
           <div class="col-md-3">
-            <span class="BC-Gov-15px-black-text">Violation Date:</span>&nbsp;<span class="text">{{ violationDate | date: "dd-MMM-yyyy" }}</span>
+            <span class="BC-Gov-15px-black-text">Violation Date:</span>&nbsp;<span class="text">{{ lastUpdatedDispute.violationTicket.issuedTs| date: "dd-MMM-yyyy" : "UTC" }}</span>
           </div>
           <div class="col-md-3">
-            <span class="BC-Gov-15px-black-text">Violation Time:</span>&nbsp;<span class="text">{{ violationTime }}</span>
+            <span class="BC-Gov-15px-black-text">Violation Time:</span>&nbsp;<span class="text">{{ lastUpdatedDispute.violationTicket.issuedTs | date: "HH:mm" : "UTC" }}</span>
           </div>
           <div class="col-md-3">
             <span class="BC-Gov-15px-black-text">Surname:</span>&nbsp;


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- [TCVP-3060](https://jag.gov.bc.ca/jira/browse/TCVP-3060)
- Updated print dcf service to nullify 'Birthdate' field if it's set to default date, convert 'Online Submission Date' to be displayed in local BC time instead of UTC time, and displaying disputant provided contact name in 'Disputant Entered Information' section based on contact type.
- Updated staff portal to show violation date and time and appearance date and time fields as it is without converting to the local time.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
