### PR TITLE
TCVP-3115 - Bug email tls verify failures

### DIFF
--- a/gitops/charts/traffic-court-dev-values.yaml
+++ b/gitops/charts/traffic-court-dev-values.yaml
@@ -251,7 +251,7 @@ staff-web:
 
 workflow-service:
   image:
-    tag: "2.5.1"
+    tag: "2.5.2"
     pullPolicy: Always
   env:
     "EmailConfiguration__Sender": "DoNotReply@gov.bc.ca"

--- a/gitops/charts/traffic-court-prod-values.yaml
+++ b/gitops/charts/traffic-court-prod-values.yaml
@@ -407,7 +407,7 @@ workflow-service:
   pdb:
     create: true
   image:
-    tag: "2.5.1"
+    tag: "2.5.2"
     pullPolicy: Always
   env:
     "EmailConfiguration__Sender": "DoNotReply@gov.bc.ca"

--- a/gitops/charts/traffic-court-test-values.yaml
+++ b/gitops/charts/traffic-court-test-values.yaml
@@ -322,7 +322,7 @@ workflow-service:
   pdb:
     create: true
   image:
-    tag: "2.5.1"
+    tag: "2.5.2"
     pullPolicy: Always
   env:
     "EmailConfiguration__Sender": "DoNotReply@gov.bc.ca"

--- a/src/backend/TrafficCourts/Workflow.Service/Configuration/SmtpConfiguration.cs
+++ b/src/backend/TrafficCourts/Workflow.Service/Configuration/SmtpConfiguration.cs
@@ -18,6 +18,11 @@ namespace TrafficCourts.Workflow.Service.Configuration
         /// </summary>
         public int Port { get; set; }
 
+        /// <summary>
+        /// Set to true if you want to ignore certificate validation
+        /// </summary>
+        public bool IgnoreCertificateValidation { get; set; }
+
         public void Validate()
         {
             if (string.IsNullOrEmpty(Host)) throw new SettingsValidationException(Section, nameof(Host), "is required");


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- TCVP-3115 add option to bypass certificate validation when sending email

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [ ] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
