### PR TITLE
Changed Remarks size limit from 256 to 4000

### DIFF
--- a/src/backend/TrafficCourts/Staff.Service/Controllers/DisputeController.cs
+++ b/src/backend/TrafficCourts/Staff.Service/Controllers/DisputeController.cs
@@ -245,7 +245,7 @@ public class DisputeController : StaffControllerBase
     /// Updates the status of a particular Dispute record to REJECTED.
     /// </summary>
     /// <param name="disputeId">Unique identifier for a specific Dispute record to cancel.</param>
-    /// <param name="rejectedReason">The reason or note (max 256 characters) the Dispute was rejected.</param>
+    /// <param name="rejectedReason">The reason or note (max 4000 characters) the Dispute was rejected.</param>
     /// <param name="cancellationToken"></param>
     /// <returns></returns>
     /// <response code="200">The Dispute is updated.</response>
@@ -253,7 +253,7 @@ public class DisputeController : StaffControllerBase
     /// <response code="401">Request lacks valid authentication credentials.</response>
     /// <response code="403">Forbidden, requires dispute:reject permission.</response>
     /// <response code="404">Dispute record not found. Update failed.</response>
-    /// <response code="405">A Dispute status can only be set to REJECTED iff status is NEW, VALIDATED or PROCESSING and the rejected reason must be &lt;= 256 characters. Update failed.</response>
+    /// <response code="405">A Dispute status can only be set to REJECTED iff status is NEW, VALIDATED or PROCESSING and the rejected reason must be &lt;= 4000 characters. Update failed.</response>
     /// <response code="409">The Dispute has already been assigned to a different user. Dispute cannot be modified until assigned time expires.</response>
     /// <response code="500">There was a server error that prevented the update from completing successfully.</response>
     [HttpPut("{disputeId}/reject")]
@@ -270,7 +270,7 @@ public class DisputeController : StaffControllerBase
         long disputeId,
         [FromForm] 
         [Required]
