### PR TITLE
Update COMS integration tests to support multiple versions

### DIFF
--- a/src/backend/TrafficCourts/TrafficCourts.Coms.Client.Test/ComsContainers.cs
+++ b/src/backend/TrafficCourts/TrafficCourts.Coms.Client.Test/ComsContainers.cs
@@ -1,10 +1,15 @@
-﻿using DotNet.Testcontainers.Builders;
+﻿using Docker.DotNet.Models;
+using DotNet.Testcontainers.Builders;
+using DotNet.Testcontainers.Configurations;
 using DotNet.Testcontainers.Containers;
 using DotNet.Testcontainers.Networks;
 using Microsoft.Extensions.Logging;
 using Minio;
+using Minio.DataModel;
 using Minio.DataModel.Args;
 using Npgsql;
+using System.Reactive.Joins;
+using System.Text.RegularExpressions;
 using Testcontainers.Minio;
 using Testcontainers.PostgreSql;
 
@@ -12,7 +17,12 @@ namespace TrafficCourts.Coms.Client.Test
 {
     public class ComsContainers : IAsyncDisposable
     {
+        /// <summary>
+        /// The version of COMS we want to test
+        /// </summary>
         private readonly string _tag;
+
+        private readonly List<string> _migrationTags;
         
         private string? _bucket;
         private INetwork? _network;
@@ -25,9 +35,30 @@ namespace TrafficCourts.Coms.Client.Test
         public PostgreSqlContainer? Postgres => _postgresContainer;
         public IContainer? Coms => _comsContainer;
 
-        public ComsContainers(string tag = "0.4.2")
+        /// <summary>
+        /// A composite collection of test containers used to test COMS integration.
+        /// </summary>
+        /// <param name="tag">The version of COMS to run</param>
+        /// <param name="migrationTags">
+        /// Optional list of migration tags to apply. The tags will be applied in the order supplied.
+        /// The <paramref name="tag"/> will be appended to the end
+        /// if it does not already exist in the supplied tags.
+        /// </param>
+        /// <remarks>
+        /// The <paramref name="migrationTags"/> are only required if you are looking to test applying a series of migrations
+        /// to simulate an upgrade path. One would assume the latest migration would handle bringing the database to the 
+        /// latest version. However, there could be situations where previous versions 
+        /// had errors that prevent newer migrations from completing successfully.
+        /// </remarks>
+        public ComsContainers(string tag, params string[] migrationTags)
         {
             _tag = tag;
+
+            _migrationTags = new List<string>(migrationTags);
+            if (!_migrationTags.Contains(tag))
+            {
+                _migrationTags.Add(tag);
+            }
         }
 
         public async ValueTask DisposeAsync()
@@ -116,16 +147,19 @@ namespace TrafficCourts.Coms.Client.Test
             _bucket = await CreateBucket(enableBucketVersioning, cancellationToken);
 
             // run the database migrations
-            var initContainer = GetComsContainer(_network, _postgresContainer, _minioContainer)
-                                .WithCommand("npm", "run", "migrate")
-                                .Build();
+            foreach (var migrationTag in _migrationTags)
+            {
+                var container = GetComsDbMigrationContainer(migrationTag, _network, _postgresContainer)
+                    .Build();
 
-            await initContainer.StartAsync(cancellationToken);
+                await container.StartAsync(cancellationToken);
 
-            await Task.Delay(TimeSpan.FromSeconds(10), cancellationToken);
+                long rc = await container.GetExitCodeAsync(cancellationToken);
+                var logs = await container.GetLogsAsync();
 
-            long rc = await initContainer.GetExitCodeAsync(cancellationToken);
-            Assert.Equal(0, rc);
+                Assert.Equal(0, rc);
+
+            }
 
             // run the coms service
             _comsContainer = GetComsContainer(_network, _postgresContainer, _minioContainer)
@@ -172,32 +206,133 @@ namespace TrafficCourts.Coms.Client.Test
             return client;
         }
 
-        private ContainerBuilder GetComsContainer(
-            INetwork network,
-            PostgreSqlContainer postgres, 
-            MinioContainer minio)
+        private static ContainerBuilder GetComsCoreContainer(string tag, INetwork network, PostgreSqlContainer postgres)
+        {
+            var containerBuilder = new ContainerBuilder()
+                .WithNetwork(network)
+                .WithImage($"docker.io/bcgovimages/common-object-management-service:{tag}")
+                .WithPostgres(postgres);
+
+            return containerBuilder;
+        }
+
+
+        private static ContainerBuilder GetComsDbMigrationContainer(string tag, INetwork network, PostgreSqlContainer postgres)
         {
             var connectionString = new NpgsqlConnectionStringBuilder(postgres.GetConnectionString());
 
-            var containerBuilder = new ContainerBuilder()
-                .WithNetwork(network)
-                .WithImage($"docker.io/bcgovimages/common-object-management-service:{_tag}")
-                .WithEnvironment("DB_ENABLED", "true")
-                .WithEnvironment("DB_DATABASE", connectionString.Database)
-                .WithEnvironment("DB_HOST", postgres.Name[1..])
-                .WithEnvironment("DB_PORT", "5432")
-                .WithEnvironment("DB_USERNAME", connectionString.Username)
-                .WithEnvironment("DB_PASSWORD", connectionString.Password)
-                .WithEnvironment("BASICAUTH_USERNAME", "username")
-                .WithEnvironment("BASICAUTH_PASSWORD", "password")
-                .WithEnvironment("OBJECTSTORAGE_ENABLED", "true")
-                .WithEnvironment("OBJECTSTORAGE_ACCESSKEYID", minio.GetAccessKey())
-                .WithEnvironment("OBJECTSTORAGE_SECRETACCESSKEY", minio.GetSecretKey())
-                .WithEnvironment("OBJECTSTORAGE_BUCKET", _bucket)
-                .WithEnvironment("OBJECTSTORAGE_ENDPOINT", $"http://{minio.Name[1..]}:9000")
-                .WithEnvironment("OBJECTSTORAGE_KEY", "/");
+            var containerBuilder = GetComsCoreContainer(tag, network, postgres)
+                .WithCommand("npm", "run", "migrate")
+                .WaitForContainerExited();
 
             return containerBuilder;
+        }
+
+        private ContainerBuilder GetComsContainer(
+            INetwork network,
+            PostgreSqlContainer postgres,
+            MinioContainer minio)
+        {
+            var containerBuilder = GetComsContainer(_tag, _bucket, network, postgres, minio);
+            return containerBuilder;
+        }
+
+        private static ContainerBuilder GetComsContainer(
+            string tag,
+            string? bucket,
+            INetwork network,
+            PostgreSqlContainer postgres,
+            MinioContainer minio)
+        {
+            var containerBuilder = GetComsCoreContainer(tag, network, postgres)
+                .WithBasicAuthentication("username", "password")
+                .WithEnvironment("OBJECTSTORAGE_ENABLED", "true")
+                .WithMinioObjectStorage(minio, bucket);
+
+            return containerBuilder;
+        }
+    }
+}
+
+public static class ContainerExtensions
+{
+    public static System.Version ContainerVersion(this IContainer container)
+    {
+        var tag = container.Image.Tag;
+
+        if (tag == "latest")
+        {
+            return new System.Version(0, 0, 0, 0);
+        }
+
+        try
+        {
+            return new System.Version(tag);
+        }
+        catch (FormatException)
+        {
+            // probably non-version type string like 2022-latest or RELEASE.2022-10-24T18-35-07Z
+            return new System.Version(-1, -1, -1, -1);
+        }
+    }
+}
+
+public static class ContainerBuilderExtensions
+{
+    public static ContainerBuilder WithBasicAuthentication(this ContainerBuilder builder, string username, string password)
+    {
+        builder = builder
+            .WithEnvironment("BASICAUTH_USERNAME", username)
+            .WithEnvironment("BASICAUTH_PASSWORD", password);
+
+        return builder;
+    }
+
+    public static ContainerBuilder WithPostgres(this ContainerBuilder builder, PostgreSqlContainer postgres)
+    {
+        var connectionString = new NpgsqlConnectionStringBuilder(postgres.GetConnectionString());
+
+        builder = builder
+            .WithEnvironment("DB_ENABLED", "true")
+            .WithEnvironment("DB_DATABASE", connectionString.Database)
+            .WithEnvironment("DB_HOST", postgres.Name[1..])
+            .WithEnvironment("DB_PORT", "5432")
+            .WithEnvironment("DB_USERNAME", connectionString.Username)
+            .WithEnvironment("DB_PASSWORD", connectionString.Password);
+
+        return builder;
+    }
+
+    public static ContainerBuilder WithMinioObjectStorage(this ContainerBuilder builder, MinioContainer minio, string? bucket)
+    {
+        builder = builder
+            .WithEnvironment("OBJECTSTORAGE_ENABLED", "true")
+            .WithEnvironment("OBJECTSTORAGE_ACCESSKEYID", minio.GetAccessKey())
+            .WithEnvironment("OBJECTSTORAGE_SECRETACCESSKEY", minio.GetSecretKey())
+            .WithEnvironment("OBJECTSTORAGE_BUCKET", bucket)
+            .WithEnvironment("OBJECTSTORAGE_ENDPOINT", $"http://{minio.Name[1..]}:9000")
+            .WithEnvironment("OBJECTSTORAGE_KEY", "/");
+
+        return builder;
+    }
+
+    public static ContainerBuilder WaitForContainerExited(this ContainerBuilder builder)
+    {
+        builder = builder
+            .WithWaitStrategy(Wait.ForUnixContainer().AddCustomWaitStrategy(new ContainerExited()));
+
+        return builder;
+    }
+
+    private sealed class ContainerExited : IWaitUntil
+    {
+        // The Flyway container will exit after executing the database migration. We do not
+        // check if the migration was successful. To verify its success, we can either
+        // check the exit code of the container or the console output, respectively the
+        // standard output (stdout) or error output (stderr).
+        public Task<bool> UntilAsync(IContainer container)
+        {
+            return Task.FromResult(TestcontainersStates.Exited.Equals(container.State));
         }
     }
 }

