### PR TITLE
TCVP-3162: Do not lock DCF from search tab and remove the admin activity event for viewing DCF

### DIFF
--- a/src/backend/TrafficCourts/Staff.Service/Controllers/JJController.cs
+++ b/src/backend/TrafficCourts/Staff.Service/Controllers/JJController.cs
@@ -192,6 +192,7 @@ public partial class JJController : StaffControllerBase
     /// <param name="jjDisputeId">Unique identifier for a specific JJ dispute record.</param>
     /// <param name="ticketNumber">Ticket number for a specific JJ dispute record.</param>
     /// <param name="assignVTC">boolean to indicate need to assign VTC.</param>
+    /// <param name="executeUserLock">A flag indicating whether to execute a user lock.</param>
     /// <param name="cancellationToken"></param>
     /// <returns>A single JJ dispute record</returns>
     /// <response code="200">The JJ dispute was found.</response>
@@ -209,7 +210,7 @@ public partial class JJController : StaffControllerBase
     [ProducesResponseType(StatusCodes.Status409Conflict)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     [KeycloakAuthorize(Resources.JJDispute, Scopes.Read)]
-    public async Task<IActionResult> GetJJDisputeAsync(long jjDisputeId, string ticketNumber, bool assignVTC, CancellationToken cancellationToken)
+    public async Task<IActionResult> GetJJDisputeAsync(long jjDisputeId, string ticketNumber, bool assignVTC, bool executeUserLock, CancellationToken cancellationToken)
     {
         _logger.LogDebug("Retrieving JJ Dispute {JJDisputeId} from oracle-data-api", jjDisputeId);
 
@@ -230,13 +231,18 @@ public partial class JJController : StaffControllerBase
                 _logger.LogWarning("GetJJDisputeAsync searches by ticket number, not jjDisputeId. The returned record does not have a matching dispute id.");
             }
 
-            var disputeLock = _disputeLockService.GetLock(ticketNumber, GetUserName(User));
-
-            if (disputeLock is not null)
+            // TCVP-3162: If executeUserLock is true, attempt to lock the dispute for the current user.
+            // Otherwise, return the dispute without a lock.
+            if (executeUserLock)
             {
-                dispute.LockId = disputeLock.LockId;
-                dispute.LockedBy = disputeLock.Username;
-                dispute.LockExpiresAtUtc = disputeLock.ExpiryTimeUtc;
+                var lockInfo = _disputeLockService.GetLock(ticketNumber, GetUserName(User));
+
+                if (lockInfo is not null)
+                {
+                    dispute.LockId = lockInfo.LockId;
+                    dispute.LockedBy = lockInfo.Username;
+                    dispute.LockExpiresAtUtc = lockInfo.ExpiryTimeUtc;
+                }
             }
 
             return Ok(dispute);

--- a/src/backend/TrafficCourts/Staff.Service/Services/JJDisputeService.cs
+++ b/src/backend/TrafficCourts/Staff.Service/Services/JJDisputeService.cs
@@ -359,19 +359,6 @@ public partial class JJDisputeService : IJJDisputeService
     public async Task AssignJJDisputesToJJ(List<string> ticketNumbers, string? username, ClaimsPrincipal user, CancellationToken cancellationToken)
     {
         await _oracleDataApi.AssignJJDisputesToJJAsync(ticketNumbers, username, cancellationToken);
-
-        // Publish file history
-        foreach (string ticketNumber in ticketNumbers)
-        {
-            JJDispute dispute = await _oracleDataApi.GetJJDisputeAsync(ticketNumber, false, cancellationToken);
-
-            SaveFileHistoryRecord fileHistoryRecord = Mapper.ToFileHistoryWithTicketNumber(
-                dispute.TicketNumber,
-                FileHistoryAuditLogEntryType.JASG, // Dispute assigned to JJ
-                GetUserName(user));
-
-            await _bus.PublishWithLog(_logger, fileHistoryRecord, cancellationToken);
-        }
     }
 
     public async Task<JJDispute> ReviewJJDisputeAsync(string ticketNumber, string remark, bool checkVTC, ClaimsPrincipal user, bool recalled, CancellationToken cancellationToken)

--- a/src/backend/TrafficCourts/Staff.Service/Services/RedisDisputeLockService.cs
+++ b/src/backend/TrafficCourts/Staff.Service/Services/RedisDisputeLockService.cs
@@ -200,7 +200,8 @@ public partial class RedisDisputeLockService : IDisputeLockService
         }
 
         // problem, why couldn't we get the lock
-        _logger.LogWarning("On AquireLock, could not create the lock and could not get lock for ticket number {TicketNumber}", ticketNumber);
+        string sanitizedTicketNumber = ticketNumber.Replace(Environment.NewLine, "").Replace("\n", "").Replace("\r", "");
+        _logger.LogWarning("On AquireLock, could not create the lock and could not get lock for ticket number {TicketNumber}", sanitizedTicketNumber);
 
         // this is a problem, hope this never happens, possible upstream bug
         // this error really should be: unable to create lock and unable to get current lock holder

--- a/src/backend/TrafficCourts/TrafficCourts.Staff.Service.Test/Controllers/JJControllerTest.cs
+++ b/src/backend/TrafficCourts/TrafficCourts.Staff.Service.Test/Controllers/JJControllerTest.cs
@@ -2,6 +2,7 @@
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using Moq;
+using System;
 using System.Collections.Generic;
 using System.Net;
 using System.Security.Claims;
@@ -359,7 +360,7 @@ public class JJControllerTest
         JJController jjDisputeController = new(mediator, jjDisputeService.Object, printService, lockService, mockLogger.Object);
 
         // Act
-        IActionResult? result = await jjDisputeController.GetJJDisputeAsync(1, ticketnumber, false, CancellationToken.None);
+        IActionResult? result = await jjDisputeController.GetJJDisputeAsync(1, ticketnumber, false, false, CancellationToken.None);
 
         // Assert
         var okResult = Assert.IsType<OkObjectResult>(result);
@@ -385,7 +386,7 @@ public class JJControllerTest
         JJController jjDisputeController = new(mediator, jjDisputeService.Object, printService, lockService, mockLogger.Object);
 
         // Act
-        IActionResult? result = await jjDisputeController.GetJJDisputeAsync(1, ticketnumber, false, CancellationToken.None);
+        IActionResult? result = await jjDisputeController.GetJJDisputeAsync(1, ticketnumber, false, false, CancellationToken.None);
 
         // Assert
         var badRequestResult = Assert.IsType<HttpError>(result);
@@ -402,7 +403,7 @@ public class JJControllerTest
         var jjDisputeService = new Mock<IJJDisputeService>();
 
         jjDisputeService
-            .Setup(_ => _.GetJJDisputeAsync(ticketnumber,false, It.IsAny<CancellationToken>()))
+            .Setup(_ => _.GetJJDisputeAsync(ticketnumber, false, It.IsAny<CancellationToken>()))
             .Throws(new ApiException("msg", StatusCodes.Status404NotFound, "rsp", null!, null));
         var mockLogger = new Mock<ILogger<JJController>>();
         var printService = Mock.Of<IPrintDigitalCaseFileService>();
@@ -411,7 +412,7 @@ public class JJControllerTest
         JJController jjDisputeController = new(mediator, jjDisputeService.Object, printService, lockService, mockLogger.Object);
 
         // Act
-        IActionResult? result = await jjDisputeController.GetJJDisputeAsync(1, ticketnumber, false, CancellationToken.None);
+        IActionResult? result = await jjDisputeController.GetJJDisputeAsync(1, ticketnumber, false, false, CancellationToken.None);
 
         // Assert
         var notFoundResult = Assert.IsType<HttpError>(result);
@@ -495,7 +496,7 @@ public class JJControllerTest
         JJController jjDisputeController = new(mediator, jjDisputeService.Object, printService, lockService, mockLogger.Object);
 
         // Act
-        IActionResult? result = await jjDisputeController.GetJJDisputeAsync(1, ticketnumber, true, CancellationToken.None);
+        IActionResult? result = await jjDisputeController.GetJJDisputeAsync(1, ticketnumber, true, false, CancellationToken.None);
 
         // Assert
         var objectResult = Assert.IsType<ObjectResult>(result);
@@ -525,12 +526,52 @@ public class JJControllerTest
         JJController jjDisputeController = new(mediator, jjDisputeService.Object, printService, lockService, mockLogger.Object);
 
         // Act
-        IActionResult? result = await jjDisputeController.GetJJDisputeAsync(1, ticketnumber, true, CancellationToken.None);
+        IActionResult? result = await jjDisputeController.GetJJDisputeAsync(1, ticketnumber, true, false, CancellationToken.None);
 
         // Assert
         var objectResult = Assert.IsType<ObjectResult>(result);
         var problemDetails = Assert.IsType<ProblemDetails>(objectResult.Value);
         Assert.Equal((int)HttpStatusCode.InternalServerError, problemDetails.Status);
         Assert.True(problemDetails?.Title?.Contains("Error Invoking COMS"));
+    }
+
+    [Fact]
+    public async Task TestGetJJDisputeWithUserLock200Result()
+    {
+        // Arrange
+        JJDispute dispute = new();
+        string ticketnumber = "AJ201092461";
+        dispute.TicketNumber = ticketnumber;
+        var jjDisputeService = new Mock<IJJDisputeService>();
+        var lockService = new Mock<IDisputeLockService>();
+
+        jjDisputeService
+            .Setup(_ => _.GetJJDisputeAsync(ticketnumber, false, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(dispute);
+
+        lockService
+            .Setup(_ => _.GetLock(ticketnumber, It.IsAny<string>()))
+            .Returns(new Models.Lock
+            {
+                LockId = Guid.NewGuid().ToString(),
+                Username = "testuser",
+                ExpiryTimeUtc = DateTime.UtcNow.AddMinutes(30)
+            });
+
+        var mockLogger = new Mock<ILogger<JJController>>();
+        var printService = Mock.Of<IPrintDigitalCaseFileService>();
+        var mediator = Mock.Of<IMediator>();
+        JJController jjDisputeController = new(mediator, jjDisputeService.Object, printService, lockService.Object, mockLogger.Object);
+
+        // Act
+        IActionResult? result = await jjDisputeController.GetJJDisputeAsync(1, ticketnumber, false, true, CancellationToken.None);
+
+        // Assert
+        var okResult = Assert.IsType<OkObjectResult>(result);
+        var returnedDispute = Assert.IsType<JJDispute>(okResult.Value);
+        Assert.Equal(dispute.TicketNumber, returnedDispute.TicketNumber);
+        Assert.NotNull(returnedDispute.LockId);
+        Assert.Equal("testuser", returnedDispute.LockedBy);
+        Assert.NotNull(returnedDispute.LockExpiresAtUtc);
     }
 }

--- a/src/frontend/staff-portal/src/app/api/api/jJ.service.ts
+++ b/src/frontend/staff-portal/src/app/api/api/jJ.service.ts
@@ -440,13 +440,14 @@ export class JJService {
      * @param jjDisputeId Unique identifier for a specific JJ dispute record.
      * @param ticketNumber Ticket number for a specific JJ dispute record.
      * @param assignVTC boolean to indicate need to assign VTC.
+     * @param executeUserLock A flag indicating whether to execute a user lock.
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
      * @param reportProgress flag to report request and response progress.
      */
-    public apiJjJjDisputeIdGet(jjDisputeId: number, ticketNumber?: string, assignVTC?: boolean, observe?: 'body', reportProgress?: boolean, options?: {httpHeaderAccept?: 'text/plain' | 'application/json' | 'text/json', context?: HttpContext}): Observable<JJDispute>;
-    public apiJjJjDisputeIdGet(jjDisputeId: number, ticketNumber?: string, assignVTC?: boolean, observe?: 'response', reportProgress?: boolean, options?: {httpHeaderAccept?: 'text/plain' | 'application/json' | 'text/json', context?: HttpContext}): Observable<HttpResponse<JJDispute>>;
-    public apiJjJjDisputeIdGet(jjDisputeId: number, ticketNumber?: string, assignVTC?: boolean, observe?: 'events', reportProgress?: boolean, options?: {httpHeaderAccept?: 'text/plain' | 'application/json' | 'text/json', context?: HttpContext}): Observable<HttpEvent<JJDispute>>;
-    public apiJjJjDisputeIdGet(jjDisputeId: number, ticketNumber?: string, assignVTC?: boolean, observe: any = 'body', reportProgress: boolean = false, options?: {httpHeaderAccept?: 'text/plain' | 'application/json' | 'text/json', context?: HttpContext}): Observable<any> {
+    public apiJjJjDisputeIdGet(jjDisputeId: number, ticketNumber?: string, assignVTC?: boolean, executeUserLock?: boolean, observe?: 'body', reportProgress?: boolean, options?: {httpHeaderAccept?: 'text/plain' | 'application/json' | 'text/json', context?: HttpContext}): Observable<JJDispute>;
+    public apiJjJjDisputeIdGet(jjDisputeId: number, ticketNumber?: string, assignVTC?: boolean, executeUserLock?: boolean, observe?: 'response', reportProgress?: boolean, options?: {httpHeaderAccept?: 'text/plain' | 'application/json' | 'text/json', context?: HttpContext}): Observable<HttpResponse<JJDispute>>;
+    public apiJjJjDisputeIdGet(jjDisputeId: number, ticketNumber?: string, assignVTC?: boolean, executeUserLock?: boolean, observe?: 'events', reportProgress?: boolean, options?: {httpHeaderAccept?: 'text/plain' | 'application/json' | 'text/json', context?: HttpContext}): Observable<HttpEvent<JJDispute>>;
+    public apiJjJjDisputeIdGet(jjDisputeId: number, ticketNumber?: string, assignVTC?: boolean, executeUserLock?: boolean, observe: any = 'body', reportProgress: boolean = false, options?: {httpHeaderAccept?: 'text/plain' | 'application/json' | 'text/json', context?: HttpContext}): Observable<any> {
         if (jjDisputeId === null || jjDisputeId === undefined) {
             throw new Error('Required parameter jjDisputeId was null or undefined when calling apiJjJjDisputeIdGet.');
         }
@@ -459,6 +460,10 @@ export class JJService {
         if (assignVTC !== undefined && assignVTC !== null) {
           localVarQueryParameters = this.addToHttpParams(localVarQueryParameters,
             <any>assignVTC, 'assignVTC');
+        }
+        if (executeUserLock !== undefined && executeUserLock !== null) {
+          localVarQueryParameters = this.addToHttpParams(localVarQueryParameters,
+            <any>executeUserLock, 'executeUserLock');
         }
 
         let localVarHeaders = this.defaultHeaders;

--- a/src/frontend/staff-portal/src/app/api/swagger.json
+++ b/src/frontend/staff-portal/src/app/api/swagger.json
@@ -1,456 +1,309 @@
 {
-    "openapi": "3.0.1",
-    "info": {
-      "title": "VTC Staff API",
-      "description": "Violation Ticket Centre Staff API",
-      "version": "v1"
-    },
-    "paths": {
-      "/api/dispute/disputes": {
-        "get": {
-          "tags": [
-            "Dispute"
-          ],
-          "summary": "Returns all Disputes from the Oracle Data API with given parameters.",
-          "parameters": [
-            {
-              "name": "excludeStatus",
-              "in": "query",
-              "description": "The status to exclude",
-              "schema": {
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/ExcludeStatus"
-                }
-              }
-            },
-            {
-              "name": "ticket",
-              "in": "query",
-              "description": "The optional ticket number to search on. The value will be searched using contains.",
-              "schema": {
-                "type": "string"
-              }
-            },
-            {
-              "name": "surname",
-              "in": "query",
-              "description": "The optional surname to search on. The value will be searched using contains.",
-              "schema": {
-                "type": "string"
-              }
-            },
-            {
-              "name": "status",
-              "in": "query",
-              "description": "The optional status to find.",
-              "schema": {
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/DisputeStatus"
-                }
-              }
-            },
-            {
-              "name": "from",
-              "in": "query",
-              "description": "The optional from date to search. The submitted date will be filtered where greater or equal to this value.",
-              "schema": {
-                "type": "string",
-                "format": "date-time"
-              }
-            },
-            {
-              "name": "thru",
-              "in": "query",
-              "description": "The optional thru date to search. The submitted date will be filtered where less than or equal to this value.",
-              "schema": {
-                "type": "string",
-                "format": "date-time"
-              }
-            },
-            {
-              "name": "courtHouse",
-              "in": "query",
-              "description": "The optional court house location to search. The value will be searched using contains.",
-              "schema": {
-                "type": "string"
-              }
-            },
-            {
-              "name": "sortBy",
-              "in": "query",
-              "description": "The optional sort by contains the attribute name to sort. The data is sorted on the attribute.",
-              "schema": {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                }
-              }
-            },
-            {
-              "name": "direction",
-              "in": "query",
-              "description": "The optional sort direction contains the asc or desc. The data is sorted by given direction.",
-              "schema": {
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/SortDirection"
-                }
-              }
-            },
-            {
-              "name": "DefaultPageSize",
-              "in": "query",
-              "description": "The default page size contains the default count of records.",
-              "schema": {
-                "type": "integer",
-                "format": "int32"
-              }
-            },
-            {
-              "name": "pageNumber",
-              "in": "query",
-              "description": "The optional page number gives the records from given page",
-              "schema": {
-                "type": "integer",
-                "format": "int32"
-              }
-            },
-            {
-              "name": "pageSize",
-              "in": "query",
-              "description": "The optional page size sets the record count",
-              "schema": {
-                "type": "integer",
-                "format": "int32"
+  "openapi": "3.0.1",
+  "info": {
+    "title": "VTC Staff API",
+    "description": "Violation Ticket Centre Staff API",
+    "version": "v1"
+  },
+  "paths": {
+    "/api/dispute/disputes": {
+      "get": {
+        "tags": [
+          "Dispute"
+        ],
+        "summary": "Returns all Disputes from the Oracle Data API with given parameters.",
+        "parameters": [
+          {
+            "name": "excludeStatus",
+            "in": "query",
+            "description": "The status to exclude",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/ExcludeStatus"
               }
             }
-          ],
-          "responses": {
-            "200": {
-              "description": "The Disputes were found.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/PagedDisputeListItemCollection"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/PagedDisputeListItemCollection"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/PagedDisputeListItemCollection"
-                  }
-                }
-              }
-            },
-            "401": {
-              "description": "Request lacks valid authentication credentials.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "403": {
-              "description": "Forbidden, requires dispute:read permission.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "500": {
-              "description": "There was a server error that prevented the search from completing successfully or no data found."
+          },
+          {
+            "name": "ticket",
+            "in": "query",
+            "description": "The optional ticket number to search on. The value will be searched using contains.",
+            "schema": {
+              "type": "string"
             }
-          }
-        }
-      },
-      "/api/dispute/disputes/count": {
-        "get": {
-          "tags": [
-            "Dispute"
-          ],
-          "summary": "Returns the count of disputes with the given status.",
-          "parameters": [
-            {
-              "name": "status",
-              "in": "query",
-              "description": "",
-              "schema": {
+          },
+          {
+            "name": "surname",
+            "in": "query",
+            "description": "The optional surname to search on. The value will be searched using contains.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "status",
+            "in": "query",
+            "description": "The optional status to find.",
+            "schema": {
+              "type": "array",
+              "items": {
                 "$ref": "#/components/schemas/DisputeStatus"
               }
             }
-          ],
-          "responses": {
-            "200": {
-              "description": "The Disputes were found.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/GetDisputeCountResponse"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/GetDisputeCountResponse"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/GetDisputeCountResponse"
-                  }
-                }
-              }
-            },
-            "401": {
-              "description": "Request lacks valid authentication credentials.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "403": {
-              "description": "Forbidden, requires dispute:read permission.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "500": {
-              "description": "There was a server error that prevented the search from completing successfully or no data found."
+          },
+          {
+            "name": "from",
+            "in": "query",
+            "description": "The optional from date to search. The submitted date will be filtered where greater or equal to this value.",
+            "schema": {
+              "type": "string",
+              "format": "date-time"
             }
-          }
-        }
-      },
-      "/api/dispute/{disputeId}": {
-        "get": {
-          "tags": [
-            "Dispute"
-          ],
-          "summary": "Returns a single Dispute with the given identifier from the Oracle Data API.",
-          "parameters": [
-            {
-              "name": "disputeId",
-              "in": "path",
-              "description": "Unique identifier for a specific Dispute record.",
-              "required": true,
-              "schema": {
-                "type": "integer",
-                "format": "int64"
-              }
+          },
+          {
+            "name": "thru",
+            "in": "query",
+            "description": "The optional thru date to search. The submitted date will be filtered where less than or equal to this value.",
+            "schema": {
+              "type": "string",
+              "format": "date-time"
             }
-          ],
-          "responses": {
-            "200": {
-              "description": "The Dispute was found.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/Dispute"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/Dispute"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/Dispute"
-                  }
-                }
-              }
-            },
-            "400": {
-              "description": "The request was not well formed. Check the parameters.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "401": {
-              "description": "Request lacks valid authentication credentials.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "403": {
-              "description": "Forbidden, requires dispute:read permission.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "404": {
-              "description": "The dispute was not found.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "409": {
-              "description": "The Dispute has already been assigned to a user. Dispute cannot be modified until assigned time expires.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "500": {
-              "description": "There was a server error that prevented the search from completing successfully or no data found."
+          },
+          {
+            "name": "courtHouse",
+            "in": "query",
+            "description": "The optional court house location to search. The value will be searched using contains.",
+            "schema": {
+              "type": "string"
             }
-          }
-        },
-        "put": {
-          "tags": [
-            "Dispute"
-          ],
-          "summary": "Updates a single Dispute through the Oracle Data Interface API based on unique dispute id and the dispute data being passed in the body.",
-          "parameters": [
-            {
-              "name": "disputeId",
-              "in": "path",
-              "description": "Unique identifier for a specific Dispute record.",
-              "required": true,
-              "schema": {
-                "type": "integer",
-                "format": "int64"
-              }
-            },
-            {
-              "name": "staffComment",
-              "in": "query",
-              "description": "VTC staff's comment for saving or updating a dispute in Ticket Validation",
-              "schema": {
-                "maxLength": 500,
-                "minLength": 0,
+          },
+          {
+            "name": "sortBy",
+            "in": "query",
+            "description": "The optional sort by contains the attribute name to sort. The data is sorted on the attribute.",
+            "schema": {
+              "type": "array",
+              "items": {
                 "type": "string"
               }
             }
-          ],
-          "requestBody": {
-            "description": "",
+          },
+          {
+            "name": "direction",
+            "in": "query",
+            "description": "The optional sort direction contains the asc or desc. The data is sorted by given direction.",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/SortDirection"
+              }
+            }
+          },
+          {
+            "name": "DefaultPageSize",
+            "in": "query",
+            "description": "The default page size contains the default count of records.",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "pageNumber",
+            "in": "query",
+            "description": "The optional page number gives the records from given page",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "pageSize",
+            "in": "query",
+            "description": "The optional page size sets the record count",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The Disputes were found.",
             "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/PagedDisputeListItemCollection"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PagedDisputeListItemCollection"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PagedDisputeListItemCollection"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Request lacks valid authentication credentials.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden, requires dispute:read permission.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "There was a server error that prevented the search from completing successfully or no data found."
+          }
+        }
+      }
+    },
+    "/api/dispute/disputes/count": {
+      "get": {
+        "tags": [
+          "Dispute"
+        ],
+        "summary": "Returns the count of disputes with the given status.",
+        "parameters": [
+          {
+            "name": "status",
+            "in": "query",
+            "description": "",
+            "schema": {
+              "$ref": "#/components/schemas/DisputeStatus"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The Disputes were found.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetDisputeCountResponse"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetDisputeCountResponse"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetDisputeCountResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Request lacks valid authentication credentials.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden, requires dispute:read permission.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "There was a server error that prevented the search from completing successfully or no data found."
+          }
+        }
+      }
+    },
+    "/api/dispute/{disputeId}": {
+      "get": {
+        "tags": [
+          "Dispute"
+        ],
+        "summary": "Returns a single Dispute with the given identifier from the Oracle Data API.",
+        "parameters": [
+          {
+            "name": "disputeId",
+            "in": "path",
+            "description": "Unique identifier for a specific Dispute record.",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The Dispute was found.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/Dispute"
+                }
+              },
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/Dispute"
@@ -460,8171 +313,8328 @@
                 "schema": {
                   "$ref": "#/components/schemas/Dispute"
                 }
+              }
+            }
+          },
+          "400": {
+            "description": "The request was not well formed. Check the parameters.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
               },
-              "application/*+json": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Request lacks valid authentication credentials.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden, requires dispute:read permission.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "The dispute was not found.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "The Dispute has already been assigned to a user. Dispute cannot be modified until assigned time expires.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "There was a server error that prevented the search from completing successfully or no data found."
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "Dispute"
+        ],
+        "summary": "Updates a single Dispute through the Oracle Data Interface API based on unique dispute id and the dispute data being passed in the body.",
+        "parameters": [
+          {
+            "name": "disputeId",
+            "in": "path",
+            "description": "Unique identifier for a specific Dispute record.",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          {
+            "name": "staffComment",
+            "in": "query",
+            "description": "VTC staff's comment for saving or updating a dispute in Ticket Validation",
+            "schema": {
+              "maxLength": 500,
+              "minLength": 0,
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Dispute"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Dispute"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Dispute"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The Dispute is updated.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/Dispute"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Dispute"
+                }
+              },
+              "text/json": {
                 "schema": {
                   "$ref": "#/components/schemas/Dispute"
                 }
               }
             }
           },
-          "responses": {
-            "200": {
-              "description": "The Dispute is updated.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/Dispute"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/Dispute"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/Dispute"
-                  }
+          "400": {
+            "description": "The request was not well formed. Check the parameters.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
                 }
               }
-            },
-            "400": {
-              "description": "The request was not well formed. Check the parameters.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "401": {
-              "description": "Request lacks valid authentication credentials.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "403": {
-              "description": "Forbidden, requires dispute:update permission.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "404": {
-              "description": "The Dispute to update was not found.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "409": {
-              "description": "The Dispute has already been assigned to a user. Dispute cannot be modified until assigned time expires.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "500": {
-              "description": "There was a server error that prevented the update from completing successfully."
             }
+          },
+          "401": {
+            "description": "Request lacks valid authentication credentials.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden, requires dispute:update permission.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "The Dispute to update was not found.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "The Dispute has already been assigned to a user. Dispute cannot be modified until assigned time expires.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "There was a server error that prevented the update from completing successfully."
           }
         }
-      },
-      "/api/dispute/{disputeId}/reject": {
-        "put": {
-          "tags": [
-            "Dispute"
-          ],
-          "summary": "Updates the status of a particular Dispute record to REJECTED.",
-          "parameters": [
-            {
-              "name": "disputeId",
-              "in": "path",
-              "description": "Unique identifier for a specific Dispute record to cancel.",
-              "required": true,
-              "schema": {
-                "type": "integer",
-                "format": "int64"
-              }
+      }
+    },
+    "/api/dispute/{disputeId}/reject": {
+      "put": {
+        "tags": [
+          "Dispute"
+        ],
+        "summary": "Updates the status of a particular Dispute record to REJECTED.",
+        "parameters": [
+          {
+            "name": "disputeId",
+            "in": "path",
+            "description": "Unique identifier for a specific Dispute record to cancel.",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
             }
-          ],
-          "requestBody": {
-            "content": {
-              "multipart/form-data": {
-                "schema": {
-                  "required": [
-                    "rejectedReason"
-                  ],
-                  "type": "object",
-                  "properties": {
-                    "rejectedReason": {
-                      "maxLength": 256,
-                      "minLength": 0,
-                      "type": "string",
-                      "description": "The reason or note (max 256 characters) the Dispute was rejected."
-                    }
-                  }
-                },
-                "encoding": {
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "required": [
+                  "rejectedReason"
+                ],
+                "type": "object",
+                "properties": {
                   "rejectedReason": {
-                    "style": "form"
+                    "maxLength": 256,
+                    "minLength": 0,
+                    "type": "string",
+                    "description": "The reason or note (max 256 characters) the Dispute was rejected."
                   }
                 }
-              }
-            }
-          },
-          "responses": {
-            "200": {
-              "description": "The Dispute is updated."
-            },
-            "400": {
-              "description": "The request was not well formed. Check the parameters.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
+              },
+              "encoding": {
+                "rejectedReason": {
+                  "style": "form"
                 }
               }
-            },
-            "401": {
-              "description": "Request lacks valid authentication credentials.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "403": {
-              "description": "Forbidden, requires dispute:reject permission.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "404": {
-              "description": "Dispute record not found. Update failed.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "405": {
-              "description": "A Dispute status can only be set to REJECTED iff status is NEW, VALIDATED or PROCESSING and the rejected reason must be <= 256 characters. Update failed.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "409": {
-              "description": "The Dispute has already been assigned to a different user. Dispute cannot be modified until assigned time expires.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "500": {
-              "description": "There was a server error that prevented the update from completing successfully."
             }
           }
-        }
-      },
-      "/api/dispute/{disputeId}/validate": {
-        "put": {
-          "tags": [
-            "Dispute"
-          ],
-          "summary": "Updates the status of a particular Dispute record to VALIDATED.",
-          "parameters": [
-            {
-              "name": "disputeId",
-              "in": "path",
-              "description": "Unique identifier for a specific Dispute record to validate.",
-              "required": true,
-              "schema": {
-                "type": "integer",
-                "format": "int64"
-              }
-            }
-          ],
-          "requestBody": {
-            "description": "Validated dispute data to update",
+        },
+        "responses": {
+          "200": {
+            "description": "The Dispute is updated."
+          },
+          "400": {
+            "description": "The request was not well formed. Check the parameters.",
             "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Dispute"
+                  "$ref": "#/components/schemas/ProblemDetails"
                 }
               },
               "text/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Dispute"
-                }
-              },
-              "application/*+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Dispute"
+                  "$ref": "#/components/schemas/ProblemDetails"
                 }
               }
             }
           },
-          "responses": {
-            "200": {
-              "description": "The Dispute is updated."
-            },
-            "400": {
-              "description": "The request was not well formed. Check the parameters.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
+          "401": {
+            "description": "Request lacks valid authentication credentials.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
                 }
               }
-            },
-            "401": {
-              "description": "Request lacks valid authentication credentials.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "403": {
-              "description": "Forbidden, requires dispute:validate permission.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "404": {
-              "description": "Dispute record not found. Update failed.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "405": {
-              "description": "A Dispute status can only be set to VALIDATED iff status is NEW. Update failed.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "409": {
-              "description": "The Dispute has already been assigned to a different user. Dispute cannot be modified until assigned time expires.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "500": {
-              "description": "There was a server error that prevented the update from completing successfully."
             }
+          },
+          "403": {
+            "description": "Forbidden, requires dispute:reject permission.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Dispute record not found. Update failed.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "A Dispute status can only be set to REJECTED iff status is NEW, VALIDATED or PROCESSING and the rejected reason must be \u003C= 256 characters. Update failed.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "The Dispute has already been assigned to a different user. Dispute cannot be modified until assigned time expires.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "There was a server error that prevented the update from completing successfully."
           }
         }
