### PR TITLE
TCVP-3152: Add filtering by surname or org name

### DIFF
--- a/src/backend/TrafficCourts/Staff.Service/Controllers/JJController.cs
+++ b/src/backend/TrafficCourts/Staff.Service/Controllers/JJController.cs
@@ -105,7 +105,7 @@ public partial class JJController : StaffControllerBase
     /// <param name="hearing_type_cd">The hearing type code to search.</param>
     /// <param name="page_number">The page number to fetch. Starts at 1.</param>
     /// <param name="page_size">The page size to use. If not specified, defaults to 25</param>
-    /// <param name="sort_by">The list of columns to sort the result by. To sort descending, add a '-' before the column name.</param>
+    /// <param name="sort_by">The list of columns to sort the result by. To sort descending, add a '-' before the column name. Note: 'surnameOrOrgName' is a pseudo field for sorting by surname or organization name.</param>
     /// <param name="cancellationToken"></param>
     /// <returns></returns>
 #if DEBUG

--- a/src/backend/TrafficCourts/Staff.Service/Controllers/JJController.cs
+++ b/src/backend/TrafficCourts/Staff.Service/Controllers/JJController.cs
@@ -93,6 +93,7 @@ public partial class JJController : StaffControllerBase
     /// <param name="submitted_thru">Disputes sumbitted on or before this date</param>
     /// <param name="ticket_number"></param>
     /// <param name="surname">The case insenstive surname to search for.</param>
+    /// <param name="surname_or_org_name">The case insenstive disputant surname or organization name to search for.</param>
     /// <param name="jj_assigned_to">The JJ assigned user</param>
     /// <param name="jj_decision_dt_from">The jj decision date where greater or equal to this date. Format must be YYYY-MM-DD.</param>
     /// <param name="jj_decision_dt_thru">The jj decision date where less or equal to this date. Format must be YYYY-MM-DD.</param>
@@ -126,6 +127,7 @@ public partial class JJController : StaffControllerBase
         string? submitted_thru,
         string? ticket_number,
         string? surname,
+        string? surname_or_org_name,
         string? jj_assigned_to,
         string? jj_decision_dt_from,
         string? jj_decision_dt_thru,
@@ -151,6 +153,7 @@ public partial class JJController : StaffControllerBase
             submitted_thru = submitted_thru,
             ticket_number  = ticket_number,
             surname = surname,
+            surname_or_org_name = surname_or_org_name,
             jj_assigned_to = jj_assigned_to,
             jj_decision_dt_from = jj_decision_dt_from,
             jj_decision_dt_thru = jj_decision_dt_thru,

--- a/src/backend/TrafficCourts/Staff.Service/Features/CourtFiles/Summaries/Handler.cs
+++ b/src/backend/TrafficCourts/Staff.Service/Features/CourtFiles/Summaries/Handler.cs
@@ -140,11 +140,12 @@ public class Handler : IRequestHandler<Request, Response>
         AddUtcDateRangeFilter(parameters, "jj_decision_dt", request.time_zone, request.jj_decision_dt_from, request.jj_decision_dt_thru);
 
         AddDateRangeFilter(parameters, "appr_tm", request.appearance_dt_from, request.appearance_dt_thru);
-
-        // Search where starts with the spuplied value. We could also use "_regexp_like" and use a regex pattern
+        
+        // Search where starts with the supplied value. We could also use "_regexp_like" and use a regex pattern
         // ticket number is always uppercase
         AddLikeFilter(parameters, "ticket_number_txt", request.ticket_number);
         AddLikeFilter(parameters, "prof_surname_nm", request.surname);
+        AddLikeFilter(parameters, "prof_surname_nm_or_org_nm", request.surname_or_org_name);
 
         if (request.jj_assigned_to is not null) parameters.Add("jj_assigned_to_eq", request.jj_assigned_to);
 
@@ -266,6 +267,7 @@ public class Handler : IRequestHandler<Request, Response>
                 "violationDate" => "violation_dt",
                 "toBeHeardAtCourthouseName" => "to_be_heard_at_agen_nm",
                 "surname" => "prof_surname_nm",
+                "surnameOrOrgName" => "prof_surname_nm_or_org_nm",
                 "disputantGivenName1" => "prof_given_1_nm",
                 "status" => "dispute_status_type_dsc",
                 "policeDetachment" => "detachment_agency_nm",
@@ -392,6 +394,7 @@ public class Handler : IRequestHandler<Request, Response>
             DisputantGivenName1 = dispute.prof_given_1_nm,
             DisputantGivenName2 = dispute.prof_given_2_nm,
             DisputantGivenName3 = dispute.prof_given_3_nm,
+            DisputantOrganizationName = dispute.prof_org_nm,
             FineReductionReason = dispute.fine_reduction_reason_txt,
             TimeToPayReason = dispute.time_to_pay_reason_txt,
             DisputeStatus = new DisputeCaseFileStatus

--- a/src/backend/TrafficCourts/Staff.Service/Features/CourtFiles/Summaries/Request.cs
+++ b/src/backend/TrafficCourts/Staff.Service/Features/CourtFiles/Summaries/Request.cs
@@ -15,6 +15,7 @@ public class Request : IRequest<Response>
 
     public string? ticket_number { get; set; }
     public string? surname { get; set; }
+    public string? surname_or_org_name { get; set; }
 
     public string? jj_assigned_to { get; set; }
 

--- a/src/backend/TrafficCourts/TrafficCourts.Core/Domain/Models/DisputeCaseFileSummary.cs
+++ b/src/backend/TrafficCourts/TrafficCourts.Core/Domain/Models/DisputeCaseFileSummary.cs
@@ -20,6 +20,7 @@ public class DisputeCaseFileSummary
     public string DisputantGivenName1 { get; set; }
     public string DisputantGivenName2 { get; set; }
     public string DisputantGivenName3 { get; set; }
+    public string DisputantOrganizationName { get; set; }
     
     public DisputeCaseFileStatus DisputeStatus { get; set; }
 

--- a/src/backend/TrafficCourts/TrafficCourts.OrdsDataService/Tco/OrdsDisputeCaseFileSummary.cs
+++ b/src/backend/TrafficCourts/TrafficCourts.OrdsDataService/Tco/OrdsDisputeCaseFileSummary.cs
@@ -21,6 +21,7 @@ public class OrdsDisputeCaseFileSummary
     public string prof_given_1_nm { get; set; }
     public string prof_given_2_nm { get; set; }
     public string prof_given_3_nm { get; set; }
+    public string prof_org_nm { get; set; }
     public string time_to_pay_reason_txt { get; set; }
     public string fine_reduction_reason_txt { get; set; }
     public string dispute_status_type_cd { get; set; }


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- [TCVP-3152](https://jag.gov.bc.ca/jira/browse/TCVP-3152)
- Added functionality to search by disputant surname or organization name through jj dispute search endpoint utilizing the new 'prof_surname_nm_or_org_nm' ords query parameter.
- Added 'disputantOrganizationName' field to return as part of dcf search request's response.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
