### PR TITLE
TCVP-3219: Fix incorrect violation date shown on JJ portal

### DIFF
--- a/src/backend/TrafficCourts/TrafficCourts.Core/Domain/Models/OracleDataApiModels.cs
+++ b/src/backend/TrafficCourts/TrafficCourts.Core/Domain/Models/OracleDataApiModels.cs
@@ -165,7 +165,7 @@ namespace TrafficCourts.Domain.Models
         public System.DateTimeOffset? SubmittedTs { get; set; }
 
         [Newtonsoft.Json.JsonProperty("issuedTs", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public System.DateTimeOffset? IssuedTs { get; set; }
+        public System.DateTime? IssuedTs { get; set; }
 
         [Newtonsoft.Json.JsonProperty("violationDate", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public System.DateTimeOffset? ViolationDate { get; set; }

--- a/src/backend/TrafficCourts/TrafficCourts.OracleDataApi/Client/V1/OracleDomainModelMappingProfile.cs
+++ b/src/backend/TrafficCourts/TrafficCourts.OracleDataApi/Client/V1/OracleDomainModelMappingProfile.cs
@@ -88,10 +88,12 @@ public class OracleDomainModelMappingProfile : AutoMapper.Profile
         CreateMap<Oracle.FileHistory, DomainModel.FileHistory>().ReverseMap();
         CreateMap<Oracle.JJDispute, DomainModel.JJDispute>()
             .ForMember(dest => dest.FileData, opt => opt.Ignore())
+            .ForMember(dest => dest.IssuedTs, src => src.MapFrom(s => UtcToPacificTimeDateTime(s.IssuedTs)))
             .ForMember(dest => dest.LockId, opt => opt.Ignore())
             .ForMember(dest => dest.LockedBy, opt => opt.Ignore())
             .ForMember(dest => dest.LockExpiresAtUtc, opt => opt.Ignore())
-            .ReverseMap();
+            .ReverseMap()
+            .ForMember(dest => dest.IssuedTs, src => src.MapFrom(s => s.IssuedTs));
         CreateMap<Oracle.JJDisputeCourtAppearanceRoP, DomainModel.JJDisputeCourtAppearanceRoP>().ReverseMap();
         CreateMap<Oracle.JJDisputedCount, DomainModel.JJDisputedCount>().ReverseMap();
         CreateMap<Oracle.JJDisputedCountRoP, DomainModel.JJDisputedCountRoP>().ReverseMap();

--- a/src/backend/oracle-data-api/src/main/resources/tco-openapi-spec.yaml
+++ b/src/backend/oracle-data-api/src/main/resources/tco-openapi-spec.yaml
@@ -546,7 +546,7 @@ components:
         issuedTs:
           type: string
           format: date-time
-          x-field-extra-annotation: "@com.fasterxml.jackson.annotation.JsonFormat(pattern=\"yyyy-MM-dd'T'HH:mm'Z'\")"
+          x-field-extra-annotation: "@com.fasterxml.jackson.annotation.JsonFormat(pattern=\"yyyy-MM-dd HH:mm\", timezone = \"PST\")"
         lawFirmNm:
           type: string
           format: nullable

--- a/src/frontend/staff-portal/src/app/components/jj-dispute-info/jj-count/jj-count.component.html
+++ b/src/frontend/staff-portal/src/app/components/jj-dispute-info/jj-count/jj-count.component.html
@@ -10,7 +10,7 @@
       <div style="display: grid; grid-template-columns: auto auto">
         <span class="section-grid-cell">
           <p class="section-grid-header">Offence Date</p>
-          <p class="section-grid-text">{{ jjDisputedCount ? (jjDisputeInfo.issuedTs | date: "dd-MMM-yyyy" : "UTC") : '&nbsp;' }}</p>
+          <p class="section-grid-text">{{ jjDisputedCount ? (jjDisputeInfo.issuedTs | date: "dd-MMM-yyyy") : '&nbsp;' }}</p>
         </span>
         <span class="section-grid-cell" style="grid-column: span 2">
           <p class="section-grid-header">Description of offence</p>

--- a/src/frontend/staff-portal/src/app/components/jj-dispute-info/jj-dispute/jj-dispute.component.html
+++ b/src/frontend/staff-portal/src/app/components/jj-dispute-info/jj-dispute/jj-dispute.component.html
@@ -83,11 +83,11 @@
             </span>
             <span class="section-grid-cell">
               <p class="section-grid-header">Violation Date</p>
-              <p class="section-grid-text">{{ lastUpdatedJJDispute.issuedTs | date: "dd-MMM-yyyy" : "UTC" }}</p>
+              <p class="section-grid-text">{{ lastUpdatedJJDispute.issuedTs | date: "dd-MMM-yyyy" }}</p>
             </span>
             <span class="section-grid-cell">
               <p class="section-grid-header">Violation Time</p>
-              <p class="section-grid-text">{{ lastUpdatedJJDispute.issuedTs | date: "HH:mm" : "UTC" }}</p>
+              <p class="section-grid-text">{{ lastUpdatedJJDispute.issuedTs | date: "HH:mm" }}</p>
             </span>
             <span class="section-grid-cell">
               <p class="section-grid-header">Online Submission Date</p>


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- [TCVP-3219](https://jira.justice.gov.bc.ca/browse/TCVP-3219)
- Fixed the issue with the violation date/time retrieved with utc offset and displayed incorrectly on jj portal.
- NOTE: This fix requires an update in TCO_REST ORDS package to retrieve the "issued_dt" in correct date format.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