-      },
-      "/api/dispute/{disputeId}/cancel": {
-        "put": {
-          "tags": [
-            "Dispute"
-          ],
-          "summary": "Updates the status of a particular Dispute record to CANCELLED.",
-          "parameters": [
-            {
-              "name": "disputeId",
-              "in": "path",
-              "description": "Unique identifier for a specific Dispute record to cancel.",
-              "required": true,
+      }
+    },
+    "/api/dispute/{disputeId}/validate": {
+      "put": {
+        "tags": [
+          "Dispute"
+        ],
+        "summary": "Updates the status of a particular Dispute record to VALIDATED.",
+        "parameters": [
+          {
+            "name": "disputeId",
+            "in": "path",
+            "description": "Unique identifier for a specific Dispute record to validate.",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "Validated dispute data to update",
+          "content": {
+            "application/json": {
               "schema": {
-                "type": "integer",
-                "format": "int64"
+                "$ref": "#/components/schemas/Dispute"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Dispute"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Dispute"
               }
             }
-          ],
-          "requestBody": {
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The Dispute is updated."
+          },
+          "400": {
+            "description": "The request was not well formed. Check the parameters.",
             "content": {
-              "multipart/form-data": {
+              "text/plain": {
                 "schema": {
-                  "required": [
-                    "cancelledReason"
-                  ],
-                  "type": "object",
-                  "properties": {
-                    "cancelledReason": {
-                      "maxLength": 256,
-                      "minLength": 0,
-                      "type": "string",
-                      "description": "The reason or note (max 256 characters) the Dispute was cancelled."
-                    }
-                  }
-                },
-                "encoding": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Request lacks valid authentication credentials.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden, requires dispute:validate permission.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Dispute record not found. Update failed.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "A Dispute status can only be set to VALIDATED iff status is NEW. Update failed.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "The Dispute has already been assigned to a different user. Dispute cannot be modified until assigned time expires.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "There was a server error that prevented the update from completing successfully."
+          }
+        }
+      }
+    },
+    "/api/dispute/{disputeId}/cancel": {
+      "put": {
+        "tags": [
+          "Dispute"
+        ],
+        "summary": "Updates the status of a particular Dispute record to CANCELLED.",
+        "parameters": [
+          {
+            "name": "disputeId",
+            "in": "path",
+            "description": "Unique identifier for a specific Dispute record to cancel.",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "required": [
+                  "cancelledReason"
+                ],
+                "type": "object",
+                "properties": {
                   "cancelledReason": {
-                    "style": "form"
-                  }
-                }
-              }
-            }
-          },
-          "responses": {
-            "200": {
-              "description": "The Dispute is updated."
-            },
-            "400": {
-              "description": "The request was not well formed. Check the parameters.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "401": {
-              "description": "Request lacks valid authentication credentials.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "403": {
-              "description": "Forbidden, requires dispute:cancel permission.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "404": {
-              "description": "Dispute record not found. Update failed.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "405": {
-              "description": "A Dispute status can only be set to CANCELLED iff status is REJECTED or PROCESSING.Update failed.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "409": {
-              "description": "The Dispute has already been assigned to a different user. Dispute cannot be modified until assigned time expires.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "500": {
-              "description": "There was a server error that prevented the update from completing successfully."
-            }
-          }
-        }
-      },
-      "/api/dispute/{disputeId}/resendemailverify": {
-        "put": {
-          "tags": [
-            "Dispute"
-          ],
-          "summary": "An endpoint for resending an email to a Disputant.",
-          "parameters": [
-            {
-              "name": "disputeId",
-              "in": "path",
-              "description": "",
-              "required": true,
-              "schema": {
-                "type": "integer",
-                "format": "int64"
-              }
-            }
-          ],
-          "responses": {
-            "200": {
-              "description": "OK",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "type": "string"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "type": "string"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "type": "string"
-                  }
-                }
-              }
-            },
-            "400": {
-              "description": "Bad Request",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "401": {
-              "description": "Unauthorized",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "403": {
-              "description": "Forbidden",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "500": {
-              "description": "Internal Server Error"
-            }
-          }
-        }
-      },
-      "/api/dispute/{disputeId}/submit": {
-        "put": {
-          "tags": [
-            "Dispute"
-          ],
-          "summary": "Submits a Dispute record, setting it's status to PROCESSING",
-          "parameters": [
-            {
-              "name": "disputeId",
-              "in": "path",
-              "description": "Unique identifier for a specific Dispute record to submit.",
-              "required": true,
-              "schema": {
-                "type": "integer",
-                "format": "int64"
-              }
-            }
-          ],
-          "responses": {
-            "200": {
-              "description": "The Dispute is updated."
-            },
-            "400": {
-              "description": "The request was not well formed. Check the parameters.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "401": {
-              "description": "Request lacks valid authentication credentials.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "403": {
-              "description": "Forbidden, requires dispute:submit permission.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "404": {
-              "description": "Dispute record not found. Update failed.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "405": {
-              "description": "A Dispute can only be submitted if the status is NEW or VALIDATED. Update failed.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "409": {
-              "description": "The Dispute has already been assigned to a different user. Dispute cannot be modified until assigned time expires.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "500": {
-              "description": "There was a server error that prevented the update from completing successfully."
-            }
-          }
-        }
-      },
-      "/api/dispute/updaterequest/{updateStatusId}/accept": {
-        "put": {
-          "tags": [
-            "Dispute"
-          ],
-          "summary": "Approves a DisputeUpdateRequest record, setting it's status to ACCEPTED.",
-          "parameters": [
-            {
-              "name": "updateStatusId",
-              "in": "path",
-              "description": "Unique identifier for a specific DisputeUpdateRequest record to accept.",
-              "required": true,
-              "schema": {
-                "type": "integer",
-                "format": "int64"
-              }
-            }
-          ],
-          "responses": {
-            "200": {
-              "description": "OK"
-            },
-            "500": {
-              "description": "Internal Server Error"
-            }
-          }
-        }
-      },
-      "/api/dispute/updaterequest/{updateStatusId}/reject": {
-        "put": {
-          "tags": [
-            "Dispute"
-          ],
-          "summary": "Rejects a DisputeUpdateRequest record, setting it's status to REJECTED.",
-          "parameters": [
-            {
-              "name": "updateStatusId",
-              "in": "path",
-              "description": "Unique identifier for a specific DisputeUpdateRequest record to reject.",
-              "required": true,
-              "schema": {
-                "type": "integer",
-                "format": "int64"
-              }
-            }
-          ],
-          "responses": {
-            "200": {
-              "description": "OK"
-            },
-            "500": {
-              "description": "Internal Server Error"
-            }
-          }
-        }
-      },
-      "/api/dispute/disputeswithupdaterequests": {
-        "get": {
-          "tags": [
-            "Dispute"
-          ],
-          "summary": "Returns all Disputes that have pending update requests from the Oracle Data API",
-          "responses": {
-            "200": {
-              "description": "The Disputes were found.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "type": "array",
-                    "items": {
-                      "$ref": "#/components/schemas/DisputeWithUpdates"
-                    }
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "type": "array",
-                    "items": {
-                      "$ref": "#/components/schemas/DisputeWithUpdates"
-                    }
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "type": "array",
-                    "items": {
-                      "$ref": "#/components/schemas/DisputeWithUpdates"
-                    }
-                  }
-                }
-              }
-            },
-            "401": {
-              "description": "Request lacks valid authentication credentials.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "403": {
-              "description": "Forbidden, requires dispute:read permission.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "500": {
-              "description": "There was a server error that prevented the search from completing successfully or no data found."
-            }
-          }
-        }
-      },
-      "/api/dispute/{disputeId}/disputeupdaterequests": {
-        "get": {
-          "tags": [
-            "Dispute"
-          ],
-          "summary": "Returns all update requests for a specific dispute",
-          "parameters": [
-            {
-              "name": "disputeId",
-              "in": "path",
-              "description": "Dispute Id",
-              "required": true,
-              "schema": {
-                "type": "integer",
-                "format": "int64"
-              }
-            }
-          ],
-          "responses": {
-            "200": {
-              "description": "The Update requests were found.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "type": "array",
-                    "items": {
-                      "$ref": "#/components/schemas/DisputeUpdateRequest"
-                    }
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "type": "array",
-                    "items": {
-                      "$ref": "#/components/schemas/DisputeUpdateRequest"
-                    }
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "type": "array",
-                    "items": {
-                      "$ref": "#/components/schemas/DisputeUpdateRequest"
-                    }
-                  }
-                }
-              }
-            },
-            "401": {
-              "description": "Request lacks valid authentication credentials.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "403": {
-              "description": "Forbidden, requires dispute:read permission.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "500": {
-              "description": "There was a server error that prevented the search from completing successfully or no data found."
-            }
-          }
-        }
-      },
-      "/api/dispute/{disputeId}/print": {
-        "get": {
-          "tags": [
-            "Dispute"
-          ],
-          "summary": "Returns generated document.",
-          "parameters": [
-            {
-              "name": "disputeId",
-              "in": "path",
-              "description": "Dispute Id",
-              "required": true,
-              "schema": {
-                "type": "integer",
-                "format": "int64"
-              }
-            },
-            {
-              "name": "timeZone",
-              "in": "query",
-              "description": "The IANA timze zone id",
-              "required": true,
-              "schema": {
-                "type": "string"
-              }
-            },
-            {
-              "name": "type",
-              "in": "query",
-              "description": "The type of template to generate",
-              "schema": {
-                "$ref": "#/components/schemas/DcfTemplateType"
-              }
-            }
-          ],
-          "responses": {
-            "200": {
-              "description": "Generated Document.",
-              "content": {
-                "application/octet-stream": {
-                  "schema": {
+                    "maxLength": 256,
+                    "minLength": 0,
                     "type": "string",
-                    "format": "binary"
+                    "description": "The reason or note (max 256 characters) the Dispute was cancelled."
                   }
                 }
-              }
-            },
-            "401": {
-              "description": "Request lacks valid authentication credentials.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
+              },
+              "encoding": {
+                "cancelledReason": {
+                  "style": "form"
                 }
               }
-            },
-            "403": {
-              "description": "Forbidden.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "500": {
-              "description": "There was a server error that prevented the search from completing successfully or no data found."
-            },
-            "400": {
-              "description": "The"
-            }
-          }
-        }
-      },
-      "/api/dispute/violationticketcount/{violationTicketCountId}": {
-        "delete": {
-          "tags": [
-            "Dispute"
-          ],
-          "summary": "Deletes a violation ticket count asynchronously.",
-          "parameters": [
-            {
-              "name": "violationTicketCountId",
-              "in": "path",
-              "description": "The ID of the violation ticket count to delete.",
-              "required": true,
-              "schema": {
-                "type": "integer",
-                "format": "int32"
-              }
-            }
-          ],
-          "responses": {
-            "204": {
-              "description": "No Content"
-            },
-            "500": {
-              "description": "Internal Server Error"
-            }
-          }
-        }
-      },
-      "/api/disputelock": {
-        "get": {
-          "tags": [
-            "DisputeLock"
-          ],
-          "summary": "Acquires a lock for a JJ Dispute.",
-          "parameters": [
-            {
-              "name": "ticketNumber",
-              "in": "query",
-              "description": "",
-              "schema": {
-                "type": "string"
-              }
-            },
-            {
-              "name": "username",
-              "in": "query",
-              "description": "",
-              "schema": {
-                "type": "string"
-              }
-            }
-          ],
-          "responses": {
-            "200": {
-              "description": "OK",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/Lock"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/Lock"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/Lock"
-                  }
-                }
-              }
-            },
-            "409": {
-              "description": "Conflict",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "500": {
-              "description": "Internal Server Error"
-            }
-          }
-        }
-      },
-      "/api/disputelock/{lockId}": {
-        "put": {
-          "tags": [
-            "DisputeLock"
-          ],
-          "summary": "Refreshes the expiry time of a lock.",
-          "parameters": [
-            {
-              "name": "lockId",
-              "in": "path",
-              "description": "",
-              "required": true,
-              "schema": {
-                "type": "string"
-              }
-            }
-          ],
-          "responses": {
-            "200": {
-              "description": "OK",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "type": "string",
-                    "format": "date-time"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "type": "string",
-                    "format": "date-time"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "type": "string",
-                    "format": "date-time"
-                  }
-                }
-              }
-            },
-            "409": {
-              "description": "Conflict",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "500": {
-              "description": "Internal Server Error"
             }
           }
         },
-        "delete": {
-          "tags": [
-            "DisputeLock"
-          ],
-          "summary": "Releases a lock.",
-          "parameters": [
-            {
-              "name": "lockId",
-              "in": "path",
-              "description": "",
-              "required": true,
-              "schema": {
-                "type": "string"
-              }
-            }
-          ],
-          "responses": {
-            "200": {
-              "description": "OK"
-            },
-            "404": {
-              "description": "Not Found",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "500": {
-              "description": "Internal Server Error"
-            }
-          }
-        }
-      },
-      "/api/document": {
-        "post": {
-          "tags": [
-            "Document"
-          ],
-          "summary": "Creates a new file the document management service along with metadata.",
-          "parameters": [
-            {
-              "name": "disputeId",
-              "in": "header",
-              "description": "The TCO dispute id to associate document with.",
-              "schema": {
-                "maximum": 2147483647,
-                "minimum": 1,
-                "type": "integer",
-                "format": "int64"
-              }
-            },
-            {
-              "name": "noticeOfDisputeId",
-              "in": "header",
-              "description": "The occam dispute id to associate document with.",
-              "required": true,
-              "schema": {
-                "type": "string"
-              }
-            },
-            {
-              "name": "documentType",
-              "in": "header",
-              "description": "The document type to associate with this file.",
-              "required": true,
-              "schema": {
-                "type": "string"
-              }
-            }
-          ],
-          "requestBody": {
+        "responses": {
+          "200": {
+            "description": "The Dispute is updated."
+          },
+          "400": {
+            "description": "The request was not well formed. Check the parameters.",
             "content": {
-              "multipart/form-data": {
+              "text/plain": {
                 "schema": {
-                  "required": [
-                    "file"
-                  ],
-                  "type": "object",
-                  "properties": {
-                    "file": {
-                      "type": "string",
-                      "description": "The file to save in the common object management service and the metadata of the uploaded file to be saved including the document type",
-                      "format": "binary"
-                    }
-                  }
-                },
-                "encoding": {
-                  "file": {
-                    "style": "form"
-                  }
+                  "$ref": "#/components/schemas/ProblemDetails"
                 }
-              }
-            }
-          },
-          "responses": {
-            "200": {
-              "description": "The document is successfully uploaded and saved.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "type": "string",
-                    "format": "uuid"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "type": "string",
-                    "format": "uuid"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "type": "string",
-                    "format": "uuid"
-                  }
-                }
-              }
-            },
-            "400": {
-              "description": "The request was not well formed. The file and ticket number are required",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "401": {
-              "description": "Unauthenticated.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "403": {
-              "description": "Forbidden, requires jjdispute:update permission.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "500": {
-              "description": "There was a server error that prevented the file upload from completing successfully."
-            }
-          }
-        },
-        "get": {
-          "tags": [
-            "Document"
-          ],
-          "summary": "Downloads a document for the given unique file ID if the virus scan staus is clean.",
-          "parameters": [
-            {
-              "name": "fileId",
-              "in": "query",
-              "description": "Unique identifier for a specific document.",
-              "schema": {
-                "type": "string",
-                "format": "uuid"
-              }
-            }
-          ],
-          "responses": {
-            "200": {
-              "description": "The document is successfully downloaded."
-            },
-            "400": {
-              "description": "The request was not well formed. Check the parameters.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "401": {
-              "description": "Unauthenticated.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "403": {
-              "description": "Forbidden, requires jjdispute:read permission.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "404": {
-              "description": "The file was not found.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "500": {
-              "description": "There was a server error that prevented the file to be downloaded successfully."
-            }
-          }
-        },
-        "delete": {
-          "tags": [
-            "Document"
-          ],
-          "summary": "Removes the specified document for the given unique file ID.",
-          "parameters": [
-            {
-              "name": "fileId",
-              "in": "query",
-              "description": "Unique identifier for a specific document.",
-              "schema": {
-                "type": "string",
-                "format": "uuid"
-              }
-            }
-          ],
-          "responses": {
-            "200": {
-              "description": "The document is successfully removed."
-            },
-            "400": {
-              "description": "The request was not well formed. Check the parameters.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "401": {
-              "description": "Unauthenticated.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "403": {
-              "description": "Forbidden, requires jjdispute:delete permission.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "500": {
-              "description": "There was a server error that prevented the file to be removed successfully."
-            }
-          }
-        }
-      },
-      "/api/emailhistory/emailhistory": {
-        "get": {
-          "tags": [
-            "EmailHistory"
-          ],
-          "summary": "Returns all File History Records from the Oracle Data API related to a specific ticket number.",
-          "parameters": [
-            {
-              "name": "ticketNumber",
-              "in": "query",
-              "description": "",
-              "schema": {
-                "type": "string"
-              }
-            }
-          ],
-          "responses": {
-            "200": {
-              "description": "The File history records were found.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "type": "array",
-                    "items": {
-                      "$ref": "#/components/schemas/EmailHistory"
-                    }
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "type": "array",
-                    "items": {
-                      "$ref": "#/components/schemas/EmailHistory"
-                    }
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "type": "array",
-                    "items": {
-                      "$ref": "#/components/schemas/EmailHistory"
-                    }
-                  }
-                }
-              }
-            },
-            "403": {
-              "description": "Forbidden, requires dispute:read permission.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "500": {
-              "description": "There was a server error that prevented the search from completing successfully or no data found."
-            },
-            "401": {
-              "description": "Unauthenticated."
-            }
-          }
-        }
-      },
-      "/api/filehistory/filehistory": {
-        "get": {
-          "tags": [
-            "FileHistory"
-          ],
-          "summary": "Returns all File History Records from the Oracle Data API related to a specific ticket number.",
-          "parameters": [
-            {
-              "name": "ticketNumber",
-              "in": "query",
-              "description": "",
-              "schema": {
-                "type": "string"
-              }
-            }
-          ],
-          "responses": {
-            "200": {
-              "description": "The File history records were found.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "type": "array",
-                    "items": {
-                      "$ref": "#/components/schemas/FileHistory"
-                    }
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "type": "array",
-                    "items": {
-                      "$ref": "#/components/schemas/FileHistory"
-                    }
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "type": "array",
-                    "items": {
-                      "$ref": "#/components/schemas/FileHistory"
-                    }
-                  }
-                }
-              }
-            },
-            "403": {
-              "description": "Forbidden, requires dispute:read permission.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "500": {
-              "description": "There was a server error that prevented the search from completing successfully or no data found."
-            },
-            "401": {
-              "description": "Unauthenticated."
-            }
-          }
-        }
-      },
-      "/api/jj/disputes": {
-        "get": {
-          "tags": [
-            "JJ"
-          ],
-          "summary": "Returns all JJ Disputes from the Oracle Data API",
-          "parameters": [
-            {
-              "name": "jjAssignedTo",
-              "in": "query",
-              "description": "If specified, will retrieve the records which are assigned to the specified jj staff",
-              "schema": {
-                "type": "string"
-              }
-            }
-          ],
-          "responses": {
-            "200": {
-              "description": "The JJ disputes were found.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "type": "array",
-                    "items": {
-                      "$ref": "#/components/schemas/JJDispute"
-                    }
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "type": "array",
-                    "items": {
-                      "$ref": "#/components/schemas/JJDispute"
-                    }
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "type": "array",
-                    "items": {
-                      "$ref": "#/components/schemas/JJDispute"
-                    }
-                  }
-                }
-              }
-            },
-            "401": {
-              "description": "Request lacks valid authentication credentials.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "403": {
-              "description": "Forbidden, requires jj-dispute:read permission.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "500": {
-              "description": "There was a server error that prevented the search from completing successfully or no data found."
-            }
-          }
-        }
-      },
-      "/api/jj/disputes/search": {
-        "get": {
-          "tags": [
-            "JJ"
-          ],
-          "summary": "",
-          "parameters": [
-            {
-              "name": "appearances",
-              "in": "query",
-              "description": "Include appearance fields",
-              "schema": {
-                "type": "boolean"
-              }
-            },
-            {
-              "name": "notice_of_hearing_yn",
-              "in": "query",
-              "description": "Include notice of hearing flag.",
-              "schema": {
-                "type": "boolean"
-              }
-            },
-            {
-              "name": "multiple_officers_yn",
-              "in": "query",
-              "description": "Include multiple officers flag",
-              "schema": {
-                "type": "boolean"
-              }
-            },
-            {
-              "name": "electronic_ticket_yn",
-              "in": "query",
-              "description": "Include electronic ticket flag",
-              "schema": {
-                "type": "boolean"
-              }
-            },
-            {
-              "name": "time_zone",
-              "in": "query",
-              "description": "The callers time zone",
-              "schema": {
-                "type": "string"
-              }
-            },
-            {
-              "name": "submitted_from",
-              "in": "query",
-              "description": "Disputes sumbitted on or after this date",
-              "schema": {
-                "type": "string"
-              }
-            },
-            {
-              "name": "submitted_thru",
-              "in": "query",
-              "description": "Disputes sumbitted on or before this date",
-              "schema": {
-                "type": "string"
-              }
-            },
-            {
-              "name": "ticket_number",
-              "in": "query",
-              "description": "",
-              "schema": {
-                "type": "string"
-              }
-            },
-            {
-              "name": "surname",
-              "in": "query",
-              "description": "The case insenstive surname to search for.",
-              "schema": {
-                "type": "string"
-              }
-            },
-            {
-              "name": "surname_or_org_name",
-              "in": "query",
-              "description": "The case insenstive disputant surname or organization name to search for.",
-              "schema": {
-                "type": "string"
-              }
-            },
-            {
-              "name": "jj_assigned_to",
-              "in": "query",
-              "description": "The JJ assigned user",
-              "schema": {
-                "type": "string"
-              }
-            },
-            {
-              "name": "jj_decision_dt_from",
-              "in": "query",
-              "description": "The jj decision date where greater or equal to this date. Format must be YYYY-MM-DD.",
-              "schema": {
-                "type": "string"
-              }
-            },
-            {
-              "name": "jj_decision_dt_thru",
-              "in": "query",
-              "description": "The jj decision date where less or equal to this date. Format must be YYYY-MM-DD.",
-              "schema": {
-                "type": "string"
-              }
-            },
-            {
-              "name": "dispute_status_codes",
-              "in": "query",
-              "description": "The comma separate list of status codes",
-              "schema": {
-                "type": "string"
-              }
-            },
-            {
-              "name": "appearance_courthouse_ids",
-              "in": "query",
-              "description": "The comma separate list of agency ids",
-              "schema": {
-                "type": "string"
-              }
-            },
-            {
-              "name": "appearance_dt_from",
-              "in": "query",
-              "description": "The appearance date from. Format must be YYYY-MM-DD.",
-              "schema": {
-                "type": "string"
-              }
-            },
-            {
-              "name": "appearance_dt_thru",
-              "in": "query",
-              "description": "The appearance date thru. Format must be YYYY-MM-DD.",
-              "schema": {
-                "type": "string"
-              }
-            },
-            {
-              "name": "to_be_heard_at_courthouse_ids",
-              "in": "query",
-              "description": "The comma separate list of agency ids",
-              "schema": {
-                "type": "string"
-              }
-            },
-            {
-              "name": "hearing_type_cd",
-              "in": "query",
-              "description": "The hearing type code to search.",
-              "schema": {
-                "type": "string"
-              }
-            },
-            {
-              "name": "sort_by",
-              "in": "query",
-              "description": "The list of columns to sort the result by. To sort descending, add a '-' before the column name. Note: 'surnameOrOrgName' is a pseudo field for sorting by surname or organization name.",
-              "schema": {
-                "type": "string"
-              }
-            },
-            {
-              "name": "page_number",
-              "in": "query",
-              "description": "The page number to fetch. Starts at 1.",
-              "schema": {
-                "type": "integer",
-                "format": "int32"
-              }
-            },
-            {
-              "name": "page_size",
-              "in": "query",
-              "description": "The page size to use. If not specified, defaults to 25",
-              "schema": {
-                "type": "integer",
-                "format": "int32"
-              }
-            }
-          ],
-          "responses": {
-            "200": {
-              "description": "OK",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/PagedDisputeCaseFileSummaryCollection"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/PagedDisputeCaseFileSummaryCollection"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/PagedDisputeCaseFileSummaryCollection"
-                  }
-                }
-              }
-            },
-            "401": {
-              "description": "Unauthorized",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "403": {
-              "description": "Forbidden",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "500": {
-              "description": "Internal Server Error"
-            }
-          }
-        }
-      },
-      "/api/jj/{jjDisputeId}": {
-        "get": {
-          "tags": [
-            "JJ"
-          ],
-          "summary": "Returns a single JJ Dispute with the given identifier from the Oracle Data API.",
-          "parameters": [
-            {
-              "name": "jjDisputeId",
-              "in": "path",
-              "description": "Unique identifier for a specific JJ dispute record.",
-              "required": true,
-              "schema": {
-                "type": "integer",
-                "format": "int64"
-              }
-            },
-            {
-              "name": "ticketNumber",
-              "in": "query",
-              "description": "Ticket number for a specific JJ dispute record.",
-              "schema": {
-                "type": "string"
-              }
-            },
-            {
-              "name": "assignVTC",
-              "in": "query",
-              "description": "boolean to indicate need to assign VTC.",
-              "schema": {
-                "type": "boolean"
-              }
-            }
-          ],
-          "responses": {
-            "200": {
-              "description": "The JJ dispute was found.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/JJDispute"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/JJDispute"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/JJDispute"
-                  }
-                }
-              }
-            },
-            "400": {
-              "description": "The request was not well formed. Check the parameters.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "401": {
-              "description": "Request lacks valid authentication credentials.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "403": {
-              "description": "Forbidden, requires jj-dispute:read permission.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "404": {
-              "description": "Not Found",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "409": {
-              "description": "The JJDispute has already been assigned to a user. JJDispute cannot be modified until assigned time expires.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "500": {
-              "description": "There was a server error that prevented the search from completing successfully or no data found."
-            }
-          }
-        }
-      },
-      "/api/jj/ticketimage/{ticketNumber}/{documentType}": {
-        "get": {
-          "tags": [
-            "JJ"
-          ],
-          "summary": "Returns a single Justin Document for a given ticket number and docment type.",
-          "parameters": [
-            {
-              "name": "ticketNumber",
-              "in": "path",
-              "description": "Ticket number for a specific JJ dispute record.",
-              "required": true,
-              "schema": {
-                "type": "string"
-              }
-            },
-            {
-              "name": "documentType",
-              "in": "path",
-              "description": "indicates document type.",
-              "required": true,
-              "schema": {
-                "$ref": "#/components/schemas/DocumentType"
-              }
-            }
-          ],
-          "responses": {
-            "200": {
-              "description": "The document was found.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/TicketImageDataJustinDocument"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/TicketImageDataJustinDocument"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/TicketImageDataJustinDocument"
-                  }
-                }
-              }
-            },
-            "400": {
-              "description": "The request was not well formed. Check the parameters.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "401": {
-              "description": "Request lacks valid authentication credentials.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "403": {
-              "description": "Forbidden, requires jj-dispute:read permission.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "404": {
-              "description": "Not Found",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "500": {
-              "description": "There was a server error that prevented the search from completing successfully or no data found."
-            }
-          }
-        }
-      },
-      "/api/jj/{ticketNumber}/cascade": {
-        "put": {
-          "tags": [
-            "JJ"
-          ],
-          "summary": "Updates a single JJ Dispute and related Dispute data.\r\nMust have update-admin permission on the JJDispute resource to use this endpoint.",
-          "parameters": [
-            {
-              "name": "ticketNumber",
-              "in": "path",
-              "description": "Unique identifier for a specific JJ Dispute record.",
-              "required": true,
-              "schema": {
-                "type": "string"
-              }
-            }
-          ],
-          "requestBody": {
-            "description": "",
-            "content": {
+              },
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/JJDispute"
+                  "$ref": "#/components/schemas/ProblemDetails"
                 }
               },
               "text/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/JJDispute"
-                }
-              },
-              "application/*+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/JJDispute"
+                  "$ref": "#/components/schemas/ProblemDetails"
                 }
               }
             }
           },
-          "responses": {
-            "200": {
-              "description": "The JJ Dispute is updated.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/JJDispute"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/JJDispute"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/JJDispute"
-                  }
-                }
-              }
-            },
-            "400": {
-              "description": "The request was not well formed. Check the parameters.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "401": {
-              "description": "Request lacks valid authentication credentials.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "403": {
-              "description": "Forbidden, requires jj-dispute:update permission.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "404": {
-              "description": "The JJ Dispute to update was not found.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "405": {
-              "description": "An invalid JJ Dispute status is provided. Update failed.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "409": {
-              "description": "Conflict",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "500": {
-              "description": "There was a server error that prevented the update from completing successfully."
-            }
-          }
-        }
-      },
-      "/api/jj/{ticketNumber}": {
-        "put": {
-          "tags": [
-            "JJ"
-          ],
-          "summary": "Updates a single JJ Dispute through the Oracle Data Interface API based on unique violation ticket number and the jj dispute data being passed in the body.",
-          "parameters": [
-            {
-              "name": "ticketNumber",
-              "in": "path",
-              "description": "Unique identifier for a specific JJ Dispute record.",
-              "required": true,
-              "schema": {
-                "type": "string"
-              }
-            },
-            {
-              "name": "jjDisputeId",
-              "in": "query",
-              "description": "Unique identifier for a specific JJ Dispute record.",
-              "schema": {
-                "type": "integer",
-                "format": "int64"
-              }
-            },
-            {
-              "name": "checkVTC",
-              "in": "query",
-              "description": "boolean to indicate need to check VTC assigned.",
-              "schema": {
-                "type": "boolean"
-              }
-            }
-          ],
-          "requestBody": {
-            "description": "",
+          "401": {
+            "description": "Request lacks valid authentication credentials.",
             "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/JJDispute"
+                  "$ref": "#/components/schemas/ProblemDetails"
                 }
               },
               "text/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/JJDispute"
-                }
-              },
-              "application/*+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/JJDispute"
+                  "$ref": "#/components/schemas/ProblemDetails"
                 }
               }
             }
           },
-          "responses": {
-            "200": {
-              "description": "Admin resolution is submitted. The JJ Dispute is updated.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/JJDispute"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/JJDispute"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/JJDispute"
-                  }
+          "403": {
+            "description": "Forbidden, requires dispute:cancel permission.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
                 }
               }
-            },
-            "400": {
-              "description": "The request was not well formed. Check the parameters.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "401": {
-              "description": "Request lacks valid authentication credentials.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "403": {
-              "description": "Forbidden, requires jj-dispute:update permission.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "404": {
-              "description": "The JJ Dispute to update was not found.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "405": {
-              "description": "An invalid JJ Dispute status is provided. Update failed.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "409": {
-              "description": "Conflict",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "500": {
-              "description": "There was a server error that prevented the update from completing successfully."
             }
+          },
+          "404": {
+            "description": "Dispute record not found. Update failed.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "A Dispute status can only be set to CANCELLED iff status is REJECTED or PROCESSING.Update failed.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "The Dispute has already been assigned to a different user. Dispute cannot be modified until assigned time expires.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "There was a server error that prevented the update from completing successfully."
           }
         }
