### PR TITLE
TCVP-3219: Fix incorrect violation date on staff portal

### DIFF
--- a/src/frontend/staff-portal/src/app/components/staff-workbench/contact-info/contact-info.component.html
+++ b/src/frontend/staff-portal/src/app/components/staff-workbench/contact-info/contact-info.component.html
@@ -54,10 +54,10 @@
               lastUpdatedDispute.ticketNumber.substring(0,1) === 'E' ? "Electronic Ticket" : "Intersection safety camera ticket" }}</span>
           </div>
           <div class="col-md-3">
-            <span class="BC-Gov-15px-black-text">Violation Date:</span>&nbsp;<span class="text">{{ lastUpdatedDispute.violationTicket.issuedTs| date: "dd-MMM-yyyy" : "UTC" }}</span>
+            <span class="BC-Gov-15px-black-text">Violation Date:</span>&nbsp;<span class="text">{{ lastUpdatedDispute.violationTicket.issuedTs| date: "dd-MMM-yyyy" }}</span>
           </div>
           <div class="col-md-3">
-            <span class="BC-Gov-15px-black-text">Violation Time:</span>&nbsp;<span class="text">{{ lastUpdatedDispute.violationTicket.issuedTs | date: "HH:mm" : "UTC" }}</span>
+            <span class="BC-Gov-15px-black-text">Violation Time:</span>&nbsp;<span class="text">{{ lastUpdatedDispute.violationTicket.issuedTs | date: "HH:mm" }}</span>
           </div>
           <div class="col-md-3">
             <span class="BC-Gov-15px-black-text">Surname:</span>&nbsp;


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- [TCVP-3219](https://jira.justice.gov.bc.ca/browse/TCVP-3219)
- Fixed the incorrect violation date/time on ticket validation screen and print version of that.

NOTE: This is a partial fix for the mentioned jira ticket above. JJ side needs to be fixed in a separate PR.

Here is the areas of the staff portal where correct violation date/time is shown:

![Screenshot 2025-03-28 at 9 55 59 AM](https://github.com/user-attachments/assets/938b5aae-c03e-4c2e-bd23-17dc606545b2)

![Screenshot 2025-03-28 at 9 57 00 AM](https://github.com/user-attachments/assets/c2e1719d-49d9-4236-ae85-df5d8c2dca22)

NOTE:

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
