### PR TITLE
TCVP-3196: Fix e-ticket violation date saved incorrect

### DIFF
--- a/src/backend/oracle-data-api/src/main/resources/occm-openapi-spec.yaml
+++ b/src/backend/oracle-data-api/src/main/resources/occm-openapi-spec.yaml
@@ -1000,7 +1000,7 @@ components:
         issuedDt:
           type: string
           format: date-time
-          x-field-extra-annotation: "@com.fasterxml.jackson.annotation.JsonFormat(pattern=\"yyyy-MM-dd HH:mm\")"
+          x-field-extra-annotation: "@com.fasterxml.jackson.annotation.JsonFormat(pattern=\"yyyy-MM-dd HH:mm\", timezone = \"PST\")"
         jjAssignedTo:
           type: string
           format: nullable
@@ -1287,7 +1287,7 @@ components:
         issuedDt:
           type: string
           format: date-time
-          x-field-extra-annotation: "@com.fasterxml.jackson.annotation.JsonFormat(pattern=\"yyyy-MM-dd HH:mm\")"
+          x-field-extra-annotation: "@com.fasterxml.jackson.annotation.JsonFormat(pattern=\"yyyy-MM-dd HH:mm\", timezone = \"PST\")"
         issuedOnRoadOrHighwayTxt:
           type: string
           format: nullable

--- a/src/frontend/citizen-portal/src/app/services/notice-of-dispute.service.ts
+++ b/src/frontend/citizen-portal/src/app/services/notice-of-dispute.service.ts
@@ -224,7 +224,7 @@ export class NoticeOfDisputeService {
                 this.router.navigate([AppRoutes.SUBMIT_SUCCESS], {
                   queryParams: {
                     ticketNumber: input.ticket_number,
-                    time: this.datePipe.transform(input.issued_date, "HH:mm", "UTC"),
+                    time: this.datePipe.transform(input.issued_date, "HH:mm"),
                     mode: DisputeFormMode.CREATE
                   },
                 });

--- a/src/frontend/citizen-portal/src/app/services/violation-ticket.service.ts
+++ b/src/frontend/citizen-portal/src/app/services/violation-ticket.service.ts
@@ -250,7 +250,7 @@ export class ViolationTicketService {
       result.drivers_licence_number = (<Field>source.fields[this.driversLicenceNumberKey]).value;
     }
     if (isDateFound || isTimeFound) {
-      result.issued_date = this.datePipe.transform(result[this.ocrTicketDateKey] + " " + result[this.ocrTicketTimeKey], "yyyy-MM-ddTHH:mm:ss'Z'");
+      result.issued_date = `${result[this.ocrTicketDateKey]}T${result[this.ocrTicketTimeKey]}`;
     }
     if (isDateFound) {
       result[this.ocrTicketDateKey] = this.datePipe.transform(result[this.ocrTicketDateKey], "MMM dd, yyyy", "UTC");


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- [TCVP-3196](https://jira.justice.gov.bc.ca/browse/TCVP-3196)
- Fixed an issue with e-ticket violation date saved incorrectly to ensure that the issuedDt value is serialized without changing the time zone by specifying the pattern with local time zone.
- Fixed an issue with incorrect issued date for paper tickets is saved due to the date is being adjusted by the UTC offset of the Pacific Time Zone in citizen portal. 
- Sending the date/time in unspecified time zone to API.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