-      },
-      "/api/jj/assign": {
-        "put": {
-          "tags": [
-            "JJ"
-          ],
-          "summary": "Updates each JJ Dispute based on the passed in IDs (ticket number) to assign them to a specific JJ or unassign them if JJ not specified.",
-          "parameters": [
-            {
-              "name": "ticketNumbers",
-              "in": "query",
-              "description": "List of Unique identifiers for JJ Dispute records to be assigend/unassigned.",
-              "required": true,
-              "schema": {
-                "type": "array",
-                "items": {
+      }
+    },
+    "/api/dispute/{disputeId}/resendemailverify": {
+      "put": {
+        "tags": [
+          "Dispute"
+        ],
+        "summary": "An endpoint for resending an email to a Disputant.",
+        "parameters": [
+          {
+            "name": "disputeId",
+            "in": "path",
+            "description": "",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "text/json": {
+                "schema": {
                   "type": "string"
                 }
               }
-            },
-            {
-              "name": "username",
-              "in": "query",
-              "description": "IDIR username of the JJ that JJ Dispute(s) will be assigned to, if specified. Otherwise JJ Disputes will be unassigned.",
-              "schema": {
-                "type": "string"
-              }
             }
-          ],
-          "responses": {
-            "200": {
-              "description": "JJ Disputes are assigned/unassigned to/from a JJ successfully. The JJ Disputes are updated."
-            },
-            "400": {
-              "description": "The request was not well formed. Check the parameters.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "401": {
-              "description": "Request lacks valid authentication credentials.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "403": {
-              "description": "Forbidden, requires jj-dispute:assign permission.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "404": {
-              "description": "The JJ Dispute(s) to update was not found.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "405": {
-              "description": "Method Not Allowed",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "500": {
-              "description": "There was a server error that prevented the update from completing successfully."
-            }
-          }
-        }
-      },
-      "/api/jj/{ticketNumber}/recall": {
-        "put": {
-          "tags": [
-            "JJ"
-          ],
-          "summary": "Updates the status of a particular JJDispute record to REVIEW when JJ wants to recall and open an ACCEPTED, CONFIRMED or CONCLUDED dispute.",
-          "parameters": [
-            {
-              "name": "ticketNumber",
-              "in": "path",
-              "description": "Unique identifier for a specific JJ Dispute record.",
-              "required": true,
-              "schema": {
-                "type": "string"
-              }
-            },
-            {
-              "name": "checkVTC",
-              "in": "query",
-              "description": "boolean to indicate need to check VTC assigned.",
-              "schema": {
-                "type": "boolean"
-              }
-            }
-          ],
-          "responses": {
-            "200": {
-              "description": "The JJDispute is updated."
-            },
-            "400": {
-              "description": "The request was not well formed. Check the parameters.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "401": {
-              "description": "Request lacks valid authentication credentials.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "403": {
-              "description": "Forbidden, requires jjdispute:review permission.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "404": {
-              "description": "JJDispute record not found. Update failed.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "405": {
-              "description": "A JJDispute status can only be set to REVIEW if status is CONFIRMED and the remark must be less than 256 characters OR if the status ACCEPTED, CONFIRMED or CONCLUDED and DCF's current hearing date = today's date. Update failed",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "409": {
-              "description": "The JJDispute has already been assigned to a different user. JJDispute cannot be modified until assigned time expires.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "500": {
-              "description": "There was a server error that prevented the update from completing successfully."
-            }
-          }
-        }
-      },
-      "/api/jj/{ticketNumber}/review": {
-        "put": {
-          "tags": [
-            "JJ"
-          ],
-          "summary": "Updates the status of a particular JJDispute record to REVIEW as well as adds an optional remark that explaining why the status was set to REVIEW.",
-          "parameters": [
-            {
-              "name": "ticketNumber",
-              "in": "path",
-              "description": "Unique identifier for a specific JJ Dispute record.",
-              "required": true,
-              "schema": {
-                "type": "string"
-              }
-            },
-            {
-              "name": "checkVTC",
-              "in": "query",
-              "description": "boolean to indicate need to check VTC assigned.",
-              "schema": {
-                "type": "boolean"
-              }
-            }
-          ],
-          "requestBody": {
+          },
+          "400": {
+            "description": "Bad Request",
             "content": {
-              "multipart/form-data": {
+              "text/plain": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "remark": {
-                      "maxLength": 256,
-                      "minLength": 0,
-                      "type": "string",
-                      "description": "The remark or note (max 256 characters) the JJDispute was set to REVIEW."
-                    }
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      }
+    },
+    "/api/dispute/{disputeId}/submit": {
+      "put": {
+        "tags": [
+          "Dispute"
+        ],
+        "summary": "Submits a Dispute record, setting it's status to PROCESSING",
+        "parameters": [
+          {
+            "name": "disputeId",
+            "in": "path",
+            "description": "Unique identifier for a specific Dispute record to submit.",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The Dispute is updated."
+          },
+          "400": {
+            "description": "The request was not well formed. Check the parameters.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Request lacks valid authentication credentials.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden, requires dispute:submit permission.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Dispute record not found. Update failed.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "A Dispute can only be submitted if the status is NEW or VALIDATED. Update failed.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "The Dispute has already been assigned to a different user. Dispute cannot be modified until assigned time expires.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "There was a server error that prevented the update from completing successfully."
+          }
+        }
+      }
+    },
+    "/api/dispute/updaterequest/{updateStatusId}/accept": {
+      "put": {
+        "tags": [
+          "Dispute"
+        ],
+        "summary": "Approves a DisputeUpdateRequest record, setting it's status to ACCEPTED.",
+        "parameters": [
+          {
+            "name": "updateStatusId",
+            "in": "path",
+            "description": "Unique identifier for a specific DisputeUpdateRequest record to accept.",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      }
+    },
+    "/api/dispute/updaterequest/{updateStatusId}/reject": {
+      "put": {
+        "tags": [
+          "Dispute"
+        ],
+        "summary": "Rejects a DisputeUpdateRequest record, setting it's status to REJECTED.",
+        "parameters": [
+          {
+            "name": "updateStatusId",
+            "in": "path",
+            "description": "Unique identifier for a specific DisputeUpdateRequest record to reject.",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      }
+    },
+    "/api/dispute/disputeswithupdaterequests": {
+      "get": {
+        "tags": [
+          "Dispute"
+        ],
+        "summary": "Returns all Disputes that have pending update requests from the Oracle Data API",
+        "responses": {
+          "200": {
+            "description": "The Disputes were found.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/DisputeWithUpdates"
                   }
-                },
-                "encoding": {
-                  "remark": {
-                    "style": "form"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/DisputeWithUpdates"
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/DisputeWithUpdates"
                   }
                 }
               }
             }
           },
-          "responses": {
-            "200": {
-              "description": "The JJDispute is updated."
-            },
-            "400": {
-              "description": "The request was not well formed. Check the parameters.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
+          "401": {
+            "description": "Request lacks valid authentication credentials.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
                 }
               }
-            },
-            "401": {
-              "description": "Request lacks valid authentication credentials.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "403": {
-              "description": "Forbidden, requires jjdispute:review permission.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "404": {
-              "description": "JJDispute record not found. Update failed.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "405": {
-              "description": "A JJDispute status can only be set to REVIEW if status is CONFIRMED and the remark must be less than 256 characters OR if the status ACCEPTED, CONFIRMED or CONCLUDED and DCF's current hearing date = today's date. Update failed",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "409": {
-              "description": "The JJDispute has already been assigned to a different user. JJDispute cannot be modified until assigned time expires.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "500": {
-              "description": "There was a server error that prevented the update from completing successfully."
             }
+          },
+          "403": {
+            "description": "Forbidden, requires dispute:read permission.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "There was a server error that prevented the search from completing successfully or no data found."
           }
         }
-      },
-      "/api/jj/{ticketNumber}/requirecourthearing": {
-        "put": {
-          "tags": [
-            "JJ"
-          ],
-          "summary": "Updates the status of a particular JJDispute record to REQUIRE_COURT_HEARING, hearing type to COURT_APPEARANCE as well as adds an optional remark that explaining why the status was set.",
-          "parameters": [
-            {
-              "name": "ticketNumber",
-              "in": "path",
-              "description": "Unique identifier for a specific JJ Dispute record.",
-              "required": true,
-              "schema": {
-                "type": "string"
-              }
+      }
+    },
+    "/api/dispute/{disputeId}/disputeupdaterequests": {
+      "get": {
+        "tags": [
+          "Dispute"
+        ],
+        "summary": "Returns all update requests for a specific dispute",
+        "parameters": [
+          {
+            "name": "disputeId",
+            "in": "path",
+            "description": "Dispute Id",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
             }
-          ],
-          "requestBody": {
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The Update requests were found.",
             "content": {
-              "multipart/form-data": {
+              "text/plain": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "remark": {
-                      "maxLength": 256,
-                      "minLength": 0,
-                      "type": "string",
-                      "description": "The remark or note (max 256 characters) the JJDispute was set to REVIEW."
-                    }
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/DisputeUpdateRequest"
                   }
-                },
-                "encoding": {
-                  "remark": {
-                    "style": "form"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/DisputeUpdateRequest"
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/DisputeUpdateRequest"
                   }
                 }
               }
             }
           },
-          "responses": {
-            "200": {
-              "description": "The JJDispute is updated."
-            },
-            "400": {
-              "description": "The request was not well formed. Check the parameters.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
+          "401": {
+            "description": "Request lacks valid authentication credentials.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
                 }
               }
-            },
-            "401": {
-              "description": "Request lacks valid authentication credentials.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "403": {
-              "description": "Forbidden, requires jjdispute:require_court_hearing permission.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "404": {
-              "description": "JJDispute record not found. Update failed.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "405": {
-              "description": "A JJDispute status can only be set to REQUIRE_COURT_HEARING iff status is one of the following: NEW, IN_PROGRESS, REVIEW, REQUIRE_COURT_HEARING and the remark must be less than or equal to 256 characters. Update failed.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "409": {
-              "description": "The JJDispute has already been assigned to a different user. JJDispute cannot be modified until assigned time expires.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "500": {
-              "description": "There was a server error that prevented the update from completing successfully."
             }
+          },
+          "403": {
+            "description": "Forbidden, requires dispute:read permission.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "There was a server error that prevented the search from completing successfully or no data found."
+          }
+        }
+      }
+    },
+    "/api/dispute/{disputeId}/print": {
+      "get": {
+        "tags": [
+          "Dispute"
+        ],
+        "summary": "Returns generated document.",
+        "parameters": [
+          {
+            "name": "disputeId",
+            "in": "path",
+            "description": "Dispute Id",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          {
+            "name": "timeZone",
+            "in": "query",
+            "description": "The IANA timze zone id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "type",
+            "in": "query",
+            "description": "The type of template to generate",
+            "schema": {
+              "$ref": "#/components/schemas/DcfTemplateType"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Generated Document.",
+            "content": {
+              "application/octet-stream": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Request lacks valid authentication credentials.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "There was a server error that prevented the search from completing successfully or no data found."
+          },
+          "400": {
+            "description": "The"
+          }
+        }
+      }
+    },
+    "/api/dispute/violationticketcount/{violationTicketCountId}": {
+      "delete": {
+        "tags": [
+          "Dispute"
+        ],
+        "summary": "Deletes a violation ticket count asynchronously.",
+        "parameters": [
+          {
+            "name": "violationTicketCountId",
+            "in": "path",
+            "description": "The ID of the violation ticket count to delete.",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      }
+    },
+    "/api/disputelock": {
+      "get": {
+        "tags": [
+          "DisputeLock"
+        ],
+        "summary": "Acquires a lock for a JJ Dispute.",
+        "parameters": [
+          {
+            "name": "ticketNumber",
+            "in": "query",
+            "description": "",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "username",
+            "in": "query",
+            "description": "",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/Lock"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Lock"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Lock"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      }
+    },
+    "/api/disputelock/{lockId}": {
+      "put": {
+        "tags": [
+          "DisputeLock"
+        ],
+        "summary": "Refreshes the expiry time of a lock.",
+        "parameters": [
+          {
+            "name": "lockId",
+            "in": "path",
+            "description": "",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string",
+                  "format": "date-time"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "string",
+                  "format": "date-time"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "string",
+                  "format": "date-time"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error"
           }
         }
       },
-      "/api/jj/{ticketNumber}/accept": {
-        "put": {
-          "tags": [
-            "JJ"
-          ],
-          "summary": "Updates the status of a particular JJDispute record to ACCEPTED.",
-          "parameters": [
-            {
-              "name": "ticketNumber",
-              "in": "path",
-              "description": "Ticket number for a specific JJ Dispute record.",
-              "required": true,
-              "schema": {
-                "type": "string"
-              }
-            },
-            {
-              "name": "checkVTC",
-              "in": "query",
-              "description": "boolean to indicate need to check VTC assigned.",
-              "schema": {
-                "type": "boolean"
-              }
-            }
-          ],
-          "responses": {
-            "200": {
-              "description": "The JJDispute is updated."
-            },
-            "400": {
-              "description": "The request was not well formed. Check the parameters.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "401": {
-              "description": "Request lacks valid authentication credentials.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "403": {
-              "description": "Forbidden, requires jjdispute:accept permission.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "404": {
-              "description": "JJDispute record not found. Update failed.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "405": {
-              "description": "A JJDispute status can only be set to ACCEPTED iff status is CONFIRMED. Update failed.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "409": {
-              "description": "The JJDispute has already been assigned to a different user. JJDispute cannot be modified until assigned time expires.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "500": {
-              "description": "There was a server error that prevented the update from completing successfully."
+      "delete": {
+        "tags": [
+          "DisputeLock"
+        ],
+        "summary": "Releases a lock.",
+        "parameters": [
+          {
+            "name": "lockId",
+            "in": "path",
+            "description": "",
+            "required": true,
+            "schema": {
+              "type": "string"
             }
           }
-        }
-      },
-      "/api/jj/{ticketNumber}/conclude": {
-        "put": {
-          "tags": [
-            "JJ"
-          ],
-          "summary": "Updates the status of a particular JJDispute record to CONCLUDED.",
-          "parameters": [
-            {
-              "name": "ticketNumber",
-              "in": "path",
-              "description": "Ticket number for a specific JJ Dispute record.",
-              "required": true,
-              "schema": {
-                "type": "string"
-              }
-            },
-            {
-              "name": "checkVTC",
-              "in": "query",
-              "description": "boolean to indicate need to check VTC assigned.",
-              "schema": {
-                "type": "boolean"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
               }
             }
-          ],
-          "responses": {
-            "200": {
-              "description": "The JJDispute is updated."
-            },
-            "400": {
-              "description": "The request was not well formed. Check the parameters.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "401": {
-              "description": "Request lacks valid authentication credentials.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "403": {
-              "description": "Forbidden, requires jjdispute:accept permission.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "404": {
-              "description": "JJDispute record not found. Update failed.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "409": {
-              "description": "The JJDispute has already been assigned to a different user. JJDispute cannot be modified until assigned time expires.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "500": {
-              "description": "There was a server error that prevented the update from completing successfully."
-            }
+          },
+          "500": {
+            "description": "Internal Server Error"
           }
         }
-      },
-      "/api/jj/{ticketNumber}/cancel": {
-        "put": {
-          "tags": [
-            "JJ"
-          ],
-          "summary": "Updates the status of a particular JJDispute record to CANCELLED.",
-          "parameters": [
-            {
-              "name": "ticketNumber",
-              "in": "path",
-              "description": "Ticket number for a specific JJ Dispute record.",
-              "required": true,
-              "schema": {
-                "type": "string"
-              }
-            },
-            {
-              "name": "checkVTC",
-              "in": "query",
-              "description": "boolean to indicate need to check VTC assigned.",
-              "schema": {
-                "type": "boolean"
-              }
+      }
+    },
+    "/api/document": {
+      "post": {
+        "tags": [
+          "Document"
+        ],
+        "summary": "Creates a new file the document management service along with metadata.",
+        "parameters": [
+          {
+            "name": "disputeId",
+            "in": "header",
+            "description": "The TCO dispute id to associate document with.",
+            "schema": {
+              "maximum": 2147483647,
+              "minimum": 1,
+              "type": "integer",
+              "format": "int64"
             }
-          ],
-          "responses": {
-            "200": {
-              "description": "The JJDispute is updated."
-            },
-            "400": {
-              "description": "The request was not well formed. Check the parameters.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "401": {
-              "description": "Request lacks valid authentication credentials.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "403": {
-              "description": "Forbidden, requires jjdispute:accept permission.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "404": {
-              "description": "JJDispute record not found. Update failed.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "409": {
-              "description": "The JJDispute has already been assigned to a different user. JJDispute cannot be modified until assigned time expires.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "500": {
-              "description": "There was a server error that prevented the update from completing successfully."
+          },
+          {
+            "name": "noticeOfDisputeId",
+            "in": "header",
+            "description": "The occam dispute id to associate document with.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "documentType",
+            "in": "header",
+            "description": "The document type to associate with this file.",
+            "required": true,
+            "schema": {
+              "type": "string"
             }
           }
-        }
-      },
-      "/api/jj/{ticketNumber}/updatecourtappearance/requirecourthearing": {
-        "put": {
-          "tags": [
-            "JJ"
-          ],
-          "summary": "Updates court appearance record as well as the status of a particular JJDispute record to REQUIRE_COURT_HEARING, hearing type to COURT_APPEARANCE.",
-          "parameters": [
-            {
-              "name": "ticketNumber",
-              "in": "path",
-              "description": "Ticket number for a specific JJ Dispute record.",
-              "required": true,
+        ],
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
               "schema": {
-                "type": "string"
-              }
-            }
-          ],
-          "responses": {
-            "200": {
-              "description": "The court appearance and JJDispute status are updated."
-            },
-            "400": {
-              "description": "The request was not well formed. Check the parameters.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "401": {
-              "description": "Request lacks valid authentication credentials.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "403": {
-              "description": "Forbidden, requires jjdispute:update permission.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "404": {
-              "description": "JJDispute record not found. Update failed.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "405": {
-              "description": "A JJDispute status can only be set to REQUIRE_COURT_HEARING iff status is one of the following: NEW, IN_PROGRESS, REVIEW, REQUIRE_COURT_HEARING. Update failed.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "409": {
-              "description": "Conflict",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "500": {
-              "description": "There was a server error that prevented the update from completing successfully."
-            }
-          }
-        }
-      },
-      "/api/jj/{ticketNumber}/updatecourtappearance/confirm": {
-        "put": {
-          "tags": [
-            "JJ"
-          ],
-          "summary": "Updates court appearance record as well as the status of a particular JJDispute record to CONFIRMED.",
-          "parameters": [
-            {
-              "name": "ticketNumber",
-              "in": "path",
-              "description": "Ticket number for a specific JJ Dispute record.",
-              "required": true,
-              "schema": {
-                "type": "string"
-              }
-            }
-          ],
-          "responses": {
-            "200": {
-              "description": "The court appearance and JJDispute status are updated."
-            },
-            "400": {
-              "description": "The request was not well formed. Check the parameters.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "401": {
-              "description": "Request lacks valid authentication credentials.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "403": {
-              "description": "Forbidden, requires jjdispute:update permission.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "404": {
-              "description": "JJDispute record not found. Update failed.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "405": {
-              "description": "A JJDispute status can only be set to CONFIRMED iff status is one of the following: REVIEW, NEW, HEARING_SCHEDULED, IN_PROGRESS, CONFIRMED. Update failed.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "409": {
-              "description": "Conflict",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "500": {
-              "description": "There was a server error that prevented the update from completing successfully."
-            }
-          }
-        }
-      },
-      "/api/jj/{ticketNumber}/print": {
-        "get": {
-          "tags": [
-            "JJ"
-          ],
-          "summary": "Returns generated document. This really should be using the tco_dispute.dispute_id.",
-          "parameters": [
-            {
-              "name": "ticketNumber",
-              "in": "path",
-              "description": "The ticket number to print. This really should be using the tco_dispute.dispute_id",
-              "required": true,
-              "schema": {
-                "type": "string"
-              }
-            },
-            {
-              "name": "timeZone",
-              "in": "query",
-              "description": "The IANA timze zone id",
-              "required": true,
-              "schema": {
-                "type": "string"
-              }
-            },
-            {
-              "name": "type",
-              "in": "query",
-              "description": "The type of template to generate",
-              "schema": {
-                "$ref": "#/components/schemas/DcfTemplateType"
-              }
-            }
-          ],
-          "responses": {
-            "200": {
-              "description": "Generated Document.",
-              "content": {
-                "application/octet-stream": {
-                  "schema": {
+                "required": [
+                  "file"
+                ],
+                "type": "object",
+                "properties": {
+                  "file": {
                     "type": "string",
+                    "description": "The file to save in the common object management service and the metadata of the uploaded file to be saved including the document type",
                     "format": "binary"
                   }
                 }
-              }
-            },
-            "401": {
-              "description": "Request lacks valid authentication credentials.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
+              },
+              "encoding": {
+                "file": {
+                  "style": "form"
                 }
               }
-            },
-            "403": {
-              "description": "Forbidden.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "500": {
-              "description": "There was a server error that prevented the search from completing successfully or no data found."
-            },
-            "400": {
-              "description": "The"
             }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The document is successfully uploaded and saved.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string",
+                  "format": "uuid"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "string",
+                  "format": "uuid"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "string",
+                  "format": "uuid"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "The request was not well formed. The file and ticket number are required",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthenticated.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden, requires jjdispute:update permission.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "There was a server error that prevented the file upload from completing successfully."
           }
         }
       },
-      "/api/keycloak/{groupName}/users": {
-        "get": {
-          "tags": [
-            "Keycloak"
-          ],
-          "summary": "Returns all Users with the given group name.",
-          "parameters": [
-            {
-              "name": "groupName",
-              "in": "path",
-              "description": "A unique group name to query.",
-              "required": true,
+      "get": {
+        "tags": [
+          "Document"
+        ],
+        "summary": "Downloads a document for the given unique file ID if the virus scan staus is clean.",
+        "parameters": [
+          {
+            "name": "fileId",
+            "in": "query",
+            "description": "Unique identifier for a specific document.",
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The document is successfully downloaded."
+          },
+          "400": {
+            "description": "The request was not well formed. Check the parameters.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthenticated.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden, requires jjdispute:read permission.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "The file was not found.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "There was a server error that prevented the file to be downloaded successfully."
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Document"
+        ],
+        "summary": "Removes the specified document for the given unique file ID.",
+        "parameters": [
+          {
+            "name": "fileId",
+            "in": "query",
+            "description": "Unique identifier for a specific document.",
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The document is successfully removed."
+          },
+          "400": {
+            "description": "The request was not well formed. Check the parameters.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthenticated.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden, requires jjdispute:delete permission.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "There was a server error that prevented the file to be removed successfully."
+          }
+        }
+      }
+    },
+    "/api/emailhistory/emailhistory": {
+      "get": {
+        "tags": [
+          "EmailHistory"
+        ],
+        "summary": "Returns all File History Records from the Oracle Data API related to a specific ticket number.",
+        "parameters": [
+          {
+            "name": "ticketNumber",
+            "in": "query",
+            "description": "",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The File history records were found.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/EmailHistory"
+                  }
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/EmailHistory"
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/EmailHistory"
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden, requires dispute:read permission.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "There was a server error that prevented the search from completing successfully or no data found."
+          },
+          "401": {
+            "description": "Unauthenticated."
+          }
+        }
+      }
+    },
+    "/api/filehistory/filehistory": {
+      "get": {
+        "tags": [
+          "FileHistory"
+        ],
+        "summary": "Returns all File History Records from the Oracle Data API related to a specific ticket number.",
+        "parameters": [
+          {
+            "name": "ticketNumber",
+            "in": "query",
+            "description": "",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The File history records were found.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/FileHistory"
+                  }
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/FileHistory"
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/FileHistory"
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden, requires dispute:read permission.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "There was a server error that prevented the search from completing successfully or no data found."
+          },
+          "401": {
+            "description": "Unauthenticated."
+          }
+        }
+      }
+    },
+    "/api/jj/disputes": {
+      "get": {
+        "tags": [
+          "JJ"
+        ],
+        "summary": "Returns all JJ Disputes from the Oracle Data API",
+        "parameters": [
+          {
+            "name": "jjAssignedTo",
+            "in": "query",
+            "description": "If specified, will retrieve the records which are assigned to the specified jj staff",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The JJ disputes were found.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/JJDispute"
+                  }
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/JJDispute"
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/JJDispute"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Request lacks valid authentication credentials.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden, requires jj-dispute:read permission.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "There was a server error that prevented the search from completing successfully or no data found."
+          }
+        }
+      }
+    },
+    "/api/jj/disputes/search": {
+      "get": {
+        "tags": [
+          "JJ"
+        ],
+        "summary": "",
+        "parameters": [
+          {
+            "name": "appearances",
+            "in": "query",
+            "description": "Include appearance fields",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "name": "notice_of_hearing_yn",
+            "in": "query",
+            "description": "Include notice of hearing flag.",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "name": "multiple_officers_yn",
+            "in": "query",
+            "description": "Include multiple officers flag",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "name": "electronic_ticket_yn",
+            "in": "query",
+            "description": "Include electronic ticket flag",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "name": "time_zone",
+            "in": "query",
+            "description": "The callers time zone",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "submitted_from",
+            "in": "query",
+            "description": "Disputes sumbitted on or after this date",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "submitted_thru",
+            "in": "query",
+            "description": "Disputes sumbitted on or before this date",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "ticket_number",
+            "in": "query",
+            "description": "",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "surname",
+            "in": "query",
+            "description": "The case insenstive surname to search for.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "surname_or_org_name",
+            "in": "query",
+            "description": "The case insenstive disputant surname or organization name to search for.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "jj_assigned_to",
+            "in": "query",
+            "description": "The JJ assigned user",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "jj_decision_dt_from",
+            "in": "query",
+            "description": "The jj decision date where greater or equal to this date. Format must be YYYY-MM-DD.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "jj_decision_dt_thru",
+            "in": "query",
+            "description": "The jj decision date where less or equal to this date. Format must be YYYY-MM-DD.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "dispute_status_codes",
+            "in": "query",
+            "description": "The comma separate list of status codes",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "appearance_courthouse_ids",
+            "in": "query",
+            "description": "The comma separate list of agency ids",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "appearance_dt_from",
+            "in": "query",
+            "description": "The appearance date from. Format must be YYYY-MM-DD.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "appearance_dt_thru",
+            "in": "query",
+            "description": "The appearance date thru. Format must be YYYY-MM-DD.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "to_be_heard_at_courthouse_ids",
+            "in": "query",
+            "description": "The comma separate list of agency ids",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "hearing_type_cd",
+            "in": "query",
+            "description": "The hearing type code to search.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "sort_by",
+            "in": "query",
+            "description": "The list of columns to sort the result by. To sort descending, add a '-' before the column name. Note: 'surnameOrOrgName' is a pseudo field for sorting by surname or organization name.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "page_number",
+            "in": "query",
+            "description": "The page number to fetch. Starts at 1.",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "page_size",
+            "in": "query",
+            "description": "The page size to use. If not specified, defaults to 25",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/PagedDisputeCaseFileSummaryCollection"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PagedDisputeCaseFileSummaryCollection"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PagedDisputeCaseFileSummaryCollection"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      }
+    },
+    "/api/jj/{jjDisputeId}": {
+      "get": {
+        "tags": [
+          "JJ"
+        ],
+        "summary": "Returns a single JJ Dispute with the given identifier from the Oracle Data API.",
+        "parameters": [
+          {
+            "name": "jjDisputeId",
+            "in": "path",
+            "description": "Unique identifier for a specific JJ dispute record.",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          {
+            "name": "ticketNumber",
+            "in": "query",
+            "description": "Ticket number for a specific JJ dispute record.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "assignVTC",
+            "in": "query",
+            "description": "boolean to indicate need to assign VTC.",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "name": "executeUserLock",
+            "in": "query",
+            "description": "A flag indicating whether to execute a user lock.",
+            "schema": {
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The JJ dispute was found.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/JJDispute"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JJDispute"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JJDispute"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "The request was not well formed. Check the parameters.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Request lacks valid authentication credentials.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden, requires jj-dispute:read permission.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "The JJDispute has already been assigned to a user. JJDispute cannot be modified until assigned time expires.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "There was a server error that prevented the search from completing successfully or no data found."
+          }
+        }
+      }
+    },
+    "/api/jj/ticketimage/{ticketNumber}/{documentType}": {
+      "get": {
+        "tags": [
+          "JJ"
+        ],
+        "summary": "Returns a single Justin Document for a given ticket number and docment type.",
+        "parameters": [
+          {
+            "name": "ticketNumber",
+            "in": "path",
+            "description": "Ticket number for a specific JJ dispute record.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "documentType",
+            "in": "path",
+            "description": "indicates document type.",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/DocumentType"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The document was found.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/TicketImageDataJustinDocument"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TicketImageDataJustinDocument"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TicketImageDataJustinDocument"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "The request was not well formed. Check the parameters.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Request lacks valid authentication credentials.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden, requires jj-dispute:read permission.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "There was a server error that prevented the search from completing successfully or no data found."
+          }
+        }
+      }
+    },
+    "/api/jj/{ticketNumber}/cascade": {
+      "put": {
+        "tags": [
+          "JJ"
+        ],
+        "summary": "Updates a single JJ Dispute and related Dispute data.\r\nMust have update-admin permission on the JJDispute resource to use this endpoint.",
+        "parameters": [
+          {
+            "name": "ticketNumber",
+            "in": "path",
+            "description": "Unique identifier for a specific JJ Dispute record.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "",
+          "content": {
+            "application/json": {
               "schema": {
+                "$ref": "#/components/schemas/JJDispute"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/JJDispute"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/JJDispute"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The JJ Dispute is updated.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/JJDispute"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JJDispute"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JJDispute"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "The request was not well formed. Check the parameters.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Request lacks valid authentication credentials.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden, requires jj-dispute:update permission.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "The JJ Dispute to update was not found.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "An invalid JJ Dispute status is provided. Update failed.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "There was a server error that prevented the update from completing successfully."
+          }
+        }
+      }
+    },
+    "/api/jj/{ticketNumber}": {
+      "put": {
+        "tags": [
+          "JJ"
+        ],
+        "summary": "Updates a single JJ Dispute through the Oracle Data Interface API based on unique violation ticket number and the jj dispute data being passed in the body.",
+        "parameters": [
+          {
+            "name": "ticketNumber",
+            "in": "path",
+            "description": "Unique identifier for a specific JJ Dispute record.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "jjDisputeId",
+            "in": "query",
+            "description": "Unique identifier for a specific JJ Dispute record.",
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          {
+            "name": "checkVTC",
+            "in": "query",
+            "description": "boolean to indicate need to check VTC assigned.",
+            "schema": {
+              "type": "boolean"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/JJDispute"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/JJDispute"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/JJDispute"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Admin resolution is submitted. The JJ Dispute is updated.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/JJDispute"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JJDispute"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JJDispute"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "The request was not well formed. Check the parameters.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Request lacks valid authentication credentials.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden, requires jj-dispute:update permission.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "The JJ Dispute to update was not found.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "An invalid JJ Dispute status is provided. Update failed.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "There was a server error that prevented the update from completing successfully."
+          }
+        }
+      }
+    },
+    "/api/jj/assign": {
+      "put": {
+        "tags": [
+          "JJ"
+        ],
+        "summary": "Updates each JJ Dispute based on the passed in IDs (ticket number) to assign them to a specific JJ or unassign them if JJ not specified.",
+        "parameters": [
+          {
+            "name": "ticketNumbers",
+            "in": "query",
+            "description": "List of Unique identifiers for JJ Dispute records to be assigend/unassigned.",
+            "required": true,
+            "schema": {
+              "type": "array",
+              "items": {
                 "type": "string"
               }
             }
-          ],
-          "responses": {
-            "200": {
-              "description": "OK",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "type": "array",
-                    "items": {
-                      "$ref": "#/components/schemas/UserRepresentation"
-                    }
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "type": "array",
-                    "items": {
-                      "$ref": "#/components/schemas/UserRepresentation"
-                    }
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "type": "array",
-                    "items": {
-                      "$ref": "#/components/schemas/UserRepresentation"
-                    }
-                  }
-                }
-              }
-            },
-            "401": {
-              "description": "Request lacks valid authentication credentials.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "500": {
-              "description": "Internal Server Error"
+          },
+          {
+            "name": "username",
+            "in": "query",
+            "description": "IDIR username of the JJ that JJ Dispute(s) will be assigned to, if specified. Otherwise JJ Disputes will be unassigned.",
+            "schema": {
+              "type": "string"
             }
           }
+        ],
+        "responses": {
+          "200": {
+            "description": "JJ Disputes are assigned/unassigned to/from a JJ successfully. The JJ Disputes are updated."
+          },
+          "400": {
+            "description": "The request was not well formed. Check the parameters.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Request lacks valid authentication credentials.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden, requires jj-dispute:assign permission.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "The JJ Dispute(s) to update was not found.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method Not Allowed",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "There was a server error that prevented the update from completing successfully."
+          }
         }
-      },
-      "/api/lookup/statutes": {
-        "get": {
-          "tags": [
-            "Lookup"
-          ],
-          "summary": "Returns a list of Violation Ticket Statutes filtered by given section text (if provided).",
-          "parameters": [
-            {
-              "name": "section",
-              "in": "query",
-              "description": "Motor vehicle act Section text to query by, ie \"13(1)(a)\" returns \"Motor Vehicle or Trailer without Licence\" contravention, or blank for no filter.",
+      }
+    },
+    "/api/jj/{ticketNumber}/recall": {
+      "put": {
+        "tags": [
+          "JJ"
+        ],
+        "summary": "Updates the status of a particular JJDispute record to REVIEW when JJ wants to recall and open an ACCEPTED, CONFIRMED or CONCLUDED dispute.",
+        "parameters": [
+          {
+            "name": "ticketNumber",
+            "in": "path",
+            "description": "Unique identifier for a specific JJ Dispute record.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "checkVTC",
+            "in": "query",
+            "description": "boolean to indicate need to check VTC assigned.",
+            "schema": {
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The JJDispute is updated."
+          },
+          "400": {
+            "description": "The request was not well formed. Check the parameters.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Request lacks valid authentication credentials.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden, requires jjdispute:review permission.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "JJDispute record not found. Update failed.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "A JJDispute status can only be set to REVIEW if status is CONFIRMED and the remark must be less than 256 characters OR if the status ACCEPTED, CONFIRMED or CONCLUDED and DCF's current hearing date = today's date. Update failed",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "The JJDispute has already been assigned to a different user. JJDispute cannot be modified until assigned time expires.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "There was a server error that prevented the update from completing successfully."
+          }
+        }
+      }
+    },
+    "/api/jj/{ticketNumber}/review": {
+      "put": {
+        "tags": [
+          "JJ"
+        ],
+        "summary": "Updates the status of a particular JJDispute record to REVIEW as well as adds an optional remark that explaining why the status was set to REVIEW.",
+        "parameters": [
+          {
+            "name": "ticketNumber",
+            "in": "path",
+            "description": "Unique identifier for a specific JJ Dispute record.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "checkVTC",
+            "in": "query",
+            "description": "boolean to indicate need to check VTC assigned.",
+            "schema": {
+              "type": "boolean"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
               "schema": {
-                "type": "string"
-              }
-            }
-          ],
-          "responses": {
-            "200": {
-              "description": "OK",
-              "content": {
-                "application/json": {
-                  "schema": {
-                    "type": "array",
-                    "items": {
-                      "$ref": "#/components/schemas/Statute"
-                    }
+                "type": "object",
+                "properties": {
+                  "remark": {
+                    "maxLength": 256,
+                    "minLength": 0,
+                    "type": "string",
+                    "description": "The remark or note (max 256 characters) the JJDispute was set to REVIEW."
                   }
                 }
+              },
+              "encoding": {
+                "remark": {
+                  "style": "form"
+                }
               }
-            },
-            "401": {
-              "description": "Request lacks valid authentication credentials.",
-              "content": {
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The JJDispute is updated."
+          },
+          "400": {
+            "description": "The request was not well formed. Check the parameters.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
                 }
               }
             }
           },
-          "deprecated": true
+          "401": {
+            "description": "Request lacks valid authentication credentials.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden, requires jjdispute:review permission.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "JJDispute record not found. Update failed.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "A JJDispute status can only be set to REVIEW if status is CONFIRMED and the remark must be less than 256 characters OR if the status ACCEPTED, CONFIRMED or CONCLUDED and DCF's current hearing date = today's date. Update failed",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "The JJDispute has already been assigned to a different user. JJDispute cannot be modified until assigned time expires.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "There was a server error that prevented the update from completing successfully."
+          }
         }
-      },
-      "/api/lookup/statutes/v2": {
-        "get": {
-          "tags": [
-            "Lookup"
-          ],
-          "summary": "Returns a list of Violation Ticket Statutes filtered by given section text (if provided).",
-          "parameters": [
-            {
-              "name": "section",
-              "in": "query",
-              "description": "Motor vehicle act Section text to query by, ie \"13(1)(a)\" returns \"Motor Vehicle or Trailer without Licence\" contravention, or blank for no filter.",
+      }
+    },
+    "/api/jj/{ticketNumber}/requirecourthearing": {
+      "put": {
+        "tags": [
+          "JJ"
+        ],
+        "summary": "Updates the status of a particular JJDispute record to REQUIRE_COURT_HEARING, hearing type to COURT_APPEARANCE as well as adds an optional remark that explaining why the status was set.",
+        "parameters": [
+          {
+            "name": "ticketNumber",
+            "in": "path",
+            "description": "Unique identifier for a specific JJ Dispute record.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
               "schema": {
-                "type": "string"
-              }
-            }
-          ],
-          "responses": {
-            "200": {
-              "description": "OK",
-              "content": {
-                "application/json": {
-                  "schema": {
-                    "type": "array",
-                    "items": {
-                      "$ref": "#/components/schemas/Statute"
-                    }
+                "type": "object",
+                "properties": {
+                  "remark": {
+                    "maxLength": 256,
+                    "minLength": 0,
+                    "type": "string",
+                    "description": "The remark or note (max 256 characters) the JJDispute was set to REVIEW."
                   }
                 }
-              }
-            },
-            "401": {
-              "description": "Request lacks valid authentication credentials.",
-              "content": {
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
+              },
+              "encoding": {
+                "remark": {
+                  "style": "form"
                 }
               }
             }
           }
-        }
-      },
-      "/api/lookup/languages": {
-        "get": {
-          "tags": [
-            "Lookup"
-          ],
-          "summary": "Returns a list of Languages.",
-          "responses": {
-            "200": {
-              "description": "OK",
-              "content": {
-                "application/json": {
-                  "schema": {
-                    "type": "array",
-                    "items": {
-                      "$ref": "#/components/schemas/Language"
-                    }
-                  }
+        },
+        "responses": {
+          "200": {
+            "description": "The JJDispute is updated."
+          },
+          "400": {
+            "description": "The request was not well formed. Check the parameters.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
                 }
               }
-            },
-            "401": {
-              "description": "Request lacks valid authentication credentials.",
-              "content": {
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
+            }
+          },
+          "401": {
+            "description": "Request lacks valid authentication credentials.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden, requires jjdispute:require_court_hearing permission.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "JJDispute record not found. Update failed.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "A JJDispute status can only be set to REQUIRE_COURT_HEARING iff status is one of the following: NEW, IN_PROGRESS, REVIEW, REQUIRE_COURT_HEARING and the remark must be less than or equal to 256 characters. Update failed.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "The JJDispute has already been assigned to a different user. JJDispute cannot be modified until assigned time expires.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "There was a server error that prevented the update from completing successfully."
+          }
+        }
+      }
+    },
+    "/api/jj/{ticketNumber}/accept": {
+      "put": {
+        "tags": [
+          "JJ"
+        ],
+        "summary": "Updates the status of a particular JJDispute record to ACCEPTED.",
+        "parameters": [
+          {
+            "name": "ticketNumber",
+            "in": "path",
+            "description": "Ticket number for a specific JJ Dispute record.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "checkVTC",
+            "in": "query",
+            "description": "boolean to indicate need to check VTC assigned.",
+            "schema": {
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The JJDispute is updated."
+          },
+          "400": {
+            "description": "The request was not well formed. Check the parameters.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Request lacks valid authentication credentials.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden, requires jjdispute:accept permission.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "JJDispute record not found. Update failed.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "A JJDispute status can only be set to ACCEPTED iff status is CONFIRMED. Update failed.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "The JJDispute has already been assigned to a different user. JJDispute cannot be modified until assigned time expires.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "There was a server error that prevented the update from completing successfully."
+          }
+        }
+      }
+    },
+    "/api/jj/{ticketNumber}/conclude": {
+      "put": {
+        "tags": [
+          "JJ"
+        ],
+        "summary": "Updates the status of a particular JJDispute record to CONCLUDED.",
+        "parameters": [
+          {
+            "name": "ticketNumber",
+            "in": "path",
+            "description": "Ticket number for a specific JJ Dispute record.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "checkVTC",
+            "in": "query",
+            "description": "boolean to indicate need to check VTC assigned.",
+            "schema": {
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The JJDispute is updated."
+          },
+          "400": {
+            "description": "The request was not well formed. Check the parameters.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Request lacks valid authentication credentials.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden, requires jjdispute:accept permission.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "JJDispute record not found. Update failed.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "The JJDispute has already been assigned to a different user. JJDispute cannot be modified until assigned time expires.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "There was a server error that prevented the update from completing successfully."
+          }
+        }
+      }
+    },
+    "/api/jj/{ticketNumber}/cancel": {
+      "put": {
+        "tags": [
+          "JJ"
+        ],
+        "summary": "Updates the status of a particular JJDispute record to CANCELLED.",
+        "parameters": [
+          {
+            "name": "ticketNumber",
+            "in": "path",
+            "description": "Ticket number for a specific JJ Dispute record.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "checkVTC",
+            "in": "query",
+            "description": "boolean to indicate need to check VTC assigned.",
+            "schema": {
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The JJDispute is updated."
+          },
+          "400": {
+            "description": "The request was not well formed. Check the parameters.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Request lacks valid authentication credentials.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden, requires jjdispute:accept permission.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "JJDispute record not found. Update failed.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "The JJDispute has already been assigned to a different user. JJDispute cannot be modified until assigned time expires.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "There was a server error that prevented the update from completing successfully."
+          }
+        }
+      }
+    },
+    "/api/jj/{ticketNumber}/updatecourtappearance/requirecourthearing": {
+      "put": {
+        "tags": [
+          "JJ"
+        ],
+        "summary": "Updates court appearance record as well as the status of a particular JJDispute record to REQUIRE_COURT_HEARING, hearing type to COURT_APPEARANCE.",
+        "parameters": [
+          {
+            "name": "ticketNumber",
+            "in": "path",
+            "description": "Ticket number for a specific JJ Dispute record.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The court appearance and JJDispute status are updated."
+          },
+          "400": {
+            "description": "The request was not well formed. Check the parameters.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Request lacks valid authentication credentials.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden, requires jjdispute:update permission.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "JJDispute record not found. Update failed.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "A JJDispute status can only be set to REQUIRE_COURT_HEARING iff status is one of the following: NEW, IN_PROGRESS, REVIEW, REQUIRE_COURT_HEARING. Update failed.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "There was a server error that prevented the update from completing successfully."
+          }
+        }
+      }
+    },
+    "/api/jj/{ticketNumber}/updatecourtappearance/confirm": {
+      "put": {
+        "tags": [
+          "JJ"
+        ],
+        "summary": "Updates court appearance record as well as the status of a particular JJDispute record to CONFIRMED.",
+        "parameters": [
+          {
+            "name": "ticketNumber",
+            "in": "path",
+            "description": "Ticket number for a specific JJ Dispute record.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The court appearance and JJDispute status are updated."
+          },
+          "400": {
+            "description": "The request was not well formed. Check the parameters.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Request lacks valid authentication credentials.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden, requires jjdispute:update permission.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "JJDispute record not found. Update failed.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "A JJDispute status can only be set to CONFIRMED iff status is one of the following: REVIEW, NEW, HEARING_SCHEDULED, IN_PROGRESS, CONFIRMED. Update failed.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "There was a server error that prevented the update from completing successfully."
+          }
+        }
+      }
+    },
+    "/api/jj/{ticketNumber}/print": {
+      "get": {
+        "tags": [
+          "JJ"
+        ],
+        "summary": "Returns generated document. This really should be using the tco_dispute.dispute_id.",
+        "parameters": [
+          {
+            "name": "ticketNumber",
+            "in": "path",
+            "description": "The ticket number to print. This really should be using the tco_dispute.dispute_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "timeZone",
+            "in": "query",
+            "description": "The IANA timze zone id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "type",
+            "in": "query",
+            "description": "The type of template to generate",
+            "schema": {
+              "$ref": "#/components/schemas/DcfTemplateType"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Generated Document.",
+            "content": {
+              "application/octet-stream": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Request lacks valid authentication credentials.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "There was a server error that prevented the search from completing successfully or no data found."
+          },
+          "400": {
+            "description": "The"
+          }
+        }
+      }
+    },
+    "/api/keycloak/{groupName}/users": {
+      "get": {
+        "tags": [
+          "Keycloak"
+        ],
+        "summary": "Returns all Users with the given group name.",
+        "parameters": [
+          {
+            "name": "groupName",
+            "in": "path",
+            "description": "A unique group name to query.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/UserRepresentation"
+                  }
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/UserRepresentation"
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/UserRepresentation"
                   }
                 }
               }
             }
           },
-          "deprecated": true
-        }
-      },
-      "/api/lookup/languages/v2": {
-        "get": {
-          "tags": [
-            "Lookup"
-          ],
-          "summary": "Returns a list of Languages.",
-          "responses": {
-            "200": {
-              "description": "OK",
-              "content": {
-                "application/json": {
-                  "schema": {
-                    "type": "array",
-                    "items": {
-                      "$ref": "#/components/schemas/Language"
-                    }
-                  }
+          "401": {
+            "description": "Request lacks valid authentication credentials.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
                 }
-              }
-            },
-            "401": {
-              "description": "Request lacks valid authentication credentials.",
-              "content": {
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
                 }
               }
             }
+          },
+          "500": {
+            "description": "Internal Server Error"
           }
         }
-      },
-      "/api/lookup/agencies": {
-        "get": {
-          "tags": [
-            "Lookup"
-          ],
-          "summary": "Returns a list of agencies.",
-          "responses": {
-            "200": {
-              "description": "OK",
-              "content": {
-                "application/json": {
-                  "schema": {
-                    "type": "array",
-                    "items": {
-                      "$ref": "#/components/schemas/Agency"
-                    }
-                  }
-                }
-              }
-            },
-            "401": {
-              "description": "Request lacks valid authentication credentials.",
-              "content": {
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
+      }
+    },
+    "/api/lookup/statutes": {
+      "get": {
+        "tags": [
+          "Lookup"
+        ],
+        "summary": "Returns a list of Violation Ticket Statutes filtered by given section text (if provided).",
+        "parameters": [
+          {
+            "name": "section",
+            "in": "query",
+            "description": "Motor vehicle act Section text to query by, ie \"13(1)(a)\" returns \"Motor Vehicle or Trailer without Licence\" contravention, or blank for no filter.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Statute"
                   }
                 }
               }
             }
           },
-          "deprecated": true
-        }
-      },
-      "/api/lookup/agencies/v2": {
-        "get": {
-          "tags": [
-            "Lookup"
-          ],
-          "summary": "Returns a list of agencies.",
-          "parameters": [
-            {
-              "name": "type",
-              "in": "query",
-              "description": "The agency type code",
-              "schema": {
-                "type": "string"
-              }
-            }
-          ],
-          "responses": {
-            "200": {
-              "description": "OK",
-              "content": {
-                "application/json": {
-                  "schema": {
-                    "type": "array",
-                    "items": {
-                      "$ref": "#/components/schemas/Agency"
-                    }
-                  }
-                }
-              }
-            },
-            "401": {
-              "description": "Request lacks valid authentication credentials.",
-              "content": {
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
+          "401": {
+            "description": "Request lacks valid authentication credentials.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
                 }
               }
             }
           }
-        }
-      },
-      "/api/lookup/province": {
-        "get": {
-          "tags": [
-            "Lookup"
-          ],
-          "summary": "Returns a list of provinces.",
-          "responses": {
-            "200": {
-              "description": "OK",
-              "content": {
-                "application/json": {
-                  "schema": {
-                    "type": "array",
-                    "items": {
-                      "$ref": "#/components/schemas/Province"
-                    }
-                  }
-                }
-              }
-            },
-            "401": {
-              "description": "Request lacks valid authentication credentials.",
-              "content": {
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
+        },
+        "deprecated": true
+      }
+    },
+    "/api/lookup/statutes/v2": {
+      "get": {
+        "tags": [
+          "Lookup"
+        ],
+        "summary": "Returns a list of Violation Ticket Statutes filtered by given section text (if provided).",
+        "parameters": [
+          {
+            "name": "section",
+            "in": "query",
+            "description": "Motor vehicle act Section text to query by, ie \"13(1)(a)\" returns \"Motor Vehicle or Trailer without Licence\" contravention, or blank for no filter.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Statute"
                   }
                 }
               }
             }
           },
-          "deprecated": true
-        }
-      },
-      "/api/lookup/provinces/v2": {
-        "get": {
-          "tags": [
-            "Lookup"
-          ],
-          "summary": "Returns a list of provinces.",
-          "responses": {
-            "200": {
-              "description": "OK",
-              "content": {
-                "application/json": {
-                  "schema": {
-                    "type": "array",
-                    "items": {
-                      "$ref": "#/components/schemas/Province"
-                    }
-                  }
+          "401": {
+            "description": "Request lacks valid authentication credentials.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
                 }
               }
-            },
-            "401": {
-              "description": "Request lacks valid authentication credentials.",
-              "content": {
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            }
-          }
-        }
-      },
-      "/api/lookup/country": {
-        "get": {
-          "tags": [
-            "Lookup"
-          ],
-          "summary": "Returns a list of countries.",
-          "responses": {
-            "200": {
-              "description": "OK",
-              "content": {
-                "application/json": {
-                  "schema": {
-                    "type": "array",
-                    "items": {
-                      "$ref": "#/components/schemas/Country"
-                    }
-                  }
-                }
-              }
-            },
-            "401": {
-              "description": "Request lacks valid authentication credentials.",
-              "content": {
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            }
-          },
-          "deprecated": true
-        }
-      },
-      "/api/lookup/countries/v2": {
-        "get": {
-          "tags": [
-            "Lookup"
-          ],
-          "summary": "Returns a list of countries.",
-          "responses": {
-            "200": {
-              "description": "OK",
-              "content": {
-                "application/json": {
-                  "schema": {
-                    "type": "array",
-                    "items": {
-                      "$ref": "#/components/schemas/Country"
-                    }
-                  }
-                }
-              }
-            },
-            "401": {
-              "description": "Request lacks valid authentication credentials.",
-              "content": {
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            }
-          }
-        }
-      },
-      "/api/lookup/dispute-case-file-statuses/v2": {
-        "get": {
-          "tags": [
-            "Lookup"
-          ],
-          "summary": "Returns a list of dispute case file status types.",
-          "responses": {
-            "200": {
-              "description": "OK",
-              "content": {
-                "application/json": {
-                  "schema": {
-                    "type": "array",
-                    "items": {
-                      "$ref": "#/components/schemas/DisputeCaseFileStatus"
-                    }
-                  }
-                }
-              }
-            },
-            "401": {
-              "description": "Request lacks valid authentication credentials.",
-              "content": {
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            }
-          }
-        }
-      },
-      "/api/permissions": {
-        "get": {
-          "tags": [
-            "Permissions"
-          ],
-          "summary": "Gets the current users permissions",
-          "operationId": "TrafficCourtsStaffServiceFeaturesPermissionsPermissionsEndpoint",
-          "responses": {
-            "200": {
-              "description": "OK",
-              "content": {
-                "application/json": {
-                  "schema": {
-                    "type": "array",
-                    "items": {
-                      "$ref": "#/components/schemas/Permission"
-                    }
-                  }
-                }
-              }
-            },
-            "401": {
-              "description": "Unauthorized"
             }
           }
         }
       }
     },
-    "components": {
-      "schemas": {
-        "Agency": {
-          "type": "object",
-          "properties": {
-            "id": {
-              "type": "string",
-              "nullable": true
-            },
-            "name": {
-              "type": "string",
-              "nullable": true
-            },
-            "typeCode": {
-              "type": "string",
-              "nullable": true
+    "/api/lookup/languages": {
+      "get": {
+        "tags": [
+          "Lookup"
+        ],
+        "summary": "Returns a list of Languages.",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Language"
+                  }
+                }
+              }
             }
           },
-          "additionalProperties": false
+          "401": {
+            "description": "Request lacks valid authentication credentials.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
         },
-        "BoundingBox": {
-          "type": "object",
-          "properties": {
-            "points": {
+        "deprecated": true
+      }
+    },
+    "/api/lookup/languages/v2": {
+      "get": {
+        "tags": [
+          "Lookup"
+        ],
+        "summary": "Returns a list of Languages.",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Language"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Request lacks valid authentication credentials.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/lookup/agencies": {
+      "get": {
+        "tags": [
+          "Lookup"
+        ],
+        "summary": "Returns a list of agencies.",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Agency"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Request lacks valid authentication credentials.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        },
+        "deprecated": true
+      }
+    },
+    "/api/lookup/agencies/v2": {
+      "get": {
+        "tags": [
+          "Lookup"
+        ],
+        "summary": "Returns a list of agencies.",
+        "parameters": [
+          {
+            "name": "type",
+            "in": "query",
+            "description": "The agency type code",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Agency"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Request lacks valid authentication credentials.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/lookup/province": {
+      "get": {
+        "tags": [
+          "Lookup"
+        ],
+        "summary": "Returns a list of provinces.",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Province"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Request lacks valid authentication credentials.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        },
+        "deprecated": true
+      }
+    },
+    "/api/lookup/provinces/v2": {
+      "get": {
+        "tags": [
+          "Lookup"
+        ],
+        "summary": "Returns a list of provinces.",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Province"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Request lacks valid authentication credentials.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/lookup/country": {
+      "get": {
+        "tags": [
+          "Lookup"
+        ],
+        "summary": "Returns a list of countries.",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Country"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Request lacks valid authentication credentials.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        },
+        "deprecated": true
+      }
+    },
+    "/api/lookup/countries/v2": {
+      "get": {
+        "tags": [
+          "Lookup"
+        ],
+        "summary": "Returns a list of countries.",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Country"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Request lacks valid authentication credentials.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/lookup/dispute-case-file-statuses/v2": {
+      "get": {
+        "tags": [
+          "Lookup"
+        ],
+        "summary": "Returns a list of dispute case file status types.",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/DisputeCaseFileStatus"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Request lacks valid authentication credentials.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/permissions": {
+      "get": {
+        "tags": [
+          "Permissions"
+        ],
+        "summary": "Gets the current users permissions",
+        "operationId": "TrafficCourtsStaffServiceFeaturesPermissionsPermissionsEndpoint",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Permission"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Agency": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "nullable": true
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "typeCode": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "BoundingBox": {
+        "type": "object",
+        "properties": {
+          "points": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Point"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "Country": {
+        "type": "object",
+        "properties": {
+          "ctryId": {
+            "type": "string",
+            "nullable": true
+          },
+          "ctryLongNm": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "CredentialRepresentation": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "nullable": true
+          },
+          "type": {
+            "type": "string",
+            "nullable": true
+          },
+          "userLabel": {
+            "type": "string",
+            "nullable": true
+          },
+          "secretData": {
+            "type": "string",
+            "nullable": true
+          },
+          "credentialData": {
+            "type": "string",
+            "nullable": true
+          },
+          "priority": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "createdDate": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "value": {
+            "type": "string",
+            "nullable": true
+          },
+          "temporary": {
+            "type": "boolean"
+          },
+          "device": {
+            "type": "string",
+            "nullable": true
+          },
+          "hashedSaltedValue": {
+            "type": "string",
+            "nullable": true
+          },
+          "salt": {
+            "type": "string",
+            "nullable": true
+          },
+          "hashIterations": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "counter": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "algorithm": {
+            "type": "string",
+            "nullable": true
+          },
+          "digits": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "period": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "config": {
+            "type": "object",
+            "additionalProperties": {
               "type": "array",
               "items": {
-                "$ref": "#/components/schemas/Point"
-              },
-              "nullable": true
-            }
-          },
-          "additionalProperties": false
-        },
-        "Country": {
-          "type": "object",
-          "properties": {
-            "ctryId": {
-              "type": "string",
-              "nullable": true
-            },
-            "ctryLongNm": {
-              "type": "string",
-              "nullable": true
-            }
-          },
-          "additionalProperties": false
-        },
-        "CredentialRepresentation": {
-          "type": "object",
-          "properties": {
-            "id": {
-              "type": "string",
-              "nullable": true
-            },
-            "type": {
-              "type": "string",
-              "nullable": true
-            },
-            "userLabel": {
-              "type": "string",
-              "nullable": true
-            },
-            "secretData": {
-              "type": "string",
-              "nullable": true
-            },
-            "credentialData": {
-              "type": "string",
-              "nullable": true
-            },
-            "priority": {
-              "type": "integer",
-              "format": "int32"
-            },
-            "createdDate": {
-              "type": "integer",
-              "format": "int64"
-            },
-            "value": {
-              "type": "string",
-              "nullable": true
-            },
-            "temporary": {
-              "type": "boolean"
-            },
-            "device": {
-              "type": "string",
-              "nullable": true
-            },
-            "hashedSaltedValue": {
-              "type": "string",
-              "nullable": true
-            },
-            "salt": {
-              "type": "string",
-              "nullable": true
-            },
-            "hashIterations": {
-              "type": "integer",
-              "format": "int32"
-            },
-            "counter": {
-              "type": "integer",
-              "format": "int32"
-            },
-            "algorithm": {
-              "type": "string",
-              "nullable": true
-            },
-            "digits": {
-              "type": "integer",
-              "format": "int32"
-            },
-            "period": {
-              "type": "integer",
-              "format": "int32"
-            },
-            "config": {
-              "type": "object",
-              "additionalProperties": {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                },
-                "nullable": true
+                "type": "string"
               },
               "nullable": true
             },
+            "nullable": true
+          },
+          "additionalProperties": {
+            "type": "object",
             "additionalProperties": {
-              "type": "object",
-              "additionalProperties": {
-                "nullable": true
-              },
               "nullable": true
-            }
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "DcfTemplateType": {
+        "enum": [
+          "DcfTemplate",
+          "HrDcfTemplate",
+          "WrDcfTemplate"
+        ],
+        "type": "string"
+      },
+      "Dispute": {
+        "type": "object",
+        "properties": {
+          "fileData": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FileMetadata"
+            },
+            "nullable": true
           },
-          "additionalProperties": false
-        },
-        "DcfTemplateType": {
-          "enum": [
-            "DcfTemplate",
-            "HrDcfTemplate",
-            "WrDcfTemplate"
-          ],
-          "type": "string"
-        },
-        "Dispute": {
-          "type": "object",
-          "properties": {
-            "fileData": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/FileMetadata"
-              },
-              "nullable": true
-            },
-            "icbcName": {
-              "$ref": "#/components/schemas/IcbcNameDetail"
-            },
-            "createdBy": {
-              "type": "string",
-              "nullable": true
-            },
-            "createdTs": {
-              "type": "string",
-              "format": "date-time"
-            },
-            "modifiedBy": {
-              "type": "string",
-              "nullable": true
-            },
-            "modifiedTs": {
-              "type": "string",
-              "format": "date-time",
-              "nullable": true
-            },
-            "disputeId": {
-              "type": "integer",
-              "format": "int64"
-            },
-            "noticeOfDisputeGuid": {
-              "type": "string",
-              "nullable": true
-            },
-            "ticketNumber": {
-              "type": "string",
-              "nullable": true
-            },
-            "issuedTs": {
-              "type": "string",
-              "format": "date-time",
-              "nullable": true
-            },
-            "submittedTs": {
-              "type": "string",
-              "format": "date-time",
-              "nullable": true
-            },
-            "disputantSurname": {
-              "type": "string",
-              "nullable": true
-            },
-            "disputantGivenName1": {
-              "type": "string",
-              "nullable": true
-            },
-            "disputantGivenName2": {
-              "type": "string",
-              "nullable": true
-            },
-            "disputantGivenName3": {
-              "type": "string",
-              "nullable": true
-            },
-            "disputantBirthdate": {
-              "type": "string",
-              "format": "date-time",
-              "nullable": true
-            },
-            "driversLicenceNumber": {
-              "maxLength": 30,
-              "minLength": 0,
-              "type": "string",
-              "nullable": true
-            },
-            "disputantOrganization": {
-              "type": "string",
-              "nullable": true
-            },
-            "disputantClientId": {
-              "type": "string",
-              "nullable": true
-            },
-            "driversLicenceIssuedCountryId": {
-              "type": "integer",
-              "format": "int32",
-              "nullable": true
-            },
-            "driversLicenceIssuedProvinceSeqNo": {
-              "type": "integer",
-              "format": "int32",
-              "nullable": true
-            },
-            "driversLicenceProvince": {
-              "maxLength": 30,
-              "minLength": 0,
-              "type": "string",
-              "nullable": true
-            },
-            "status": {
-              "$ref": "#/components/schemas/DisputeStatus"
-            },
-            "addressLine1": {
-              "type": "string",
-              "nullable": true
-            },
-            "addressLine2": {
-              "type": "string",
-              "nullable": true
-            },
-            "addressLine3": {
-              "type": "string",
-              "nullable": true
-            },
-            "addressCity": {
-              "maxLength": 30,
-              "minLength": 0,
-              "type": "string",
-              "nullable": true
-            },
-            "addressProvince": {
-              "maxLength": 30,
-              "minLength": 0,
-              "type": "string",
-              "nullable": true
-            },
-            "addressProvinceCountryId": {
-              "type": "integer",
-              "format": "int32",
-              "nullable": true
-            },
-            "addressProvinceSeqNo": {
-              "type": "integer",
-              "format": "int32",
-              "nullable": true
-            },
-            "addressCountryId": {
-              "type": "integer",
-              "format": "int32",
-              "nullable": true
-            },
-            "postalCode": {
-              "maxLength": 10,
-              "minLength": 0,
-              "type": "string",
-              "nullable": true
-            },
-            "homePhoneNumber": {
-              "type": "string",
-              "nullable": true
-            },
-            "workPhoneNumber": {
-              "type": "string",
-              "nullable": true
-            },
-            "emailAddress": {
-              "type": "string",
-              "nullable": true
-            },
-            "emailAddressVerified": {
-              "type": "boolean"
-            },
-            "filingDate": {
-              "type": "string",
-              "format": "date-time",
-              "nullable": true
-            },
-            "representedByLawyer": {
-              "$ref": "#/components/schemas/DisputeRepresentedByLawyer"
-            },
-            "lawFirmName": {
-              "type": "string",
-              "nullable": true
-            },
-            "lawyerSurname": {
-              "type": "string",
-              "nullable": true
-            },
-            "lawyerGivenName1": {
-              "type": "string",
-              "nullable": true
-            },
-            "lawyerGivenName2": {
-              "type": "string",
-              "nullable": true
-            },
-            "lawyerGivenName3": {
-              "type": "string",
-              "nullable": true
-            },
-            "lawyerAddress": {
-              "maxLength": 300,
-              "minLength": 0,
-              "type": "string",
-              "nullable": true
-            },
-            "lawyerPhoneNumber": {
-              "type": "string",
-              "nullable": true
-            },
-            "lawyerEmail": {
-              "maxLength": 100,
-              "minLength": 0,
-              "type": "string",
-              "nullable": true
-            },
-            "officerPin": {
-              "type": "string",
-              "nullable": true
-            },
-            "contactTypeCd": {
-              "$ref": "#/components/schemas/DisputeContactTypeCd"
-            },
-            "requestCourtAppearanceYn": {
-              "$ref": "#/components/schemas/DisputeRequestCourtAppearanceYn"
-            },
-            "contactLawFirmNm": {
-              "type": "string",
-              "nullable": true
-            },
-            "contactGiven1Nm": {
-              "type": "string",
-              "nullable": true
-            },
-            "contactGiven2Nm": {
-              "type": "string",
-              "nullable": true
-            },
-            "contactGiven3Nm": {
-              "type": "string",
-              "nullable": true
-            },
-            "contactSurnameNm": {
-              "type": "string",
-              "nullable": true
-            },
-            "appearanceDtm": {
-              "type": "string",
-              "format": "date-time",
-              "nullable": true
-            },
-            "appearanceLessThan14DaysYn": {
-              "$ref": "#/components/schemas/DisputeAppearanceLessThan14DaysYn"
-            },
-            "detachmentLocation": {
-              "type": "string",
-              "nullable": true
-            },
-            "courtAgenId": {
-              "type": "string",
-              "nullable": true
-            },
-            "interpreterLanguageCd": {
-              "maxLength": 3,
-              "minLength": 0,
-              "type": "string",
-              "nullable": true
-            },
-            "interpreterRequired": {
-              "$ref": "#/components/schemas/DisputeInterpreterRequired"
-            },
-            "witnessNo": {
-              "type": "integer",
-              "format": "int32",
-              "nullable": true
-            },
-            "fineReductionReason": {
-              "type": "string",
-              "nullable": true
-            },
-            "timeToPayReason": {
-              "type": "string",
-              "nullable": true
-            },
-            "disputantComment": {
-              "type": "string",
-              "nullable": true
-            },
-            "rejectedReason": {
-              "type": "string",
-              "nullable": true
-            },
-            "userAssignedTo": {
-              "type": "string",
-              "nullable": true
-            },
-            "userAssignedTs": {
-              "type": "string",
-              "format": "date-time",
-              "nullable": true
-            },
-            "disputantDetectedOcrIssues": {
-              "$ref": "#/components/schemas/DisputeDisputantDetectedOcrIssues"
-            },
-            "disputantOcrIssues": {
-              "type": "string",
-              "nullable": true
-            },
-            "systemDetectedOcrIssues": {
-              "$ref": "#/components/schemas/DisputeSystemDetectedOcrIssues"
-            },
-            "ocrTicketFilename": {
-              "maxLength": 100,
-              "minLength": 0,
-              "type": "string",
-              "nullable": true
-            },
-            "signatoryType": {
-              "$ref": "#/components/schemas/DisputeSignatoryType"
-            },
-            "signatoryName": {
-              "maxLength": 100,
-              "minLength": 0,
-              "type": "string",
-              "nullable": true
-            },
-            "violationTicket": {
-              "$ref": "#/components/schemas/ViolationTicket"
-            },
-            "disputeCounts": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/DisputeCount"
-              },
-              "nullable": true
-            },
+          "icbcName": {
+            "$ref": "#/components/schemas/IcbcNameDetail"
+          },
+          "createdBy": {
+            "type": "string",
+            "nullable": true
+          },
+          "createdTs": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "modifiedBy": {
+            "type": "string",
+            "nullable": true
+          },
+          "modifiedTs": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "disputeId": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "noticeOfDisputeGuid": {
+            "type": "string",
+            "nullable": true
+          },
+          "ticketNumber": {
+            "type": "string",
+            "nullable": true
+          },
+          "issuedTs": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "submittedTs": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "disputantSurname": {
+            "type": "string",
+            "nullable": true
+          },
+          "disputantGivenName1": {
+            "type": "string",
+            "nullable": true
+          },
+          "disputantGivenName2": {
+            "type": "string",
+            "nullable": true
+          },
+          "disputantGivenName3": {
+            "type": "string",
+            "nullable": true
+          },
+          "disputantBirthdate": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "driversLicenceNumber": {
+            "maxLength": 30,
+            "minLength": 0,
+            "type": "string",
+            "nullable": true
+          },
+          "disputantOrganization": {
+            "type": "string",
+            "nullable": true
+          },
+          "disputantClientId": {
+            "type": "string",
+            "nullable": true
+          },
+          "driversLicenceIssuedCountryId": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "driversLicenceIssuedProvinceSeqNo": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "driversLicenceProvince": {
+            "maxLength": 30,
+            "minLength": 0,
+            "type": "string",
+            "nullable": true
+          },
+          "status": {
+            "$ref": "#/components/schemas/DisputeStatus"
+          },
+          "addressLine1": {
+            "type": "string",
+            "nullable": true
+          },
+          "addressLine2": {
+            "type": "string",
+            "nullable": true
+          },
+          "addressLine3": {
+            "type": "string",
+            "nullable": true
+          },
+          "addressCity": {
+            "maxLength": 30,
+            "minLength": 0,
+            "type": "string",
+            "nullable": true
+          },
+          "addressProvince": {
+            "maxLength": 30,
+            "minLength": 0,
+            "type": "string",
+            "nullable": true
+          },
+          "addressProvinceCountryId": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "addressProvinceSeqNo": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "addressCountryId": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "postalCode": {
+            "maxLength": 10,
+            "minLength": 0,
+            "type": "string",
+            "nullable": true
+          },
+          "homePhoneNumber": {
+            "type": "string",
+            "nullable": true
+          },
+          "workPhoneNumber": {
+            "type": "string",
+            "nullable": true
+          },
+          "emailAddress": {
+            "type": "string",
+            "nullable": true
+          },
+          "emailAddressVerified": {
+            "type": "boolean"
+          },
+          "filingDate": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "representedByLawyer": {
+            "$ref": "#/components/schemas/DisputeRepresentedByLawyer"
+          },
+          "lawFirmName": {
+            "type": "string",
+            "nullable": true
+          },
+          "lawyerSurname": {
+            "type": "string",
+            "nullable": true
+          },
+          "lawyerGivenName1": {
+            "type": "string",
+            "nullable": true
+          },
+          "lawyerGivenName2": {
+            "type": "string",
+            "nullable": true
+          },
+          "lawyerGivenName3": {
+            "type": "string",
+            "nullable": true
+          },
+          "lawyerAddress": {
+            "maxLength": 300,
+            "minLength": 0,
+            "type": "string",
+            "nullable": true
+          },
+          "lawyerPhoneNumber": {
+            "type": "string",
+            "nullable": true
+          },
+          "lawyerEmail": {
+            "maxLength": 100,
+            "minLength": 0,
+            "type": "string",
+            "nullable": true
+          },
+          "officerPin": {
+            "type": "string",
+            "nullable": true
+          },
+          "contactTypeCd": {
+            "$ref": "#/components/schemas/DisputeContactTypeCd"
+          },
+          "requestCourtAppearanceYn": {
+            "$ref": "#/components/schemas/DisputeRequestCourtAppearanceYn"
+          },
+          "contactLawFirmNm": {
+            "type": "string",
+            "nullable": true
+          },
+          "contactGiven1Nm": {
+            "type": "string",
+            "nullable": true
+          },
+          "contactGiven2Nm": {
+            "type": "string",
+            "nullable": true
+          },
+          "contactGiven3Nm": {
+            "type": "string",
+            "nullable": true
+          },
+          "contactSurnameNm": {
+            "type": "string",
+            "nullable": true
+          },
+          "appearanceDtm": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "appearanceLessThan14DaysYn": {
+            "$ref": "#/components/schemas/DisputeAppearanceLessThan14DaysYn"
+          },
+          "detachmentLocation": {
+            "type": "string",
+            "nullable": true
+          },
+          "courtAgenId": {
+            "type": "string",
+            "nullable": true
+          },
+          "interpreterLanguageCd": {
+            "maxLength": 3,
+            "minLength": 0,
+            "type": "string",
+            "nullable": true
+          },
+          "interpreterRequired": {
+            "$ref": "#/components/schemas/DisputeInterpreterRequired"
+          },
+          "witnessNo": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "fineReductionReason": {
+            "type": "string",
+            "nullable": true
+          },
+          "timeToPayReason": {
+            "type": "string",
+            "nullable": true
+          },
+          "disputantComment": {
+            "type": "string",
+            "nullable": true
+          },
+          "rejectedReason": {
+            "type": "string",
+            "nullable": true
+          },
+          "userAssignedTo": {
+            "type": "string",
+            "nullable": true
+          },
+          "userAssignedTs": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "disputantDetectedOcrIssues": {
+            "$ref": "#/components/schemas/DisputeDisputantDetectedOcrIssues"
+          },
+          "disputantOcrIssues": {
+            "type": "string",
+            "nullable": true
+          },
+          "systemDetectedOcrIssues": {
+            "$ref": "#/components/schemas/DisputeSystemDetectedOcrIssues"
+          },
+          "ocrTicketFilename": {
+            "maxLength": 100,
+            "minLength": 0,
+            "type": "string",
+            "nullable": true
+          },
+          "signatoryType": {
+            "$ref": "#/components/schemas/DisputeSignatoryType"
+          },
+          "signatoryName": {
+            "maxLength": 100,
+            "minLength": 0,
+            "type": "string",
+            "nullable": true
+          },
+          "violationTicket": {
+            "$ref": "#/components/schemas/ViolationTicket"
+          },
+          "disputeCounts": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DisputeCount"
+            },
+            "nullable": true
+          },
+          "additionalProperties": {
+            "type": "object",
             "additionalProperties": {
-              "type": "object",
-              "additionalProperties": {
-                "nullable": true
-              },
               "nullable": true
-            }
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "DisputeAppearanceLessThan14DaysYn": {
+        "enum": [
+          "UNKNOWN",
+          "Y",
+          "N"
+        ],
+        "type": "string"
+      },
+      "DisputeCaseFileStatus": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string",
+            "nullable": true
           },
-          "additionalProperties": false
+          "description": {
+            "type": "string",
+            "nullable": true
+          }
         },
-        "DisputeAppearanceLessThan14DaysYn": {
-          "enum": [
-            "UNKNOWN",
-            "Y",
-            "N"
-          ],
-          "type": "string"
-        },
-        "DisputeCaseFileStatus": {
-          "type": "object",
-          "properties": {
-            "code": {
-              "type": "string",
-              "nullable": true
-            },
-            "description": {
-              "type": "string",
-              "nullable": true
-            }
+        "additionalProperties": false
+      },
+      "DisputeCaseFileSummary": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int64"
           },
-          "additionalProperties": false
-        },
-        "DisputeCaseFileSummary": {
-          "type": "object",
-          "properties": {
-            "id": {
-              "type": "integer",
-              "format": "int64"
-            },
-            "submittedTs": {
-              "type": "string",
-              "format": "date-time",
-              "nullable": true
-            },
-            "jjDecisionDate": {
-              "type": "string",
-              "format": "date-time",
-              "nullable": true
-            },
-            "signatoryName": {
-              "type": "string",
-              "nullable": true
-            },
-            "hearingType": {
-              "type": "string",
-              "nullable": true
-            },
-            "ticketNumber": {
-              "type": "string",
-              "nullable": true
-            },
-            "violationDate": {
-              "type": "string",
-              "format": "date-time",
-              "nullable": true
-            },
-            "violationDateCount": {
-              "type": "integer",
-              "format": "int32"
-            },
-            "toBeHeardAtCourthouseId": {
-              "type": "number",
-              "format": "double",
-              "nullable": true
-            },
-            "toBeHeardAtCourthouseName": {
-              "type": "string",
-              "nullable": true
-            },
-            "disputantSurname": {
-              "type": "string",
-              "nullable": true
-            },
-            "disputantGivenName1": {
-              "type": "string",
-              "nullable": true
-            },
-            "disputantGivenName2": {
-              "type": "string",
-              "nullable": true
-            },
-            "disputantGivenName3": {
-              "type": "string",
-              "nullable": true
-            },
-            "disputantOrganizationName": {
-              "type": "string",
-              "nullable": true
-            },
-            "disputeStatus": {
-              "$ref": "#/components/schemas/DisputeCaseFileStatus"
-            },
-            "policeDetachment": {
-              "type": "string",
-              "nullable": true
-            },
-            "policeDetachmentId": {
-              "type": "number",
-              "format": "double",
-              "nullable": true
-            },
-            "accidentYn": {
-              "$ref": "#/components/schemas/YesNo"
-            },
-            "multipleOfficersYn": {
-              "$ref": "#/components/schemas/YesNo"
-            },
-            "noticeOfHearingYn": {
-              "$ref": "#/components/schemas/YesNo"
-            },
-            "electronicTicketYn": {
-              "$ref": "#/components/schemas/YesNo"
-            },
-            "jjAssignedTo": {
-              "type": "string",
-              "nullable": true
-            },
-            "vtcAssignedTo": {
-              "type": "string",
-              "nullable": true
-            },
-            "vtcAssignedTs": {
-              "type": "string",
-              "format": "date-time",
-              "nullable": true
-            },
-            "appearanceCourthouseId": {
-              "type": "number",
-              "format": "double",
-              "nullable": true
-            },
-            "appearanceCourthouseName": {
-              "type": "string",
-              "nullable": true
-            },
-            "appearanceRoomCode": {
-              "type": "string",
-              "nullable": true
-            },
-            "appearanceTs": {
-              "type": "string",
-              "format": "date-time",
-              "nullable": true
-            },
-            "appearanceDuration": {
-              "type": "integer",
-              "format": "int32"
-            },
-            "timeToPayReason": {
-              "type": "string",
-              "nullable": true
-            },
-            "fineReductionReason": {
-              "type": "string",
-              "nullable": true
-            }
+          "submittedTs": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
           },
-          "additionalProperties": false
+          "jjDecisionDate": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "signatoryName": {
+            "type": "string",
+            "nullable": true
+          },
+          "hearingType": {
+            "type": "string",
+            "nullable": true
+          },
+          "ticketNumber": {
+            "type": "string",
+            "nullable": true
+          },
+          "violationDate": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "violationDateCount": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "toBeHeardAtCourthouseId": {
+            "type": "number",
+            "format": "double",
+            "nullable": true
+          },
+          "toBeHeardAtCourthouseName": {
+            "type": "string",
+            "nullable": true
+          },
+          "disputantSurname": {
+            "type": "string",
+            "nullable": true
+          },
+          "disputantGivenName1": {
+            "type": "string",
+            "nullable": true
+          },
+          "disputantGivenName2": {
+            "type": "string",
+            "nullable": true
+          },
+          "disputantGivenName3": {
+            "type": "string",
+            "nullable": true
+          },
+          "disputantOrganizationName": {
+            "type": "string",
+            "nullable": true
+          },
+          "disputeStatus": {
+            "$ref": "#/components/schemas/DisputeCaseFileStatus"
+          },
+          "policeDetachment": {
+            "type": "string",
+            "nullable": true
+          },
+          "policeDetachmentId": {
+            "type": "number",
+            "format": "double",
+            "nullable": true
+          },
+          "accidentYn": {
+            "$ref": "#/components/schemas/YesNo"
+          },
+          "multipleOfficersYn": {
+            "$ref": "#/components/schemas/YesNo"
+          },
+          "noticeOfHearingYn": {
+            "$ref": "#/components/schemas/YesNo"
+          },
+          "electronicTicketYn": {
+            "$ref": "#/components/schemas/YesNo"
+          },
+          "jjAssignedTo": {
+            "type": "string",
+            "nullable": true
+          },
+          "vtcAssignedTo": {
+            "type": "string",
+            "nullable": true
+          },
+          "vtcAssignedTs": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "appearanceCourthouseId": {
+            "type": "number",
+            "format": "double",
+            "nullable": true
+          },
+          "appearanceCourthouseName": {
+            "type": "string",
+            "nullable": true
+          },
+          "appearanceRoomCode": {
+            "type": "string",
+            "nullable": true
+          },
+          "appearanceTs": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "appearanceDuration": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "timeToPayReason": {
+            "type": "string",
+            "nullable": true
+          },
+          "fineReductionReason": {
+            "type": "string",
+            "nullable": true
+          }
         },
-        "DisputeContactTypeCd": {
-          "enum": [
-            "UNKNOWN",
-            "INDIVIDUAL",
-            "LAWYER",
-            "OTHER"
-          ],
-          "type": "string"
-        },
-        "DisputeCount": {
-          "type": "object",
-          "properties": {
-            "createdBy": {
-              "type": "string",
-              "nullable": true
-            },
-            "createdTs": {
-              "type": "string",
-              "format": "date-time"
-            },
-            "modifiedBy": {
-              "type": "string",
-              "nullable": true
-            },
-            "modifiedTs": {
-              "type": "string",
-              "format": "date-time",
-              "nullable": true
-            },
-            "countNo": {
-              "maximum": 3,
-              "minimum": 1,
-              "type": "integer",
-              "format": "int32"
-            },
-            "pleaCode": {
-              "$ref": "#/components/schemas/DisputeCountPleaCode"
-            },
-            "requestTimeToPay": {
-              "$ref": "#/components/schemas/DisputeCountRequestTimeToPay"
-            },
-            "requestReduction": {
-              "$ref": "#/components/schemas/DisputeCountRequestReduction"
-            },
-            "requestCourtAppearance": {
-              "$ref": "#/components/schemas/DisputeCountRequestCourtAppearance"
-            },
+        "additionalProperties": false
+      },
+      "DisputeContactTypeCd": {
+        "enum": [
+          "UNKNOWN",
+          "INDIVIDUAL",
+          "LAWYER",
+          "OTHER"
+        ],
+        "type": "string"
+      },
+      "DisputeCount": {
+        "type": "object",
+        "properties": {
+          "createdBy": {
+            "type": "string",
+            "nullable": true
+          },
+          "createdTs": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "modifiedBy": {
+            "type": "string",
+            "nullable": true
+          },
+          "modifiedTs": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "countNo": {
+            "maximum": 3,
+            "minimum": 1,
+            "type": "integer",
+            "format": "int32"
+          },
+          "pleaCode": {
+            "$ref": "#/components/schemas/DisputeCountPleaCode"
+          },
+          "requestTimeToPay": {
+            "$ref": "#/components/schemas/DisputeCountRequestTimeToPay"
+          },
+          "requestReduction": {
+            "$ref": "#/components/schemas/DisputeCountRequestReduction"
+          },
+          "requestCourtAppearance": {
+            "$ref": "#/components/schemas/DisputeCountRequestCourtAppearance"
+          },
+          "additionalProperties": {
+            "type": "object",
             "additionalProperties": {
-              "type": "object",
-              "additionalProperties": {
-                "nullable": true
-              },
               "nullable": true
-            }
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "DisputeCountPleaCode": {
+        "enum": [
+          "UNKNOWN",
+          "G",
+          "N"
+        ],
+        "type": "string"
+      },
+      "DisputeCountRequestCourtAppearance": {
+        "enum": [
+          "UNKNOWN",
+          "Y",
+          "N"
+        ],
+        "type": "string"
+      },
+      "DisputeCountRequestReduction": {
+        "enum": [
+          "UNKNOWN",
+          "Y",
+          "N"
+        ],
+        "type": "string"
+      },
+      "DisputeCountRequestTimeToPay": {
+        "enum": [
+          "UNKNOWN",
+          "Y",
+          "N"
+        ],
+        "type": "string"
+      },
+      "DisputeDisputantDetectedOcrIssues": {
+        "enum": [
+          "UNKNOWN",
+          "Y",
+          "N"
+        ],
+        "type": "string"
+      },
+      "DisputeInterpreterRequired": {
+        "enum": [
+          "UNKNOWN",
+          "Y",
+          "N"
+        ],
+        "type": "string"
+      },
+      "DisputeListItem": {
+        "type": "object",
+        "properties": {
+          "disputeId": {
+            "type": "integer",
+            "format": "int64"
           },
-          "additionalProperties": false
-        },
-        "DisputeCountPleaCode": {
-          "enum": [
-            "UNKNOWN",
-            "G",
-            "N"
-          ],
-          "type": "string"
-        },
-        "DisputeCountRequestCourtAppearance": {
-          "enum": [
-            "UNKNOWN",
-            "Y",
-            "N"
-          ],
-          "type": "string"
-        },
-        "DisputeCountRequestReduction": {
-          "enum": [
-            "UNKNOWN",
-            "Y",
-            "N"
-          ],
-          "type": "string"
-        },
-        "DisputeCountRequestTimeToPay": {
-          "enum": [
-            "UNKNOWN",
-            "Y",
-            "N"
-          ],
-          "type": "string"
-        },
-        "DisputeDisputantDetectedOcrIssues": {
-          "enum": [
-            "UNKNOWN",
-            "Y",
-            "N"
-          ],
-          "type": "string"
-        },
-        "DisputeInterpreterRequired": {
-          "enum": [
-            "UNKNOWN",
-            "Y",
-            "N"
-          ],
-          "type": "string"
-        },
-        "DisputeListItem": {
-          "type": "object",
-          "properties": {
-            "disputeId": {
-              "type": "integer",
-              "format": "int64"
-            },
-            "ticketNumber": {
-              "type": "string",
-              "nullable": true
-            },
-            "submittedTs": {
-              "type": "string",
-              "format": "date-time",
-              "nullable": true
-            },
-            "disputantSurname": {
-              "type": "string",
-              "nullable": true
-            },
-            "disputantGivenName1": {
-              "type": "string",
-              "nullable": true
-            },
-            "disputantGivenName2": {
-              "type": "string",
-              "nullable": true
-            },
-            "disputantGivenName3": {
-              "type": "string",
-              "nullable": true
-            },
-            "status": {
-              "$ref": "#/components/schemas/DisputeListItemStatus"
-            },
-            "emailAddress": {
-              "type": "string",
-              "nullable": true
-            },
-            "emailAddressVerified": {
-              "type": "boolean"
-            },
-            "filingDate": {
-              "type": "string",
-              "format": "date-time",
-              "nullable": true
-            },
-            "requestCourtAppearanceYn": {
-              "$ref": "#/components/schemas/DisputeListItemRequestCourtAppearanceYn"
-            },
-            "userAssignedTo": {
-              "type": "string",
-              "nullable": true
-            },
-            "userAssignedTs": {
-              "type": "string",
-              "format": "date-time",
-              "nullable": true
-            },
-            "disputantDetectedOcrIssues": {
-              "$ref": "#/components/schemas/DisputeListItemDisputantDetectedOcrIssues"
-            },
-            "systemDetectedOcrIssues": {
-              "$ref": "#/components/schemas/DisputeListItemSystemDetectedOcrIssues"
-            },
-            "violationDate": {
-              "type": "string",
-              "format": "date-time",
-              "nullable": true
-            },
-            "jjDisputeStatus": {
-              "$ref": "#/components/schemas/DisputeListItemJjDisputeStatus"
-            },
-            "jjAssignedTo": {
-              "type": "string",
-              "nullable": true
-            },
-            "decisionMadeBy": {
-              "type": "string",
-              "nullable": true
-            },
-            "jjDecisionDate": {
-              "type": "string",
-              "format": "date-time",
-              "nullable": true
-            },
-            "courtAgenId": {
-              "type": "string",
-              "nullable": true
-            },
+          "ticketNumber": {
+            "type": "string",
+            "nullable": true
+          },
+          "submittedTs": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "disputantSurname": {
+            "type": "string",
+            "nullable": true
+          },
+          "disputantGivenName1": {
+            "type": "string",
+            "nullable": true
+          },
+          "disputantGivenName2": {
+            "type": "string",
+            "nullable": true
+          },
+          "disputantGivenName3": {
+            "type": "string",
+            "nullable": true
+          },
+          "status": {
+            "$ref": "#/components/schemas/DisputeListItemStatus"
+          },
+          "emailAddress": {
+            "type": "string",
+            "nullable": true
+          },
+          "emailAddressVerified": {
+            "type": "boolean"
+          },
+          "filingDate": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "requestCourtAppearanceYn": {
+            "$ref": "#/components/schemas/DisputeListItemRequestCourtAppearanceYn"
+          },
+          "userAssignedTo": {
+            "type": "string",
+            "nullable": true
+          },
+          "userAssignedTs": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "disputantDetectedOcrIssues": {
+            "$ref": "#/components/schemas/DisputeListItemDisputantDetectedOcrIssues"
+          },
+          "systemDetectedOcrIssues": {
+            "$ref": "#/components/schemas/DisputeListItemSystemDetectedOcrIssues"
+          },
+          "violationDate": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "jjDisputeStatus": {
+            "$ref": "#/components/schemas/DisputeListItemJjDisputeStatus"
+          },
+          "jjAssignedTo": {
+            "type": "string",
+            "nullable": true
+          },
+          "decisionMadeBy": {
+            "type": "string",
+            "nullable": true
+          },
+          "jjDecisionDate": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "courtAgenId": {
+            "type": "string",
+            "nullable": true
+          },
+          "additionalProperties": {
+            "type": "object",
             "additionalProperties": {
-              "type": "object",
-              "additionalProperties": {
-                "nullable": true
-              },
               "nullable": true
-            }
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "DisputeListItemDisputantDetectedOcrIssues": {
+        "enum": [
+          "UNKNOWN",
+          "Y",
+          "N"
+        ],
+        "type": "string"
+      },
+      "DisputeListItemJjDisputeStatus": {
+        "enum": [
+          "UNKNOWN",
+          "NEW",
+          "IN_PROGRESS",
+          "DATA_UPDATE",
+          "CONFIRMED",
+          "REQUIRE_COURT_HEARING",
+          "REQUIRE_MORE_INFO",
+          "ACCEPTED",
+          "REVIEW",
+          "CONCLUDED",
+          "CANCELLED",
+          "HEARING_SCHEDULED"
+        ],
+        "type": "string"
+      },
+      "DisputeListItemRequestCourtAppearanceYn": {
+        "enum": [
+          "UNKNOWN",
+          "Y",
+          "N"
+        ],
+        "type": "string"
+      },
+      "DisputeListItemStatus": {
+        "enum": [
+          "UNKNOWN",
+          "NEW",
+          "VALIDATED",
+          "PROCESSING",
+          "REJECTED",
+          "CANCELLED",
+          "CONCLUDED"
+        ],
+        "type": "string"
+      },
+      "DisputeListItemSystemDetectedOcrIssues": {
+        "enum": [
+          "UNKNOWN",
+          "Y",
+          "N"
+        ],
+        "type": "string"
+      },
+      "DisputeRepresentedByLawyer": {
+        "enum": [
+          "UNKNOWN",
+          "Y",
+          "N"
+        ],
+        "type": "string"
+      },
+      "DisputeRequestCourtAppearanceYn": {
+        "enum": [
+          "UNKNOWN",
+          "Y",
+          "N"
+        ],
+        "type": "string"
+      },
+      "DisputeSignatoryType": {
+        "enum": [
+          "U",
+          "D",
+          "A"
+        ],
+        "type": "string"
+      },
+      "DisputeStatus": {
+        "enum": [
+          "UNKNOWN",
+          "NEW",
+          "VALIDATED",
+          "PROCESSING",
+          "REJECTED",
+          "CANCELLED",
+          "CONCLUDED"
+        ],
+        "type": "string"
+      },
+      "DisputeSystemDetectedOcrIssues": {
+        "enum": [
+          "UNKNOWN",
+          "Y",
+          "N"
+        ],
+        "type": "string"
+      },
+      "DisputeUpdateRequest": {
+        "required": [
+          "status",
+          "updateJson",
+          "updateType"
+        ],
+        "type": "object",
+        "properties": {
+          "createdBy": {
+            "type": "string",
+            "nullable": true
           },
-          "additionalProperties": false
-        },
-        "DisputeListItemDisputantDetectedOcrIssues": {
-          "enum": [
-            "UNKNOWN",
-            "Y",
-            "N"
-          ],
-          "type": "string"
-        },
-        "DisputeListItemJjDisputeStatus": {
-          "enum": [
-            "UNKNOWN",
-            "NEW",
-            "IN_PROGRESS",
-            "DATA_UPDATE",
-            "CONFIRMED",
-            "REQUIRE_COURT_HEARING",
-            "REQUIRE_MORE_INFO",
-            "ACCEPTED",
-            "REVIEW",
-            "CONCLUDED",
-            "CANCELLED",
-            "HEARING_SCHEDULED"
-          ],
-          "type": "string"
-        },
-        "DisputeListItemRequestCourtAppearanceYn": {
-          "enum": [
-            "UNKNOWN",
-            "Y",
-            "N"
-          ],
-          "type": "string"
-        },
-        "DisputeListItemStatus": {
-          "enum": [
-            "UNKNOWN",
-            "NEW",
-            "VALIDATED",
-            "PROCESSING",
-            "REJECTED",
-            "CANCELLED",
-            "CONCLUDED"
-          ],
-          "type": "string"
-        },
-        "DisputeListItemSystemDetectedOcrIssues": {
-          "enum": [
-            "UNKNOWN",
-            "Y",
-            "N"
-          ],
-          "type": "string"
-        },
-        "DisputeRepresentedByLawyer": {
-          "enum": [
-            "UNKNOWN",
-            "Y",
-            "N"
-          ],
-          "type": "string"
-        },
-        "DisputeRequestCourtAppearanceYn": {
-          "enum": [
-            "UNKNOWN",
-            "Y",
-            "N"
-          ],
-          "type": "string"
-        },
-        "DisputeSignatoryType": {
-          "enum": [
-            "U",
-            "D",
-            "A"
-          ],
-          "type": "string"
-        },
-        "DisputeStatus": {
-          "enum": [
-            "UNKNOWN",
-            "NEW",
-            "VALIDATED",
-            "PROCESSING",
-            "REJECTED",
-            "CANCELLED",
-            "CONCLUDED"
-          ],
-          "type": "string"
-        },
-        "DisputeSystemDetectedOcrIssues": {
-          "enum": [
-            "UNKNOWN",
-            "Y",
-            "N"
-          ],
-          "type": "string"
-        },
-        "DisputeUpdateRequest": {
-          "required": [
-            "status",
-            "updateJson",
-            "updateType"
-          ],
-          "type": "object",
-          "properties": {
-            "createdBy": {
-              "type": "string",
+          "createdTs": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "modifiedBy": {
+            "type": "string",
+            "nullable": true
+          },
+          "modifiedTs": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "disputeUpdateRequestId": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "disputeId": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "status": {
+            "$ref": "#/components/schemas/DisputeUpdateRequestStatus2"
+          },
+          "updateType": {
+            "$ref": "#/components/schemas/DisputeUpdateRequestUpdateType"
+          },
+          "updateJson": {
+            "maxLength": 4000,
+            "minLength": 3,
+            "type": "string"
+          },
+          "currentJson": {
+            "maxLength": 4000,
+            "minLength": 0,
+            "type": "string",
+            "nullable": true
+          },
+          "statusUpdateTs": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "additionalProperties": {
+            "type": "object",
+            "additionalProperties": {
               "nullable": true
             },
-            "createdTs": {
-              "type": "string",
-              "format": "date-time"
-            },
-            "modifiedBy": {
-              "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "DisputeUpdateRequestStatus2": {
+        "enum": [
+          "UNKNOWN",
+          "ACCEPTED",
+          "PENDING",
+          "REJECTED"
+        ],
+        "type": "string"
+      },
+      "DisputeUpdateRequestUpdateType": {
+        "enum": [
+          "UNKNOWN",
+          "DISPUTANT_ADDRESS",
+          "DISPUTANT_PHONE",
+          "DISPUTANT_NAME",
+          "COUNT",
+          "DISPUTANT_EMAIL",
+          "DISPUTANT_DOCUMENT",
+          "COURT_OPTIONS"
+        ],
+        "type": "string"
+      },
+      "DisputeWithUpdates": {
+        "type": "object",
+        "properties": {
+          "disputeId": {
+            "type": "integer",
+            "description": "ID",
+            "format": "int64"
+          },
+          "ticketNumber": {
+            "type": "string",
+            "description": "Ticket Number",
+            "nullable": true
+          },
+          "submittedTs": {
+            "type": "string",
+            "description": "Timestamp that disputant submitted the notice of dispute",
+            "format": "date-time",
+            "nullable": true
+          },
+          "disputantSurname": {
+            "type": "string",
+            "description": "Disputant Surname",
+            "nullable": true
+          },
+          "disputantGivenName1": {
+            "type": "string",
+            "description": "Disputant Given Name 1",
+            "nullable": true
+          },
+          "disputantGivenName2": {
+            "type": "string",
+            "description": "Disputant Given Name 2",
+            "nullable": true
+          },
+          "disputantGivenName3": {
+            "type": "string",
+            "description": "Disputant Given Name 3",
+            "nullable": true
+          },
+          "status": {
+            "$ref": "#/components/schemas/DisputeStatus"
+          },
+          "userAssignedTo": {
+            "type": "string",
+            "description": "VTC Staff assigned to dispute",
+            "nullable": true
+          },
+          "userAssignedTs": {
+            "type": "string",
+            "description": "Timestamp that VTC Staff was assigned to dispute",
+            "format": "date-time",
+            "nullable": true
+          },
+          "adjournmentDocument": {
+            "type": "boolean",
+            "description": "Whether or Not there is a pending request for an adjournment from the Disputant",
+            "nullable": true
+          },
+          "changeOfPlea": {
+            "type": "boolean",
+            "description": "Whether or not there is a pending request for a change of Plea from the Disputant",
+            "nullable": true
+          },
+          "hearingDate": {
+            "type": "string",
+            "description": "Date of next upcoming hearing (if there is one)",
+            "format": "date-time",
+            "nullable": true
+          },
+          "emailAddress": {
+            "type": "string",
+            "description": "Email address",
+            "nullable": true
+          },
+          "emailAddressVerified": {
+            "type": "boolean",
+            "description": "Email address verified",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "Represents a violation ticket notice of dispute."
+      },
+      "DocumentSource": {
+        "enum": [
+          "Citizen",
+          "Staff"
+        ],
+        "type": "string"
+      },
+      "DocumentType": {
+        "enum": [
+          "UNKNOWN",
+          "NOTICE_OF_DISPUTE",
+          "TICKET_IMAGE"
+        ],
+        "type": "string"
+      },
+      "EmailHistory": {
+        "type": "object",
+        "properties": {
+          "createdBy": {
+            "type": "string",
+            "nullable": true
+          },
+          "createdTs": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "modifiedBy": {
+            "type": "string",
+            "nullable": true
+          },
+          "modifiedTs": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "emailHistoryId": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "emailSentTs": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "fromEmailAddress": {
+            "maxLength": 100,
+            "minLength": 0,
+            "type": "string",
+            "nullable": true
+          },
+          "toEmailAddress": {
+            "maxLength": 4000,
+            "minLength": 0,
+            "type": "string",
+            "nullable": true
+          },
+          "ccEmailAddress": {
+            "maxLength": 4000,
+            "minLength": 0,
+            "type": "string",
+            "nullable": true
+          },
+          "bccEmailAddress": {
+            "maxLength": 4000,
+            "minLength": 0,
+            "type": "string",
+            "nullable": true
+          },
+          "subject": {
+            "maxLength": 1000,
+            "minLength": 0,
+            "type": "string",
+            "nullable": true
+          },
+          "htmlContent": {
+            "maxLength": 4000,
+            "minLength": 0,
+            "type": "string",
+            "nullable": true
+          },
+          "plainTextContent": {
+            "maxLength": 4000,
+            "minLength": 0,
+            "type": "string",
+            "nullable": true
+          },
+          "successfullySent": {
+            "$ref": "#/components/schemas/EmailHistorySuccessfullySent"
+          },
+          "occamDisputeId": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "additionalProperties": {
+            "type": "object",
+            "additionalProperties": {
               "nullable": true
             },
-            "modifiedTs": {
-              "type": "string",
-              "format": "date-time",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "EmailHistorySuccessfullySent": {
+        "enum": [
+          "UNKNOWN",
+          "Y",
+          "N"
+        ],
+        "type": "string"
+      },
+      "ExcludeStatus": {
+        "enum": [
+          "UNKNOWN",
+          "NEW",
+          "VALIDATED",
+          "PROCESSING",
+          "REJECTED",
+          "CANCELLED",
+          "CONCLUDED"
+        ],
+        "type": "string"
+      },
+      "FederatedIdentityRepresentation": {
+        "type": "object",
+        "properties": {
+          "identityProvider": {
+            "type": "string",
+            "nullable": true
+          },
+          "userId": {
+            "type": "string",
+            "nullable": true
+          },
+          "userName": {
+            "type": "string",
+            "nullable": true
+          },
+          "additionalProperties": {
+            "type": "object",
+            "additionalProperties": {
               "nullable": true
             },
-            "disputeUpdateRequestId": {
-              "type": "integer",
-              "format": "int64"
-            },
-            "disputeId": {
-              "type": "integer",
-              "format": "int64"
-            },
-            "status": {
-              "$ref": "#/components/schemas/DisputeUpdateRequestStatus2"
-            },
-            "updateType": {
-              "$ref": "#/components/schemas/DisputeUpdateRequestUpdateType"
-            },
-            "updateJson": {
-              "maxLength": 4000,
-              "minLength": 3,
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "Field": {
+        "type": "object",
+        "properties": {
+          "value": {
+            "type": "string",
+            "nullable": true
+          },
+          "fieldConfidence": {
+            "type": "number",
+            "format": "float",
+            "nullable": true
+          },
+          "validationErrors": {
+            "type": "array",
+            "items": {
               "type": "string"
             },
-            "currentJson": {
-              "maxLength": 4000,
-              "minLength": 0,
-              "type": "string",
-              "nullable": true
-            },
-            "statusUpdateTs": {
-              "type": "string",
-              "format": "date-time",
-              "nullable": true
-            },
-            "additionalProperties": {
-              "type": "object",
-              "additionalProperties": {
-                "nullable": true
-              },
-              "nullable": true
-            }
+            "nullable": true
           },
-          "additionalProperties": false
-        },
-        "DisputeUpdateRequestStatus2": {
-          "enum": [
-            "UNKNOWN",
-            "ACCEPTED",
-            "PENDING",
-            "REJECTED"
-          ],
-          "type": "string"
-        },
-        "DisputeUpdateRequestUpdateType": {
-          "enum": [
-            "UNKNOWN",
-            "DISPUTANT_ADDRESS",
-            "DISPUTANT_PHONE",
-            "DISPUTANT_NAME",
-            "COUNT",
-            "DISPUTANT_EMAIL",
-            "DISPUTANT_DOCUMENT",
-            "COURT_OPTIONS"
-          ],
-          "type": "string"
-        },
-        "DisputeWithUpdates": {
-          "type": "object",
-          "properties": {
-            "disputeId": {
-              "type": "integer",
-              "description": "ID",
-              "format": "int64"
-            },
-            "ticketNumber": {
-              "type": "string",
-              "description": "Ticket Number",
-              "nullable": true
-            },
-            "submittedTs": {
-              "type": "string",
-              "description": "Timestamp that disputant submitted the notice of dispute",
-              "format": "date-time",
-              "nullable": true
-            },
-            "disputantSurname": {
-              "type": "string",
-              "description": "Disputant Surname",
-              "nullable": true
-            },
-            "disputantGivenName1": {
-              "type": "string",
-              "description": "Disputant Given Name 1",
-              "nullable": true
-            },
-            "disputantGivenName2": {
-              "type": "string",
-              "description": "Disputant Given Name 2",
-              "nullable": true
-            },
-            "disputantGivenName3": {
-              "type": "string",
-              "description": "Disputant Given Name 3",
-              "nullable": true
-            },
-            "status": {
-              "$ref": "#/components/schemas/DisputeStatus"
-            },
-            "userAssignedTo": {
-              "type": "string",
-              "description": "VTC Staff assigned to dispute",
-              "nullable": true
-            },
-            "userAssignedTs": {
-              "type": "string",
-              "description": "Timestamp that VTC Staff was assigned to dispute",
-              "format": "date-time",
-              "nullable": true
-            },
-            "adjournmentDocument": {
-              "type": "boolean",
-              "description": "Whether or Not there is a pending request for an adjournment from the Disputant",
-              "nullable": true
-            },
-            "changeOfPlea": {
-              "type": "boolean",
-              "description": "Whether or not there is a pending request for a change of Plea from the Disputant",
-              "nullable": true
-            },
-            "hearingDate": {
-              "type": "string",
-              "description": "Date of next upcoming hearing (if there is one)",
-              "format": "date-time",
-              "nullable": true
-            },
-            "emailAddress": {
-              "type": "string",
-              "description": "Email address",
-              "nullable": true
-            },
-            "emailAddressVerified": {
-              "type": "boolean",
-              "description": "Email address verified",
-              "nullable": true
-            }
+          "type": {
+            "type": "string",
+            "nullable": true
           },
-          "additionalProperties": false,
-          "description": "Represents a violation ticket notice of dispute."
-        },
-        "DocumentSource": {
-          "enum": [
-            "Citizen",
-            "Staff"
-          ],
-          "type": "string"
-        },
-        "DocumentType": {
-          "enum": [
-            "UNKNOWN",
-            "NOTICE_OF_DISPUTE",
-            "TICKET_IMAGE"
-          ],
-          "type": "string"
-        },
-        "EmailHistory": {
-          "type": "object",
-          "properties": {
-            "createdBy": {
-              "type": "string",
-              "nullable": true
-            },
-            "createdTs": {
-              "type": "string",
-              "format": "date-time"
-            },
-            "modifiedBy": {
-              "type": "string",
-              "nullable": true
-            },
-            "modifiedTs": {
-              "type": "string",
-              "format": "date-time",
-              "nullable": true
-            },
-            "emailHistoryId": {
-              "type": "integer",
-              "format": "int64"
-            },
-            "emailSentTs": {
-              "type": "string",
-              "format": "date-time"
-            },
-            "fromEmailAddress": {
-              "maxLength": 100,
-              "minLength": 0,
-              "type": "string",
-              "nullable": true
-            },
-            "toEmailAddress": {
-              "maxLength": 4000,
-              "minLength": 0,
-              "type": "string",
-              "nullable": true
-            },
-            "ccEmailAddress": {
-              "maxLength": 4000,
-              "minLength": 0,
-              "type": "string",
-              "nullable": true
-            },
-            "bccEmailAddress": {
-              "maxLength": 4000,
-              "minLength": 0,
-              "type": "string",
-              "nullable": true
-            },
-            "subject": {
-              "maxLength": 1000,
-              "minLength": 0,
-              "type": "string",
-              "nullable": true
-            },
-            "htmlContent": {
-              "maxLength": 4000,
-              "minLength": 0,
-              "type": "string",
-              "nullable": true
-            },
-            "plainTextContent": {
-              "maxLength": 4000,
-              "minLength": 0,
-              "type": "string",
-              "nullable": true
-            },
-            "successfullySent": {
-              "$ref": "#/components/schemas/EmailHistorySuccessfullySent"
-            },
-            "occamDisputeId": {
-              "type": "integer",
-              "format": "int64"
-            },
-            "additionalProperties": {
-              "type": "object",
-              "additionalProperties": {
-                "nullable": true
-              },
-              "nullable": true
-            }
-          },
-          "additionalProperties": false
-        },
-        "EmailHistorySuccessfullySent": {
-          "enum": [
-            "UNKNOWN",
-            "Y",
-            "N"
-          ],
-          "type": "string"
-        },
-        "ExcludeStatus": {
-          "enum": [
-            "UNKNOWN",
-            "NEW",
-            "VALIDATED",
-            "PROCESSING",
-            "REJECTED",
-            "CANCELLED",
-            "CONCLUDED"
-          ],
-          "type": "string"
-        },
-        "FederatedIdentityRepresentation": {
-          "type": "object",
-          "properties": {
-            "identityProvider": {
-              "type": "string",
-              "nullable": true
-            },
-            "userId": {
-              "type": "string",
-              "nullable": true
-            },
-            "userName": {
-              "type": "string",
-              "nullable": true
-            },
-            "additionalProperties": {
-              "type": "object",
-              "additionalProperties": {
-                "nullable": true
-              },
-              "nullable": true
-            }
-          },
-          "additionalProperties": false
-        },
-        "Field": {
-          "type": "object",
-          "properties": {
-            "value": {
-              "type": "string",
-              "nullable": true
-            },
-            "fieldConfidence": {
-              "type": "number",
-              "format": "float",
-              "nullable": true
-            },
-            "validationErrors": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              },
-              "nullable": true
-            },
-            "type": {
-              "type": "string",
-              "nullable": true
-            },
-            "boundingBoxes": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/BoundingBox"
-              },
-              "nullable": true
-            }
-          },
-          "additionalProperties": false
-        },
-        "FileHistory": {
-          "required": [
-            "auditLogEntryType"
-          ],
-          "type": "object",
-          "properties": {
-            "createdBy": {
-              "type": "string",
-              "nullable": true
-            },
-            "createdTs": {
-              "type": "string",
-              "format": "date-time"
-            },
-            "modifiedBy": {
-              "type": "string",
-              "nullable": true
-            },
-            "modifiedTs": {
-              "type": "string",
-              "format": "date-time",
-              "nullable": true
-            },
-            "fileHistoryId": {
-              "type": "integer",
-              "format": "int64"
-            },
-            "disputeId": {
-              "type": "integer",
-              "format": "int64"
-            },
-            "auditLogEntryType": {
-              "$ref": "#/components/schemas/FileHistoryAuditLogEntryType"
-            },
-            "description": {
-              "type": "string",
-              "nullable": true
-            },
-            "comment": {
-              "type": "string",
-              "nullable": true
-            },
-            "actionByApplicationUser": {
-              "type": "string",
-              "nullable": true
-            },
-            "additionalProperties": {
-              "type": "object",
-              "additionalProperties": {
-                "nullable": true
-              },
-              "nullable": true
-            }
-          },
-          "additionalProperties": false
-        },
-        "FileHistoryAuditLogEntryType": {
-          "enum": [
-            "UNKNOWN",
-            "ARFL",
-            "CAIN",
-            "CAWT",
-            "CCAN",
-            "CCON",
-            "CCWR",
-            "CLEG",
-            "CUEM",
-            "CUEV",
-            "CUIN",
-            "CULG",
-            "CUPD",
-            "CUWR",
-            "CUWT",
-            "DURA",
-            "DURR",
-            "EMCA",
-            "EMCF",
-            "EMCR",
-            "EMDC",
-            "EMFD",
-            "EMPR",
-            "EMRJ",
-            "EMRV",
-            "EMST",
-            "EMUP",
-            "EMVF",
-            "ESUR",
-            "FDLD",
-            "FDLS",
-            "FUPD",
-            "FUPS",
-            "FRMK",
-            "INIT",
-            "JASG",
-            "JCNF",
-            "JDIV",
-            "JPRG",
-            "OCNT",
-            "RCLD",
-            "RECN",
-            "SADM",
-            "SCAN",
-            "SPRC",
-            "SREJ",
-            "SUB",
-            "SUPL",
-            "SVAL",
-            "URSR",
-            "VREV",
-            "VSUB"
-          ],
-          "type": "string"
-        },
-        "FileMetadata": {
-          "type": "object",
-          "properties": {
-            "fileId": {
-              "type": "string",
-              "format": "uuid",
-              "nullable": true
-            },
-            "fileName": {
-              "type": "string",
-              "nullable": true
-            },
-            "noticeOfDisputeGuid": {
-              "type": "string",
-              "nullable": true
-            },
-            "documentSource": {
-              "$ref": "#/components/schemas/DocumentSource"
-            },
-            "documentType": {
-              "type": "string",
-              "nullable": true
-            },
-            "virusScanStatus": {
-              "type": "string",
-              "nullable": true
-            },
-            "documentStatus": {
-              "type": "string",
-              "nullable": true
-            },
-            "ticketNumber": {
-              "type": "string",
-              "nullable": true
-            },
-            "disputeId": {
-              "type": "integer",
-              "format": "int64",
-              "nullable": true
-            },
-            "pendingFileStream": {
-              "type": "string",
-              "nullable": true
-            },
-            "deleteRequested": {
-              "type": "boolean",
-              "nullable": true
-            }
-          },
-          "additionalProperties": false
-        },
-        "GetDisputeCountResponse": {
-          "type": "object",
-          "properties": {
-            "status": {
-              "$ref": "#/components/schemas/DisputeStatus"
-            },
-            "count": {
-              "type": "integer",
-              "format": "int32"
-            }
-          },
-          "additionalProperties": false
-        },
-        "IcbcNameDetail": {
-          "type": "object",
-          "properties": {
-            "surname": {
-              "type": "string",
-              "nullable": true
-            },
-            "firstGivenName": {
-              "type": "string",
-              "nullable": true
-            },
-            "secondGivenName": {
-              "type": "string",
-              "nullable": true
-            }
-          },
-          "additionalProperties": false
-        },
-        "JJDispute": {
-          "type": "object",
-          "properties": {
-            "fileData": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/FileMetadata"
-              },
-              "nullable": true
-            },
-            "lockId": {
-              "type": "string",
-              "nullable": true
-            },
-            "lockedBy": {
-              "type": "string",
-              "nullable": true
-            },
-            "lockExpiresAtUtc": {
-              "type": "string",
-              "format": "date-time",
-              "nullable": true
-            },
-            "createdBy": {
-              "type": "string",
-              "nullable": true
-            },
-            "createdTs": {
-              "type": "string",
-              "format": "date-time"
-            },
-            "modifiedBy": {
-              "type": "string",
-              "nullable": true
-            },
-            "modifiedTs": {
-              "type": "string",
-              "format": "date-time",
-              "nullable": true
-            },
-            "id": {
-              "type": "integer",
-              "format": "int64"
-            },
-            "ticketNumber": {
-              "type": "string",
-              "nullable": true
-            },
-            "accidentYn": {
-              "$ref": "#/components/schemas/JJDisputeAccidentYn"
-            },
-            "addressLine1": {
-              "type": "string",
-              "nullable": true
-            },
-            "addressLine2": {
-              "type": "string",
-              "nullable": true
-            },
-            "addressLine3": {
-              "type": "string",
-              "nullable": true
-            },
-            "addressCity": {
-              "type": "string",
-              "nullable": true
-            },
-            "addressProvince": {
-              "type": "string",
-              "nullable": true
-            },
-            "addressCountry": {
-              "type": "string",
-              "nullable": true
-            },
-            "addressPostalCode": {
-              "type": "string",
-              "nullable": true
-            },
-            "disputantSurname": {
-              "type": "string",
-              "nullable": true
-            },
-            "disputantGivenName1": {
-              "type": "string",
-              "nullable": true
-            },
-            "disputantGivenName2": {
-              "type": "string",
-              "nullable": true
-            },
-            "disputantGivenName3": {
-              "type": "string",
-              "nullable": true
-            },
-            "disputantBirthdate": {
-              "type": "string",
-              "format": "date-time",
-              "nullable": true
-            },
-            "driversLicenceNumber": {
-              "type": "string",
-              "nullable": true
-            },
-            "drvLicIssuedProvSeqNo": {
-              "type": "string",
-              "nullable": true
-            },
-            "drvLicIssuedCtryId": {
-              "type": "string",
-              "nullable": true
-            },
-            "emailAddress": {
-              "type": "string",
-              "nullable": true
-            },
-            "status": {
-              "$ref": "#/components/schemas/JJDisputeStatus"
-            },
-            "hearingType": {
-              "$ref": "#/components/schemas/JJDisputeHearingType"
-            },
-            "multipleOfficersYn": {
-              "$ref": "#/components/schemas/JJDisputeMultipleOfficersYn"
-            },
-            "noticeOfDisputeGuid": {
-              "type": "string",
-              "nullable": true
-            },
-            "noticeOfHearingYn": {
-              "$ref": "#/components/schemas/JJDisputeNoticeOfHearingYn"
-            },
-            "occamDisputantGiven1Nm": {
-              "type": "string",
-              "nullable": true
-            },
-            "occamDisputantGiven2Nm": {
-              "type": "string",
-              "nullable": true
-            },
-            "occamDisputantGiven3Nm": {
-              "type": "string",
-              "nullable": true
-            },
-            "occamDisputantSurnameNm": {
-              "type": "string",
-              "nullable": true
-            },
-            "occamDisputantPhoneNumber": {
-              "type": "string",
-              "nullable": true
-            },
-            "occamDisputeId": {
-              "type": "integer",
-              "format": "int64"
-            },
-            "occamViolationTicketUpldId": {
-              "type": "string",
-              "nullable": true
-            },
-            "submittedTs": {
-              "type": "string",
-              "format": "date-time",
-              "nullable": true
-            },
-            "issuedTs": {
-              "type": "string",
-              "format": "date-time",
-              "nullable": true
-            },
-            "violationDate": {
-              "type": "string",
-              "format": "date-time",
-              "nullable": true
-            },
-            "icbcReceivedDate": {
-              "type": "string",
-              "format": "date-time",
-              "nullable": true
-            },
-            "enforcementOfficer": {
-              "type": "string",
-              "nullable": true
-            },
-            "electronicTicketYn": {
-              "$ref": "#/components/schemas/JJDisputeElectronicTicketYn"
-            },
-            "policeDetachment": {
-              "type": "string",
-              "nullable": true
-            },
-            "courthouseLocation": {
-              "type": "string",
-              "nullable": true
-            },
-            "offenceLocation": {
-              "type": "string",
-              "nullable": true
-            },
-            "jjAssignedTo": {
-              "type": "string",
-              "nullable": true
-            },
-            "decisionMadeBy": {
-              "type": "string",
-              "nullable": true
-            },
-            "jjDecisionDate": {
-              "type": "string",
-              "format": "date-time",
-              "nullable": true
-            },
-            "vtcAssignedTo": {
-              "type": "string",
-              "nullable": true
-            },
-            "vtcAssignedTs": {
-              "type": "string",
-              "format": "date-time",
-              "nullable": true
-            },
-            "fineReductionReason": {
-              "type": "string",
-              "nullable": true
-            },
-            "timeToPayReason": {
-              "type": "string",
-              "nullable": true
-            },
-            "contactLawFirmName": {
-              "type": "string",
-              "nullable": true
-            },
-            "contactGivenName1": {
-              "type": "string",
-              "nullable": true
-            },
-            "contactGivenName2": {
-              "type": "string",
-              "nullable": true
-            },
-            "contactGivenName3": {
-              "type": "string",
-              "nullable": true
-            },
-            "contactSurname": {
-              "type": "string",
-              "nullable": true
-            },
-            "contactType": {
-              "$ref": "#/components/schemas/JJDisputeContactType"
-            },
-            "appearInCourt": {
-              "$ref": "#/components/schemas/JJDisputeAppearInCourt"
-            },
-            "courtAgenId": {
-              "type": "string",
-              "nullable": true
-            },
-            "recalled": {
-              "type": "boolean",
-              "nullable": true
-            },
-            "lawFirmName": {
-              "type": "string",
-              "nullable": true
-            },
-            "lawyerSurname": {
-              "type": "string",
-              "nullable": true
-            },
-            "lawyerGivenName1": {
-              "type": "string",
-              "nullable": true
-            },
-            "lawyerGivenName2": {
-              "type": "string",
-              "nullable": true
-            },
-            "lawyerGivenName3": {
-              "type": "string",
-              "nullable": true
-            },
-            "justinRccId": {
-              "type": "string",
-              "nullable": true
-            },
-            "interpreterLanguageCd": {
-              "type": "string",
-              "nullable": true
-            },
-            "witnessNo": {
-              "type": "integer",
-              "format": "int32",
-              "nullable": true
-            },
-            "disputantAttendanceType": {
-              "$ref": "#/components/schemas/JJDisputeDisputantAttendanceType"
-            },
-            "signatoryType": {
-              "$ref": "#/components/schemas/JJDisputeSignatoryType"
-            },
-            "signatoryName": {
-              "maxLength": 100,
-              "minLength": 0,
-              "type": "string",
-              "nullable": true
-            },
-            "remarks": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/JJDisputeRemark"
-              },
-              "nullable": true
-            },
-            "jjDisputedCounts": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/JJDisputedCount"
-              },
-              "nullable": true
-            },
-            "jjDisputeCourtAppearanceRoPs": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/JJDisputeCourtAppearanceRoP"
-              },
-              "nullable": true
-            },
-            "additionalProperties": {
-              "type": "object",
-              "additionalProperties": {
-                "nullable": true
-              },
-              "nullable": true
-            }
-          },
-          "additionalProperties": false
-        },
-        "JJDisputeAccidentYn": {
-          "enum": [
-            "UNKNOWN",
-            "Y",
-            "N"
-          ],
-          "type": "string"
-        },
-        "JJDisputeAppearInCourt": {
-          "enum": [
-            "UNKNOWN",
-            "Y",
-            "N"
-          ],
-          "type": "string"
-        },
-        "JJDisputeContactType": {
-          "enum": [
-            "UNKNOWN",
-            "INDIVIDUAL",
-            "LAWYER",
-            "OTHER"
-          ],
-          "type": "string"
-        },
-        "JJDisputeCourtAppearanceRoP": {
-          "type": "object",
-          "properties": {
-            "justinAppearanceId": {
-              "type": "string",
-              "nullable": true
-            },
-            "id": {
-              "type": "integer",
-              "format": "int64",
-              "nullable": true
-            },
-            "appearanceTs": {
-              "type": "string",
-              "format": "date-time",
-              "nullable": true
-            },
-            "room": {
-              "type": "string",
-              "nullable": true
-            },
-            "duration": {
-              "type": "integer",
-              "format": "int32",
-              "nullable": true
-            },
-            "reason": {
-              "type": "string",
-              "nullable": true
-            },
-            "appCd": {
-              "$ref": "#/components/schemas/JJDisputeCourtAppearanceRoPAppCd"
-            },
-            "noAppTs": {
-              "type": "string",
-              "format": "date-time",
-              "nullable": true
-            },
-            "clerkRecord": {
-              "type": "string",
-              "nullable": true
-            },
-            "defenceCounsel": {
-              "type": "string",
-              "nullable": true
-            },
-            "dattCd": {
-              "$ref": "#/components/schemas/JJDisputeCourtAppearanceRoPDattCd"
-            },
-            "crown": {
-              "$ref": "#/components/schemas/JJDisputeCourtAppearanceRoPCrown"
-            },
-            "jjSeized": {
-              "$ref": "#/components/schemas/JJDisputeCourtAppearanceRoPJjSeized"
-            },
-            "adjudicator": {
-              "type": "string",
-              "nullable": true
-            },
-            "comments": {
-              "maxLength": 4000,
-              "minLength": 0,
-              "type": "string",
-              "nullable": true
-            },
-            "additionalProperties": {
-              "type": "object",
-              "additionalProperties": {
-                "nullable": true
-              },
-              "nullable": true
-            }
-          },
-          "additionalProperties": false
-        },
-        "JJDisputeCourtAppearanceRoPAppCd": {
-          "enum": [
-            "UNKNOWN",
-            "A",
-            "P",
-            "N"
-          ],
-          "type": "string"
-        },
-        "JJDisputeCourtAppearanceRoPCrown": {
-          "enum": [
-            "UNKNOWN",
-            "P",
-            "N"
-          ],
-          "type": "string"
-        },
-        "JJDisputeCourtAppearanceRoPDattCd": {
-          "enum": [
-            "UNKNOWN",
-            "A",
-            "C",
-            "N"
-          ],
-          "type": "string"
-        },
-        "JJDisputeCourtAppearanceRoPJjSeized": {
-          "enum": [
-            "UNKNOWN",
-            "Y",
-            "N"
-          ],
-          "type": "string"
-        },
-        "JJDisputeDisputantAttendanceType": {
-          "enum": [
-            "UNKNOWN",
-            "WRITTEN_REASONS",
-            "VIDEO_CONFERENCE",
-            "TELEPHONE_CONFERENCE",
-            "MSTEAMS_AUDIO",
-            "MSTEAMS_VIDEO",
-            "IN_PERSON"
-          ],
-          "type": "string"
-        },
-        "JJDisputeElectronicTicketYn": {
-          "enum": [
-            "UNKNOWN",
-            "Y",
-            "N"
-          ],
-          "type": "string"
-        },
-        "JJDisputeHearingType": {
-          "enum": [
-            "UNKNOWN",
-            "COURT_APPEARANCE",
-            "WRITTEN_REASONS"
-          ],
-          "type": "string"
-        },
-        "JJDisputeMultipleOfficersYn": {
-          "enum": [
-            "UNKNOWN",
-            "Y",
-            "N"
-          ],
-          "type": "string"
-        },
-        "JJDisputeNoticeOfHearingYn": {
-          "enum": [
-            "UNKNOWN",
-            "Y",
-            "N"
-          ],
-          "type": "string"
-        },
-        "JJDisputeRemark": {
-          "type": "object",
-          "properties": {
-            "createdBy": {
-              "type": "string",
-              "nullable": true
-            },
-            "createdTs": {
-              "type": "string",
-              "format": "date-time"
-            },
-            "modifiedBy": {
-              "type": "string",
-              "nullable": true
-            },
-            "modifiedTs": {
-              "type": "string",
-              "format": "date-time",
-              "nullable": true
-            },
-            "id": {
-              "type": "integer",
-              "format": "int64"
-            },
-            "userFullName": {
-              "type": "string",
-              "nullable": true
-            },
-            "note": {
-              "maxLength": 4000,
-              "minLength": 0,
-              "type": "string",
-              "nullable": true
-            },
-            "remarksMadeTs": {
-              "type": "string",
-              "format": "date-time"
-            },
-            "additionalProperties": {
-              "type": "object",
-              "additionalProperties": {
-                "nullable": true
-              },
-              "nullable": true
-            }
-          },
-          "additionalProperties": false
-        },
-        "JJDisputeSignatoryType": {
-          "enum": [
-            "U",
-            "D",
-            "A"
-          ],
-          "type": "string"
-        },
-        "JJDisputeStatus": {
-          "enum": [
-            "UNKNOWN",
-            "NEW",
-            "IN_PROGRESS",
-            "DATA_UPDATE",
-            "CONFIRMED",
-            "REQUIRE_COURT_HEARING",
-            "REQUIRE_MORE_INFO",
-            "ACCEPTED",
-            "REVIEW",
-            "CONCLUDED",
-            "CANCELLED",
-            "HEARING_SCHEDULED"
-          ],
-          "type": "string"
-        },
-        "JJDisputedCount": {
-          "type": "object",
-          "properties": {
-            "createdBy": {
-              "type": "string",
-              "nullable": true
-            },
-            "createdTs": {
-              "type": "string",
-              "format": "date-time"
-            },
-            "modifiedBy": {
-              "type": "string",
-              "nullable": true
-            },
-            "modifiedTs": {
-              "type": "string",
-              "format": "date-time",
-              "nullable": true
-            },
-            "id": {
-              "type": "integer",
-              "format": "int64"
-            },
-            "plea": {
-              "$ref": "#/components/schemas/JJDisputedCountPlea"
-            },
-            "count": {
-              "maximum": 3,
-              "minimum": 1,
-              "type": "integer",
-              "format": "int32"
-            },
-            "requestTimeToPay": {
-              "$ref": "#/components/schemas/JJDisputedCountRequestTimeToPay"
-            },
-            "requestReduction": {
-              "$ref": "#/components/schemas/JJDisputedCountRequestReduction"
-            },
-            "appearInCourt": {
-              "$ref": "#/components/schemas/JJDisputedCountAppearInCourt"
-            },
-            "description": {
-              "type": "string",
-              "nullable": true
-            },
-            "dueDate": {
-              "type": "string",
-              "format": "date-time",
-              "nullable": true
-            },
-            "ticketedFineAmount": {
-              "type": "number",
-              "format": "float",
-              "nullable": true
-            },
-            "lesserOrGreaterAmount": {
-              "type": "number",
-              "format": "float",
-              "nullable": true
-            },
-            "includesSurcharge": {
-              "$ref": "#/components/schemas/JJDisputedCountIncludesSurcharge"
-            },
-            "revisedDueDate": {
-              "type": "string",
-              "format": "date-time",
-              "nullable": true
-            },
-            "totalFineAmount": {
-              "type": "number",
-              "format": "float",
-              "nullable": true
-            },
-            "violationDate": {
-              "type": "string",
-              "format": "date-time",
-              "nullable": true
-            },
-            "comments": {
-              "maxLength": 4000,
-              "minLength": 0,
-              "type": "string",
-              "nullable": true
-            },
-            "latestPlea": {
-              "$ref": "#/components/schemas/JJDisputedCountLatestPlea"
-            },
-            "latestPleaUpdateTs": {
-              "type": "string",
-              "format": "date-time",
-              "nullable": true
-            },
-            "jjDisputedCountRoP": {
-              "$ref": "#/components/schemas/JJDisputedCountRoP"
-            },
-            "additionalProperties": {
-              "type": "object",
-              "additionalProperties": {
-                "nullable": true
-              },
-              "nullable": true
-            }
-          },
-          "additionalProperties": false
-        },
-        "JJDisputedCountAppearInCourt": {
-          "enum": [
-            "UNKNOWN",
-            "Y",
-            "N"
-          ],
-          "type": "string"
-        },
-        "JJDisputedCountIncludesSurcharge": {
-          "enum": [
-            "UNKNOWN",
-            "Y",
-            "N"
-          ],
-          "type": "string"
-        },
-        "JJDisputedCountLatestPlea": {
-          "enum": [
-            "UNKNOWN",
-            "G",
-            "N"
-          ],
-          "type": "string"
-        },
-        "JJDisputedCountPlea": {
-          "enum": [
-            "UNKNOWN",
-            "G",
-            "N"
-          ],
-          "type": "string"
-        },
-        "JJDisputedCountRequestReduction": {
-          "enum": [
-            "UNKNOWN",
-            "Y",
-            "N"
-          ],
-          "type": "string"
-        },
-        "JJDisputedCountRequestTimeToPay": {
-          "enum": [
-            "UNKNOWN",
-            "Y",
-            "N"
-          ],
-          "type": "string"
-        },
-        "JJDisputedCountRoP": {
-          "type": "object",
-          "properties": {
-            "createdBy": {
-              "type": "string",
-              "nullable": true
-            },
-            "createdTs": {
-              "type": "string",
-              "format": "date-time"
-            },
-            "modifiedBy": {
-              "type": "string",
-              "nullable": true
-            },
-            "modifiedTs": {
-              "type": "string",
-              "format": "date-time",
-              "nullable": true
-            },
-            "id": {
-              "type": "integer",
-              "format": "int64"
-            },
-            "finding": {
-              "$ref": "#/components/schemas/JJDisputedCountRoPFinding"
-            },
-            "lesserDescription": {
-              "type": "string",
-              "nullable": true
-            },
-            "ssProbationDuration": {
-              "type": "string",
-              "nullable": true
-            },
-            "ssProbationConditions": {
-              "type": "string",
-              "nullable": true
-            },
-            "jailDuration": {
-              "type": "string",
-              "nullable": true
-            },
-            "jailIntermittent": {
-              "$ref": "#/components/schemas/JJDisputedCountRoPJailIntermittent"
-            },
-            "probationDuration": {
-              "type": "string",
-              "nullable": true
-            },
-            "probationConditions": {
-              "type": "string",
-              "nullable": true
-            },
-            "drivingProhibition": {
-              "type": "string",
-              "nullable": true
-            },
-            "drivingProhibitionMVASection": {
-              "type": "string",
-              "nullable": true
-            },
-            "dismissed": {
-              "$ref": "#/components/schemas/JJDisputedCountRoPDismissed"
-            },
-            "forWantOfProsecution": {
-              "$ref": "#/components/schemas/JJDisputedCountRoPForWantOfProsecution"
-            },
-            "withdrawn": {
-              "$ref": "#/components/schemas/JJDisputedCountRoPWithdrawn"
-            },
-            "abatement": {
-              "$ref": "#/components/schemas/JJDisputedCountRoPAbatement"
-            },
-            "stayOfProceedingsBy": {
-              "type": "string",
-              "nullable": true
-            },
-            "other": {
-              "type": "string",
-              "nullable": true
-            },
-            "additionalProperties": {
-              "type": "object",
-              "additionalProperties": {
-                "nullable": true
-              },
-              "nullable": true
-            }
-          },
-          "additionalProperties": false
-        },
-        "JJDisputedCountRoPAbatement": {
-          "enum": [
-            "UNKNOWN",
-            "Y",
-            "N"
-          ],
-          "type": "string"
-        },
-        "JJDisputedCountRoPDismissed": {
-          "enum": [
-            "UNKNOWN",
-            "Y",
-            "N"
-          ],
-          "type": "string"
-        },
-        "JJDisputedCountRoPFinding": {
-          "enum": [
-            "UNKNOWN",
-            "GUILTY",
-            "NOT_GUILTY",
-            "CANCELLED",
-            "PAID_PRIOR_TO_APPEARANCE",
-            "GUILTY_LESSER"
-          ],
-          "type": "string"
-        },
-        "JJDisputedCountRoPForWantOfProsecution": {
-          "enum": [
-            "UNKNOWN",
-            "Y",
-            "N"
-          ],
-          "type": "string"
-        },
-        "JJDisputedCountRoPJailIntermittent": {
-          "enum": [
-            "UNKNOWN",
-            "Y",
-            "N"
-          ],
-          "type": "string"
-        },
-        "JJDisputedCountRoPWithdrawn": {
-          "enum": [
-            "UNKNOWN",
-            "Y",
-            "N"
-          ],
-          "type": "string"
-        },
-        "Language": {
-          "type": "object",
-          "properties": {
-            "code": {
-              "type": "string",
-              "nullable": true
-            },
-            "description": {
-              "type": "string",
-              "nullable": true
-            }
-          },
-          "additionalProperties": false
-        },
-        "Lock": {
-          "type": "object",
-          "properties": {
-            "lockId": {
-              "type": "string",
-              "description": "Lock ID",
-              "nullable": true
-            },
-            "ticketNumber": {
-              "type": "string",
-              "description": "The ticket number associated with the dispute.",
-              "nullable": true
-            },
-            "username": {
-              "type": "string",
-              "description": "Username of the person who acquired the lock.",
-              "nullable": true
-            },
-            "expiryTimeUtc": {
-              "type": "string",
-              "description": "The time in UTC when the acquired lock expires.",
-              "format": "date-time"
-            },
-            "createdAtUtc": {
-              "type": "string",
-              "description": "The time in UTC when the lock was created.",
-              "format": "date-time"
-            }
-          },
-          "additionalProperties": false
-        },
-        "OcrViolationTicket": {
-          "type": "object",
-          "properties": {
-            "ticketVersion": {
-              "$ref": "#/components/schemas/ViolationTicketVersion"
-            },
-            "imageFilename": {
-              "type": "string",
-              "nullable": true
-            },
-            "globalConfidence": {
-              "type": "number",
-              "format": "float"
-            },
-            "fields": {
-              "type": "object",
-              "additionalProperties": {
-                "$ref": "#/components/schemas/Field"
-              },
-              "nullable": true
-            }
-          },
-          "additionalProperties": false
-        },
-        "PagedDisputeCaseFileSummaryCollection": {
-          "type": "object",
-          "properties": {
+          "boundingBoxes": {
+            "type": "array",
             "items": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/DisputeCaseFileSummary"
-              },
+              "$ref": "#/components/schemas/BoundingBox"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "FileHistory": {
+        "required": [
+          "auditLogEntryType"
+        ],
+        "type": "object",
+        "properties": {
+          "createdBy": {
+            "type": "string",
+            "nullable": true
+          },
+          "createdTs": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "modifiedBy": {
+            "type": "string",
+            "nullable": true
+          },
+          "modifiedTs": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "fileHistoryId": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "disputeId": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "auditLogEntryType": {
+            "$ref": "#/components/schemas/FileHistoryAuditLogEntryType"
+          },
+          "description": {
+            "type": "string",
+            "nullable": true
+          },
+          "comment": {
+            "type": "string",
+            "nullable": true
+          },
+          "actionByApplicationUser": {
+            "type": "string",
+            "nullable": true
+          },
+          "additionalProperties": {
+            "type": "object",
+            "additionalProperties": {
               "nullable": true
             },
-            "pageNumber": {
-              "type": "integer",
-              "format": "int32"
-            },
-            "pageSize": {
-              "type": "integer",
-              "format": "int32"
-            },
-            "totalPages": {
-              "type": "integer",
-              "format": "int32"
-            },
-            "totalRows": {
-              "type": "integer",
-              "format": "int32"
-            }
-          },
-          "additionalProperties": false
+            "nullable": true
+          }
         },
-        "PagedDisputeListItemCollection": {
-          "type": "object",
-          "properties": {
+        "additionalProperties": false
+      },
+      "FileHistoryAuditLogEntryType": {
+        "enum": [
+          "UNKNOWN",
+          "ARFL",
+          "CAIN",
+          "CAWT",
+          "CCAN",
+          "CCON",
+          "CCWR",
+          "CLEG",
+          "CUEM",
+          "CUEV",
+          "CUIN",
+          "CULG",
+          "CUPD",
+          "CUWR",
+          "CUWT",
+          "DURA",
+          "DURR",
+          "EMCA",
+          "EMCF",
+          "EMCR",
+          "EMDC",
+          "EMFD",
+          "EMPR",
+          "EMRJ",
+          "EMRV",
+          "EMST",
+          "EMUP",
+          "EMVF",
+          "ESUR",
+          "FDLD",
+          "FDLS",
+          "FUPD",
+          "FUPS",
+          "FRMK",
+          "INIT",
+          "JASG",
+          "JCNF",
+          "JDIV",
+          "JPRG",
+          "OCNT",
+          "RCLD",
+          "RECN",
+          "SADM",
+          "SCAN",
+          "SPRC",
+          "SREJ",
+          "SUB",
+          "SUPL",
+          "SVAL",
+          "URSR",
+          "VREV",
+          "VSUB"
+        ],
+        "type": "string"
+      },
+      "FileMetadata": {
+        "type": "object",
+        "properties": {
+          "fileId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "fileName": {
+            "type": "string",
+            "nullable": true
+          },
+          "noticeOfDisputeGuid": {
+            "type": "string",
+            "nullable": true
+          },
+          "documentSource": {
+            "$ref": "#/components/schemas/DocumentSource"
+          },
+          "documentType": {
+            "type": "string",
+            "nullable": true
+          },
+          "virusScanStatus": {
+            "type": "string",
+            "nullable": true
+          },
+          "documentStatus": {
+            "type": "string",
+            "nullable": true
+          },
+          "ticketNumber": {
+            "type": "string",
+            "nullable": true
+          },
+          "disputeId": {
+            "type": "integer",
+            "format": "int64",
+            "nullable": true
+          },
+          "pendingFileStream": {
+            "type": "string",
+            "nullable": true
+          },
+          "deleteRequested": {
+            "type": "boolean",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "GetDisputeCountResponse": {
+        "type": "object",
+        "properties": {
+          "status": {
+            "$ref": "#/components/schemas/DisputeStatus"
+          },
+          "count": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "additionalProperties": false
+      },
+      "IcbcNameDetail": {
+        "type": "object",
+        "properties": {
+          "surname": {
+            "type": "string",
+            "nullable": true
+          },
+          "firstGivenName": {
+            "type": "string",
+            "nullable": true
+          },
+          "secondGivenName": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "JJDispute": {
+        "type": "object",
+        "properties": {
+          "fileData": {
+            "type": "array",
             "items": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/DisputeListItem"
-              },
-              "nullable": true
+              "$ref": "#/components/schemas/FileMetadata"
             },
-            "pageNumber": {
-              "type": "integer",
-              "format": "int32",
-              "readOnly": true
-            },
-            "pageSize": {
-              "type": "integer",
-              "format": "int32",
-              "readOnly": true
-            },
-            "pageCount": {
-              "type": "integer",
-              "format": "int32",
-              "readOnly": true
-            },
-            "totalItemCount": {
-              "type": "integer",
-              "format": "int32",
-              "readOnly": true
-            },
-            "hasPreviousPage": {
-              "type": "boolean",
-              "readOnly": true
-            },
-            "hasNextPage": {
-              "type": "boolean",
-              "readOnly": true
-            },
-            "isFirstPage": {
-              "type": "boolean",
-              "readOnly": true
-            },
-            "isLastPage": {
-              "type": "boolean",
-              "readOnly": true
-            }
+            "nullable": true
           },
-          "additionalProperties": false
-        },
-        "Permission": {
-          "type": "object",
-          "properties": {
-            "name": {
-              "type": "string",
-              "description": "The permission name.",
-              "nullable": true
-            },
-            "has": {
-              "type": "boolean",
-              "description": "A flag indicating if the user has this permission."
-            }
+          "lockId": {
+            "type": "string",
+            "nullable": true
           },
-          "additionalProperties": false,
-          "description": "Represents a single permission."
-        },
-        "Point": {
-          "type": "object",
-          "properties": {
-            "x": {
-              "type": "number",
-              "format": "float"
-            },
-            "y": {
-              "type": "number",
-              "format": "float"
-            }
+          "lockedBy": {
+            "type": "string",
+            "nullable": true
           },
-          "additionalProperties": false
-        },
-        "ProblemDetails": {
-          "type": "object",
-          "properties": {
-            "type": {
-              "type": "string",
-              "nullable": true
-            },
-            "title": {
-              "type": "string",
-              "nullable": true
-            },
-            "status": {
-              "type": "integer",
-              "format": "int32",
-              "nullable": true
-            },
-            "detail": {
-              "type": "string",
-              "nullable": true
-            },
-            "instance": {
-              "type": "string",
-              "nullable": true
-            }
+          "lockExpiresAtUtc": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
           },
-          "additionalProperties": { }
-        },
-        "Province": {
-          "type": "object",
-          "properties": {
-            "ctryId": {
-              "type": "string",
-              "nullable": true
-            },
-            "provSeqNo": {
-              "type": "string",
-              "nullable": true
-            },
-            "provNm": {
-              "type": "string",
-              "nullable": true
-            },
-            "provAbbreviationCd": {
-              "type": "string",
-              "nullable": true
-            }
+          "createdBy": {
+            "type": "string",
+            "nullable": true
           },
-          "additionalProperties": false
-        },
-        "SocialLinkRepresentation": {
-          "type": "object",
-          "properties": {
-            "socialProvider": {
-              "type": "string",
-              "nullable": true
+          "createdTs": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "modifiedBy": {
+            "type": "string",
+            "nullable": true
+          },
+          "modifiedTs": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "ticketNumber": {
+            "type": "string",
+            "nullable": true
+          },
+          "accidentYn": {
+            "$ref": "#/components/schemas/JJDisputeAccidentYn"
+          },
+          "addressLine1": {
+            "type": "string",
+            "nullable": true
+          },
+          "addressLine2": {
+            "type": "string",
+            "nullable": true
+          },
+          "addressLine3": {
+            "type": "string",
+            "nullable": true
+          },
+          "addressCity": {
+            "type": "string",
+            "nullable": true
+          },
+          "addressProvince": {
+            "type": "string",
+            "nullable": true
+          },
+          "addressCountry": {
+            "type": "string",
+            "nullable": true
+          },
+          "addressPostalCode": {
+            "type": "string",
+            "nullable": true
+          },
+          "disputantSurname": {
+            "type": "string",
+            "nullable": true
+          },
+          "disputantGivenName1": {
+            "type": "string",
+            "nullable": true
+          },
+          "disputantGivenName2": {
+            "type": "string",
+            "nullable": true
+          },
+          "disputantGivenName3": {
+            "type": "string",
+            "nullable": true
+          },
+          "disputantBirthdate": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "driversLicenceNumber": {
+            "type": "string",
+            "nullable": true
+          },
+          "drvLicIssuedProvSeqNo": {
+            "type": "string",
+            "nullable": true
+          },
+          "drvLicIssuedCtryId": {
+            "type": "string",
+            "nullable": true
+          },
+          "emailAddress": {
+            "type": "string",
+            "nullable": true
+          },
+          "status": {
+            "$ref": "#/components/schemas/JJDisputeStatus"
+          },
+          "hearingType": {
+            "$ref": "#/components/schemas/JJDisputeHearingType"
+          },
+          "multipleOfficersYn": {
+            "$ref": "#/components/schemas/JJDisputeMultipleOfficersYn"
+          },
+          "noticeOfDisputeGuid": {
+            "type": "string",
+            "nullable": true
+          },
+          "noticeOfHearingYn": {
+            "$ref": "#/components/schemas/JJDisputeNoticeOfHearingYn"
+          },
+          "occamDisputantGiven1Nm": {
+            "type": "string",
+            "nullable": true
+          },
+          "occamDisputantGiven2Nm": {
+            "type": "string",
+            "nullable": true
+          },
+          "occamDisputantGiven3Nm": {
+            "type": "string",
+            "nullable": true
+          },
+          "occamDisputantSurnameNm": {
+            "type": "string",
+            "nullable": true
+          },
+          "occamDisputantPhoneNumber": {
+            "type": "string",
+            "nullable": true
+          },
+          "occamDisputeId": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "occamViolationTicketUpldId": {
+            "type": "string",
+            "nullable": true
+          },
+          "submittedTs": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "issuedTs": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "violationDate": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "icbcReceivedDate": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "enforcementOfficer": {
+            "type": "string",
+            "nullable": true
+          },
+          "electronicTicketYn": {
+            "$ref": "#/components/schemas/JJDisputeElectronicTicketYn"
+          },
+          "policeDetachment": {
+            "type": "string",
+            "nullable": true
+          },
+          "courthouseLocation": {
+            "type": "string",
+            "nullable": true
+          },
+          "offenceLocation": {
+            "type": "string",
+            "nullable": true
+          },
+          "jjAssignedTo": {
+            "type": "string",
+            "nullable": true
+          },
+          "decisionMadeBy": {
+            "type": "string",
+            "nullable": true
+          },
+          "jjDecisionDate": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "vtcAssignedTo": {
+            "type": "string",
+            "nullable": true
+          },
+          "vtcAssignedTs": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "fineReductionReason": {
+            "type": "string",
+            "nullable": true
+          },
+          "timeToPayReason": {
+            "type": "string",
+            "nullable": true
+          },
+          "contactLawFirmName": {
+            "type": "string",
+            "nullable": true
+          },
+          "contactGivenName1": {
+            "type": "string",
+            "nullable": true
+          },
+          "contactGivenName2": {
+            "type": "string",
+            "nullable": true
+          },
+          "contactGivenName3": {
+            "type": "string",
+            "nullable": true
+          },
+          "contactSurname": {
+            "type": "string",
+            "nullable": true
+          },
+          "contactType": {
+            "$ref": "#/components/schemas/JJDisputeContactType"
+          },
+          "appearInCourt": {
+            "$ref": "#/components/schemas/JJDisputeAppearInCourt"
+          },
+          "courtAgenId": {
+            "type": "string",
+            "nullable": true
+          },
+          "recalled": {
+            "type": "boolean",
+            "nullable": true
+          },
+          "lawFirmName": {
+            "type": "string",
+            "nullable": true
+          },
+          "lawyerSurname": {
+            "type": "string",
+            "nullable": true
+          },
+          "lawyerGivenName1": {
+            "type": "string",
+            "nullable": true
+          },
+          "lawyerGivenName2": {
+            "type": "string",
+            "nullable": true
+          },
+          "lawyerGivenName3": {
+            "type": "string",
+            "nullable": true
+          },
+          "justinRccId": {
+            "type": "string",
+            "nullable": true
+          },
+          "interpreterLanguageCd": {
+            "type": "string",
+            "nullable": true
+          },
+          "witnessNo": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "disputantAttendanceType": {
+            "$ref": "#/components/schemas/JJDisputeDisputantAttendanceType"
+          },
+          "signatoryType": {
+            "$ref": "#/components/schemas/JJDisputeSignatoryType"
+          },
+          "signatoryName": {
+            "maxLength": 100,
+            "minLength": 0,
+            "type": "string",
+            "nullable": true
+          },
+          "remarks": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/JJDisputeRemark"
             },
-            "socialUserId": {
-              "type": "string",
-              "nullable": true
+            "nullable": true
+          },
+          "jjDisputedCounts": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/JJDisputedCount"
             },
-            "socialUsername": {
-              "type": "string",
-              "nullable": true
+            "nullable": true
+          },
+          "jjDisputeCourtAppearanceRoPs": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/JJDisputeCourtAppearanceRoP"
             },
+            "nullable": true
+          },
+          "additionalProperties": {
+            "type": "object",
             "additionalProperties": {
-              "type": "object",
-              "additionalProperties": {
-                "nullable": true
-              },
               "nullable": true
-            }
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "JJDisputeAccidentYn": {
+        "enum": [
+          "UNKNOWN",
+          "Y",
+          "N"
+        ],
+        "type": "string"
+      },
+      "JJDisputeAppearInCourt": {
+        "enum": [
+          "UNKNOWN",
+          "Y",
+          "N"
+        ],
+        "type": "string"
+      },
+      "JJDisputeContactType": {
+        "enum": [
+          "UNKNOWN",
+          "INDIVIDUAL",
+          "LAWYER",
+          "OTHER"
+        ],
+        "type": "string"
+      },
+      "JJDisputeCourtAppearanceRoP": {
+        "type": "object",
+        "properties": {
+          "justinAppearanceId": {
+            "type": "string",
+            "nullable": true
           },
-          "additionalProperties": false
-        },
-        "SortDirection": {
-          "enum": [
-            "asc",
-            "desc"
-          ],
-          "type": "string"
-        },
-        "Statute": {
-          "type": "object",
-          "properties": {
-            "id": {
-              "type": "string",
-              "nullable": true
-            },
-            "actCode": {
-              "type": "string",
-              "nullable": true
-            },
-            "sectionText": {
-              "type": "string",
-              "nullable": true
-            },
-            "subsectionText": {
-              "type": "string",
-              "nullable": true
-            },
-            "paragraphText": {
-              "type": "string",
-              "nullable": true
-            },
-            "subparagraphText": {
-              "type": "string",
-              "nullable": true
-            },
-            "code": {
-              "type": "string",
-              "nullable": true
-            },
-            "shortDescriptionText": {
-              "type": "string",
-              "nullable": true
-            },
-            "descriptionText": {
-              "type": "string",
-              "nullable": true
-            }
+          "id": {
+            "type": "integer",
+            "format": "int64",
+            "nullable": true
           },
-          "additionalProperties": false
-        },
-        "TicketImageDataJustinDocument": {
-          "type": "object",
-          "properties": {
-            "reportType": {
-              "$ref": "#/components/schemas/TicketImageDataJustinDocumentReportType"
-            },
-            "reportFormat": {
-              "type": "string",
-              "nullable": true
-            },
-            "partId": {
-              "type": "string",
-              "nullable": true
-            },
-            "participantName": {
-              "type": "string",
-              "nullable": true
-            },
-            "index": {
-              "type": "string",
-              "nullable": true
-            },
-            "fileData": {
-              "type": "string",
-              "nullable": true
-            },
+          "appearanceTs": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "room": {
+            "type": "string",
+            "nullable": true
+          },
+          "duration": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "reason": {
+            "type": "string",
+            "nullable": true
+          },
+          "appCd": {
+            "$ref": "#/components/schemas/JJDisputeCourtAppearanceRoPAppCd"
+          },
+          "noAppTs": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "clerkRecord": {
+            "type": "string",
+            "nullable": true
+          },
+          "defenceCounsel": {
+            "type": "string",
+            "nullable": true
+          },
+          "dattCd": {
+            "$ref": "#/components/schemas/JJDisputeCourtAppearanceRoPDattCd"
+          },
+          "crown": {
+            "$ref": "#/components/schemas/JJDisputeCourtAppearanceRoPCrown"
+          },
+          "jjSeized": {
+            "$ref": "#/components/schemas/JJDisputeCourtAppearanceRoPJjSeized"
+          },
+          "adjudicator": {
+            "type": "string",
+            "nullable": true
+          },
+          "comments": {
+            "maxLength": 4000,
+            "minLength": 0,
+            "type": "string",
+            "nullable": true
+          },
+          "additionalProperties": {
+            "type": "object",
             "additionalProperties": {
-              "type": "object",
-              "additionalProperties": {
-                "nullable": true
-              },
               "nullable": true
-            }
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "JJDisputeCourtAppearanceRoPAppCd": {
+        "enum": [
+          "UNKNOWN",
+          "A",
+          "P",
+          "N"
+        ],
+        "type": "string"
+      },
+      "JJDisputeCourtAppearanceRoPCrown": {
+        "enum": [
+          "UNKNOWN",
+          "P",
+          "N"
+        ],
+        "type": "string"
+      },
+      "JJDisputeCourtAppearanceRoPDattCd": {
+        "enum": [
+          "UNKNOWN",
+          "A",
+          "C",
+          "N"
+        ],
+        "type": "string"
+      },
+      "JJDisputeCourtAppearanceRoPJjSeized": {
+        "enum": [
+          "UNKNOWN",
+          "Y",
+          "N"
+        ],
+        "type": "string"
+      },
+      "JJDisputeDisputantAttendanceType": {
+        "enum": [
+          "UNKNOWN",
+          "WRITTEN_REASONS",
+          "VIDEO_CONFERENCE",
+          "TELEPHONE_CONFERENCE",
+          "MSTEAMS_AUDIO",
+          "MSTEAMS_VIDEO",
+          "IN_PERSON"
+        ],
+        "type": "string"
+      },
+      "JJDisputeElectronicTicketYn": {
+        "enum": [
+          "UNKNOWN",
+          "Y",
+          "N"
+        ],
+        "type": "string"
+      },
+      "JJDisputeHearingType": {
+        "enum": [
+          "UNKNOWN",
+          "COURT_APPEARANCE",
+          "WRITTEN_REASONS"
+        ],
+        "type": "string"
+      },
+      "JJDisputeMultipleOfficersYn": {
+        "enum": [
+          "UNKNOWN",
+          "Y",
+          "N"
+        ],
+        "type": "string"
+      },
+      "JJDisputeNoticeOfHearingYn": {
+        "enum": [
+          "UNKNOWN",
+          "Y",
+          "N"
+        ],
+        "type": "string"
+      },
+      "JJDisputeRemark": {
+        "type": "object",
+        "properties": {
+          "createdBy": {
+            "type": "string",
+            "nullable": true
           },
-          "additionalProperties": false
-        },
-        "TicketImageDataJustinDocumentReportType": {
-          "enum": [
-            "UNKNOWN",
-            "NOTICE_OF_DISPUTE",
-            "TICKET_IMAGE"
-          ],
-          "type": "string"
-        },
-        "UserConsentRepresentation": {
-          "type": "object",
-          "properties": {
-            "clientId": {
-              "type": "string",
-              "nullable": true
-            },
-            "grantedClientScopes": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              },
-              "nullable": true
-            },
-            "createdDate": {
-              "type": "integer",
-              "format": "int64"
-            },
-            "lastUpdatedDate": {
-              "type": "integer",
-              "format": "int64"
-            },
-            "grantedRealmRoles": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              },
-              "nullable": true
-            },
+          "createdTs": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "modifiedBy": {
+            "type": "string",
+            "nullable": true
+          },
+          "modifiedTs": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "userFullName": {
+            "type": "string",
+            "nullable": true
+          },
+          "note": {
+            "maxLength": 4000,
+            "minLength": 0,
+            "type": "string",
+            "nullable": true
+          },
+          "remarksMadeTs": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "additionalProperties": {
+            "type": "object",
             "additionalProperties": {
-              "type": "object",
-              "additionalProperties": {
-                "nullable": true
-              },
               "nullable": true
-            }
-          },
-          "additionalProperties": false
+            },
+            "nullable": true
+          }
         },
-        "UserRepresentation": {
-          "type": "object",
-          "properties": {
-            "self": {
-              "type": "string",
-              "nullable": true
-            },
-            "id": {
-              "type": "string",
-              "nullable": true
-            },
-            "createdTimestamp": {
-              "type": "integer",
-              "format": "int64"
-            },
-            "firstName": {
-              "type": "string",
-              "nullable": true
-            },
-            "lastName": {
-              "type": "string",
-              "nullable": true
-            },
-            "email": {
-              "type": "string",
-              "nullable": true
-            },
-            "username": {
-              "type": "string",
-              "nullable": true
-            },
-            "enabled": {
-              "type": "boolean"
-            },
-            "totp": {
-              "type": "boolean"
-            },
-            "emailVerified": {
-              "type": "boolean"
-            },
-            "attributes": {
-              "type": "object",
-              "additionalProperties": {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                },
-                "nullable": true
-              },
-              "nullable": true
-            },
-            "credentials": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/CredentialRepresentation"
-              },
-              "nullable": true
-            },
-            "requiredActions": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              },
-              "nullable": true
-            },
-            "federatedIdentities": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/FederatedIdentityRepresentation"
-              },
-              "nullable": true
-            },
-            "socialLinks": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/SocialLinkRepresentation"
-              },
-              "nullable": true
-            },
-            "realmRoles": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              },
-              "nullable": true
-            },
-            "clientRoles": {
-              "type": "object",
-              "additionalProperties": {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                },
-                "nullable": true
-              },
-              "nullable": true
-            },
-            "clientConsents": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/UserConsentRepresentation"
-              },
-              "nullable": true
-            },
-            "notBefore": {
-              "type": "integer",
-              "format": "int32"
-            },
-            "applicationRoles": {
-              "type": "object",
-              "additionalProperties": {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                },
-                "nullable": true
-              },
-              "nullable": true
-            },
-            "federationLink": {
-              "type": "string",
-              "nullable": true
-            },
-            "serviceAccountClientId": {
-              "type": "string",
-              "nullable": true
-            },
-            "groups": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              },
-              "nullable": true
-            },
-            "origin": {
-              "type": "string",
-              "nullable": true
-            },
-            "disableableCredentialTypes": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              },
-              "nullable": true
-            },
-            "access": {
-              "type": "object",
-              "additionalProperties": {
-                "type": "boolean"
-              },
-              "nullable": true
-            },
+        "additionalProperties": false
+      },
+      "JJDisputeSignatoryType": {
+        "enum": [
+          "U",
+          "D",
+          "A"
+        ],
+        "type": "string"
+      },
+      "JJDisputeStatus": {
+        "enum": [
+          "UNKNOWN",
+          "NEW",
+          "IN_PROGRESS",
+          "DATA_UPDATE",
+          "CONFIRMED",
+          "REQUIRE_COURT_HEARING",
+          "REQUIRE_MORE_INFO",
+          "ACCEPTED",
+          "REVIEW",
+          "CONCLUDED",
+          "CANCELLED",
+          "HEARING_SCHEDULED"
+        ],
+        "type": "string"
+      },
+      "JJDisputedCount": {
+        "type": "object",
+        "properties": {
+          "createdBy": {
+            "type": "string",
+            "nullable": true
+          },
+          "createdTs": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "modifiedBy": {
+            "type": "string",
+            "nullable": true
+          },
+          "modifiedTs": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "plea": {
+            "$ref": "#/components/schemas/JJDisputedCountPlea"
+          },
+          "count": {
+            "maximum": 3,
+            "minimum": 1,
+            "type": "integer",
+            "format": "int32"
+          },
+          "requestTimeToPay": {
+            "$ref": "#/components/schemas/JJDisputedCountRequestTimeToPay"
+          },
+          "requestReduction": {
+            "$ref": "#/components/schemas/JJDisputedCountRequestReduction"
+          },
+          "appearInCourt": {
+            "$ref": "#/components/schemas/JJDisputedCountAppearInCourt"
+          },
+          "description": {
+            "type": "string",
+            "nullable": true
+          },
+          "dueDate": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "ticketedFineAmount": {
+            "type": "number",
+            "format": "float",
+            "nullable": true
+          },
+          "lesserOrGreaterAmount": {
+            "type": "number",
+            "format": "float",
+            "nullable": true
+          },
+          "includesSurcharge": {
+            "$ref": "#/components/schemas/JJDisputedCountIncludesSurcharge"
+          },
+          "revisedDueDate": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "totalFineAmount": {
+            "type": "number",
+            "format": "float",
+            "nullable": true
+          },
+          "violationDate": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "comments": {
+            "maxLength": 4000,
+            "minLength": 0,
+            "type": "string",
+            "nullable": true
+          },
+          "latestPlea": {
+            "$ref": "#/components/schemas/JJDisputedCountLatestPlea"
+          },
+          "latestPleaUpdateTs": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "jjDisputedCountRoP": {
+            "$ref": "#/components/schemas/JJDisputedCountRoP"
+          },
+          "additionalProperties": {
+            "type": "object",
             "additionalProperties": {
-              "type": "object",
-              "additionalProperties": {
-                "nullable": true
-              },
               "nullable": true
-            }
-          },
-          "additionalProperties": false
+            },
+            "nullable": true
+          }
         },
-        "ViolationTicket": {
-          "type": "object",
-          "properties": {
-            "createdBy": {
-              "type": "string",
-              "nullable": true
-            },
-            "createdTs": {
-              "type": "string",
-              "format": "date-time"
-            },
-            "modifiedBy": {
-              "type": "string",
-              "nullable": true
-            },
-            "modifiedTs": {
-              "type": "string",
-              "format": "date-time",
-              "nullable": true
-            },
-            "violationTicketId": {
-              "type": "integer",
-              "format": "int64"
-            },
-            "ticketNumber": {
-              "type": "string",
-              "nullable": true
-            },
-            "disputantOrganizationName": {
-              "type": "string",
-              "nullable": true
-            },
-            "disputantSurname": {
-              "type": "string",
-              "nullable": true
-            },
-            "disputantGivenNames": {
-              "type": "string",
-              "nullable": true
-            },
-            "isYoungPerson": {
-              "$ref": "#/components/schemas/ViolationTicketIsYoungPerson"
-            },
-            "disputantDriversLicenceNumber": {
-              "maxLength": 30,
-              "minLength": 7,
-              "type": "string",
-              "nullable": true
-            },
-            "disputantClientNumber": {
-              "type": "string",
-              "nullable": true
-            },
-            "driversLicenceProvince": {
-              "maxLength": 100,
-              "minLength": 0,
-              "type": "string",
-              "nullable": true
-            },
-            "driversLicenceCountry": {
-              "maxLength": 100,
-              "minLength": 0,
-              "type": "string",
-              "nullable": true
-            },
-            "driversLicenceIssuedYear": {
-              "type": "integer",
-              "format": "int32",
-              "nullable": true
-            },
-            "driversLicenceExpiryYear": {
-              "type": "integer",
-              "format": "int32",
-              "nullable": true
-            },
-            "disputantBirthdate": {
-              "type": "string",
-              "format": "date-time",
-              "nullable": true
-            },
-            "address": {
-              "maxLength": 100,
-              "minLength": 0,
-              "type": "string",
-              "nullable": true
-            },
-            "addressCity": {
-              "type": "string",
-              "nullable": true
-            },
-            "addressProvince": {
-              "type": "string",
-              "nullable": true
-            },
-            "addressPostalCode": {
-              "type": "string",
-              "nullable": true
-            },
-            "addressCountry": {
-              "type": "string",
-              "nullable": true
-            },
-            "officerPin": {
-              "type": "string",
-              "nullable": true
-            },
-            "detachmentLocation": {
-              "type": "string",
-              "nullable": true
-            },
-            "issuedTs": {
-              "type": "string",
-              "format": "date-time",
-              "nullable": true
-            },
-            "issuedOnRoadOrHighway": {
-              "type": "string",
-              "nullable": true
-            },
-            "issuedAtOrNearCity": {
-              "type": "string",
-              "nullable": true
-            },
-            "isChangeOfAddress": {
-              "$ref": "#/components/schemas/ViolationTicketIsChangeOfAddress"
-            },
-            "isDriver": {
-              "$ref": "#/components/schemas/ViolationTicketIsDriver"
-            },
-            "isOwner": {
-              "$ref": "#/components/schemas/ViolationTicketIsOwner"
-            },
-            "courtLocation": {
-              "type": "string",
-              "nullable": true
-            },
-            "violationTicketCounts": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/ViolationTicketCount"
-              },
-              "nullable": true
-            },
+        "additionalProperties": false
+      },
+      "JJDisputedCountAppearInCourt": {
+        "enum": [
+          "UNKNOWN",
+          "Y",
+          "N"
+        ],
+        "type": "string"
+      },
+      "JJDisputedCountIncludesSurcharge": {
+        "enum": [
+          "UNKNOWN",
+          "Y",
+          "N"
+        ],
+        "type": "string"
+      },
+      "JJDisputedCountLatestPlea": {
+        "enum": [
+          "UNKNOWN",
+          "G",
+          "N"
+        ],
+        "type": "string"
+      },
+      "JJDisputedCountPlea": {
+        "enum": [
+          "UNKNOWN",
+          "G",
+          "N"
+        ],
+        "type": "string"
+      },
+      "JJDisputedCountRequestReduction": {
+        "enum": [
+          "UNKNOWN",
+          "Y",
+          "N"
+        ],
+        "type": "string"
+      },
+      "JJDisputedCountRequestTimeToPay": {
+        "enum": [
+          "UNKNOWN",
+          "Y",
+          "N"
+        ],
+        "type": "string"
+      },
+      "JJDisputedCountRoP": {
+        "type": "object",
+        "properties": {
+          "createdBy": {
+            "type": "string",
+            "nullable": true
+          },
+          "createdTs": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "modifiedBy": {
+            "type": "string",
+            "nullable": true
+          },
+          "modifiedTs": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "finding": {
+            "$ref": "#/components/schemas/JJDisputedCountRoPFinding"
+          },
+          "lesserDescription": {
+            "type": "string",
+            "nullable": true
+          },
+          "ssProbationDuration": {
+            "type": "string",
+            "nullable": true
+          },
+          "ssProbationConditions": {
+            "type": "string",
+            "nullable": true
+          },
+          "jailDuration": {
+            "type": "string",
+            "nullable": true
+          },
+          "jailIntermittent": {
+            "$ref": "#/components/schemas/JJDisputedCountRoPJailIntermittent"
+          },
+          "probationDuration": {
+            "type": "string",
+            "nullable": true
+          },
+          "probationConditions": {
+            "type": "string",
+            "nullable": true
+          },
+          "drivingProhibition": {
+            "type": "string",
+            "nullable": true
+          },
+          "drivingProhibitionMVASection": {
+            "type": "string",
+            "nullable": true
+          },
+          "dismissed": {
+            "$ref": "#/components/schemas/JJDisputedCountRoPDismissed"
+          },
+          "forWantOfProsecution": {
+            "$ref": "#/components/schemas/JJDisputedCountRoPForWantOfProsecution"
+          },
+          "withdrawn": {
+            "$ref": "#/components/schemas/JJDisputedCountRoPWithdrawn"
+          },
+          "abatement": {
+            "$ref": "#/components/schemas/JJDisputedCountRoPAbatement"
+          },
+          "stayOfProceedingsBy": {
+            "type": "string",
+            "nullable": true
+          },
+          "other": {
+            "type": "string",
+            "nullable": true
+          },
+          "additionalProperties": {
+            "type": "object",
             "additionalProperties": {
-              "type": "object",
-              "additionalProperties": {
-                "nullable": true
-              },
               "nullable": true
             },
-            "violationTicketImage": {
-              "$ref": "#/components/schemas/ViolationTicketImage"
-            },
-            "ocrViolationTicket": {
-              "$ref": "#/components/schemas/OcrViolationTicket"
-            }
-          },
-          "additionalProperties": false
+            "nullable": true
+          }
         },
-        "ViolationTicketCount": {
-          "type": "object",
-          "properties": {
-            "createdBy": {
-              "type": "string",
-              "nullable": true
-            },
-            "createdTs": {
-              "type": "string",
-              "format": "date-time"
-            },
-            "modifiedBy": {
-              "type": "string",
-              "nullable": true
-            },
-            "modifiedTs": {
-              "type": "string",
-              "format": "date-time",
-              "nullable": true
-            },
-            "violationTicketCountId": {
-              "type": "integer",
-              "format": "int64"
-            },
-            "countNo": {
-              "maximum": 3,
-              "minimum": 1,
-              "type": "integer",
-              "format": "int32"
-            },
-            "description": {
-              "type": "string",
-              "nullable": true
-            },
-            "actOrRegulationNameCode": {
-              "type": "string",
-              "nullable": true
-            },
-            "isAct": {
-              "$ref": "#/components/schemas/ViolationTicketCountIsAct"
-            },
-            "isRegulation": {
-              "$ref": "#/components/schemas/ViolationTicketCountIsRegulation"
-            },
-            "section": {
-              "maxLength": 10,
-              "minLength": 0,
-              "type": "string",
-              "nullable": true
-            },
-            "subsection": {
-              "maxLength": 4,
-              "minLength": 0,
-              "type": "string",
-              "nullable": true
-            },
-            "paragraph": {
-              "maxLength": 3,
-              "minLength": 0,
-              "type": "string",
-              "nullable": true
-            },
-            "subparagraph": {
-              "maxLength": 5,
-              "minLength": 0,
-              "type": "string",
-              "nullable": true
-            },
-            "ticketedAmount": {
-              "type": "number",
-              "format": "float",
-              "nullable": true
-            },
+        "additionalProperties": false
+      },
+      "JJDisputedCountRoPAbatement": {
+        "enum": [
+          "UNKNOWN",
+          "Y",
+          "N"
+        ],
+        "type": "string"
+      },
+      "JJDisputedCountRoPDismissed": {
+        "enum": [
+          "UNKNOWN",
+          "Y",
+          "N"
+        ],
+        "type": "string"
+      },
+      "JJDisputedCountRoPFinding": {
+        "enum": [
+          "UNKNOWN",
+          "GUILTY",
+          "NOT_GUILTY",
+          "CANCELLED",
+          "PAID_PRIOR_TO_APPEARANCE",
+          "GUILTY_LESSER"
+        ],
+        "type": "string"
+      },
+      "JJDisputedCountRoPForWantOfProsecution": {
+        "enum": [
+          "UNKNOWN",
+          "Y",
+          "N"
+        ],
+        "type": "string"
+      },
+      "JJDisputedCountRoPJailIntermittent": {
+        "enum": [
+          "UNKNOWN",
+          "Y",
+          "N"
+        ],
+        "type": "string"
+      },
+      "JJDisputedCountRoPWithdrawn": {
+        "enum": [
+          "UNKNOWN",
+          "Y",
+          "N"
+        ],
+        "type": "string"
+      },
+      "Language": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string",
+            "nullable": true
+          },
+          "description": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "Lock": {
+        "type": "object",
+        "properties": {
+          "lockId": {
+            "type": "string",
+            "description": "Lock ID",
+            "nullable": true
+          },
+          "ticketNumber": {
+            "type": "string",
+            "description": "The ticket number associated with the dispute.",
+            "nullable": true
+          },
+          "username": {
+            "type": "string",
+            "description": "Username of the person who acquired the lock.",
+            "nullable": true
+          },
+          "expiryTimeUtc": {
+            "type": "string",
+            "description": "The time in UTC when the acquired lock expires.",
+            "format": "date-time"
+          },
+          "createdAtUtc": {
+            "type": "string",
+            "description": "The time in UTC when the lock was created.",
+            "format": "date-time"
+          }
+        },
+        "additionalProperties": false
+      },
+      "OcrViolationTicket": {
+        "type": "object",
+        "properties": {
+          "ticketVersion": {
+            "$ref": "#/components/schemas/ViolationTicketVersion"
+          },
+          "imageFilename": {
+            "type": "string",
+            "nullable": true
+          },
+          "globalConfidence": {
+            "type": "number",
+            "format": "float"
+          },
+          "fields": {
+            "type": "object",
             "additionalProperties": {
-              "type": "object",
-              "additionalProperties": {
-                "nullable": true
-              },
-              "nullable": true
-            }
-          },
-          "additionalProperties": false
-        },
-        "ViolationTicketCountIsAct": {
-          "enum": [
-            "UNKNOWN",
-            "Y",
-            "N"
-          ],
-          "type": "string"
-        },
-        "ViolationTicketCountIsRegulation": {
-          "enum": [
-            "UNKNOWN",
-            "Y",
-            "N"
-          ],
-          "type": "string"
-        },
-        "ViolationTicketImage": {
-          "type": "object",
-          "properties": {
-            "image": {
-              "type": "string",
-              "format": "byte",
-              "nullable": true
+              "$ref": "#/components/schemas/Field"
             },
-            "mimeType": {
-              "type": "string",
-              "nullable": true
-            }
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "PagedDisputeCaseFileSummaryCollection": {
+        "type": "object",
+        "properties": {
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DisputeCaseFileSummary"
+            },
+            "nullable": true
           },
-          "additionalProperties": false
+          "pageNumber": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "pageSize": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "totalPages": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "totalRows": {
+            "type": "integer",
+            "format": "int32"
+          }
         },
-        "ViolationTicketIsChangeOfAddress": {
-          "enum": [
-            "UNKNOWN",
-            "Y",
-            "N"
-          ],
-          "type": "string"
+        "additionalProperties": false
+      },
+      "PagedDisputeListItemCollection": {
+        "type": "object",
+        "properties": {
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DisputeListItem"
+            },
+            "nullable": true
+          },
+          "pageNumber": {
+            "type": "integer",
+            "format": "int32",
+            "readOnly": true
+          },
+          "pageSize": {
+            "type": "integer",
+            "format": "int32",
+            "readOnly": true
+          },
+          "pageCount": {
+            "type": "integer",
+            "format": "int32",
+            "readOnly": true
+          },
+          "totalItemCount": {
+            "type": "integer",
+            "format": "int32",
+            "readOnly": true
+          },
+          "hasPreviousPage": {
+            "type": "boolean",
+            "readOnly": true
+          },
+          "hasNextPage": {
+            "type": "boolean",
+            "readOnly": true
+          },
+          "isFirstPage": {
+            "type": "boolean",
+            "readOnly": true
+          },
+          "isLastPage": {
+            "type": "boolean",
+            "readOnly": true
+          }
         },
-        "ViolationTicketIsDriver": {
-          "enum": [
-            "UNKNOWN",
-            "Y",
-            "N"
-          ],
-          "type": "string"
+        "additionalProperties": false
+      },
+      "Permission": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "The permission name.",
+            "nullable": true
+          },
+          "has": {
+            "type": "boolean",
+            "description": "A flag indicating if the user has this permission."
+          }
         },
-        "ViolationTicketIsOwner": {
-          "enum": [
-            "UNKNOWN",
-            "Y",
-            "N"
-          ],
-          "type": "string"
+        "additionalProperties": false,
+        "description": "Represents a single permission."
+      },
+      "Point": {
+        "type": "object",
+        "properties": {
+          "x": {
+            "type": "number",
+            "format": "float"
+          },
+          "y": {
+            "type": "number",
+            "format": "float"
+          }
         },
-        "ViolationTicketIsYoungPerson": {
-          "enum": [
-            "UNKNOWN",
-            "Y",
-            "N"
-          ],
-          "type": "string"
+        "additionalProperties": false
+      },
+      "ProblemDetails": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "nullable": true
+          },
+          "title": {
+            "type": "string",
+            "nullable": true
+          },
+          "status": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "detail": {
+            "type": "string",
+            "nullable": true
+          },
+          "instance": {
+            "type": "string",
+            "nullable": true
+          }
         },
-        "ViolationTicketVersion": {
-          "enum": [
-            "VT1",
-            "VT2"
-          ],
-          "type": "string"
-        },
-        "YesNo": {
-          "enum": [
-            "Unknown",
-            "Yes",
-            "No"
-          ],
-          "type": "string"
+        "additionalProperties": {
+
         }
       },
-      "securitySchemes": {
-        "Bearer": {
-          "type": "apiKey",
-          "description": "JWT Authorization header using the Bearer scheme. Example: \"Authorization: Bearer {token}\"",
-          "name": "Authorization",
-          "in": "header"
-        }
+      "Province": {
+        "type": "object",
+        "properties": {
+          "ctryId": {
+            "type": "string",
+            "nullable": true
+          },
+          "provSeqNo": {
+            "type": "string",
+            "nullable": true
+          },
+          "provNm": {
+            "type": "string",
+            "nullable": true
+          },
+          "provAbbreviationCd": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "SocialLinkRepresentation": {
+        "type": "object",
+        "properties": {
+          "socialProvider": {
+            "type": "string",
+            "nullable": true
+          },
+          "socialUserId": {
+            "type": "string",
+            "nullable": true
+          },
+          "socialUsername": {
+            "type": "string",
+            "nullable": true
+          },
+          "additionalProperties": {
+            "type": "object",
+            "additionalProperties": {
+              "nullable": true
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "SortDirection": {
+        "enum": [
+          "asc",
+          "desc"
+        ],
+        "type": "string"
+      },
+      "Statute": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "nullable": true
+          },
+          "actCode": {
+            "type": "string",
+            "nullable": true
+          },
+          "sectionText": {
+            "type": "string",
+            "nullable": true
+          },
+          "subsectionText": {
+            "type": "string",
+            "nullable": true
+          },
+          "paragraphText": {
+            "type": "string",
+            "nullable": true
+          },
+          "subparagraphText": {
+            "type": "string",
+            "nullable": true
+          },
+          "code": {
+            "type": "string",
+            "nullable": true
+          },
+          "shortDescriptionText": {
+            "type": "string",
+            "nullable": true
+          },
+          "descriptionText": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "TicketImageDataJustinDocument": {
+        "type": "object",
+        "properties": {
+          "reportType": {
+            "$ref": "#/components/schemas/TicketImageDataJustinDocumentReportType"
+          },
+          "reportFormat": {
+            "type": "string",
+            "nullable": true
+          },
+          "partId": {
+            "type": "string",
+            "nullable": true
+          },
+          "participantName": {
+            "type": "string",
+            "nullable": true
+          },
+          "index": {
+            "type": "string",
+            "nullable": true
+          },
+          "fileData": {
+            "type": "string",
+            "nullable": true
+          },
+          "additionalProperties": {
+            "type": "object",
+            "additionalProperties": {
+              "nullable": true
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "TicketImageDataJustinDocumentReportType": {
+        "enum": [
+          "UNKNOWN",
+          "NOTICE_OF_DISPUTE",
+          "TICKET_IMAGE"
+        ],
+        "type": "string"
+      },
+      "UserConsentRepresentation": {
+        "type": "object",
+        "properties": {
+          "clientId": {
+            "type": "string",
+            "nullable": true
+          },
+          "grantedClientScopes": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true
+          },
+          "createdDate": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "lastUpdatedDate": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "grantedRealmRoles": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true
+          },
+          "additionalProperties": {
+            "type": "object",
+            "additionalProperties": {
+              "nullable": true
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "UserRepresentation": {
+        "type": "object",
+        "properties": {
+          "self": {
+            "type": "string",
+            "nullable": true
+          },
+          "id": {
+            "type": "string",
+            "nullable": true
+          },
+          "createdTimestamp": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "firstName": {
+            "type": "string",
+            "nullable": true
+          },
+          "lastName": {
+            "type": "string",
+            "nullable": true
+          },
+          "email": {
+            "type": "string",
+            "nullable": true
+          },
+          "username": {
+            "type": "string",
+            "nullable": true
+          },
+          "enabled": {
+            "type": "boolean"
+          },
+          "totp": {
+            "type": "boolean"
+          },
+          "emailVerified": {
+            "type": "boolean"
+          },
+          "attributes": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "nullable": true
+            },
+            "nullable": true
+          },
+          "credentials": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CredentialRepresentation"
+            },
+            "nullable": true
+          },
+          "requiredActions": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true
+          },
+          "federatedIdentities": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FederatedIdentityRepresentation"
+            },
+            "nullable": true
+          },
+          "socialLinks": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SocialLinkRepresentation"
+            },
+            "nullable": true
+          },
+          "realmRoles": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true
+          },
+          "clientRoles": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "nullable": true
+            },
+            "nullable": true
+          },
+          "clientConsents": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/UserConsentRepresentation"
+            },
+            "nullable": true
+          },
+          "notBefore": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "applicationRoles": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "nullable": true
+            },
+            "nullable": true
+          },
+          "federationLink": {
+            "type": "string",
+            "nullable": true
+          },
+          "serviceAccountClientId": {
+            "type": "string",
+            "nullable": true
+          },
+          "groups": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true
+          },
+          "origin": {
+            "type": "string",
+            "nullable": true
+          },
+          "disableableCredentialTypes": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true
+          },
+          "access": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "boolean"
+            },
+            "nullable": true
+          },
+          "additionalProperties": {
+            "type": "object",
+            "additionalProperties": {
+              "nullable": true
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "ViolationTicket": {
+        "type": "object",
+        "properties": {
+          "createdBy": {
+            "type": "string",
+            "nullable": true
+          },
+          "createdTs": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "modifiedBy": {
+            "type": "string",
+            "nullable": true
+          },
+          "modifiedTs": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "violationTicketId": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "ticketNumber": {
+            "type": "string",
+            "nullable": true
+          },
+          "disputantOrganizationName": {
+            "type": "string",
+            "nullable": true
+          },
+          "disputantSurname": {
+            "type": "string",
+            "nullable": true
+          },
+          "disputantGivenNames": {
+            "type": "string",
+            "nullable": true
+          },
+          "isYoungPerson": {
+            "$ref": "#/components/schemas/ViolationTicketIsYoungPerson"
+          },
+          "disputantDriversLicenceNumber": {
+            "maxLength": 30,
+            "minLength": 7,
+            "type": "string",
+            "nullable": true
+          },
+          "disputantClientNumber": {
+            "type": "string",
+            "nullable": true
+          },
+          "driversLicenceProvince": {
+            "maxLength": 100,
+            "minLength": 0,
+            "type": "string",
+            "nullable": true
+          },
+          "driversLicenceCountry": {
+            "maxLength": 100,
+            "minLength": 0,
+            "type": "string",
+            "nullable": true
+          },
+          "driversLicenceIssuedYear": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "driversLicenceExpiryYear": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "disputantBirthdate": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "address": {
+            "maxLength": 100,
+            "minLength": 0,
+            "type": "string",
+            "nullable": true
+          },
+          "addressCity": {
+            "type": "string",
+            "nullable": true
+          },
+          "addressProvince": {
+            "type": "string",
+            "nullable": true
+          },
+          "addressPostalCode": {
+            "type": "string",
+            "nullable": true
+          },
+          "addressCountry": {
+            "type": "string",
+            "nullable": true
+          },
+          "officerPin": {
+            "type": "string",
+            "nullable": true
+          },
+          "detachmentLocation": {
+            "type": "string",
+            "nullable": true
+          },
+          "issuedTs": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "issuedOnRoadOrHighway": {
+            "type": "string",
+            "nullable": true
+          },
+          "issuedAtOrNearCity": {
+            "type": "string",
+            "nullable": true
+          },
+          "isChangeOfAddress": {
+            "$ref": "#/components/schemas/ViolationTicketIsChangeOfAddress"
+          },
+          "isDriver": {
+            "$ref": "#/components/schemas/ViolationTicketIsDriver"
+          },
+          "isOwner": {
+            "$ref": "#/components/schemas/ViolationTicketIsOwner"
+          },
+          "courtLocation": {
+            "type": "string",
+            "nullable": true
+          },
+          "violationTicketCounts": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ViolationTicketCount"
+            },
+            "nullable": true
+          },
+          "additionalProperties": {
+            "type": "object",
+            "additionalProperties": {
+              "nullable": true
+            },
+            "nullable": true
+          },
+          "violationTicketImage": {
+            "$ref": "#/components/schemas/ViolationTicketImage"
+          },
+          "ocrViolationTicket": {
+            "$ref": "#/components/schemas/OcrViolationTicket"
+          }
+        },
+        "additionalProperties": false
+      },
+      "ViolationTicketCount": {
+        "type": "object",
+        "properties": {
+          "createdBy": {
+            "type": "string",
+            "nullable": true
+          },
+          "createdTs": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "modifiedBy": {
+            "type": "string",
+            "nullable": true
+          },
+          "modifiedTs": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "violationTicketCountId": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "countNo": {
+            "maximum": 3,
+            "minimum": 1,
+            "type": "integer",
+            "format": "int32"
+          },
+          "description": {
+            "type": "string",
+            "nullable": true
+          },
+          "actOrRegulationNameCode": {
+            "type": "string",
+            "nullable": true
+          },
+          "isAct": {
+            "$ref": "#/components/schemas/ViolationTicketCountIsAct"
+          },
+          "isRegulation": {
+            "$ref": "#/components/schemas/ViolationTicketCountIsRegulation"
+          },
+          "section": {
+            "maxLength": 10,
+            "minLength": 0,
+            "type": "string",
+            "nullable": true
+          },
+          "subsection": {
+            "maxLength": 4,
+            "minLength": 0,
+            "type": "string",
+            "nullable": true
+          },
+          "paragraph": {
+            "maxLength": 3,
+            "minLength": 0,
+            "type": "string",
+            "nullable": true
+          },
+          "subparagraph": {
+            "maxLength": 5,
+            "minLength": 0,
+            "type": "string",
+            "nullable": true
+          },
+          "ticketedAmount": {
+            "type": "number",
+            "format": "float",
+            "nullable": true
+          },
+          "additionalProperties": {
+            "type": "object",
+            "additionalProperties": {
+              "nullable": true
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "ViolationTicketCountIsAct": {
+        "enum": [
+          "UNKNOWN",
+          "Y",
+          "N"
+        ],
+        "type": "string"
+      },
+      "ViolationTicketCountIsRegulation": {
+        "enum": [
+          "UNKNOWN",
+          "Y",
+          "N"
+        ],
+        "type": "string"
+      },
+      "ViolationTicketImage": {
+        "type": "object",
+        "properties": {
+          "image": {
+            "type": "string",
+            "format": "byte",
+            "nullable": true
+          },
+          "mimeType": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "ViolationTicketIsChangeOfAddress": {
+        "enum": [
+          "UNKNOWN",
+          "Y",
+          "N"
+        ],
+        "type": "string"
+      },
+      "ViolationTicketIsDriver": {
+        "enum": [
+          "UNKNOWN",
+          "Y",
+          "N"
+        ],
+        "type": "string"
+      },
+      "ViolationTicketIsOwner": {
+        "enum": [
+          "UNKNOWN",
+          "Y",
+          "N"
+        ],
+        "type": "string"
+      },
+      "ViolationTicketIsYoungPerson": {
+        "enum": [
+          "UNKNOWN",
+          "Y",
+          "N"
+        ],
+        "type": "string"
+      },
+      "ViolationTicketVersion": {
+        "enum": [
+          "VT1",
+          "VT2"
+        ],
+        "type": "string"
+      },
+      "YesNo": {
+        "enum": [
+          "Unknown",
+          "Yes",
+          "No"
+        ],
+        "type": "string"
       }
     },
-    "security": [
-      {
-        "Bearer": [ ]
+    "securitySchemes": {
+      "Bearer": {
+        "type": "apiKey",
+        "description": "JWT Authorization header using the Bearer scheme. Example: \"Authorization: Bearer {token}\"",
+        "name": "Authorization",
+        "in": "header"
       }
-    ]
-  }
+    }
+  },
+  "security": [
+    {
+      "Bearer": []
+    }
+  ]
+}

--- a/src/frontend/staff-portal/src/app/components/jj-dispute-info/jj-dispute/jj-dispute.component.ts
+++ b/src/frontend/staff-portal/src/app/components/jj-dispute-info/jj-dispute/jj-dispute.component.ts
@@ -20,6 +20,7 @@ import { Dispute } from 'app/services/dispute.service';
 import { DisputeStatus } from '@shared/consts/DisputeStatus.model';
 import { HearingType } from '@shared/consts/HearingType.model';
 import { ChangeDetectorRef } from '@angular/core';
+import { ToastService } from '@core/services/toast.service';
 
 @Component({
   selector: 'app-jj-dispute',
@@ -134,6 +135,7 @@ export class JJDisputeComponent implements OnInit {
     private documentService: DocumentService,
     private historyRecordService: HistoryRecordService,
     private cdr: ChangeDetectorRef,
+    private toastService: ToastService,
   ) {
     this.authService.jjList$.subscribe(result => {
       this.jjList = result;
@@ -160,12 +162,22 @@ export class JJDisputeComponent implements OnInit {
   getJJDispute(): void {
     this.logger.log('JJDisputeComponent::getJJDispute');
     let assignVTC = false;
+    let executeUserLock = false;
     if(this.type === TabType.DECISION_VALIDATION) {
       assignVTC = true;
     }
+    if (this.type !== TabType.DCF) {
+      executeUserLock = true;
+    }
 
-    this.jjDisputeService.getJJDispute(this.tcoDisputeInfo.id, this.tcoDisputeInfo.ticketNumber, assignVTC).subscribe(response => {
+    this.jjDisputeService.getJJDispute(this.tcoDisputeInfo.id, this.tcoDisputeInfo.ticketNumber, assignVTC, executeUserLock).subscribe(response => {
       this.retrieving = false;
+      if (response.lockedBy && response.lockedBy !== this.jjIDIR) {
+        this.logger.warn("This dispute is currently being worked on by another user.");
+        // Show toast message to user and navigate back to inbox
+        this.toastService.openErrorToast("This dispute is currently being worked on by another user.");
+        this.onBackClicked();
+      }
       this.logger.info(
         'JJDisputeComponent::getJJDispute response',
         response

--- a/src/frontend/staff-portal/src/app/services/jj-dispute.service.ts
+++ b/src/frontend/staff-portal/src/app/services/jj-dispute.service.ts
@@ -313,8 +313,8 @@ export class JJDisputeService {
    *
    * @param disputeId
    */
-  public getJJDispute(disputeId: number, ticketNumber: string, assignVTC: boolean): Observable<JJDispute> {
-    return this.jjApiService.apiJjJjDisputeIdGet(disputeId, ticketNumber, assignVTC)
+  public getJJDispute(disputeId: number, ticketNumber: string, assignVTC: boolean, executeUserLock: boolean): Observable<JJDispute> {
+    return this.jjApiService.apiJjJjDisputeIdGet(disputeId, ticketNumber, assignVTC, executeUserLock)
       .pipe(
         map((response: JJDispute) => {
           this.logger.info('jj-DisputeService::getJJDispute', response)


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- [TCVP-3162](https://jira.justice.gov.bc.ca/browse/TCVP-3162)
- Removed the unnecessary admin activity event message (JASG) that is published each time a DCF viewed and assigned.
- Added a new 'executeUserLock' flag to GetJJDisputeAsync endpoint in order to attempt to lock the dispute for the current user only if true. 
- Updated unit tests and added a new test for confirming lock is returned with dispute if the flag is true.
- Regenerated the api of staff portal based on the updated swagger.json to update getJJDispute endpoint to be consumed.
- Added logic to determine executing the DCF lock for the logged in user based on the accessed view. 
- Updated the call to getJJDispute service to provide new flag for determining user lock for DCF.
- Added a toast message to show user if the DCF is currently being worked on by another user.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
