### PR TITLE
TCVP-3163: Fix TTP date on final disposition

### DIFF
--- a/src/frontend/staff-portal/src/app/components/jj-dispute-info/jj-count/jj-count.component.ts
+++ b/src/frontend/staff-portal/src/app/components/jj-dispute-info/jj-count/jj-count.component.ts
@@ -158,10 +158,11 @@ export class JJCountComponent implements OnInit, OnChanges {
       this.fineReduction = this.jjDisputedCount ? (this.jjDisputedCount.totalFineAmount && 
           this.jjDisputedCount.lesserOrGreaterAmount ? (this.jjDisputedCount.lesserOrGreaterAmount !== null && 
           this.jjDisputedCount.lesserOrGreaterAmount != this.jjDisputedCount.ticketedFineAmount ? 
-          "yes" : "no") : "") : "";      
-      this.timeToPay = this.jjDisputedCount ? ((this.jjDisputedCount.revisedDueDate && this.jjDisputeInfo.jjDecisionDate) ? 
+          "yes" : "no") : "") : "";
+      let today = new Date();      
+      this.timeToPay = this.jjDisputedCount ? ((this.jjDisputedCount.revisedDueDate) ? 
         (new Date(this.jjDisputedCount.dueDate).getDate() != new Date(this.jjDisputedCount.revisedDueDate).getDate() 
-          && this.jjDisputedCount.revisedDueDate.split('T')[0] != this.jjDisputeInfo.jjDecisionDate.split('T')[0]
+          && this.jjDisputedCount.revisedDueDate.split('T')[0] != today.toISOString().split('T')[0]
           ? "yes" : "no") : "") : "";
       this.bindRevisedDueDate(this.jjDisputedCount.revisedDueDate);
       this.updateInclSurcharge(this.inclSurcharge);
@@ -286,6 +287,7 @@ export class JJCountComponent implements OnInit, OnChanges {
         this.jjDisputedCount = { ...this.jjDisputedCount, ...this.countForm.value };
         if (this.jjDisputedCount.revisedDueDate) {
           let revisedDueDate = new Date(this.jjDisputedCount.revisedDueDate);
+          revisedDueDate.setDate(revisedDueDate.getDate() + 1);
           revisedDueDate.setHours(0, 0, 0, 0);
           this.jjDisputedCount.revisedDueDate = revisedDueDate.toISOString().slice(0, 10);
         }


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- [TCVP-3154](https://jira.justice.gov.bc.ca/browse/TCVP-3154)
- Fixed an issue with 'Time to Pay' field was not showing the recorded date where the decision was entered after selecting 'save and finish'.
- Fixed an issue with 'Time to Pay' date was not showing the correct entered date at the bottom of final disposition section and on the confirm and adjourn/require hearing dialog pop ups.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
