### PR TITLE
TCVP-3224: Fix violation date for OCR tickets is saved incorrectly after validation

### DIFF
--- a/src/frontend/staff-portal/src/app/components/staff-workbench/ticket-info/ticket-info.component.ts
+++ b/src/frontend/staff-portal/src/app/components/staff-workbench/ticket-info/ticket-info.component.ts
@@ -592,8 +592,7 @@ export class TicketInfoComponent implements OnInit {
       this.form
         .get('violationTicket')
         .get('violationTime')
-        .value.substring(2, 4) +
-      'Z';
+        .value.substring(2, 4);
     putDispute.issuedTs =
       this.form.get('violationTicket').get('violationDate').value +
       'T' +
@@ -605,8 +604,7 @@ export class TicketInfoComponent implements OnInit {
       this.form
         .get('violationTicket')
         .get('violationTime')
-        .value.substring(2, 4) +
-      ':00Z';
+        .value.substring(2, 4);
 
     // Counts 1,2,3
     putDispute.violationTicket.violationTicketCounts =


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- [TCVP-3224](https://jira.justice.gov.bc.ca/browse/TCVP-3224)
- Fixed the issue with violation date/time for submitted OCR tickets incorrectly adjusted when updating or validating the data on staff portal.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [ ] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [x] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
