### PR TITLE
TCVP-3074: Assign Empty Value to Includes Surcharge

### DIFF
--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/service/JJDisputeService.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/service/JJDisputeService.java
@@ -161,7 +161,12 @@ public class JJDisputeService {
 		}
 		// Add updated ticket counts
 		jjDisputeToUpdate.addJJDisputedCounts(jjDispute.getJjDisputedCounts());
-
+		
+		// TCVP-3074: Set all UNKNOWN includesSurcharge to null since database field does not allow more than 1 character
+		jjDisputeToUpdate.getJjDisputedCounts().stream()
+	    	.filter(jjDisputedCount -> YesNo.UNKNOWN.equals(jjDisputedCount.getIncludesSurcharge()))
+	    	.forEach(jjDisputedCount -> jjDisputedCount.setIncludesSurcharge(null));
+		
 		// Remove all existing jj dispute court appearances that are associated to this jj dispute
 		if (jjDisputeToUpdate.getJjDisputeCourtAppearanceRoPs() != null) {
 			jjDisputeToUpdate.getJjDisputeCourtAppearanceRoPs().clear();


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- [TCVP-3074](https://jag.gov.bc.ca/jira/browse/TCVP-3074)
- Fixed a bug which prevents JJDispute to be updated due to trying to insert 'UNKNOWN' enum value for 'includesSurcharge' field in the database which does not allow more than 1 characters so set this value to null when 'UNKNOWN' passed in.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
