### PR TITLE
TCVP-3078: Remove jj decision timestamp from dcf

### DIFF
--- a/src/frontend/staff-portal/src/app/components/jj-dispute-info/jj-count/jj-count.component.html
+++ b/src/frontend/staff-portal/src/app/components/jj-dispute-info/jj-count/jj-count.component.html
@@ -131,7 +131,7 @@
             adaptivePosition: true }">
         </div>
         <ng-template #view_plea_date_content>
-          <span class="section-grid-text">{{ jjDisputedCount?.latestPleaUpdateTs | date: "dd-MMM-YYYY HH:mm" }}</span>
+          <span class="section-grid-text">{{ jjDisputedCount?.latestPleaUpdateTs | date: "dd-MMM-YYYY" }}</span>
         </ng-template>
       </div>
     </div>


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- [TCVP-3078](https://jag.gov.bc.ca/jira/browse/TCVP-3078)
- Removed time portion of jj decision date field to display only date on DCFs that are opened via the DCF Search and the Decision Validation screen.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