-        [StringLength(256, ErrorMessage = "Rejected reason cannot exceed 256 characters.")] string rejectedReason, 
+        [StringLength(4000, ErrorMessage = "Rejected reason cannot exceed 4000 characters.")] string rejectedReason, 
         CancellationToken cancellationToken)
     {
         _logger.LogDebug("Updating the Dispute status");
@@ -366,7 +366,7 @@ public class DisputeController : StaffControllerBase
     /// Updates the status of a particular Dispute record to CANCELLED.
     /// </summary>
     /// <param name="disputeId">Unique identifier for a specific Dispute record to cancel.</param>
-    /// <param name="cancelledReason">The reason or note (max 256 characters) the Dispute was cancelled.</param>
+    /// <param name="cancelledReason">The reason or note (max 4000 characters) the Dispute was cancelled.</param>
     /// <param name="cancellationToken"></param>
     /// <returns></returns>
     /// <response code="200">The Dispute is updated.</response>
@@ -390,7 +390,7 @@ public class DisputeController : StaffControllerBase
     public async Task<IActionResult> CancelDisputeAsync(long disputeId,
         [FromForm]
         [Required]
-        [StringLength(256, ErrorMessage = "Cancelled reason cannot exceed 256 characters.")] string cancelledReason,
+        [StringLength(4000, ErrorMessage = "Cancelled reason cannot exceed 4000 characters.")] string cancelledReason,
         CancellationToken cancellationToken)
     {
         _logger.LogDebug("Updating the Dispute status to {Status}", "CANCELLED");

--- a/src/backend/TrafficCourts/Staff.Service/Controllers/JJController.cs
+++ b/src/backend/TrafficCourts/Staff.Service/Controllers/JJController.cs
@@ -588,7 +588,7 @@ public partial class JJController : StaffControllerBase
     /// <response code="401">Request lacks valid authentication credentials.</response>
     /// <response code="403">Forbidden, requires jjdispute:review permission.</response>
     /// <response code="404">JJDispute record not found. Update failed.</response>
-    /// <response code="405">A JJDispute status can only be set to REVIEW if status is CONFIRMED and the remark must be less than 256 characters OR if the status ACCEPTED, CONFIRMED or CONCLUDED and DCF's current hearing date = today's date. Update failed</response>
+    /// <response code="405">A JJDispute status can only be set to REVIEW if status is CONFIRMED and the remark must be less than or equal to 4000 characters OR if the status ACCEPTED, CONFIRMED or CONCLUDED and DCF's current hearing date = today's date. Update failed</response>
     /// <response code="409">The JJDispute has already been assigned to a different user. JJDispute cannot be modified until assigned time expires.</response>
     /// <response code="500">There was a server error that prevented the update from completing successfully.</response>
     [HttpPut("{ticketNumber}/recall")]
@@ -649,7 +649,7 @@ public partial class JJController : StaffControllerBase
     /// Updates the status of a particular JJDispute record to REVIEW as well as adds an optional remark that explaining why the status was set to REVIEW.
     /// </summary>
     /// <param name="ticketNumber">Unique identifier for a specific JJ Dispute record.</param>
-    /// <param name="remark">The remark or note (max 256 characters) the JJDispute was set to REVIEW.</param>
+    /// <param name="remark">The remark or note (max 4000 characters) the JJDispute was set to REVIEW.</param>
     /// <param name="checkVTC">boolean to indicate need to check VTC assigned.</param>
     /// <param name="cancellationToken"></param>
     /// <returns></returns>
@@ -658,7 +658,7 @@ public partial class JJController : StaffControllerBase
     /// <response code="401">Request lacks valid authentication credentials.</response>
     /// <response code="403">Forbidden, requires jjdispute:review permission.</response>
     /// <response code="404">JJDispute record not found. Update failed.</response>
-    /// <response code="405">A JJDispute status can only be set to REVIEW if status is CONFIRMED and the remark must be less than 256 characters OR if the status ACCEPTED, CONFIRMED or CONCLUDED and DCF's current hearing date = today's date. Update failed</response>
+    /// <response code="405">A JJDispute status can only be set to REVIEW if status is CONFIRMED and the remark must be less than or equal to 4000 characters OR if the status ACCEPTED, CONFIRMED or CONCLUDED and DCF's current hearing date = today's date. Update failed</response>
     /// <response code="409">The JJDispute has already been assigned to a different user. JJDispute cannot be modified until assigned time expires.</response>
     /// <response code="500">There was a server error that prevented the update from completing successfully.</response>
     [HttpPut("{ticketNumber}/review")]
@@ -674,7 +674,7 @@ public partial class JJController : StaffControllerBase
     public async Task<IActionResult> ReviewJJDisputeAsync(
         string ticketNumber,
         [FromForm]
-        [StringLength(256, ErrorMessage = "Remark note cannot exceed 256 characters.")] string remark,
+        [StringLength(4000, ErrorMessage = "Remark note cannot exceed 4000 characters.")] string remark,
         bool checkVTC,
         CancellationToken cancellationToken)
     {
@@ -721,7 +721,7 @@ public partial class JJController : StaffControllerBase
     /// Updates the status of a particular JJDispute record to REQUIRE_COURT_HEARING, hearing type to COURT_APPEARANCE as well as adds an optional remark that explaining why the status was set.
     /// </summary>
     /// <param name="ticketNumber">Unique identifier for a specific JJ Dispute record.</param>
-    /// <param name="remark">The remark or note (max 256 characters) the JJDispute was set to REVIEW.</param>
+    /// <param name="remark">The remark or note (max 4000 characters) the JJDispute was set to REVIEW.</param>
     /// <param name="cancellationToken"></param>
     /// <returns></returns>
     /// <response code="200">The JJDispute is updated.</response>
@@ -729,7 +729,7 @@ public partial class JJController : StaffControllerBase
     /// <response code="401">Request lacks valid authentication credentials.</response>
     /// <response code="403">Forbidden, requires jjdispute:require_court_hearing permission.</response>
     /// <response code="404">JJDispute record not found. Update failed.</response>
-    /// <response code="405">A JJDispute status can only be set to REQUIRE_COURT_HEARING iff status is one of the following: NEW, IN_PROGRESS, REVIEW, REQUIRE_COURT_HEARING and the remark must be less than or equal to 256 characters. Update failed.</response>
+    /// <response code="405">A JJDispute status can only be set to REQUIRE_COURT_HEARING iff status is one of the following: NEW, IN_PROGRESS, REVIEW, REQUIRE_COURT_HEARING and the remark must be less than or equal to 4000 characters. Update failed.</response>
     /// <response code="409">The JJDispute has already been assigned to a different user. JJDispute cannot be modified until assigned time expires.</response>
     /// <response code="500">There was a server error that prevented the update from completing successfully.</response>
     [HttpPut("{ticketNumber}/requirecourthearing")]
@@ -745,7 +745,7 @@ public partial class JJController : StaffControllerBase
     public async Task<IActionResult> RequireCourtHearingJJDisputeAsync(
         string ticketNumber,
         [FromForm]
-        [StringLength(256, ErrorMessage = "Remark note cannot exceed 256 characters.")] string remark,
+        [StringLength(4000, ErrorMessage = "Remark note cannot exceed 4000 characters.")] string remark,
         CancellationToken cancellationToken)
     {
         _logger.LogDebug("Updating the JJDispute status to REQUIRE_COURT_HEARING");

--- a/src/backend/TrafficCourts/Staff.Service/Services/IDisputeService.cs
+++ b/src/backend/TrafficCourts/Staff.Service/Services/IDisputeService.cs
@@ -67,7 +67,7 @@ public interface IDisputeService
 
     /// <summary>Updates the status of a particular Dispute record to CANCELLED.</summary>
     /// <param name="id">Unique identifier of a Dispute record to cancel.</param>
-    /// <param name="cancelledReason">The reason or note (max 256 characters) for the cancellation.</param>
+    /// <param name="cancelledReason">The reason or note (max 4000 characters) for the cancellation.</param>
     /// <param name="user"></param>
     /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
     /// <returns></returns>
@@ -77,7 +77,7 @@ public interface IDisputeService
     /// <summary>Updates the status of a particular Dispute record to REJECTED.</summary>
     /// <param name="id">Unique identifier of a Dispute record to cancel.</param>
     /// <param name="user"></param>
-    /// <param name="rejectedReason">The reason or note (max 256 characters) for the rejection.</param>
+    /// <param name="rejectedReason">The reason or note (max 4000 characters) for the rejection.</param>
     /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
     /// <returns></returns>
     /// <exception cref="ApiException">A server side error occurred.</exception>

--- a/src/backend/TrafficCourts/Staff.Service/Services/IJJDisputeService.cs
+++ b/src/backend/TrafficCourts/Staff.Service/Services/IJJDisputeService.cs
@@ -63,7 +63,7 @@ public interface IJJDisputeService
 
     /// <summary>Updates the status of a particular JJDispute record to REVIEW as well as adds an optional remark that explaining why the status was set to REVIEW.</summary>
     /// <param name="ticketNumber">Ticket number JJ Dispute record.</param>
-    /// <param name="remark">The remark or note (max 256 characters) the JJDispute was set to REVIEW.</param>
+    /// <param name="remark">The remark or note (max 4000 characters) the JJDispute was set to REVIEW.</param>
     /// <param name="checkVTC">boolean to indicate need to check VTC assigned.</param>
     /// <param name="user">The user executing the operation</param>
     /// <param name="recalled">Indicates the dispute is re-opened by a JJ</param>
@@ -75,7 +75,7 @@ public interface IJJDisputeService
 
     /// <summary>Updates the status of a particular JJDispute record to REQUIRE_COURT_HEARING as well as adds an optional remark that explaining why the status was set to REVIEW and sets hearing type to COURT_APPEARANCE.</summary>
     /// <param name="ticketNumber">Ticket number for a specific JJ Dispute record.</param>
-    /// <param name="remark">The remark or note (max 256 characters) the JJDispute was set.</param>
+    /// <param name="remark">The remark or note (max 4000 characters) the JJDispute was set.</param>
     /// <param name="user">The user executing the operation</param>    
     /// <param name="cancellationToken"></param>
     /// <returns></returns>

--- a/src/backend/TrafficCourts/TrafficCourts.OracleDataApi/Client/V1/OracleDataApi.v1_0.json
+++ b/src/backend/TrafficCourts/TrafficCourts.OracleDataApi/Client/V1/OracleDataApi.v1_0.json
@@ -142,7 +142,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "maxLength": 256,
+                "maxLength": 4000,
                 "minLength": 0,
                 "type": "string"
               }
@@ -171,7 +171,7 @@
             }
           },
           "405": {
-            "description": "A JJDispute status can only be set to REVIEW if status is CONFIRMED and the remark must be \u003C= 256 characters OR if the status ACCEPTED, CONFIRMED or CONCLUDED and DCF's current hearing date = today's date. Update failed.",
+            "description": "A JJDispute status can only be set to REVIEW if status is CONFIRMED and the remark must be \u003C= 4000 characters OR if the status ACCEPTED, CONFIRMED or CONCLUDED and DCF's current hearing date = today's date. Update failed.",
             "content": {
               "*/*": {
                 "schema": {
@@ -224,7 +224,7 @@
             "in": "query",
             "required": false,
             "schema": {
-              "maxLength": 256,
+              "maxLength": 4000,
               "minLength": 0,
               "type": "string"
             }
@@ -252,7 +252,7 @@
             }
           },
           "405": {
-            "description": "A JJDispute status can only be set to REQUIRE_COURT_HEARING iff status is one of the following: NEW, IN_PROGRESS, REVIEW, REQUIRE_COURT_HEARING and the remark must be \u003C= 256 characters. Update failed.",
+            "description": "A JJDispute status can only be set to REQUIRE_COURT_HEARING iff status is one of the following: NEW, IN_PROGRESS, REVIEW, REQUIRE_COURT_HEARING and the remark must be \u003C= 4000 characters. Update failed.",
             "content": {
               "*/*": {
                 "schema": {
@@ -1114,7 +1114,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "maxLength": 256,
+                "maxLength": 4000,
                 "minLength": 1,
                 "type": "string"
               }
@@ -1144,7 +1144,7 @@
             }
           },
           "405": {
-            "description": "A Dispute status can only be set to REJECTED iff status is NEW, VALIDATED or PROCESSING and the rejected reason must be \u003C= 256 characters. Update failed.",
+            "description": "A Dispute status can only be set to REJECTED iff status is NEW, VALIDATED or PROCESSING and the rejected reason must be \u003C= 4000 characters. Update failed.",
             "content": {
               "*/*": {
                 "schema": {
@@ -1358,7 +1358,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "maxLength": 256,
+                "maxLength": 4000,
                 "minLength": 1,
                 "type": "string"
               }

--- a/src/backend/TrafficCourts/TrafficCourts.OracleDataApi/Client/V1/OracleDataApiClient.g.cs
+++ b/src/backend/TrafficCourts/TrafficCourts.OracleDataApi/Client/V1/OracleDataApiClient.g.cs
@@ -872,7 +872,7 @@ namespace TrafficCourts.OracleDataApi.Client.V1
                             {
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
-                            throw new ApiException<FileResponse>("A JJDispute status can only be set to REVIEW if status is CONFIRMED and the remark must be <= 256 characters OR if the status ACCEPTED, CONFIRMED or CONCLUDED and DCF\'s current hearing date = today\'s date. Update failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                            throw new ApiException<FileResponse>("A JJDispute status can only be set to REVIEW if status is CONFIRMED and the remark must be <= 4000 characters OR if the status ACCEPTED, CONFIRMED or CONCLUDED and DCF\'s current hearing date = today\'s date. Update failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 500)
@@ -1008,7 +1008,7 @@ namespace TrafficCourts.OracleDataApi.Client.V1
                             {
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
-                            throw new ApiException<FileResponse>("A JJDispute status can only be set to REQUIRE_COURT_HEARING iff status is one of the following: NEW, IN_PROGRESS, REVIEW, REQUIRE_COURT_HEARING and the remark must be <= 256 characters. Update failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                            throw new ApiException<FileResponse>("A JJDispute status can only be set to REQUIRE_COURT_HEARING iff status is one of the following: NEW, IN_PROGRESS, REVIEW, REQUIRE_COURT_HEARING and the remark must be <= 4000 characters. Update failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 500)
@@ -2512,7 +2512,7 @@ namespace TrafficCourts.OracleDataApi.Client.V1
                             {
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
-                            throw new ApiException<FileResponse>("A Dispute status can only be set to REJECTED iff status is NEW, VALIDATED or PROCESSING and the rejected reason must be <= 256 characters. Update failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                            throw new ApiException<FileResponse>("A Dispute status can only be set to REJECTED iff status is NEW, VALIDATED or PROCESSING and the rejected reason must be <= 4000 characters. Update failed.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 500)

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/controller/v1_0/JJDisputeController.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/controller/v1_0/JJDisputeController.java
@@ -185,13 +185,13 @@ public class JJDisputeController {
 		@ApiResponse(responseCode = "200", description = "Ok. Updated JJDispute record returned."),
 		@ApiResponse(responseCode = "400", description = "Bad Request."),
 		@ApiResponse(responseCode = "404", description = "JJDispute record not found. Update failed."),
-		@ApiResponse(responseCode = "405", description = "A JJDispute status can only be set to REVIEW if status is CONFIRMED and the remark must be <= 256 characters OR "
+		@ApiResponse(responseCode = "405", description = "A JJDispute status can only be set to REVIEW if status is CONFIRMED and the remark must be <= 4000 characters OR "
 				+ "if the status ACCEPTED, CONFIRMED or CONCLUDED and DCF's current hearing date = today's date. Update failed."),
 		@ApiResponse(responseCode = "500", description = "Internal server error occured.")
 	})
 	@PutMapping("/dispute/{ticketNumber}/review")
 	public ResponseEntity<JJDispute> reviewJJDispute(@PathVariable String ticketNumber,
-			@RequestBody (required = false) @Size(max = 256) String remark,
+			@RequestBody (required = false) @Size(max = 4000) String remark,
 			boolean checkVTCAssigned,
 			Principal principal,
 			boolean recalled) {
@@ -273,12 +273,12 @@ public class JJDisputeController {
 		@ApiResponse(responseCode = "400", description = "Bad Request."),
 		@ApiResponse(responseCode = "404", description = "JJDispute record not found. Update failed."),
 		@ApiResponse(responseCode = "405", description = "A JJDispute status can only be set to REQUIRE_COURT_HEARING iff status is one of the following: "
-				+ "NEW, IN_PROGRESS, REVIEW, REQUIRE_COURT_HEARING and the remark must be <= 256 characters. Update failed."),
+				+ "NEW, IN_PROGRESS, REVIEW, REQUIRE_COURT_HEARING and the remark must be <= 4000 characters. Update failed."),
 		@ApiResponse(responseCode = "500", description = "Internal server error occured.")
 	})
 	@PutMapping("/dispute/{ticketNumber}/requirecourthearing")
 	public ResponseEntity<JJDispute> requireCourtHearingJJDispute(@PathVariable String ticketNumber,
-			@RequestParam (required = false) @Size(max = 256) String remark,
+			@RequestParam (required = false) @Size(max = 4000) String remark,
 			Principal principal) {
 		logger.debug("PUT /jj/dispute/{}/requirecourthearing called", StructuredArguments.value("ticketNumber", ticketNumber));
 

--- a/src/backend/oracle-data-api/src/test/java/ca/bc/gov/open/jag/tco/oracledataapi/controller/v1_0/DisputeControllerTest.java
+++ b/src/backend/oracle-data-api/src/test/java/ca/bc/gov/open/jag/tco/oracledataapi/controller/v1_0/DisputeControllerTest.java
@@ -156,11 +156,12 @@ class DisputeControllerTest extends BaseTestSuite {
 		rejectDispute(disputeId, "")
 		.andExpect(status().isBadRequest());
 
-		// try using an long reason, > 256 (should fail with 400 error)
-		rejectDispute(disputeId, RandomStringUtils.random(257))
+		// try using an long reason, > 4000 (should fail with 400 error)
+		rejectDispute(disputeId, RandomStringUtils.random(4001))
 		.andExpect(status().isBadRequest());
 
-		String longString = RandomStringUtils.randomAlphabetic(256);
+		// proper length should not fail]
+		String longString = RandomStringUtils.randomAlphabetic(4000);
 
 		// Set the status to REJECTED
 		rejectDispute(disputeId, longString)
@@ -231,11 +232,12 @@ class DisputeControllerTest extends BaseTestSuite {
 		cancelDispute(disputeId, "")
 		.andExpect(status().isBadRequest());
 
-		// try using an long reason, > 256 (should fail with 400 error)
-		cancelDispute(disputeId, RandomStringUtils.random(257))
+		// try using an long reason, > 4000 (should fail with 400 error)
+		cancelDispute(disputeId, RandomStringUtils.random(4001))
 		.andExpect(status().isBadRequest());
 
-		String longString = RandomStringUtils.randomAlphabetic(256);
+		// proper length should not fail
+		String longString = RandomStringUtils.randomAlphabetic(4000);
 
 		// Set the status to CANCELLED
 		cancelDispute(disputeId, longString)

--- a/src/backend/oracle-data-api/src/test/java/ca/bc/gov/open/jag/tco/oracledataapi/controller/v1_0/DisputeControllerTest.java
+++ b/src/backend/oracle-data-api/src/test/java/ca/bc/gov/open/jag/tco/oracledataapi/controller/v1_0/DisputeControllerTest.java
@@ -156,12 +156,12 @@ class DisputeControllerTest extends BaseTestSuite {
 		rejectDispute(disputeId, "")
 		.andExpect(status().isBadRequest());
 
-		// try using an long reason, > 4000 (should fail with 400 error)
-		rejectDispute(disputeId, RandomStringUtils.random(4001))
+		// try using an long reason, > 256 (should fail with 400 error)
+		rejectDispute(disputeId, RandomStringUtils.random(257))
 		.andExpect(status().isBadRequest());
 
 		// proper length should not fail
-		String longString = RandomStringUtils.randomAlphabetic(4000);
+		String longString = RandomStringUtils.randomAlphabetic(256);
 
 		// Set the status to REJECTED
 		rejectDispute(disputeId, longString)
@@ -232,12 +232,12 @@ class DisputeControllerTest extends BaseTestSuite {
 		cancelDispute(disputeId, "")
 		.andExpect(status().isBadRequest());
 
-		// try using an long reason, > 4000 (should fail with 400 error)
-		cancelDispute(disputeId, RandomStringUtils.random(4001))
+		// try using an long reason, > 256 (should fail with 400 error)
+		cancelDispute(disputeId, RandomStringUtils.random(257))
 		.andExpect(status().isBadRequest());
 
 		// proper length should not fail
-		String longString = RandomStringUtils.randomAlphabetic(4000);
+		String longString = RandomStringUtils.randomAlphabetic(256);
 
 		// Set the status to CANCELLED
 		cancelDispute(disputeId, longString)

--- a/src/frontend/staff-portal/src/app/api/api/dispute.service.ts
+++ b/src/frontend/staff-portal/src/app/api/api/dispute.service.ts
@@ -126,7 +126,7 @@ export class DisputeService {
     /**
      * Updates the status of a particular Dispute record to CANCELLED.
      * @param disputeId Unique identifier for a specific Dispute record to cancel.
-     * @param cancelledReason The reason or note (max 256 characters) the Dispute was cancelled.
+     * @param cancelledReason The reason or note (max 4000 characters) the Dispute was cancelled.
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
      * @param reportProgress flag to report request and response progress.
      */
@@ -507,7 +507,7 @@ export class DisputeService {
     /**
      * Updates the status of a particular Dispute record to REJECTED.
      * @param disputeId Unique identifier for a specific Dispute record to cancel.
-     * @param rejectedReason The reason or note (max 256 characters) the Dispute was rejected.
+     * @param rejectedReason The reason or note (max 4000 characters) the Dispute was rejected.
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
      * @param reportProgress flag to report request and response progress.
      */

--- a/src/frontend/staff-portal/src/app/api/api/jJ.service.ts
+++ b/src/frontend/staff-portal/src/app/api/api/jJ.service.ts
@@ -1065,7 +1065,7 @@ export class JJService {
     /**
      * Updates the status of a particular JJDispute record to REQUIRE_COURT_HEARING, hearing type to COURT_APPEARANCE as well as adds an optional remark that explaining why the status was set.
      * @param ticketNumber Unique identifier for a specific JJ Dispute record.
-     * @param remark The remark or note (max 256 characters) the JJDispute was set to REVIEW.
+     * @param remark The remark or note (max 4000 characters) the JJDispute was set to REVIEW.
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
      * @param reportProgress flag to report request and response progress.
      */
@@ -1153,7 +1153,7 @@ export class JJService {
      * Updates the status of a particular JJDispute record to REVIEW as well as adds an optional remark that explaining why the status was set to REVIEW.
      * @param ticketNumber Unique identifier for a specific JJ Dispute record.
      * @param checkVTC boolean to indicate need to check VTC assigned.
-     * @param remark The remark or note (max 256 characters) the JJDispute was set to REVIEW.
+     * @param remark The remark or note (max 4000 characters) the JJDispute was set to REVIEW.
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
      * @param reportProgress flag to report request and response progress.
      */

--- a/src/frontend/staff-portal/src/app/api/swagger.json
+++ b/src/frontend/staff-portal/src/app/api/swagger.json
@@ -4017,7 +4017,7 @@
             }
           },
           "405": {
-            "description": "A JJDispute status can only be set to REVIEW if status is CONFIRMED and the remark must be less than 256 characters OR if the status ACCEPTED, CONFIRMED or CONCLUDED and DCF's current hearing date = today's date. Update failed",
+            "description": "A JJDispute status can only be set to REVIEW if status is CONFIRMED and the remark must be less than or equal to 4000 characters OR if the status ACCEPTED, CONFIRMED or CONCLUDED and DCF's current hearing date = today's date. Update failed",
             "content": {
               "text/plain": {
                 "schema": {
@@ -4094,10 +4094,10 @@
                 "type": "object",
                 "properties": {
                   "remark": {
-                    "maxLength": 256,
+                    "maxLength": 4000,
                     "minLength": 0,
                     "type": "string",
-                    "description": "The remark or note (max 256 characters) the JJDispute was set to REVIEW."
+                    "description": "The remark or note (max 4000 characters) the JJDispute was set to REVIEW."
                   }
                 }
               },
@@ -4194,7 +4194,7 @@
             }
           },
           "405": {
-            "description": "A JJDispute status can only be set to REVIEW if status is CONFIRMED and the remark must be less than 256 characters OR if the status ACCEPTED, CONFIRMED or CONCLUDED and DCF's current hearing date = today's date. Update failed",
+            "description": "A JJDispute status can only be set to REVIEW if status is CONFIRMED and the remark must be less than or equal to 4000 characters OR if the status ACCEPTED, CONFIRMED or CONCLUDED and DCF's current hearing date = today's date. Update failed",
             "content": {
               "text/plain": {
                 "schema": {
@@ -4263,10 +4263,10 @@
                 "type": "object",
                 "properties": {
                   "remark": {
-                    "maxLength": 256,
+                    "maxLength": 4000,
                     "minLength": 0,
                     "type": "string",
-                    "description": "The remark or note (max 256 characters) the JJDispute was set to REVIEW."
+                    "description": "The remark or note (max 4000 characters) the JJDispute was set to REVIEW."
                   }
                 }
               },
@@ -4363,7 +4363,7 @@
             }
           },
           "405": {
-            "description": "A JJDispute status can only be set to REQUIRE_COURT_HEARING iff status is one of the following: NEW, IN_PROGRESS, REVIEW, REQUIRE_COURT_HEARING and the remark must be less than or equal to 256 characters. Update failed.",
+            "description": "A JJDispute status can only be set to REQUIRE_COURT_HEARING iff status is one of the following: NEW, IN_PROGRESS, REVIEW, REQUIRE_COURT_HEARING and the remark must be less than or equal to 4000 characters. Update failed.",
             "content": {
               "text/plain": {
                 "schema": {

--- a/src/frontend/staff-portal/src/app/components/staff-workbench/contact-info/contact-info.component.ts
+++ b/src/frontend/staff-portal/src/app/components/staff-workbench/contact-info/contact-info.component.ts
@@ -79,7 +79,7 @@ export class ContactInfoComponent implements OnInit {
       addressProvinceCountryId: [null],
       addressProvinceSeqNo: [null],
       addressCountryId: [null, [Validators.required]],
-      rejectedReason: [null, Validators.maxLength(256)], // Optional
+      rejectedReason: [null, Validators.maxLength(4000)], // Optional
       postalCode: [null],
       driversLicenceNumber: [null], // Optional
       driversLicenceProvinceProvId: [null],

--- a/src/frontend/staff-portal/src/app/components/staff-workbench/ticket-info/ticket-info.component.ts
+++ b/src/frontend/staff-portal/src/app/components/staff-workbench/ticket-info/ticket-info.component.ts
@@ -155,7 +155,7 @@ export class TicketInfoComponent implements OnInit {
       driversLicenceProvinceProvId: [null],
       driversLicenceCountryId: [null],
       driversLicenceProvinceSeqNo: [null],
-      rejectedReason: [null, Validators.maxLength(256)],
+      rejectedReason: [null, Validators.maxLength(4000)],
       violationTicket: this.formBuilder.group({
         ticketNumber: [null, Validators.required],
         courtLocation: [null, [Validators.required, Validators.maxLength(50)]],

--- a/src/frontend/staff-portal/src/app/shared/dialogs/confirm-reason-dialog/confirm-reason-dialog.component.html
+++ b/src/frontend/staff-portal/src/app/shared/dialogs/confirm-reason-dialog/confirm-reason-dialog.component.html
@@ -52,7 +52,7 @@
     </div>
   </section>
   <mat-form-field class="custom-form-field">
-    <textarea matInput maxlength="256" style="min-height: 20vh;" [formControl]="reasonForm.get('reason')"></textarea>
+    <textarea matInput maxlength="4000" style="min-height: 20vh;" [formControl]="reasonForm.get('reason')"></textarea>
     <mat-error *ngIf="reasonForm.get('reason').hasError('required')">{{ "error.required" | translate
     }}</mat-error>
   </mat-form-field>

--- a/src/frontend/staff-portal/src/app/shared/dialogs/confirm-reason-dialog/confirm-reason-dialog.component.ts
+++ b/src/frontend/staff-portal/src/app/shared/dialogs/confirm-reason-dialog/confirm-reason-dialog.component.ts
@@ -35,7 +35,7 @@ export class ConfirmReasonDialogComponent {
     this.dialogContentOutput = null;
 
     this.reasonForm = this.fb.group({
-      reason: [this.options.message, [Validators.maxLength(256), Validators.required]]
+      reason: [this.options.message, [Validators.maxLength(4000), Validators.required]]
     })
 
     this.authService.userProfile$.subscribe(userProfile => {


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- TCVP-3183 - Updated the Remarks UI and Application processes to allow a remark size of 4000 (up from 256)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Tested in localdev

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
