### PR TITLE
[TCVP-3092] bugfix, ocr error box hitting enter key propagation

### DIFF
--- a/src/frontend/citizen-portal/src/app/shared/dialogs/image-ticket-not-found-dialog/image-ticket-not-found-dialog.component.ts
+++ b/src/frontend/citizen-portal/src/app/shared/dialogs/image-ticket-not-found-dialog/image-ticket-not-found-dialog.component.ts
@@ -1,4 +1,4 @@
-import { Component, Inject, ChangeDetectionStrategy} from '@angular/core';
+import { Component, Inject, ChangeDetectionStrategy, HostListener} from '@angular/core';
 import { MatLegacyDialog as MatDialog } from '@angular/material/legacy-dialog';
 import { MAT_LEGACY_DIALOG_DATA as MAT_DIALOG_DATA, MatLegacyDialogRef as MatDialogRef } from '@angular/material/legacy-dialog';
 
@@ -58,6 +58,16 @@ export class ImageTicketNotFoundDialogComponent {
       icon: options.actionType === 'warn' ? 'warning' : 'help',
       ...options,
     };
+  }
+  @HostListener('document:keydown', ['$event'])
+  public preventEvent(event: KeyboardEvent): void {
+    if (this.options.messageKey === 'error500') {
+      event.preventDefault();
+      event.stopPropagation();
+      if (event.key === 'Enter') {
+        this.dialogRef.close();
+      }
+    }
   }
 
 }


### PR DESCRIPTION

# Description
when user press enter key when the ocr error box is shown, it shouldn't open brows window in browser
[https://jira.justice.gov.bc.ca/browse/TCVP-3092](url)

This PR includes the following proposed change(s):

- added `preventDefault()`
- added `stopPropagation()`
- in the event of pressing enter key, now it closes the error dialog

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
