### PR TITLE
[TCVP-3062] User to be returned to same page after viewing a dispute

### DIFF
--- a/src/frontend/staff-portal/src/app/components/jj-workbench/jj-dispute-digital-case-file/jj-dispute-digital-case-file.component.ts
+++ b/src/frontend/staff-portal/src/app/components/jj-workbench/jj-dispute-digital-case-file/jj-dispute-digital-case-file.component.ts
@@ -37,6 +37,7 @@ export class JJDisputeDigitalCaseFileComponent implements OnInit {
   sortBy: string = "submittedTs";
   sortDirection: SortDirection = SortDirection.Desc;
   filters: TableFilter = new TableFilter();
+  previousFilters: TableFilter = new TableFilter();
   disputeStatus = DisputeStatus;
 
   constructor(
@@ -50,6 +51,8 @@ export class JJDisputeDigitalCaseFileComponent implements OnInit {
     let dataFilter: TableFilter = this.tableFilterService.tableFilters[this.tabIndex];
     dataFilter.status = dataFilter.status ?? "";
     this.filters = dataFilter; 
+    this.previousFilters = { ...dataFilter };
+    this.currentPage = this.tableFilterService.currentPage[this.tabIndex];
     this.getTCODisputes();    
   }
 
@@ -86,8 +89,12 @@ export class JJDisputeDigitalCaseFileComponent implements OnInit {
   }
 
   onApplyFilter(dataFilters: TableFilter) {
+    if (JSON.stringify(this.previousFilters) !== JSON.stringify(dataFilters)) { // Add this line
+      this.currentPage = 1;
+      this.tableFilterService.currentPage[this.tabIndex] = 1;
+    }
     this.filters = dataFilters;
-    this.currentPage = 1;
+    this.previousFilters = { ...dataFilters };
     this.getTCODisputes();
   }
 
@@ -95,11 +102,13 @@ export class JJDisputeDigitalCaseFileComponent implements OnInit {
     this.sortBy = sort.active;
     this.sortDirection = sort.direction ? sort.direction as SortDirection : SortDirection.Desc;
     this.currentPage = 1;
+    this.tableFilterService.currentPage[this.tabIndex] = 1;
     this.getTCODisputes();
   }
 
   onPageChange(event: number) {
     this.currentPage = event;
+    this.tableFilterService.currentPage[this.tabIndex] = event;
     this.getTCODisputes();
   }
 

--- a/src/frontend/staff-portal/src/app/components/staff-workbench/dispute-decision-inbox/dispute-decision-inbox.component.ts
+++ b/src/frontend/staff-portal/src/app/components/staff-workbench/dispute-decision-inbox/dispute-decision-inbox.component.ts
@@ -45,6 +45,7 @@ export class DisputeDecisionInboxComponent implements OnInit {
   sortBy: string = "jjDecisionDate";
   sortDirection: SortDirection = SortDirection.Asc;
   filters: TableFilter = new TableFilter();
+  previousFilters: TableFilter = new TableFilter();
   disputeStatus = DisputeStatus;
 
   constructor(
@@ -70,6 +71,8 @@ export class DisputeDecisionInboxComponent implements OnInit {
     let dataFilter: TableFilter = this.tableFilterService.tableFilters[this.tabIndex];
     dataFilter.status = dataFilter.status ?? "";
     this.filters = dataFilter;
+    this.previousFilters = { ...dataFilter };
+    this.currentPage = this.tableFilterService.currentPage[this.tabIndex];
     this.authService.userProfile$.subscribe(userProfile => {
       if (userProfile) {
         this.IDIR = userProfile.idir;
@@ -115,8 +118,12 @@ export class DisputeDecisionInboxComponent implements OnInit {
   }
 
   onApplyFilter(dataFilters: TableFilter) {
+    if (JSON.stringify(this.previousFilters) !== JSON.stringify(dataFilters)) { // Add this line
+      this.currentPage = 1;
+      this.tableFilterService.currentPage[this.tabIndex] = 1;
+    }
     this.filters = dataFilters;
-    this.currentPage = 1;
+    this.previousFilters = { ...dataFilters };
     this.getTCODisputes();
   }
 
@@ -124,11 +131,13 @@ export class DisputeDecisionInboxComponent implements OnInit {
     this.sortBy = sort.active;
     this.sortDirection = sort.direction ? sort.direction as SortDirection : SortDirection.Desc;
     this.currentPage = 1;
+    this.tableFilterService.currentPage[this.tabIndex] = 1;
     this.getTCODisputes();
   }
 
   onPageChange(event: number) {
     this.currentPage = event;
+    this.tableFilterService.currentPage[this.tabIndex] = event;
     this.getTCODisputes();
   }
 }

--- a/src/frontend/staff-portal/src/app/components/staff-workbench/ticket-inbox/ticket-inbox.component.ts
+++ b/src/frontend/staff-portal/src/app/components/staff-workbench/ticket-inbox/ticket-inbox.component.ts
@@ -48,6 +48,7 @@ export class TicketInboxComponent implements OnInit {
   sortDirection: Array<SortDirection> = [SortDirection.Desc];
   newCount: number = 0;
   filters: TableFilter = new TableFilter();
+  previousFilters: TableFilter = new TableFilter();
 
   constructor(
     private disputeService: DisputeService,
@@ -72,6 +73,8 @@ export class TicketInboxComponent implements OnInit {
     let dataFilter: TableFilter = this.tableFilterService.tableFilters[this.tabIndex];
     dataFilter.status = dataFilter.status ?? "";
     this.filters = dataFilter;
+    this.previousFilters = { ...dataFilter };
+    this.currentPage = this.tableFilterService.currentPage[this.tabIndex];
     this.getAllDisputes();
     this.countNewTickets();
   }
@@ -119,8 +122,12 @@ export class TicketInboxComponent implements OnInit {
 
   // called on keyup in filter field
   onApplyFilter(dataFilters: TableFilter) {
+    if (JSON.stringify(this.previousFilters) !== JSON.stringify(dataFilters)) { // Add this line
+      this.currentPage = 1;
+      this.tableFilterService.currentPage[this.tabIndex] = 1;
+    }
     this.filters = dataFilters;
-    this.currentPage = 1;
+    this.previousFilters = { ...dataFilters };
     this.getAllDisputes();
   }
 
@@ -132,11 +139,13 @@ export class TicketInboxComponent implements OnInit {
     this.sortBy = [sort.active];
     this.sortDirection = [sort.direction ? sort.direction as SortDirection : SortDirection.Desc];
     this.currentPage = 1;
+    this.tableFilterService.currentPage[this.tabIndex] = 1;
     this.getAllDisputes();
   }
 
   onPageChange(event: number) {
     this.currentPage = event;
+    this.tableFilterService.currentPage[this.tabIndex] = event;
     this.getAllDisputes();
   }
 }

--- a/src/frontend/staff-portal/src/app/services/table-filter.service.ts
+++ b/src/frontend/staff-portal/src/app/services/table-filter.service.ts
@@ -6,7 +6,7 @@ import { TableFilter } from '@shared/models/table-filter-options.model';
 })
 export class TableFilterService { // Temp
   tableFilters: TableFilter[] = new Array(4).fill(new TableFilter());
-
+  currentPage: number[] = new Array(4).fill(1);
   constructor(
   ) {
   }


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

#TCVP-3062 
updated filters of ticket-validation-inbox, decision-validation-inbox and DCF, in order to keep last selected page, after returning to inbox

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
