### PR TITLE
TCVP-3060: Print DCF Date of Birth and ICBC received date fields do not match portal view

### DIFF
--- a/src/backend/TrafficCourts/Staff.Service/Services/PrintDigitalCaseFileService.cs
+++ b/src/backend/TrafficCourts/Staff.Service/Services/PrintDigitalCaseFileService.cs
@@ -94,7 +94,11 @@ public class PrintDigitalCaseFileService : IPrintDigitalCaseFileService
         ticket.Number = dispute.ViolationTicket.TicketNumber;
         ticket.Surname = dispute.ViolationTicket.DisputantSurname;
         ticket.GivenNames = dispute.ViolationTicket.DisputantGivenNames;
-        ticket.DateOfBirth = dispute.ViolationTicket.DisputantBirthdate?.ToString("yyyy-MM-ddTHH:mm:ss.fffK") == "0001-01-01T08:00:00.000+00:00" ? FormattedDateOnly.Empty : new FormattedDateOnly(dispute.DisputantBirthdate);
+        ticket.DateOfBirth = 
+            dispute.ViolationTicket.DisputantBirthdate == null || 
+            dispute.ViolationTicket.DisputantBirthdate?.ToString("yyyy-MM-ddTHH:mm:ss.fffK") == "0001-01-01T08:00:00.000+00:00" 
+            ? FormattedDateOnly.Empty 
+            : new FormattedDateOnly(dispute.DisputantBirthdate);
         ticket.PoliceDetachment = dispute.ViolationTicket.DetachmentLocation;
         ticket.Issued = new FormattedDateTime(dispute.ViolationTicket.IssuedTs);
         if (dispute.SubmittedTs.HasValue)
@@ -292,7 +296,11 @@ public class PrintDigitalCaseFileService : IPrintDigitalCaseFileService
         ticket.Number = dispute.TicketNumber;
         ticket.Surname = dispute.DisputantSurname;
         ticket.GivenNames = ConcatenateWithSpaces(dispute.DisputantGivenName1, dispute.DisputantGivenName2, dispute.DisputantGivenName3);
-        ticket.DateOfBirth = dispute.DisputantBirthdate?.ToString("yyyy-MM-ddTHH:mm:ss.fffK") == "0001-01-01T08:00:00.000+00:00" ? FormattedDateOnly.Empty : new FormattedDateOnly(dispute.DisputantBirthdate);
+        ticket.DateOfBirth = 
+            dispute.DisputantBirthdate == null || 
+            dispute.DisputantBirthdate?.ToString("yyyy-MM-ddTHH:mm:ss.fffK") == "0001-01-01T08:00:00.000+00:00" 
+            ? FormattedDateOnly.Empty 
+            : new FormattedDateOnly(dispute.DisputantBirthdate);
         ticket.OffenceLocation = dispute.OffenceLocation;
         ticket.PoliceDetachment = dispute.PoliceDetachment;
         ticket.Issued = new FormattedDateTime(dispute.IssuedTs);

--- a/src/frontend/staff-portal/src/app/components/jj-dispute-info/jj-dispute/jj-dispute.component.html
+++ b/src/frontend/staff-portal/src/app/components/jj-dispute-info/jj-dispute/jj-dispute.component.html
@@ -94,7 +94,7 @@
             </span>
             <span class="section-grid-cell">
               <p class="section-grid-header">Date Received from ICBC</p>
-              <p class="section-grid-text">{{ lastUpdatedJJDispute.icbcReceivedDate | date: "dd-MMM-yyyy" }}
+              <p class="section-grid-text">{{ lastUpdatedJJDispute.icbcReceivedDate | date: "dd-MMM-yyyy" : "UTC" }}
               </p>
             </span>
             <ng-container *ngIf="type !== 'ticket'">


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- [TCVP-3060](https://jag.gov.bc.ca/jira/browse/TCVP-3060)
- Fixed an issue with date of birth field defaults to min date/time value on print DCF when the value is null.
- Fixed an issue with 'Date Received From ICBC' field on staff portal did not match print version by not converting the date to local browser time on staff portal view.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
