### PR TITLE
TCVP-3078: Remove time from JJ decision calendar pick

### DIFF
--- a/src/frontend/staff-portal/src/app/components/jj-dispute-info/jj-count/jj-count.component.html
+++ b/src/frontend/staff-portal/src/app/components/jj-dispute-info/jj-count/jj-count.component.html
@@ -121,13 +121,13 @@
     </div>
     <div class="row mt-1">
       <div class="col-md-4">
-        <span class="section-grid-header">Date/Time</span>
+        <span class="section-grid-header">Date</span>
       </div>
       <div class="col-md-8" *ngIf="jjDisputedCount">
         <div *ngIf="type !== 'ticket' && !isViewOnly; else view_plea_date_content ">
           <input type="text" formControlName="latestPleaUpdateTs" class="section-grid-text latest-plea-text"
-            bsDatepicker placeholder="DD-MMM-YYYY HH:mm" [bsConfig]="{ withTimepicker: true, keepDatepickerOpened: true, 
-            dateInputFormat: 'DD-MMM-YYYY HH:mm', containerClass: 'theme-dark-blue', isAnimated: true, showWeekNumbers: false, 
+            bsDatepicker placeholder="DD-MMM-YYYY" [bsConfig]="{ withTimepicker: false, keepDatepickerOpened: true, 
+            dateInputFormat: 'DD-MMM-YYYY', containerClass: 'theme-dark-blue', isAnimated: true, showWeekNumbers: false, 
             adaptivePosition: true }">
         </div>
         <ng-template #view_plea_date_content>


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- Updated 'JJ Decision' date/time entry label from 'Date/Time' to 'Date' and changed the calendar picker to only include the date and no time portion reference and updated the placeholder accordingly.

<img width="518" alt="Screenshot 2024-10-30 at 2 49 25 PM" src="https://github.com/user-attachments/assets/c78035be-2f0e-468c-be2f-1d0e3589fdc0">

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