--- a/src/backend/TrafficCourts/TrafficCourts.Coms.Client.Test/ComsIntegrationTest.cs
+++ b/src/backend/TrafficCourts/TrafficCourts.Coms.Client.Test/ComsIntegrationTest.cs
@@ -1,4 +1,5 @@
-﻿using Xunit.Abstractions;
+﻿using System.Text.RegularExpressions;
+using Xunit.Abstractions;
 
 namespace TrafficCourts.Coms.Client.Test
 {
@@ -19,9 +20,9 @@ namespace TrafficCourts.Coms.Client.Test
     public abstract class ComsIntegrationTest : IAsyncLifetime
     {
         private readonly bool _versioningEnabled;
-
-        private readonly ComsContainers _containers = new();
         private readonly ITestOutputHelper _output;
+
+        private ComsContainers _containers;
 
         protected ComsIntegrationTest(bool versioningEnabled, ITestOutputHelper output)
         {
@@ -31,7 +32,6 @@ namespace TrafficCourts.Coms.Client.Test
 
         public async Task InitializeAsync()
         {
-            await _containers.BuildAndStartAsync(_versioningEnabled, CancellationToken.None);
         }
 
         public async Task DisposeAsync()
@@ -39,9 +39,14 @@ namespace TrafficCourts.Coms.Client.Test
             await _containers.DisposeAsync().AsTask();
         }
 
-        [IntegrationTestFact]
-        public async Task client_can_delete_files()
+        [IntegrationTestTheory]
+        [InlineData("0.4.2")]
+        [InlineData("0.5.0")]
+        public async Task client_can_delete_files(string version)
         {
+            _containers = new(version);
+            await _containers.BuildAndStartAsync(_versioningEnabled, CancellationToken.None);
+
             var client = _containers.GetObjectManagementClient();
 
             // create a file
@@ -58,9 +63,14 @@ namespace TrafficCourts.Coms.Client.Test
             Assert.Equal(404, e.StatusCode);
         }
 
-        [IntegrationTestFact]
-        public async Task service_can_delete_files()
+        [IntegrationTestTheory]
+        [InlineData("0.4.2")]
+        [InlineData("0.5.0")]
+        public async Task service_can_delete_files(string version)
         {
+            _containers = new(version);
+            await _containers.BuildAndStartAsync(_versioningEnabled, CancellationToken.None);
+
             var client = _containers.GetObjectManagementClient();
             var service = _containers.GetObjectManagementService();
 
@@ -79,9 +89,14 @@ namespace TrafficCourts.Coms.Client.Test
             var actual = Assert.ThrowsAsync<FileNotFoundException>(() => service.GetFileAsync(id, CancellationToken.None));
         }
 
-        [IntegrationTestFact]
-        public async Task client_after_delete_file_search_files_does_not_find_file()
+        [IntegrationTestTheory]
+        [InlineData("0.4.2")]
+        [InlineData("0.5.0")]
+        public async Task client_after_delete_file_search_files_does_not_find_file(string version)
         {
+            _containers = new(version);
+            await _containers.BuildAndStartAsync(_versioningEnabled, CancellationToken.None);
+
             var client = _containers.GetObjectManagementClient();
 
             // create a file
@@ -104,9 +119,14 @@ namespace TrafficCourts.Coms.Client.Test
             Assert.Empty(searchResult);
         }
 
-        [IntegrationTestFact]
-        public async Task service_after_delete_file_search_files_does_not_find_file()
+        [IntegrationTestTheory]
+        [InlineData("0.4.2")]
+        [InlineData("0.5.0")]
+        public async Task service_after_delete_file_search_files_does_not_find_file(string version)
         {
+            _containers = new(version);
+            await _containers.BuildAndStartAsync(_versioningEnabled, CancellationToken.None);
+
             var client = _containers.GetObjectManagementClient();
             var service = _containers.GetObjectManagementService();
 
@@ -131,9 +151,14 @@ namespace TrafficCourts.Coms.Client.Test
             Assert.Empty(searchResult);
         }
 
-        [IntegrationTestFact]
-        public async Task test_coms_operations()
+        [IntegrationTestTheory]
+        [InlineData("0.4.2")]
+        [InlineData("0.5.0")]
+        public async Task test_coms_operations(string version)
         {
+            _containers = new(version);
+            await _containers.BuildAndStartAsync(_versioningEnabled, CancellationToken.None);
+
             byte[] buffer = new byte[4 * 1024];
             var stream = new MemoryStream(buffer);
 
@@ -152,9 +177,26 @@ namespace TrafficCourts.Coms.Client.Test
             IList<Anonymous3> fetchTagsResponse = await client.FetchTagsAsync([objectId], null, CancellationToken.None);
 
             var objectTags = Assert.Single(fetchTagsResponse, _ => _.ObjectId == objectId);
-            var objectTagValue = Assert.Single(objectTags.Tagset);
-            Assert.Equal("a", objectTagValue.Key);
-            Assert.Equal("1", objectTagValue.Value);
+
+            var comsVersion = _containers.Coms.ContainerVersion();
+
+            if (comsVersion.Minor == 4)
+            {
+                var objectTagValue = Assert.Single(objectTags.Tagset);
+                Assert.Equal("a", objectTagValue.Key);
+                Assert.Equal("1", objectTagValue.Value);
+            }
+            else //if (comsVersion.Minor == 5)
+            {
+                // 0.5.0 adds coms-id tag
+                var objectTagValue = Assert.Single(objectTags.Tagset, _ => _.Key == "a");
+                Assert.Equal("a", objectTagValue.Key);
+                Assert.Equal("1", objectTagValue.Value);
+
+                objectTagValue = Assert.Single(objectTags.Tagset, _ => _.Key == "coms-id");
+                Assert.Equal("coms-id", objectTagValue.Key);
+                Assert.Equal(objectId.ToString(), objectTagValue.Value);
+            }
 
             tags.Add("b", "2");
             tags.Remove("a");
@@ -162,8 +204,16 @@ namespace TrafficCourts.Coms.Client.Test
             await client.AddTaggingAsync(objectId, tags, null);
             fetchTagsResponse = await client.FetchTagsAsync([objectId]);
 
-            objectTags = Assert.Single(fetchTagsResponse, _ => _.ObjectId == objectId);
-            Assert.Equal(2, objectTags.Tagset.Count);
+            if (comsVersion.Minor == 4)
+            {
+                objectTags = Assert.Single(fetchTagsResponse, _ => _.ObjectId == objectId);
+                Assert.Equal(2, objectTags.Tagset.Count);
+            }
+            else //if (comsVersion.Minor == 5)
+            {
+                objectTags = Assert.Single(fetchTagsResponse, _ => _.ObjectId == objectId);
+                Assert.Equal(3, objectTags.Tagset.Count);
+            }
 
             // 
             IList<Anonymous2> fetchMetadataResponse = await client.FetchMetadataAsync([objectId], null, CancellationToken.None);

--- a/src/backend/TrafficCourts/TrafficCourts.Coms.Client.Test/TrafficCourts.Coms.Client.Test.csproj
+++ b/src/backend/TrafficCourts/TrafficCourts.Coms.Client.Test/TrafficCourts.Coms.Client.Test.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
@@ -25,14 +25,14 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="9.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageReference Include="Minio" Version="6.0.3" />
+    <PackageReference Include="Minio" Version="6.0.4" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="Npgsql" Version="9.0.2" />
     <PackageReference Include="NSubstitute" Version="5.3.0" />
     <PackageReference Include="Refit.HttpClientFactory" Version="8.0.0" />
     <PackageReference Include="RichardSzalay.MockHttp" Version="7.0.0" />
-    <PackageReference Include="Testcontainers.Minio" Version="4.1.0" />
-    <PackageReference Include="Testcontainers.PostgreSql" Version="4.1.0" />
+    <PackageReference Include="Testcontainers.Minio" Version="4.2.0" />
+    <PackageReference Include="Testcontainers.PostgreSql" Version="4.2.0" />
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- updates the integration tests for COMS to validate upgrade
- during testing, the delete operation changed behavior in 0.5.0 and throw error when file does not exist
- if we ever get budget to upgrade stuff, we can use these changes to test the features of COMS TCO uses

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [ ] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
