### PR TITLE
TCVP-3082: Set time to pay date to JJ signature date

### DIFF
--- a/src/frontend/staff-portal/src/app/components/jj-dispute-info/jj-count/jj-count.component.html
+++ b/src/frontend/staff-portal/src/app/components/jj-dispute-info/jj-count/jj-count.component.html
@@ -377,7 +377,9 @@
           </div>
           <div class="col-md-7" *ngIf="timeToPay">
             <span class="section-grid-text">{{ timeToPay === 'no' ? 'No' : 'Yes' }}</span><br>
-            <span class="section-grid-header text-body">{{ jjDisputedCount?.revisedDueDate | 
+            <span class="section-grid-header text-body"
+              *ngIf="(jjDisputedCount?.revisedDueDate && timeToPay === 'Yes')">{{
+              jjDisputedCount?.revisedDueDate | 
               date: "dd-MMM-yyyy" : "UTC" }}</span>
           </div>
         </div>

--- a/src/frontend/staff-portal/src/app/components/jj-dispute-info/jj-count/jj-count.component.ts
+++ b/src/frontend/staff-portal/src/app/components/jj-dispute-info/jj-count/jj-count.component.ts
@@ -161,7 +161,8 @@ export class JJCountComponent implements OnInit, OnChanges {
           "yes" : "no") : "") : "";      
       this.timeToPay = this.jjDisputedCount ? (this.jjDisputedCount.revisedDueDate ? 
         (new Date(this.jjDisputedCount.dueDate).getDate() != new Date(this.jjDisputedCount.revisedDueDate).getDate() 
-        ? "yes" : "no") : "") : "";
+          && this.jjDisputedCount.revisedDueDate.split('T')[0] != this.jjDisputeInfo.jjDecisionDate.split('T')[0]
+          ? "Yes" : "No") : "") : "";
       this.bindRevisedDueDate(this.jjDisputedCount.revisedDueDate);
       this.updateInclSurcharge(this.inclSurcharge);
 
@@ -485,11 +486,9 @@ export class JJCountComponent implements OnInit, OnChanges {
   }
 
   updateRevisedDueDate(event: MatRadioChange) {
-    // if they select no set it back to passed in due date
+    // if they select no set it to null
     if (event.value == "no") {
-      const revisedDueDate = new Date(this.jjDisputedCount?.dueDate);
-      revisedDueDate.setDate(revisedDueDate.getDate() + 1);
-      this.form.controls.revisedDueDate.setValue(revisedDueDate);
+      this.form.controls.revisedDueDate.setValue(null);
     }
   }
 

--- a/src/frontend/staff-portal/src/app/components/jj-dispute-info/jj-dispute/jj-dispute.component.ts
+++ b/src/frontend/staff-portal/src/app/components/jj-dispute-info/jj-dispute/jj-dispute.component.ts
@@ -230,6 +230,13 @@ export class JJDisputeComponent implements OnInit {
   }
 
   onConfirm(): void {
+    // TCVP-3082: Set dueDate values to current date before opening the dialog
+    this.lastUpdatedJJDispute.jjDisputedCounts.forEach(count => {
+      if (!count.revisedDueDate) {
+        count.revisedDueDate = new Date().toISOString();
+      }
+    });
+
     const data: DialogOptions = {
       titleKey: "Submit to VTC Staff?",
       messageKey: "Are you sure this dispute is ready to be submitted to VTC Staff?",

--- a/src/frontend/staff-portal/src/app/shared/dialogs/confirm-dialog/confirm-dialog.component.html
+++ b/src/frontend/staff-portal/src/app/shared/dialogs/confirm-dialog/confirm-dialog.component.html
@@ -34,8 +34,8 @@
             <span class="section-grid-text">
               {{
                 count.jjDisputedCountRoP?.finding === 'NOT_GUILTY' ? '' :
-                (count.revisedDueDate ? (count.revisedDueDate | date: "dd-MMM-yyyy") :
-                (count.dueDate ? (count.dueDate | date: "dd-MMM-yyyy") : ''))
+                (count.revisedDueDate ? (count.revisedDueDate | date: "dd-MMM-yyyy" : "UTC") :
+                (count.dueDate ? (count.dueDate | date: "dd-MMM-yyyy" : "UTC") : ''))
               }}
             </span>
           </span>


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- [TCVP-3082](https://jag.gov.bc.ca/jira/browse/TCVP-3082)
- Added functionality to set the due date for count to the JJ confirmed/signed date when JJ selects 'no' for time to pay in final disposition section or leaves the field blank.
- Fixed UTC time issue for count due dates on the confirm dialog pop up.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
