### PR TITLE
TCVP-3242: Standardize date-time format for Oracle Data Api with no timezone specified

### DIFF
--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/config/DateOnlyDeserializer.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/config/DateOnlyDeserializer.java
@@ -16,6 +16,11 @@ import java.util.Date;
 public class DateOnlyDeserializer extends JsonDeserializer<Date> {
     
     private static final SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd");
+    
+    static {
+        // Make parsing strict - don't allow lenient parsing
+        DATE_FORMAT.setLenient(false);
+    }
 
     @Override
     public Date deserialize(JsonParser parser, DeserializationContext context) throws IOException {
@@ -26,7 +31,12 @@ public class DateOnlyDeserializer extends JsonDeserializer<Date> {
         }
         
         try {
-            return DATE_FORMAT.parse(dateString.trim());
+            String trimmed = dateString.trim();
+            // Additional validation: ensure the string matches exact expected format
+            if (!trimmed.matches("\\d{4}-\\d{2}-\\d{2}")) {
+                throw new ParseException("Date string does not match expected format yyyy-MM-dd: " + trimmed, 0);
+            }
+            return DATE_FORMAT.parse(trimmed);
         } catch (ParseException e) {
             throw new IOException("Failed to parse date: " + dateString + ". Expected format: yyyy-MM-dd", e);
         }

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/config/DateOnlyDeserializer.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/config/DateOnlyDeserializer.java
@@ -1,0 +1,34 @@
+package ca.bc.gov.open.jag.tco.oracledataapi.config;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+
+import java.io.IOException;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+/**
+ * Custom Jackson deserializer for Date fields that should only parse date (yyyy-MM-dd)
+ * without time component. Creates Date objects from date-only strings.
+ */
+public class DateOnlyDeserializer extends JsonDeserializer<Date> {
+    
+    private static final SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd");
+
+    @Override
+    public Date deserialize(JsonParser parser, DeserializationContext context) throws IOException {
+        String dateString = parser.getText();
+        
+        if (dateString == null || dateString.trim().isEmpty()) {
+            return null;
+        }
+        
+        try {
+            return DATE_FORMAT.parse(dateString.trim());
+        } catch (ParseException e) {
+            throw new IOException("Failed to parse date: " + dateString + ". Expected format: yyyy-MM-dd", e);
+        }
+    }
+}

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/config/DateOnlySerializer.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/config/DateOnlySerializer.java
@@ -1,0 +1,25 @@
+package ca.bc.gov.open.jag.tco.oracledataapi.config;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+
+import java.io.IOException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+/**
+ * Custom Jackson serializer for Date fields that should only show date (yyyy-MM-dd)
+ * without time component. Preserves the exact date value from the database.
+ */
+public class DateOnlySerializer extends JsonSerializer<Date> {
+    
+    private static final SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd");
+
+    @Override
+    public void serialize(Date date, JsonGenerator gen, SerializerProvider serializers) throws IOException {
+        if (date != null) {
+            gen.writeString(DATE_FORMAT.format(date));
+        }
+    }
+}

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/config/DateTimeDeserializer.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/config/DateTimeDeserializer.java
@@ -17,6 +17,11 @@ public class DateTimeDeserializer extends JsonDeserializer<Date> {
     
     private static final SimpleDateFormat DATE_TIME_FORMAT = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
     
+    static {
+        // Make parsing strict - don't allow lenient parsing
+        DATE_TIME_FORMAT.setLenient(false);
+    }
+    
     @Override
     public Date deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
         String dateString = p.getValueAsString();
@@ -25,11 +30,15 @@ public class DateTimeDeserializer extends JsonDeserializer<Date> {
         }
         
         try {
+            String trimmed = dateString.trim();
+            // Additional validation: ensure the string matches exact expected format
+            if (!trimmed.matches("\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}")) {
+                throw new ParseException("DateTime string does not match expected format yyyy-MM-ddTHH:mm:ss: " + trimmed, 0);
+            }
             // Parse without timezone interpretation - treats as local time
-            return DATE_TIME_FORMAT.parse(dateString);
+            return DATE_TIME_FORMAT.parse(trimmed);
         } catch (ParseException e) {
-            throw new IOException("Failed to parse date: " + dateString, e);
+            throw new IOException("Failed to parse date: " + dateString + ". Expected format: yyyy-MM-ddTHH:mm:ss", e);
         }
     }
 }
-

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/config/DateTimeDeserializer.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/config/DateTimeDeserializer.java
@@ -1,0 +1,35 @@
+package ca.bc.gov.open.jag.tco.oracledataapi.config;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+
+import java.io.IOException;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+/**
+ * Custom Jackson deserializer for Date fields that preserves the exact date/time values
+ * without any timezone conversion. Treats incoming datetime strings as raw values.
+ */
+public class DateTimeDeserializer extends JsonDeserializer<Date> {
+    
+    private static final SimpleDateFormat DATE_TIME_FORMAT = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
+    
+    @Override
+    public Date deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+        String dateString = p.getValueAsString();
+        if (dateString == null || dateString.trim().isEmpty()) {
+            return null;
+        }
+        
+        try {
+            // Parse without timezone interpretation - treats as local time
+            return DATE_TIME_FORMAT.parse(dateString);
+        } catch (ParseException e) {
+            throw new IOException("Failed to parse date: " + dateString, e);
+        }
+    }
+}
+

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/config/DateTimeSerializer.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/config/DateTimeSerializer.java
@@ -1,0 +1,26 @@
+package ca.bc.gov.open.jag.tco.oracledataapi.config;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+
+import java.io.IOException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+/**
+ * Custom Jackson serializer for Date fields that preserves the exact date/time values
+ * from the database without any timezone conversion. Uses the raw Date value as-is.
+ */
+public class DateTimeSerializer extends JsonSerializer<Date> {
+    
+    // Use the same pattern as GlobalDateSerializer for consistency
+    private static final SimpleDateFormat DATE_TIME_FORMAT = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
+
+    @Override
+    public void serialize(Date date, JsonGenerator gen, SerializerProvider serializers) throws IOException {
+        if (date != null) {
+            gen.writeString(DATE_TIME_FORMAT.format(date));
+        }
+    }
+}

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/config/GlobalDateSerializer.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/config/GlobalDateSerializer.java
@@ -1,0 +1,43 @@
+package ca.bc.gov.open.jag.tco.oracledataapi.config;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+
+import java.io.IOException;
+import java.text.SimpleDateFormat;
+import java.util.Calendar;
+import java.util.Date;
+
+/**
+ * Timezone-neutral Jackson serializer that preserves database date/time values exactly as stored,
+ * without any timezone interpretation or conversion. Treats dates as raw timestamp values.
+ */
+public class GlobalDateSerializer extends JsonSerializer<Date> {
+    
+    // Create formatters without any timezone - they will use the date's raw millisecond value
+    private static final SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd");
+    private static final SimpleDateFormat DATE_TIME_FORMAT = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
+
+    @Override
+    public void serialize(Date date, JsonGenerator gen, SerializerProvider serializers) throws IOException {
+        if (date != null) {
+            // Use default calendar (no timezone override) to check for time components
+            Calendar cal = Calendar.getInstance();
+            cal.setTime(date);
+            
+            boolean hasTimeComponent = cal.get(Calendar.HOUR_OF_DAY) != 0 || 
+                                     cal.get(Calendar.MINUTE) != 0 || 
+                                     cal.get(Calendar.SECOND) != 0 ||
+                                     cal.get(Calendar.MILLISECOND) != 0;
+            
+            if (hasTimeComponent) {
+                // Format as date-time using the date's raw value without timezone conversion
+                gen.writeString(DATE_TIME_FORMAT.format(date));
+            } else {
+                // Format as date-only using the date's raw value without timezone conversion
+                gen.writeString(DATE_FORMAT.format(date));
+            }
+        }
+    }
+}

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/config/JacksonConfig.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/config/JacksonConfig.java
@@ -1,0 +1,41 @@
+package ca.bc.gov.open.jag.tco.oracledataapi.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+
+import java.util.Date;
+
+/**
+ * Jackson configuration for consistent date/time formatting across all endpoints.
+ * Uses timezone-neutral approach to preserve database values without any conversion.
+ * This configuration overrides any @JsonFormat annotations from the models.
+ */
+@Configuration
+public class JacksonConfig {
+
+    @Bean
+    @Primary
+    public ObjectMapper objectMapper() {
+        ObjectMapper mapper = new ObjectMapper();
+        
+        // Disable writing dates as timestamps
+        mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        
+        // DO NOT set timezone - this keeps it timezone-neutral
+        
+        // Register JavaTimeModule for JSR-310 support
+        mapper.registerModule(new JavaTimeModule());
+        
+        // Create a custom module to handle Date serialization globally
+        SimpleModule dateModule = new SimpleModule("DateModule");
+        dateModule.addSerializer(Date.class, new GlobalDateSerializer());
+        mapper.registerModule(dateModule);
+        
+        return mapper;
+    }
+}

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/repository/impl/ords/DisputeRepositoryImpl.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/repository/impl/ords/DisputeRepositoryImpl.java
@@ -6,7 +6,6 @@ import java.util.Date;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Optional;
-import java.util.TimeZone;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
@@ -25,7 +24,6 @@ import ca.bc.gov.open.jag.tco.oracledataapi.model.Dispute;
 import ca.bc.gov.open.jag.tco.oracledataapi.model.DisputeListItem;
 import ca.bc.gov.open.jag.tco.oracledataapi.model.DisputeResult;
 import ca.bc.gov.open.jag.tco.oracledataapi.model.DisputeStatus;
-import ca.bc.gov.open.jag.tco.oracledataapi.model.DisputeUpdateRequestStatus;
 import ca.bc.gov.open.jag.tco.oracledataapi.model.EmptyObject;
 import ca.bc.gov.open.jag.tco.oracledataapi.model.ViolationTicketCount;
 import ca.bc.gov.open.jag.tco.oracledataapi.ords.occam.api.ViolationTicketApi;
@@ -255,8 +253,6 @@ public class DisputeRepositoryImpl implements DisputeRepository {
 	@Override
 	public void unassignDisputes(Date olderThan) {
 		SimpleDateFormat simpleDateFormat = new SimpleDateFormat(DateUtil.DATE_TIME_FORMAT);
-		simpleDateFormat.setTimeZone(TimeZone.getTimeZone("UTC")); // FIXME: UTC is a time standard, not a time zone - I
-																	// think this should be GMT.
 		String dateStr = simpleDateFormat.format(olderThan);
 
 		logger.debug("Unassigning Disputes older than {}", StructuredArguments.value("date", dateStr));

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/util/DateUtil.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/util/DateUtil.java
@@ -6,26 +6,53 @@ import org.apache.commons.lang3.time.DateFormatUtils;
 
 public class DateUtil {
 
-	public static final String DATE_TIME_FORMAT = "yyyy-MM-dd'T'HH:mm:ss'Z'";
+	public static final String DATE_TIME_FORMAT = "yyyy-MM-dd'T'HH:mm:ss";
 	public static final String DATE_FORMAT = "yyyy-MM-dd";
 	public static final String TIME_FORMAT = "HH:mm";
 
 	/**
-	 * Returns the time portion (HH:mm) of the given date in 24-hour clock (GMT).
+	 * Returns the time portion (HH:mm) of the given date without any timezone conversion.
 	 * @param date
 	 * @return
 	 */
-	public static String formatAsHourMinuteUTC(Date date) {
-		return DateFormatUtils.formatUTC(date, TIME_FORMAT);
+	public static String formatAsHourMinute(Date date) {
+		return DateFormatUtils.format(date, TIME_FORMAT);
 	}
 
 	/**
-	 * Returns the date in the format "yyyy-MM-dd'T'HH:mm:ss'Z'"
+	 * Returns the date in the format "yyyy-MM-dd'T'HH:mm:ss" without any timezone conversion
 	 * @param date
 	 * @return
 	 */
+	public static String formatAsDateTime(Date date) {
+		return DateFormatUtils.format(date, DATE_TIME_FORMAT);
+	}
+
+	/**
+	 * Returns the date in the format "yyyy-MM-dd" without any timezone conversion
+	 * @param date
+	 * @return
+	 */
+	public static String formatAsDate(Date date) {
+		return DateFormatUtils.format(date, DATE_FORMAT);
+	}
+
+	// Legacy methods for backward compatibility - now timezone neutral
+	
+	/**
+	 * @deprecated Use formatAsHourMinute instead. This method is now timezone neutral.
+	 */
+	@Deprecated
+	public static String formatAsHourMinuteUTC(Date date) {
+		return formatAsHourMinute(date);
+	}
+
+	/**
+	 * @deprecated Use formatAsDateTime instead. This method is now timezone neutral.
+	 */
+	@Deprecated
 	public static String formatAsDateTimeUTC(Date date) {
-		return DateFormatUtils.formatUTC(date, DATE_TIME_FORMAT);
+		return formatAsDateTime(date);
 	}
 
 }

--- a/src/backend/oracle-data-api/src/main/resources/application.yml
+++ b/src/backend/oracle-data-api/src/main/resources/application.yml
@@ -5,6 +5,11 @@ spring:
   application:  
     name: oracle-data-api
 
+  jackson:
+    serialization:
+      write-dates-as-timestamps: false
+    date-format: "yyyy-MM-dd'T'HH:mm:ss"
+
   jmx:
     enabled: true
 

--- a/src/backend/oracle-data-api/src/main/resources/occm-openapi-spec.yaml
+++ b/src/backend/oracle-data-api/src/main/resources/occm-openapi-spec.yaml
@@ -783,6 +783,7 @@ components:
         currentTimestamp:
           type: string
           format: date-time
+          x-field-extra-annotation: "@com.fasterxml.jackson.databind.annotation.JsonSerialize(using = ca.bc.gov.open.jag.tco.oracledataapi.config.DateTimeSerializer.class) @com.fasterxml.jackson.databind.annotation.JsonDeserialize(using = ca.bc.gov.open.jag.tco.oracledataapi.config.DateTimeDeserializer.class)"
     ResponseResult:
       type: object
       properties:
@@ -874,13 +875,13 @@ components:
         entDtm:
           type: string
           format: date-time
-          x-field-extra-annotation: "@com.fasterxml.jackson.annotation.JsonFormat(pattern=\"yyyy-MM-dd HH:mm:ss\", timezone = \"PST\")"
+          x-field-extra-annotation: "@com.fasterxml.jackson.databind.annotation.JsonSerialize(using = ca.bc.gov.open.jag.tco.oracledataapi.config.DateTimeSerializer.class) @com.fasterxml.jackson.databind.annotation.JsonDeserialize(using = ca.bc.gov.open.jag.tco.oracledataapi.config.DateTimeDeserializer.class)"
         entUserId:
           type: string
         updDtm:
           type: string
           format: date-time
-          x-field-extra-annotation: "@com.fasterxml.jackson.annotation.JsonFormat(pattern=\"yyyy-MM-dd HH:mm:ss\", timezone = \"PST\")"
+          x-field-extra-annotation: "@com.fasterxml.jackson.databind.annotation.JsonSerialize(using = ca.bc.gov.open.jag.tco.oracledataapi.config.DateTimeSerializer.class) @com.fasterxml.jackson.databind.annotation.JsonDeserialize(using = ca.bc.gov.open.jag.tco.oracledataapi.config.DateTimeDeserializer.class)"
         updUserId:
           type: string
           format: nullable
@@ -915,7 +916,7 @@ components:
         appearanceDtm:
           type: string
           format: date-time
-          x-field-extra-annotation: "@com.fasterxml.jackson.annotation.JsonFormat(pattern=\"yyyy-MM-dd'T'HH:mm:ss'Z'\")"
+          x-field-extra-annotation: "@com.fasterxml.jackson.databind.annotation.JsonSerialize(using = ca.bc.gov.open.jag.tco.oracledataapi.config.DateTimeSerializer.class) @com.fasterxml.jackson.databind.annotation.JsonDeserialize(using = ca.bc.gov.open.jag.tco.oracledataapi.config.DateTimeDeserializer.class)"
         appearanceLessThan14Days:
           type: string
         contactGiven1Nm:
@@ -989,7 +990,7 @@ components:
         filingDt:
           type: string
           format: date
-          x-field-extra-annotation: "@com.fasterxml.jackson.annotation.JsonFormat(pattern=\"yyyy-MM-dd'Z'\")"
+          x-field-extra-annotation: "@com.fasterxml.jackson.databind.annotation.JsonSerialize(using = ca.bc.gov.open.jag.tco.oracledataapi.config.DateOnlySerializer.class) @com.fasterxml.jackson.databind.annotation.JsonDeserialize(using = ca.bc.gov.open.jag.tco.oracledataapi.config.DateOnlyDeserializer.class)"
         fineReductionReasonTxt:
           type: string
         homePhoneNumberTxt:
@@ -1000,7 +1001,7 @@ components:
         issuedDt:
           type: string
           format: date-time
-          x-field-extra-annotation: "@com.fasterxml.jackson.annotation.JsonFormat(pattern=\"yyyy-MM-dd HH:mm\", timezone = \"PST\")"
+          x-field-extra-annotation: "@com.fasterxml.jackson.databind.annotation.JsonSerialize(using = ca.bc.gov.open.jag.tco.oracledataapi.config.DateTimeSerializer.class) @com.fasterxml.jackson.databind.annotation.JsonDeserialize(using = ca.bc.gov.open.jag.tco.oracledataapi.config.DateTimeDeserializer.class)"
         jjAssignedTo:
           type: string
           format: nullable
@@ -1088,7 +1089,7 @@ components:
         submittedDt:
           type: string
           format: date-time
-          x-field-extra-annotation: "@com.fasterxml.jackson.annotation.JsonFormat(pattern=\"yyyy-MM-dd'T'HH:mm:ss'Z'\")"
+          x-field-extra-annotation: "@com.fasterxml.jackson.databind.annotation.JsonSerialize(using = ca.bc.gov.open.jag.tco.oracledataapi.config.DateTimeSerializer.class) @com.fasterxml.jackson.databind.annotation.JsonDeserialize(using = ca.bc.gov.open.jag.tco.oracledataapi.config.DateTimeDeserializer.class)"
         systemDetectOcrIssuesYn:
           type: string
         timeToPayReasonTxt:
@@ -1096,7 +1097,7 @@ components:
         userAssignedDtm:
           type: string
           format: date-time
-          x-field-extra-annotation: "@com.fasterxml.jackson.annotation.JsonFormat(pattern=\"yyyy-MM-dd'T'HH:mm:ss'Z'\")"
+          x-field-extra-annotation: "@com.fasterxml.jackson.databind.annotation.JsonSerialize(using = ca.bc.gov.open.jag.tco.oracledataapi.config.DateTimeSerializer.class) @com.fasterxml.jackson.databind.annotation.JsonDeserialize(using = ca.bc.gov.open.jag.tco.oracledataapi.config.DateTimeDeserializer.class)"
         userAssignedTo:
           type: string
           format: nullable
@@ -1134,7 +1135,7 @@ components:
         submitted_dt:
           type: string
           format: date-time
-          x-field-extra-annotation: "@com.fasterxml.jackson.annotation.JsonFormat(pattern=\"yyyy-MM-dd'T'HH:mm:ss'Z'\")"
+          x-field-extra-annotation: "@com.fasterxml.jackson.databind.annotation.JsonSerialize(using = ca.bc.gov.open.jag.tco.oracledataapi.config.DateTimeSerializer.class) @com.fasterxml.jackson.databind.annotation.JsonDeserialize(using = ca.bc.gov.open.jag.tco.oracledataapi.config.DateTimeDeserializer.class)"
         disputant_surname_nm:
           type: string
         disputant_given_1_nm:
@@ -1152,7 +1153,7 @@ components:
         filing_dt:
           type: string
           format: date
-          x-field-extra-annotation: "@com.fasterxml.jackson.annotation.JsonFormat(pattern=\"yyyy-MM-dd'Z'\")"
+          x-field-extra-annotation: "@com.fasterxml.jackson.databind.annotation.JsonSerialize(using = ca.bc.gov.open.jag.tco.oracledataapi.config.DateOnlySerializer.class) @com.fasterxml.jackson.databind.annotation.JsonDeserialize(using = ca.bc.gov.open.jag.tco.oracledataapi.config.DateOnlyDeserializer.class)"
         request_court_appearance_yn:
           type: string
         disputant_detect_ocr_issues_yn:
@@ -1164,11 +1165,11 @@ components:
         user_assigned_dtm:
           type: string
           format: date-time
-          x-field-extra-annotation: "@com.fasterxml.jackson.annotation.JsonFormat(pattern=\"yyyy-MM-dd'T'HH:mm:ss'Z'\")"
+          x-field-extra-annotation: "@com.fasterxml.jackson.databind.annotation.JsonSerialize(using = ca.bc.gov.open.jag.tco.oracledataapi.config.DateTimeSerializer.class) @com.fasterxml.jackson.databind.annotation.JsonDeserialize(using = ca.bc.gov.open.jag.tco.oracledataapi.config.DateTimeDeserializer.class)"
         violation_dt:
           type: string
           format: date
-          x-field-extra-annotation: "@com.fasterxml.jackson.annotation.JsonFormat(pattern=\"yyyy-MM-dd'Z'\")"
+          x-field-extra-annotation: "@com.fasterxml.jackson.databind.annotation.JsonSerialize(using = ca.bc.gov.open.jag.tco.oracledataapi.config.DateOnlySerializer.class) @com.fasterxml.jackson.databind.annotation.JsonDeserialize(using = ca.bc.gov.open.jag.tco.oracledataapi.config.DateOnlyDeserializer.class)"
         tco_dispute_status:
           type: string
         jj_assigned_to:
@@ -1178,7 +1179,7 @@ components:
         jj_decision_dt:
           type: string
           format: date-time
-          x-field-extra-annotation: "@com.fasterxml.jackson.annotation.JsonFormat(pattern=\"yyyy-MM-dd'T'HH:mm:ss'Z'\")"
+          x-field-extra-annotation: "@com.fasterxml.jackson.databind.annotation.JsonSerialize(using = ca.bc.gov.open.jag.tco.oracledataapi.config.DateTimeSerializer.class) @com.fasterxml.jackson.databind.annotation.JsonDeserialize(using = ca.bc.gov.open.jag.tco.oracledataapi.config.DateTimeDeserializer.class)"
         court_agen_id:
           type: number
     Statute:
@@ -1287,7 +1288,7 @@ components:
         issuedDt:
           type: string
           format: date-time
-          x-field-extra-annotation: "@com.fasterxml.jackson.annotation.JsonFormat(pattern=\"yyyy-MM-dd HH:mm\", timezone = \"PST\")"
+          x-field-extra-annotation: "@com.fasterxml.jackson.databind.annotation.JsonSerialize(using = ca.bc.gov.open.jag.tco.oracledataapi.config.DateTimeSerializer.class) @com.fasterxml.jackson.databind.annotation.JsonDeserialize(using = ca.bc.gov.open.jag.tco.oracledataapi.config.DateTimeDeserializer.class)"
         issuedOnRoadOrHighwayTxt:
           type: string
           format: nullable
@@ -1355,7 +1356,7 @@ components:
         statusUpdateDtm:
           type: string
           format: date-time
-          x-field-extra-annotation: "@com.fasterxml.jackson.annotation.JsonFormat(pattern=\"yyyy-MM-dd'T'HH:mm:ss'Z'\")"
+          x-field-extra-annotation: "@com.fasterxml.jackson.databind.annotation.JsonSerialize(using = ca.bc.gov.open.jag.tco.oracledataapi.config.DateTimeSerializer.class) @com.fasterxml.jackson.databind.annotation.JsonDeserialize(using = ca.bc.gov.open.jag.tco.oracledataapi.config.DateTimeDeserializer.class)"
       allOf:
         - $ref: '#/components/schemas/AuditBase'
     AuditLogEntry:
@@ -1386,7 +1387,7 @@ components:
         emailSentDtm:
           type: string
           format: date-time
-          x-field-extra-annotation: "@com.fasterxml.jackson.annotation.JsonFormat(pattern=\"yyyy-MM-dd'T'HH:mm:ss'Z'\")"
+          x-field-extra-annotation: "@com.fasterxml.jackson.databind.annotation.JsonSerialize(using = ca.bc.gov.open.jag.tco.oracledataapi.config.DateTimeSerializer.class) @com.fasterxml.jackson.databind.annotation.JsonDeserialize(using = ca.bc.gov.open.jag.tco.oracledataapi.config.DateTimeDeserializer.class)"
         emailSubjectTxt:
           type: string
         fromEmailAddress:

--- a/src/backend/oracle-data-api/src/main/resources/tco-openapi-spec.yaml
+++ b/src/backend/oracle-data-api/src/main/resources/tco-openapi-spec.yaml
@@ -392,13 +392,13 @@ components:
         entDtm:
           type: string
           format: date-time
-          x-field-extra-annotation: "@com.fasterxml.jackson.annotation.JsonFormat(pattern=\"yyyy-MM-dd HH:mm:ss\", timezone = \"PST\")"
+          x-field-extra-annotation: "@com.fasterxml.jackson.databind.annotation.JsonSerialize(using = ca.bc.gov.open.jag.tco.oracledataapi.config.DateTimeSerializer.class) @com.fasterxml.jackson.databind.annotation.JsonDeserialize(using = ca.bc.gov.open.jag.tco.oracledataapi.config.DateTimeDeserializer.class)"
         entUserId:
           type: string
         updDtm:
           type: string
           format: date-time
-          x-field-extra-annotation: "@com.fasterxml.jackson.annotation.JsonFormat(pattern=\"yyyy-MM-dd HH:mm:ss\", timezone = \"PST\")"
+          x-field-extra-annotation: "@com.fasterxml.jackson.databind.annotation.JsonSerialize(using = ca.bc.gov.open.jag.tco.oracledataapi.config.DateTimeSerializer.class) @com.fasterxml.jackson.databind.annotation.JsonDeserialize(using = ca.bc.gov.open.jag.tco.oracledataapi.config.DateTimeDeserializer.class)"
         updUserId:
           type: string
           format: nullable
@@ -477,8 +477,8 @@ components:
           format: nullable
         disputantBirthDt:
           type: string
-          format: date  
-          x-field-extra-annotation: "@com.fasterxml.jackson.annotation.JsonFormat(pattern=\"yyyy-MM-dd\")"
+          format: date
+          x-field-extra-annotation: "@com.fasterxml.jackson.databind.annotation.JsonSerialize(using = ca.bc.gov.open.jag.tco.oracledataapi.config.DateOnlySerializer.class) @com.fasterxml.jackson.databind.annotation.JsonDeserialize(using = ca.bc.gov.open.jag.tco.oracledataapi.config.DateOnlyDeserializer.class)"
         disputantDrvLicNumberTxt:
           type: string
           format: nullable
@@ -533,20 +533,20 @@ components:
         jjDecisionDt:
           type: string
           format: date-time
-          x-field-extra-annotation: "@com.fasterxml.jackson.annotation.JsonFormat(pattern=\"yyyy-MM-dd'T'HH:mm:ss'Z'\")"
+          x-field-extra-annotation: "@com.fasterxml.jackson.databind.annotation.JsonSerialize(using = ca.bc.gov.open.jag.tco.oracledataapi.config.DateTimeSerializer.class) @com.fasterxml.jackson.databind.annotation.JsonDeserialize(using = ca.bc.gov.open.jag.tco.oracledataapi.config.DateTimeDeserializer.class)"
         justinRccId:
           type: string
         icbcReceivedDt:
           type: string
-          format: date  
-          x-field-extra-annotation: "@com.fasterxml.jackson.annotation.JsonFormat(pattern=\"yyyy-MM-dd\")"
+          format: date
+          x-field-extra-annotation: "@com.fasterxml.jackson.databind.annotation.JsonSerialize(using = ca.bc.gov.open.jag.tco.oracledataapi.config.DateOnlySerializer.class) @com.fasterxml.jackson.databind.annotation.JsonDeserialize(using = ca.bc.gov.open.jag.tco.oracledataapi.config.DateOnlyDeserializer.class)"
         interpreterLanguageCd:
           type: string
           format: nullable
         issuedTs:
           type: string
           format: date-time
-          x-field-extra-annotation: "@com.fasterxml.jackson.annotation.JsonFormat(pattern=\"yyyy-MM-dd HH:mm\", timezone = \"PST\")"
+          x-field-extra-annotation: "@com.fasterxml.jackson.databind.annotation.JsonSerialize(using = ca.bc.gov.open.jag.tco.oracledataapi.config.DateTimeSerializer.class) @com.fasterxml.jackson.databind.annotation.JsonDeserialize(using = ca.bc.gov.open.jag.tco.oracledataapi.config.DateTimeDeserializer.class)"
         lawFirmNm:
           type: string
           format: nullable
@@ -597,7 +597,7 @@ components:
         submittedDt:
           type: string
           format: date-time
-          x-field-extra-annotation: "@com.fasterxml.jackson.annotation.JsonFormat(pattern=\"yyyy-MM-dd'T'HH:mm:ss'Z'\")"
+          x-field-extra-annotation: "@com.fasterxml.jackson.databind.annotation.JsonSerialize(using = ca.bc.gov.open.jag.tco.oracledataapi.config.DateTimeSerializer.class) @com.fasterxml.jackson.databind.annotation.JsonDeserialize(using = ca.bc.gov.open.jag.tco.oracledataapi.config.DateTimeDeserializer.class)"
         ticketNumberTxt:
           type: string
         timeToPayReasonTxt:
@@ -606,14 +606,14 @@ components:
         violationDt:
           type: string
           format: date
-          x-field-extra-annotation: "@com.fasterxml.jackson.annotation.JsonFormat(pattern=\"yyyy-MM-dd\")"
+          x-field-extra-annotation: "@com.fasterxml.jackson.databind.annotation.JsonSerialize(using = ca.bc.gov.open.jag.tco.oracledataapi.config.DateOnlySerializer.class) @com.fasterxml.jackson.databind.annotation.JsonDeserialize(using = ca.bc.gov.open.jag.tco.oracledataapi.config.DateOnlyDeserializer.class)"
         vtcAssignedTo:
           type: string
           format: nullable
         vtcAssignedDtm:
           type: string
           format: date-time
-          x-field-extra-annotation: "@com.fasterxml.jackson.annotation.JsonFormat(pattern=\"yyyy-MM-dd'T'HH:mm:ss'Z'\")"
+          x-field-extra-annotation: "@com.fasterxml.jackson.databind.annotation.JsonSerialize(using = ca.bc.gov.open.jag.tco.oracledataapi.config.DateTimeSerializer.class) @com.fasterxml.jackson.databind.annotation.JsonDeserialize(using = ca.bc.gov.open.jag.tco.oracledataapi.config.DateTimeDeserializer.class)"
         witnessNo:
           type: string
           format: nullable
@@ -634,13 +634,13 @@ components:
         accEntDtm:
           type: string
           format: date-time
-          x-field-extra-annotation: "@com.fasterxml.jackson.annotation.JsonFormat(pattern=\"yyyy-MM-dd HH:mm:ss\", timezone = \"PST\")"
+          x-field-extra-annotation: "@com.fasterxml.jackson.databind.annotation.JsonSerialize(using = ca.bc.gov.open.jag.tco.oracledataapi.config.DateTimeSerializer.class) @com.fasterxml.jackson.databind.annotation.JsonDeserialize(using = ca.bc.gov.open.jag.tco.oracledataapi.config.DateTimeDeserializer.class)"
         accEntUserId:
           type: string
         accUpdDtm:
           type: string
           format: date-time
-          x-field-extra-annotation: "@com.fasterxml.jackson.annotation.JsonFormat(pattern=\"yyyy-MM-dd HH:mm:ss\", timezone = \"PST\")"
+          x-field-extra-annotation: "@com.fasterxml.jackson.databind.annotation.JsonSerialize(using = ca.bc.gov.open.jag.tco.oracledataapi.config.DateTimeSerializer.class) @com.fasterxml.jackson.databind.annotation.JsonDeserialize(using = ca.bc.gov.open.jag.tco.oracledataapi.config.DateTimeDeserializer.class)"
         accUpdUserId:
           type: string
         adjustedAmt:
@@ -670,7 +670,7 @@ components:
         fineDueDt:
           type: string
           format: date
-          x-field-extra-annotation: "@com.fasterxml.jackson.annotation.JsonFormat(pattern=\"yyyy-MM-dd'Z'\")"
+          x-field-extra-annotation: "@com.fasterxml.jackson.databind.annotation.JsonSerialize(using = ca.bc.gov.open.jag.tco.oracledataapi.config.DateOnlySerializer.class) @com.fasterxml.jackson.databind.annotation.JsonDeserialize(using = ca.bc.gov.open.jag.tco.oracledataapi.config.DateOnlyDeserializer.class)"
         includesSurchargeYn:
           type: string
         jailDurationTxt:
@@ -682,7 +682,7 @@ components:
         latestPleaUpdateDtm:
           type: string
           format: date-time
-          x-field-extra-annotation: "@com.fasterxml.jackson.annotation.JsonFormat(pattern=\"yyyy-MM-dd'T'HH:mm:ss'Z'\")"
+          x-field-extra-annotation: "@com.fasterxml.jackson.databind.annotation.JsonSerialize(using = ca.bc.gov.open.jag.tco.oracledataapi.config.DateTimeSerializer.class) @com.fasterxml.jackson.databind.annotation.JsonDeserialize(using = ca.bc.gov.open.jag.tco.oracledataapi.config.DateTimeDeserializer.class)"
         lesserChargeDescTxt:
           type: string
         otherTxt:
@@ -704,7 +704,7 @@ components:
         revisedDueDt:
           type: string
           format: date
-          x-field-extra-annotation: "@com.fasterxml.jackson.annotation.JsonFormat(pattern=\"yyyy-MM-dd\")"
+          x-field-extra-annotation: "@com.fasterxml.jackson.databind.annotation.JsonSerialize(using = ca.bc.gov.open.jag.tco.oracledataapi.config.DateOnlySerializer.class) @com.fasterxml.jackson.databind.annotation.JsonDeserialize(using = ca.bc.gov.open.jag.tco.oracledataapi.config.DateOnlyDeserializer.class)"
         statuteId:
           type: string
         stayOfProceedingsByTxt:
@@ -720,7 +720,7 @@ components:
         violationDt:
           type: string
           format: date
-          x-field-extra-annotation: "@com.fasterxml.jackson.annotation.JsonFormat(pattern=\"yyyy-MM-dd'Z'\")"
+          x-field-extra-annotation: "@com.fasterxml.jackson.databind.annotation.JsonSerialize(using = ca.bc.gov.open.jag.tco.oracledataapi.config.DateOnlySerializer.class) @com.fasterxml.jackson.databind.annotation.JsonDeserialize(using = ca.bc.gov.open.jag.tco.oracledataapi.config.DateOnlyDeserializer.class)"
         withdrawnYn:
           type: string
       allOf:
@@ -731,7 +731,7 @@ components:
         appearanceDtm:
           type: string
           format: date-time
-          x-field-extra-annotation: "@com.fasterxml.jackson.annotation.JsonFormat(pattern=\"yyyy-MM-dd'T'HH:mm:ss'Z'\")"
+          x-field-extra-annotation: "@com.fasterxml.jackson.databind.annotation.JsonSerialize(using = ca.bc.gov.open.jag.tco.oracledataapi.config.DateTimeSerializer.class) @com.fasterxml.jackson.databind.annotation.JsonDeserialize(using = ca.bc.gov.open.jag.tco.oracledataapi.config.DateTimeDeserializer.class)"
         appearanceReasonTxt:
           type: string
         commentsTxt:
@@ -753,7 +753,7 @@ components:
         disputantNotPresentDtm:
           type: string
           format: date-time
-          x-field-extra-annotation: "@com.fasterxml.jackson.annotation.JsonFormat(pattern=\"yyyy-MM-dd'T'HH:mm:ss'Z'\")"
+          x-field-extra-annotation: "@com.fasterxml.jackson.databind.annotation.JsonSerialize(using = ca.bc.gov.open.jag.tco.oracledataapi.config.DateTimeSerializer.class) @com.fasterxml.jackson.databind.annotation.JsonDeserialize(using = ca.bc.gov.open.jag.tco.oracledataapi.config.DateTimeDeserializer.class)"
         durationHours:
           type: Integer
         durationMinutes:
@@ -780,7 +780,7 @@ components:
         remarksMadeDtm:
           type: string
           format: date-time
-          x-field-extra-annotation: "@com.fasterxml.jackson.annotation.JsonFormat(pattern=\"yyyy-MM-dd'T'HH:mm:ss'Z'\")"
+          x-field-extra-annotation: "@com.fasterxml.jackson.databind.annotation.JsonSerialize(using = ca.bc.gov.open.jag.tco.oracledataapi.config.DateTimeSerializer.class) @com.fasterxml.jackson.databind.annotation.JsonDeserialize(using = ca.bc.gov.open.jag.tco.oracledataapi.config.DateTimeDeserializer.class)"
       allOf:
         - $ref: '#/components/schemas/AuditBase'
     PingResult:
@@ -791,6 +791,7 @@ components:
         currentTimestamp:
           type: string
           format: date-time
+          x-field-extra-annotation: "@com.fasterxml.jackson.databind.annotation.JsonSerialize(using = ca.bc.gov.open.jag.tco.oracledataapi.config.DateTimeSerializer.class) @com.fasterxml.jackson.databind.annotation.JsonDeserialize(using = ca.bc.gov.open.jag.tco.oracledataapi.config.DateTimeDeserializer.class)"
     ResponseResult:
       type: object
       properties:

--- a/src/backend/oracle-data-api/src/test/java/ca/bc/gov/open/jag/tco/oracledataapi/config/DateSerializationIntegrationTest.java
+++ b/src/backend/oracle-data-api/src/test/java/ca/bc/gov/open/jag/tco/oracledataapi/config/DateSerializationIntegrationTest.java
@@ -1,0 +1,286 @@
+package ca.bc.gov.open.jag.tco.oracledataapi.config;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.text.SimpleDateFormat;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.TimeZone;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import ca.bc.gov.open.jag.tco.oracledataapi.ords.occam.api.model.Dispute;
+import ca.bc.gov.open.jag.tco.oracledataapi.ords.occam.api.model.PingResult;
+import ca.bc.gov.open.jag.tco.oracledataapi.ords.occam.api.model.ViolationTicket;
+
+/**
+ * Integration tests for date serialization to ensure
+ * the complete ORDS service pipeline handles dates correctly with timezone preservation.
+ * This is a lightweight test that doesn't require full Spring Boot context.
+ */
+public class DateSerializationIntegrationTest {
+
+    private ObjectMapper objectMapper;
+
+    @BeforeEach
+    void setUp() {
+        // Create ObjectMapper with our custom configuration
+        JacksonConfig jacksonConfig = new JacksonConfig();
+        objectMapper = jacksonConfig.objectMapper();
+    }
+
+    @Test
+    void testJacksonConfigurationIsApplied() {
+        // Verify that our custom Jackson configuration is properly loaded
+        assertNotNull(objectMapper, "ObjectMapper should be available");
+        
+        // Check that WRITE_DATES_AS_TIMESTAMPS is disabled
+        assertEquals(false, objectMapper.getSerializationConfig().isEnabled(
+                com.fasterxml.jackson.databind.SerializationFeature.WRITE_DATES_AS_TIMESTAMPS),
+                "WRITE_DATES_AS_TIMESTAMPS should be disabled");
+    }
+
+    @Test
+    void testPingResultJsonSerialization() throws Exception {
+        // Test the PingResult model to verify datetime serialization
+        PingResult pingResult = new PingResult();
+        Calendar cal = Calendar.getInstance();
+        cal.set(2024, Calendar.JANUARY, 15, 14, 30, 45);
+        cal.set(Calendar.MILLISECOND, 0);
+        Date testDate = cal.getTime();
+        
+        pingResult.setCurrentTimestamp(testDate);
+        pingResult.setStatus("OK");
+        
+        String json = objectMapper.writeValueAsString(pingResult);
+        
+        // Parse the JSON response
+        JsonNode jsonNode = objectMapper.readTree(json);
+        
+        // Verify that currentTimestamp is in the expected datetime format
+        JsonNode timestampNode = jsonNode.get("currentTimestamp");
+        assertNotNull(timestampNode, "currentTimestamp should be present");
+        
+        String timestamp = timestampNode.asText();
+        
+        // Verify format matches yyyy-MM-ddTHH:mm:ss
+        assertTrue(timestamp.matches("\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}"),
+                  "Ping currentTimestamp should be in format yyyy-MM-ddTHH:mm:ss, but was: " + timestamp);
+        
+        // Verify it can be parsed back to a Date
+        SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
+        Date parsedDate = format.parse(timestamp);
+        assertNotNull(parsedDate, "Timestamp should be parseable");
+    }
+
+    @Test
+    void testViolationTicketJsonSerialization() throws Exception {
+        // Test ViolationTicket serialization
+        ViolationTicket testTicket = createTestViolationTicket();
+        
+        String requestJson = objectMapper.writeValueAsString(testTicket);
+        
+        // Verify the JSON contains properly formatted dates
+        assertTrue(requestJson.contains("\"issuedDt\":\"2024-03-15T10:30:45\""),
+                  "ViolationTicket issuedDt should be serialized as datetime");
+        assertTrue(requestJson.contains("\"entDtm\":\"2024-03-16T14:20:30\""),
+                  "ViolationTicket entDtm should be serialized as datetime");
+        
+        // Test deserialization
+        ViolationTicket deserializedTicket = objectMapper.readValue(requestJson, ViolationTicket.class);
+        assertEquals(testTicket.getIssuedDt(), deserializedTicket.getIssuedDt(),
+                    "Deserialized issuedDt should match original");
+        assertEquals(testTicket.getEntDtm(), deserializedTicket.getEntDtm(),
+                    "Deserialized entDtm should match original");
+    }
+
+    @Test
+    void testDisputeMixedDateSerialization() throws Exception {
+        // Test Dispute with both date-only and datetime fields
+        Dispute testDispute = createTestDispute();
+        
+        String requestJson = objectMapper.writeValueAsString(testDispute);
+        
+        // Verify mixed date format serialization
+        assertTrue(requestJson.contains("\"filingDt\":\"2024-04-10\""),
+                  "Dispute filingDt should be serialized as date-only");
+        assertTrue(requestJson.contains("\"submittedDt\":\"2024-04-11T09:15:20\""),
+                  "Dispute submittedDt should be serialized as datetime");
+        assertTrue(requestJson.contains("\"entDtm\":\"2024-04-12T16:45:10\""),
+                  "Dispute entDtm should be serialized as datetime");
+        
+        // Test deserialization preserves both formats
+        Dispute deserializedDispute = objectMapper.readValue(requestJson, Dispute.class);
+        
+        // For date-only field, compare date components
+        Calendar originalCal = Calendar.getInstance();
+        originalCal.setTime(testDispute.getFilingDt());
+        Calendar deserializedCal = Calendar.getInstance();
+        deserializedCal.setTime(deserializedDispute.getFilingDt());
+        
+        assertEquals(originalCal.get(Calendar.YEAR), deserializedCal.get(Calendar.YEAR));
+        assertEquals(originalCal.get(Calendar.MONTH), deserializedCal.get(Calendar.MONTH));
+        assertEquals(originalCal.get(Calendar.DAY_OF_MONTH), deserializedCal.get(Calendar.DAY_OF_MONTH));
+        
+        // For datetime fields, exact match
+        assertEquals(testDispute.getSubmittedDt(), deserializedDispute.getSubmittedDt());
+        assertEquals(testDispute.getEntDtm(), deserializedDispute.getEntDtm());
+    }
+
+    @Test
+    void testTimezoneIndependentSerialization() throws Exception {
+        // Test that serialization produces consistent results across different system timezones
+        TimeZone originalTimezone = TimeZone.getDefault();
+        
+        try {
+            // Create test data
+            PingResult pingResult = new PingResult();
+            Calendar cal = Calendar.getInstance();
+            cal.set(2024, Calendar.MAY, 20, 13, 45, 30);
+            cal.set(Calendar.MILLISECOND, 0);
+            Date testDate = cal.getTime();
+            pingResult.setCurrentTimestamp(testDate);
+            pingResult.setStatus("OK");
+            
+            // Serialize in original timezone
+            String jsonInOriginalTz = objectMapper.writeValueAsString(pingResult);
+            
+            // Change system timezone
+            TimeZone.setDefault(TimeZone.getTimeZone("America/New_York"));
+            
+            // Serialize in different timezone
+            String jsonInDifferentTz = objectMapper.writeValueAsString(pingResult);
+            
+            // Change to another timezone
+            TimeZone.setDefault(TimeZone.getTimeZone("Europe/London"));
+            
+            // Serialize in third timezone
+            String jsonInThirdTz = objectMapper.writeValueAsString(pingResult);
+            
+            // All JSON outputs should be identical
+            assertEquals(jsonInOriginalTz, jsonInDifferentTz,
+                        "JSON should be identical across timezone changes (original vs NY)");
+            assertEquals(jsonInOriginalTz, jsonInThirdTz,
+                        "JSON should be identical across timezone changes (original vs London)");
+            
+            // Verify the timestamp format is preserved
+            assertTrue(jsonInOriginalTz.contains("\"currentTimestamp\":\"2024-05-20T13:45:30\""),
+                      "Timestamp should maintain original format regardless of system timezone");
+            
+        } finally {
+            // Restore original timezone
+            TimeZone.setDefault(originalTimezone);
+        }
+    }
+
+    @Test
+    void testGlobalDateSerializerIntegration() throws Exception {
+        // Test that the GlobalDateSerializer correctly determines date vs datetime formats
+        
+        // Create a date with no time component
+        Calendar cal = Calendar.getInstance();
+        cal.set(2024, Calendar.JUNE, 15, 0, 0, 0);
+        cal.set(Calendar.MILLISECOND, 0);
+        Date dateOnly = cal.getTime();
+        
+        // Create a date with time component
+        cal.set(2024, Calendar.JUNE, 16, 14, 30, 45);
+        cal.set(Calendar.MILLISECOND, 0);
+        Date dateTime = cal.getTime();
+        
+        Dispute dispute = new Dispute();
+        dispute.setDisputeId("testGlobal");
+        dispute.setFilingDt(dateOnly);  // Should be serialized as date-only
+        dispute.setSubmittedDt(dateTime);  // Should be serialized as datetime
+        
+        String json = objectMapper.writeValueAsString(dispute);
+        
+        // Verify the global serializer correctly identifies and formats each type
+        assertTrue(json.contains("\"filingDt\":\"2024-06-15\""),
+                  "Date with no time component should be serialized as date-only");
+        assertTrue(json.contains("\"submittedDt\":\"2024-06-16T14:30:45\""),
+                  "Date with time component should be serialized as datetime");
+    }
+
+    @Test
+    void testEdgeCaseDateHandling() throws Exception {
+        // Test edge cases for date handling
+        
+        Calendar cal = Calendar.getInstance();
+        
+        // Test midnight (edge case between date-only and datetime)
+        cal.set(2024, Calendar.JULY, 4, 0, 0, 0);
+        cal.set(Calendar.MILLISECOND, 1); // 1 millisecond should trigger datetime format
+        Date midnightWithMillis = cal.getTime();
+        
+        // Test exactly midnight with no sub-second components
+        cal.set(Calendar.MILLISECOND, 0);
+        Date exactMidnight = cal.getTime();
+        
+        Dispute dispute = new Dispute();
+        dispute.setDisputeId("edgeCase");
+        dispute.setSubmittedDt(midnightWithMillis);
+        dispute.setUserAssignedDtm(exactMidnight);
+        
+        String json = objectMapper.writeValueAsString(dispute);
+        
+        // Even 1 millisecond should trigger datetime format
+        assertTrue(json.contains("\"submittedDt\":\"2024-07-04T00:00:00\""),
+                  "Midnight with milliseconds should be serialized as datetime");
+        
+        // Exact midnight with no time components should still be datetime if detected as having time
+        assertTrue(json.contains("\"userAssignedDtm\":\"2024-07-04T00:00:00\"") || 
+                  json.contains("\"userAssignedDtm\":\"2024-07-04\""),
+                  "Exact midnight should be serialized consistently");
+    }
+
+    private ViolationTicket createTestViolationTicket() {
+        ViolationTicket ticket = new ViolationTicket();
+        
+        Calendar cal = Calendar.getInstance();
+        cal.set(2024, Calendar.MARCH, 15, 10, 30, 45);
+        cal.set(Calendar.MILLISECOND, 0);
+        ticket.setIssuedDt(cal.getTime());
+        
+        cal.set(2024, Calendar.MARCH, 16, 14, 20, 30);
+        cal.set(Calendar.MILLISECOND, 0);
+        ticket.setEntDtm(cal.getTime());
+        
+        ticket.setTicketNumberTxt("TEST123456");
+        ticket.setViolationTicketId("VT001");
+        ticket.setEntUserId("testuser");
+        
+        return ticket;
+    }
+
+    private Dispute createTestDispute() {
+        Dispute dispute = new Dispute();
+        
+        Calendar cal = Calendar.getInstance();
+        
+        // Date-only field
+        cal.set(2024, Calendar.APRIL, 10, 0, 0, 0);
+        cal.set(Calendar.MILLISECOND, 0);
+        dispute.setFilingDt(cal.getTime());
+        
+        // Datetime fields
+        cal.set(2024, Calendar.APRIL, 11, 9, 15, 20);
+        cal.set(Calendar.MILLISECOND, 0);
+        dispute.setSubmittedDt(cal.getTime());
+        
+        cal.set(2024, Calendar.APRIL, 12, 16, 45, 10);
+        cal.set(Calendar.MILLISECOND, 0);
+        dispute.setEntDtm(cal.getTime());
+        
+        dispute.setDisputeId("DISP001");
+        dispute.setEntUserId("testuser");
+        
+        return dispute;
+    }
+}

--- a/src/backend/oracle-data-api/src/test/java/ca/bc/gov/open/jag/tco/oracledataapi/config/DateSerializationTest.java
+++ b/src/backend/oracle-data-api/src/test/java/ca/bc/gov/open/jag/tco/oracledataapi/config/DateSerializationTest.java
@@ -1,0 +1,366 @@
+package ca.bc.gov.open.jag.tco.oracledataapi.config;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.TimeZone;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import ca.bc.gov.open.jag.tco.oracledataapi.ords.occam.api.model.AuditLogEntry;
+import ca.bc.gov.open.jag.tco.oracledataapi.ords.occam.api.model.Dispute;
+import ca.bc.gov.open.jag.tco.oracledataapi.ords.occam.api.model.DisputeListItem;
+import ca.bc.gov.open.jag.tco.oracledataapi.ords.occam.api.model.DisputeUpdateRequest;
+import ca.bc.gov.open.jag.tco.oracledataapi.ords.occam.api.model.OutgoingEmail;
+import ca.bc.gov.open.jag.tco.oracledataapi.ords.occam.api.model.PingResult;
+import ca.bc.gov.open.jag.tco.oracledataapi.ords.occam.api.model.ViolationTicket;
+
+/**
+ * Test class to verify that date serialization/deserialization preserves exact database values
+ * without timezone conversion, ensuring consistency across different system timezones.
+ */
+public class DateSerializationTest {
+
+    private ObjectMapper objectMapper;
+
+    private SimpleDateFormat dateOnlyFormat;
+    private SimpleDateFormat dateTimeFormat;
+
+    @BeforeEach
+    void setUp() {
+        // Create ObjectMapper with our custom configuration
+        JacksonConfig jacksonConfig = new JacksonConfig();
+        objectMapper = jacksonConfig.objectMapper();
+        
+        dateOnlyFormat = new SimpleDateFormat("yyyy-MM-dd");
+        dateTimeFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
+        // Ensure formatters are timezone-neutral for testing
+        dateOnlyFormat.setTimeZone(TimeZone.getDefault());
+        dateTimeFormat.setTimeZone(TimeZone.getDefault());
+    }
+
+    @Test
+    void testPingResultCurrentTimestampSerialization() throws JsonProcessingException, ParseException {
+        // Test datetime serialization for PingResult.currentTimestamp
+        PingResult pingResult = new PingResult();
+        
+        // Create a test datetime with specific values
+        Calendar cal = Calendar.getInstance();
+        cal.set(2024, Calendar.JANUARY, 15, 14, 30, 45);
+        cal.set(Calendar.MILLISECOND, 0);
+        Date testDateTime = cal.getTime();
+        
+        pingResult.setCurrentTimestamp(testDateTime);
+        pingResult.setStatus("OK");
+
+        String json = objectMapper.writeValueAsString(pingResult);
+        
+        // Verify the datetime is serialized in the expected format
+        assertTrue(json.contains("\"currentTimestamp\":\"2024-01-15T14:30:45\""), 
+                   "PingResult currentTimestamp should be serialized as datetime format");
+        
+        // Test deserialization preserves the exact value
+        PingResult deserializedResult = objectMapper.readValue(json, PingResult.class);
+        assertEquals(testDateTime, deserializedResult.getCurrentTimestamp(),
+                     "Deserialized datetime should match original exactly");
+    }
+
+    @Test
+    void testDisputeDateOnlySerialization() throws JsonProcessingException, ParseException {
+        // Test date-only serialization for Dispute.filingDt
+        Dispute dispute = new Dispute();
+        
+        // Create a date-only value (no time component)
+        Calendar cal = Calendar.getInstance();
+        cal.set(2024, Calendar.MARCH, 10, 0, 0, 0);
+        cal.set(Calendar.MILLISECOND, 0);
+        Date testDate = cal.getTime();
+        
+        dispute.setFilingDt(testDate);
+        dispute.setDisputeId("12345");
+
+        String json = objectMapper.writeValueAsString(dispute);
+        
+        // Verify the date is serialized in date-only format
+        assertTrue(json.contains("\"filingDt\":\"2024-03-10\""), 
+                   "Dispute filingDt should be serialized as date-only format");
+        
+        // Test deserialization preserves the date value
+        Dispute deserializedDispute = objectMapper.readValue(json, Dispute.class);
+        
+        // Compare only the date components (ignore any time differences due to timezone handling)
+        Calendar originalCal = Calendar.getInstance();
+        originalCal.setTime(testDate);
+        Calendar deserializedCal = Calendar.getInstance();
+        deserializedCal.setTime(deserializedDispute.getFilingDt());
+        
+        assertEquals(originalCal.get(Calendar.YEAR), deserializedCal.get(Calendar.YEAR));
+        assertEquals(originalCal.get(Calendar.MONTH), deserializedCal.get(Calendar.MONTH));
+        assertEquals(originalCal.get(Calendar.DAY_OF_MONTH), deserializedCal.get(Calendar.DAY_OF_MONTH));
+    }
+
+    @Test
+    void testDisputeDateTimeSerialization() throws JsonProcessingException {
+        // Test datetime serialization for Dispute audit fields
+        Dispute dispute = new Dispute();
+        
+        // Create datetime values with specific time components
+        Calendar cal = Calendar.getInstance();
+        cal.set(2024, Calendar.FEBRUARY, 20, 9, 15, 30);
+        cal.set(Calendar.MILLISECOND, 0);
+        Date entDtm = cal.getTime();
+        
+        cal.set(2024, Calendar.FEBRUARY, 21, 16, 45, 15);
+        cal.set(Calendar.MILLISECOND, 0);
+        Date updDtm = cal.getTime();
+
+        dispute.setEntDtm(entDtm);
+        dispute.setUpdDtm(updDtm);
+        dispute.setEntUserId("testuser1");
+        dispute.setUpdUserId("testuser2");
+        dispute.setDisputeId("67890");
+
+        String json = objectMapper.writeValueAsString(dispute);
+        
+        // Verify datetime fields are serialized with time components
+        assertTrue(json.contains("\"entDtm\":\"2024-02-20T09:15:30\""), 
+                   "Dispute entDtm should be serialized as datetime format");
+        assertTrue(json.contains("\"updDtm\":\"2024-02-21T16:45:15\""), 
+                   "Dispute updDtm should be serialized as datetime format");
+        
+        // Test deserialization
+        Dispute deserializedDispute = objectMapper.readValue(json, Dispute.class);
+        assertEquals(entDtm, deserializedDispute.getEntDtm(),
+                     "Deserialized entDtm should match original exactly");
+        assertEquals(updDtm, deserializedDispute.getUpdDtm(),
+                     "Deserialized updDtm should match original exactly");
+    }
+
+    @Test
+    void testViolationTicketDateTimeSerialization() throws JsonProcessingException {
+        // Test datetime serialization for ViolationTicket.issuedDt
+        ViolationTicket ticket = new ViolationTicket();
+        
+        Calendar cal = Calendar.getInstance();
+        cal.set(2024, Calendar.APRIL, 5, 13, 20, 45);
+        cal.set(Calendar.MILLISECOND, 0);
+        Date issuedDt = cal.getTime();
+        
+        ticket.setIssuedDt(issuedDt);
+        ticket.setTicketNumberTxt("AA12345678");
+        ticket.setViolationTicketId("98765");
+
+        String json = objectMapper.writeValueAsString(ticket);
+        
+        assertTrue(json.contains("\"issuedDt\":\"2024-04-05T13:20:45\""), 
+                   "ViolationTicket issuedDt should be serialized as datetime format");
+        
+        ViolationTicket deserializedTicket = objectMapper.readValue(json, ViolationTicket.class);
+        assertEquals(issuedDt, deserializedTicket.getIssuedDt(),
+                     "Deserialized issuedDt should match original exactly");
+    }
+
+    @Test
+    void testDisputeListItemMixedDateFormats() throws JsonProcessingException {
+        // Test both date-only and datetime serialization in DisputeListItem
+        DisputeListItem listItem = new DisputeListItem();
+        
+        // Date-only field
+        Calendar cal = Calendar.getInstance();
+        cal.set(2024, Calendar.MAY, 12, 0, 0, 0);
+        cal.set(Calendar.MILLISECOND, 0);
+        Date filingDt = cal.getTime();
+        
+        // Datetime field
+        cal.set(2024, Calendar.MAY, 13, 10, 30, 0);
+        cal.set(Calendar.MILLISECOND, 0);
+        Date submittedDt = cal.getTime();
+        
+        listItem.setFilingDt(filingDt);
+        listItem.setSubmittedDt(submittedDt);
+        listItem.setDisputeId(12345);
+        listItem.setTicketNumberTxt("BB98765432");
+
+        String json = objectMapper.writeValueAsString(listItem);
+        
+        // The field with @JsonSerialize(using = DateOnlySerializer.class) should be date-only
+        assertTrue(json.contains("\"filing_dt\":\"2024-05-12\""), 
+                   "DisputeListItem filing_dt should be serialized as date-only format, but was: " + json);
+        
+        // Verify datetime field works correctly
+        assertTrue(json.contains("\"submitted_dt\":\"2024-05-13T10:30:00\""), 
+                   "DisputeListItem submitted_dt should be serialized as datetime, but was: " + json);
+        
+        // Test deserialization
+        DisputeListItem deserializedItem = objectMapper.readValue(json, DisputeListItem.class);
+        
+        // Verify date-only field preserves date (compare only date components)
+        Calendar originalFilingCal = Calendar.getInstance();
+        originalFilingCal.setTime(filingDt);
+        Calendar deserializedFilingCal = Calendar.getInstance();
+        deserializedFilingCal.setTime(deserializedItem.getFilingDt());
+        
+        assertEquals(originalFilingCal.get(Calendar.YEAR), deserializedFilingCal.get(Calendar.YEAR));
+        assertEquals(originalFilingCal.get(Calendar.MONTH), deserializedFilingCal.get(Calendar.MONTH));
+        assertEquals(originalFilingCal.get(Calendar.DAY_OF_MONTH), deserializedFilingCal.get(Calendar.DAY_OF_MONTH));
+        
+        // Verify datetime field preserves exact time
+        assertEquals(submittedDt, deserializedItem.getSubmittedDt());
+    }
+
+    @Test
+    void testAuditLogEntryDateTimeSerialization() throws JsonProcessingException {
+        // Test datetime serialization for AuditLogEntry audit fields
+        AuditLogEntry auditEntry = new AuditLogEntry();
+        
+        Calendar cal = Calendar.getInstance();
+        cal.set(2024, Calendar.JUNE, 8, 11, 45, 20);
+        cal.set(Calendar.MILLISECOND, 0);
+        Date entDtm = cal.getTime();
+        
+        auditEntry.setEntDtm(entDtm);
+        auditEntry.setEntUserId("audituser");
+        auditEntry.setAuditLogEntryId("audit123");
+        auditEntry.setDisputeId("dispute456");
+
+        String json = objectMapper.writeValueAsString(auditEntry);
+        
+        assertTrue(json.contains("\"entDtm\":\"2024-06-08T11:45:20\""), 
+                   "AuditLogEntry entDtm should be serialized as datetime format");
+        
+        AuditLogEntry deserializedEntry = objectMapper.readValue(json, AuditLogEntry.class);
+        assertEquals(entDtm, deserializedEntry.getEntDtm(),
+                     "Deserialized entDtm should match original exactly");
+    }
+
+    @Test
+    void testOutgoingEmailDateTimeSerialization() throws JsonProcessingException {
+        // Test datetime serialization for OutgoingEmail.emailSentDtm
+        OutgoingEmail email = new OutgoingEmail();
+        
+        Calendar cal = Calendar.getInstance();
+        cal.set(2024, Calendar.JULY, 15, 14, 20, 35);
+        cal.set(Calendar.MILLISECOND, 0);
+        Date emailSentDtm = cal.getTime();
+        
+        email.setEmailSentDtm(emailSentDtm);
+        email.setOutgoingEmailId("email789");
+        email.setDisputeId("dispute321");
+
+        String json = objectMapper.writeValueAsString(email);
+        
+        assertTrue(json.contains("\"emailSentDtm\":\"2024-07-15T14:20:35\""), 
+                   "OutgoingEmail emailSentDtm should be serialized as datetime format");
+        
+        OutgoingEmail deserializedEmail = objectMapper.readValue(json, OutgoingEmail.class);
+        assertEquals(emailSentDtm, deserializedEmail.getEmailSentDtm(),
+                     "Deserialized emailSentDtm should match original exactly");
+    }
+
+    @Test
+    void testDisputeUpdateRequestDateTimeSerialization() throws JsonProcessingException {
+        // Test datetime serialization for DisputeUpdateRequest.statusUpdateDtm
+        DisputeUpdateRequest updateRequest = new DisputeUpdateRequest();
+        
+        Calendar cal = Calendar.getInstance();
+        cal.set(2024, Calendar.AUGUST, 22, 16, 55, 10);
+        cal.set(Calendar.MILLISECOND, 0);
+        Date statusUpdateDtm = cal.getTime();
+        
+        updateRequest.setStatusUpdateDtm(statusUpdateDtm);
+        updateRequest.setDisputeUpdateRequestId("update123");
+        updateRequest.setDisputeId("dispute789");
+
+        String json = objectMapper.writeValueAsString(updateRequest);
+        
+        assertTrue(json.contains("\"statusUpdateDtm\":\"2024-08-22T16:55:10\""), 
+                   "DisputeUpdateRequest statusUpdateDtm should be serialized as datetime format");
+        
+        DisputeUpdateRequest deserializedRequest = objectMapper.readValue(json, DisputeUpdateRequest.class);
+        assertEquals(statusUpdateDtm, deserializedRequest.getStatusUpdateDtm(),
+                     "Deserialized statusUpdateDtm should match original exactly");
+    }
+
+    @Test
+    void testTimezoneIndependence() throws JsonProcessingException {
+        // Test that serialization is timezone-independent
+        TimeZone originalTimezone = TimeZone.getDefault();
+        
+        try {
+            // Create a test date in the current timezone
+            Calendar cal = Calendar.getInstance();
+            cal.set(2024, Calendar.SEPTEMBER, 10, 12, 30, 45);
+            cal.set(Calendar.MILLISECOND, 0);
+            Date testDate = cal.getTime();
+            
+            PingResult pingResult = new PingResult();
+            pingResult.setCurrentTimestamp(testDate);
+            pingResult.setStatus("OK");
+            
+            // Serialize in original timezone
+            String jsonInOriginalTz = objectMapper.writeValueAsString(pingResult);
+            
+            // Change to a different timezone
+            TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
+            
+            // Serialize in different timezone
+            String jsonInDifferentTz = objectMapper.writeValueAsString(pingResult);
+            
+            // The JSON should be identical regardless of system timezone
+            assertEquals(jsonInOriginalTz, jsonInDifferentTz,
+                        "Serialization should be timezone-independent");
+            
+            // Verify deserialization gives same result in both timezones
+            PingResult deserializedInOriginal = objectMapper.readValue(jsonInOriginalTz, PingResult.class);
+            PingResult deserializedInDifferent = objectMapper.readValue(jsonInDifferentTz, PingResult.class);
+            
+            assertEquals(deserializedInOriginal.getCurrentTimestamp(), 
+                        deserializedInDifferent.getCurrentTimestamp(),
+                        "Deserialization should give same result regardless of timezone");
+            
+        } finally {
+            // Restore original timezone
+            TimeZone.setDefault(originalTimezone);
+        }
+    }
+
+    @Test
+    void testNullDateHandling() throws JsonProcessingException {
+        // Test that null dates are handled properly
+        Dispute dispute = new Dispute();
+        dispute.setDisputeId("nulltest");
+        dispute.setFilingDt(null);
+        dispute.setEntDtm(null);
+        dispute.setUpdDtm(null);
+
+        String json = objectMapper.writeValueAsString(dispute);
+        
+        // Verify null dates are serialized as null
+        assertTrue(json.contains("\"filingDt\":null") || !json.contains("\"filingDt\""), 
+                   "Null filingDt should be serialized as null or omitted");
+        
+        Dispute deserializedDispute = objectMapper.readValue(json, Dispute.class);
+        assertEquals(null, deserializedDispute.getFilingDt(),
+                     "Null filingDt should remain null after deserialization");
+    }
+
+    @Test
+    void testObjectMapperConfiguration() {
+        // Verify that the ObjectMapper is properly configured
+        assertNotNull(objectMapper, "ObjectMapper should be available");
+        
+        // Verify that WRITE_DATES_AS_TIMESTAMPS is disabled
+        assertEquals(false, objectMapper.getSerializationConfig().isEnabled(
+                com.fasterxml.jackson.databind.SerializationFeature.WRITE_DATES_AS_TIMESTAMPS),
+                     "WRITE_DATES_AS_TIMESTAMPS should be disabled");
+    }
+}

--- a/src/backend/oracle-data-api/src/test/java/ca/bc/gov/open/jag/tco/oracledataapi/config/DateSerializerDeserializerTest.java
+++ b/src/backend/oracle-data-api/src/test/java/ca/bc/gov/open/jag/tco/oracledataapi/config/DateSerializerDeserializerTest.java
@@ -1,0 +1,313 @@
+package ca.bc.gov.open.jag.tco.oracledataapi.config;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.io.IOException;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Calendar;
+import java.util.Date;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.SerializerProvider;
+
+/**
+ * Unit tests for individual date serializers and deserializers to ensure 
+ * they handle date formatting and timezone preservation correctly.
+ */
+public class DateSerializerDeserializerTest {
+
+    @Mock
+    private JsonGenerator jsonGenerator;
+    
+    @Mock
+    private JsonParser jsonParser;
+    
+    @Mock
+    private SerializerProvider serializerProvider;
+    
+    @Mock
+    private DeserializationContext deserializationContext;
+
+    private DateOnlySerializer dateOnlySerializer;
+    private DateOnlyDeserializer dateOnlyDeserializer;
+    private DateTimeSerializer dateTimeSerializer;
+    private DateTimeDeserializer dateTimeDeserializer;
+    private GlobalDateSerializer globalDateSerializer;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        dateOnlySerializer = new DateOnlySerializer();
+        dateOnlyDeserializer = new DateOnlyDeserializer();
+        dateTimeSerializer = new DateTimeSerializer();
+        dateTimeDeserializer = new DateTimeDeserializer();
+        globalDateSerializer = new GlobalDateSerializer();
+    }
+
+    @Test
+    void testDateOnlySerializerWithValidDate() throws IOException {
+        // Test date-only serialization
+        Calendar cal = Calendar.getInstance();
+        cal.set(2024, Calendar.MARCH, 15, 10, 30, 45); // Time component should be ignored
+        cal.set(Calendar.MILLISECOND, 0);
+        Date testDate = cal.getTime();
+
+        dateOnlySerializer.serialize(testDate, jsonGenerator, serializerProvider);
+
+        Mockito.verify(jsonGenerator).writeString("2024-03-15");
+    }
+
+    @Test
+    void testDateOnlySerializerWithNullDate() throws IOException {
+        // Test null handling
+        dateOnlySerializer.serialize(null, jsonGenerator, serializerProvider);
+
+        Mockito.verify(jsonGenerator, Mockito.never()).writeString(Mockito.anyString());
+    }
+
+    @Test
+    void testDateOnlyDeserializerWithValidDateString() throws IOException, ParseException {
+        // Test date-only deserialization
+        Mockito.when(jsonParser.getText()).thenReturn("2024-03-15");
+
+        Date result = dateOnlyDeserializer.deserialize(jsonParser, deserializationContext);
+
+        SimpleDateFormat expectedFormat = new SimpleDateFormat("yyyy-MM-dd");
+        Date expectedDate = expectedFormat.parse("2024-03-15");
+        assertEquals(expectedDate, result);
+    }
+
+    @Test
+    void testDateOnlyDeserializerWithNullString() throws IOException {
+        // Test null string handling
+        Mockito.when(jsonParser.getText()).thenReturn(null);
+
+        Date result = dateOnlyDeserializer.deserialize(jsonParser, deserializationContext);
+
+        assertNull(result);
+    }
+
+    @Test
+    void testDateOnlyDeserializerWithEmptyString() throws IOException {
+        // Test empty string handling
+        Mockito.when(jsonParser.getText()).thenReturn("   ");
+
+        Date result = dateOnlyDeserializer.deserialize(jsonParser, deserializationContext);
+
+        assertNull(result);
+    }
+
+    @Test
+    void testDateOnlyDeserializerWithInvalidFormat() throws IOException {
+        // Test invalid date format
+        Mockito.when(jsonParser.getText()).thenReturn("15-03-2024");
+
+        assertThrows(IOException.class, () -> {
+            dateOnlyDeserializer.deserialize(jsonParser, deserializationContext);
+        });
+    }
+
+    @Test
+    void testDateTimeSerializerWithValidDateTime() throws IOException {
+        // Test datetime serialization
+        Calendar cal = Calendar.getInstance();
+        cal.set(2024, Calendar.APRIL, 20, 14, 45, 30);
+        cal.set(Calendar.MILLISECOND, 0);
+        Date testDateTime = cal.getTime();
+
+        dateTimeSerializer.serialize(testDateTime, jsonGenerator, serializerProvider);
+
+        Mockito.verify(jsonGenerator).writeString("2024-04-20T14:45:30");
+    }
+
+    @Test
+    void testDateTimeSerializerWithNullDate() throws IOException {
+        // Test null handling
+        dateTimeSerializer.serialize(null, jsonGenerator, serializerProvider);
+
+        Mockito.verify(jsonGenerator, Mockito.never()).writeString(Mockito.anyString());
+    }
+
+    @Test
+    void testDateTimeDeserializerWithValidDateTime() throws IOException, ParseException {
+        // Test datetime deserialization
+        Mockito.when(jsonParser.getValueAsString()).thenReturn("2024-04-20T14:45:30");
+
+        Date result = dateTimeDeserializer.deserialize(jsonParser, deserializationContext);
+
+        SimpleDateFormat expectedFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
+        Date expectedDate = expectedFormat.parse("2024-04-20T14:45:30");
+        assertEquals(expectedDate, result);
+    }
+
+    @Test
+    void testDateTimeDeserializerWithNullString() throws IOException {
+        // Test null string handling
+        Mockito.when(jsonParser.getValueAsString()).thenReturn(null);
+
+        Date result = dateTimeDeserializer.deserialize(jsonParser, deserializationContext);
+
+        assertNull(result);
+    }
+
+    @Test
+    void testDateTimeDeserializerWithEmptyString() throws IOException {
+        // Test empty string handling
+        Mockito.when(jsonParser.getValueAsString()).thenReturn("  ");
+
+        Date result = dateTimeDeserializer.deserialize(jsonParser, deserializationContext);
+
+        assertNull(result);
+    }
+
+    @Test
+    void testDateTimeDeserializerWithInvalidFormat() throws IOException {
+        // Test invalid datetime format
+        Mockito.when(jsonParser.getValueAsString()).thenReturn("2024-04-20 14:45:30");
+
+        assertThrows(IOException.class, () -> {
+            dateTimeDeserializer.deserialize(jsonParser, deserializationContext);
+        });
+    }
+
+    @Test
+    void testGlobalDateSerializerWithDateOnly() throws IOException {
+        // Test global serializer with date-only (no time component)
+        Calendar cal = Calendar.getInstance();
+        cal.set(2024, Calendar.MAY, 10, 0, 0, 0);
+        cal.set(Calendar.MILLISECOND, 0);
+        Date dateOnly = cal.getTime();
+
+        globalDateSerializer.serialize(dateOnly, jsonGenerator, serializerProvider);
+
+        Mockito.verify(jsonGenerator).writeString("2024-05-10");
+    }
+
+    @Test
+    void testGlobalDateSerializerWithDateTime() throws IOException {
+        // Test global serializer with datetime (has time component)
+        Calendar cal = Calendar.getInstance();
+        cal.set(2024, Calendar.MAY, 10, 15, 30, 45);
+        cal.set(Calendar.MILLISECOND, 500);
+        Date dateTime = cal.getTime();
+
+        globalDateSerializer.serialize(dateTime, jsonGenerator, serializerProvider);
+
+        Mockito.verify(jsonGenerator).writeString("2024-05-10T15:30:45");
+    }
+
+    @Test
+    void testGlobalDateSerializerWithTimeComponentButZeroValues() throws IOException {
+        // Test edge case: hour/minute/second are 0 but milliseconds are not
+        Calendar cal = Calendar.getInstance();
+        cal.set(2024, Calendar.MAY, 10, 0, 0, 0);
+        cal.set(Calendar.MILLISECOND, 100); // Non-zero milliseconds should trigger datetime format
+        Date dateTime = cal.getTime();
+
+        globalDateSerializer.serialize(dateTime, jsonGenerator, serializerProvider);
+
+        Mockito.verify(jsonGenerator).writeString("2024-05-10T00:00:00");
+    }
+
+    @Test
+    void testGlobalDateSerializerWithNullDate() throws IOException {
+        // Test null handling
+        globalDateSerializer.serialize(null, jsonGenerator, serializerProvider);
+
+        Mockito.verify(jsonGenerator, Mockito.never()).writeString(Mockito.anyString());
+    }
+
+    @Test
+    void testGlobalDateSerializerTimeDetection() throws IOException {
+        // Test various time combinations to ensure proper detection
+        Calendar cal = Calendar.getInstance();
+        
+        // Test with only hour set
+        cal.set(2024, Calendar.JUNE, 1, 1, 0, 0);
+        cal.set(Calendar.MILLISECOND, 0);
+        Date hourOnly = cal.getTime();
+        
+        globalDateSerializer.serialize(hourOnly, jsonGenerator, serializerProvider);
+        Mockito.verify(jsonGenerator).writeString("2024-06-01T01:00:00");
+        
+        Mockito.reset(jsonGenerator);
+        
+        // Test with only minute set
+        cal.set(2024, Calendar.JUNE, 2, 0, 1, 0);
+        cal.set(Calendar.MILLISECOND, 0);
+        Date minuteOnly = cal.getTime();
+        
+        globalDateSerializer.serialize(minuteOnly, jsonGenerator, serializerProvider);
+        Mockito.verify(jsonGenerator).writeString("2024-06-02T00:01:00");
+        
+        Mockito.reset(jsonGenerator);
+        
+        // Test with only second set
+        cal.set(2024, Calendar.JUNE, 3, 0, 0, 1);
+        cal.set(Calendar.MILLISECOND, 0);
+        Date secondOnly = cal.getTime();
+        
+        globalDateSerializer.serialize(secondOnly, jsonGenerator, serializerProvider);
+        Mockito.verify(jsonGenerator).writeString("2024-06-03T00:00:01");
+    }
+
+    @Test
+    void testSerializerConsistency() throws IOException, ParseException {
+        // Test that serialization and deserialization are consistent
+        Calendar cal = Calendar.getInstance();
+        cal.set(2024, Calendar.JULY, 25, 16, 20, 10);
+        cal.set(Calendar.MILLISECOND, 0);
+        Date originalDate = cal.getTime();
+        
+        // Serialize with DateTime serializer
+        dateTimeSerializer.serialize(originalDate, jsonGenerator, serializerProvider);
+        
+        // Capture the serialized string
+        Mockito.verify(jsonGenerator).writeString("2024-07-25T16:20:10");
+        
+        // Mock parser to return the serialized string
+        Mockito.when(jsonParser.getValueAsString()).thenReturn("2024-07-25T16:20:10");
+        
+        // Deserialize
+        Date deserializedDate = dateTimeDeserializer.deserialize(jsonParser, deserializationContext);
+        
+        // Verify consistency
+        assertEquals(originalDate, deserializedDate);
+    }
+
+    @Test
+    void testDateOnlyConsistency() throws IOException, ParseException {
+        // Test date-only serialization/deserialization consistency
+        Calendar cal = Calendar.getInstance();
+        cal.set(2024, Calendar.AUGUST, 15, 0, 0, 0);
+        cal.set(Calendar.MILLISECOND, 0);
+        Date originalDate = cal.getTime();
+        
+        // Serialize with DateOnly serializer
+        dateOnlySerializer.serialize(originalDate, jsonGenerator, serializerProvider);
+        
+        // Capture the serialized string
+        Mockito.verify(jsonGenerator).writeString("2024-08-15");
+        
+        // Mock parser to return the serialized string
+        Mockito.when(jsonParser.getText()).thenReturn("2024-08-15");
+        
+        // Deserialize
+        Date deserializedDate = dateOnlyDeserializer.deserialize(jsonParser, deserializationContext);
+        
+        // For date-only, we only compare date components since time might differ
+        SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd");
+        assertEquals(dateFormat.format(originalDate), dateFormat.format(deserializedDate));
+    }
+}

--- a/src/backend/oracle-data-api/src/test/java/ca/bc/gov/open/jag/tco/oracledataapi/config/TcoDateSerializationIntegrationTest.java
+++ b/src/backend/oracle-data-api/src/test/java/ca/bc/gov/open/jag/tco/oracledataapi/config/TcoDateSerializationIntegrationTest.java
@@ -1,0 +1,488 @@
+package ca.bc.gov.open.jag.tco.oracledataapi.config;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.text.SimpleDateFormat;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.TimeZone;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import ca.bc.gov.open.jag.tco.oracledataapi.ords.tco.api.model.AuditLogEntry;
+import ca.bc.gov.open.jag.tco.oracledataapi.ords.tco.api.model.JJCourtAppearance;
+import ca.bc.gov.open.jag.tco.oracledataapi.ords.tco.api.model.JJDispute;
+import ca.bc.gov.open.jag.tco.oracledataapi.ords.tco.api.model.JJDisputeCount;
+import ca.bc.gov.open.jag.tco.oracledataapi.ords.tco.api.model.JJDisputeRemark;
+import ca.bc.gov.open.jag.tco.oracledataapi.ords.tco.api.model.PingResult;
+
+/**
+ * Integration tests for TCO date serialization to ensure
+ * the complete ORDS service pipeline handles dates correctly with timezone preservation.
+ * This is a lightweight test that doesn't require full Spring Boot context.
+ */
+public class TcoDateSerializationIntegrationTest {
+
+    private ObjectMapper objectMapper;
+
+    @BeforeEach
+    void setUp() {
+        // Create ObjectMapper with our custom configuration
+        JacksonConfig jacksonConfig = new JacksonConfig();
+        objectMapper = jacksonConfig.objectMapper();
+    }
+
+    @Test
+    void testJacksonConfigurationIsApplied() {
+        // Verify that our custom Jackson configuration is properly loaded
+        assertNotNull(objectMapper, "ObjectMapper should be available");
+        
+        // Check that WRITE_DATES_AS_TIMESTAMPS is disabled
+        assertEquals(false, objectMapper.getSerializationConfig().isEnabled(
+                com.fasterxml.jackson.databind.SerializationFeature.WRITE_DATES_AS_TIMESTAMPS),
+                "WRITE_DATES_AS_TIMESTAMPS should be disabled");
+    }
+
+    @Test
+    void testPingResultJsonSerialization() throws Exception {
+        // Test the PingResult model to verify datetime serialization
+        PingResult pingResult = new PingResult();
+        Calendar cal = Calendar.getInstance();
+        cal.set(2024, Calendar.JANUARY, 15, 14, 30, 45);
+        cal.set(Calendar.MILLISECOND, 0);
+        Date testDate = cal.getTime();
+        
+        pingResult.setCurrentTimestamp(testDate);
+        pingResult.setStatus("OK");
+        
+        String json = objectMapper.writeValueAsString(pingResult);
+        
+        // Parse the JSON response
+        JsonNode jsonNode = objectMapper.readTree(json);
+        
+        // Verify that currentTimestamp is in the expected datetime format
+        JsonNode timestampNode = jsonNode.get("currentTimestamp");
+        assertNotNull(timestampNode, "currentTimestamp should be present");
+        
+        String timestamp = timestampNode.asText();
+        
+        // Verify format matches yyyy-MM-ddTHH:mm:ss
+        assertTrue(timestamp.matches("\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}"),
+                  "Ping currentTimestamp should be in format yyyy-MM-ddTHH:mm:ss, but was: " + timestamp);
+        
+        // Verify it can be parsed back to a Date
+        SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
+        Date parsedDate = format.parse(timestamp);
+        assertNotNull(parsedDate, "Timestamp should be parseable");
+    }
+
+    @Test
+    void testJJDisputeJsonSerialization() throws Exception {
+        // Test JJDispute serialization with mixed date formats
+        JJDispute testDispute = createTestJJDispute();
+        
+        String requestJson = objectMapper.writeValueAsString(testDispute);
+        
+        // Verify the JSON contains properly formatted dates
+        assertTrue(requestJson.contains("\"disputantBirthDt\":\"2024-03-15\""),
+                  "JJDispute disputantBirthDt should be serialized as date-only");
+        assertTrue(requestJson.contains("\"jjDecisionDt\":\"2024-03-16T14:20:30\""),
+                  "JJDispute jjDecisionDt should be serialized as datetime");
+        assertTrue(requestJson.contains("\"entDtm\":\"2024-03-17T16:45:10\""),
+                  "JJDispute entDtm should be serialized as datetime");
+        
+        // Test deserialization
+        JJDispute deserializedDispute = objectMapper.readValue(requestJson, JJDispute.class);
+        
+        // For date-only field, compare date components
+        Calendar originalCal = Calendar.getInstance();
+        originalCal.setTime(testDispute.getDisputantBirthDt());
+        Calendar deserializedCal = Calendar.getInstance();
+        deserializedCal.setTime(deserializedDispute.getDisputantBirthDt());
+        
+        assertEquals(originalCal.get(Calendar.YEAR), deserializedCal.get(Calendar.YEAR));
+        assertEquals(originalCal.get(Calendar.MONTH), deserializedCal.get(Calendar.MONTH));
+        assertEquals(originalCal.get(Calendar.DAY_OF_MONTH), deserializedCal.get(Calendar.DAY_OF_MONTH));
+        
+        // For datetime fields, exact match
+        assertEquals(testDispute.getJjDecisionDt(), deserializedDispute.getJjDecisionDt());
+        assertEquals(testDispute.getEntDtm(), deserializedDispute.getEntDtm());
+    }
+
+    @Test
+    void testJJDisputeCountMixedDateSerialization() throws Exception {
+        // Test JJDisputeCount with both date-only and datetime fields
+        JJDisputeCount testDisputeCount = createTestJJDisputeCount();
+        
+        String requestJson = objectMapper.writeValueAsString(testDisputeCount);
+        
+        // Verify mixed date format serialization
+        assertTrue(requestJson.contains("\"fineDueDt\":\"2024-04-10\""),
+                  "JJDisputeCount fineDueDt should be serialized as date-only");
+        assertTrue(requestJson.contains("\"violationDt\":\"2024-04-12\""),
+                  "JJDisputeCount violationDt should be serialized as date-only");
+        assertTrue(requestJson.contains("\"latestPleaUpdateDtm\":\"2024-04-11T09:15:20\""),
+                  "JJDisputeCount latestPleaUpdateDtm should be serialized as datetime");
+        assertTrue(requestJson.contains("\"accEntDtm\":\"2024-04-13T16:45:10\""),
+                  "JJDisputeCount accEntDtm should be serialized as datetime");
+        
+        // Test deserialization preserves both formats
+        JJDisputeCount deserializedCount = objectMapper.readValue(requestJson, JJDisputeCount.class);
+        
+        // For date-only fields, compare date components
+        Calendar originalCal = Calendar.getInstance();
+        originalCal.setTime(testDisputeCount.getFineDueDt());
+        Calendar deserializedCal = Calendar.getInstance();
+        deserializedCal.setTime(deserializedCount.getFineDueDt());
+        
+        assertEquals(originalCal.get(Calendar.YEAR), deserializedCal.get(Calendar.YEAR));
+        assertEquals(originalCal.get(Calendar.MONTH), deserializedCal.get(Calendar.MONTH));
+        assertEquals(originalCal.get(Calendar.DAY_OF_MONTH), deserializedCal.get(Calendar.DAY_OF_MONTH));
+        
+        // For datetime fields, exact match
+        assertEquals(testDisputeCount.getLatestPleaUpdateDtm(), deserializedCount.getLatestPleaUpdateDtm());
+        assertEquals(testDisputeCount.getAccEntDtm(), deserializedCount.getAccEntDtm());
+    }
+
+    @Test
+    void testJJCourtAppearanceJsonSerialization() throws Exception {
+        // Test JJCourtAppearance serialization
+        JJCourtAppearance testCourtAppearance = createTestJJCourtAppearance();
+        
+        String requestJson = objectMapper.writeValueAsString(testCourtAppearance);
+        
+        // Verify the JSON contains properly formatted datetime
+        assertTrue(requestJson.contains("\"appearanceDtm\":\"2024-05-20T10:30:45\""),
+                  "JJCourtAppearance appearanceDtm should be serialized as datetime");
+        assertTrue(requestJson.contains("\"disputantNotPresentDtm\":\"2024-05-21T14:20:30\""),
+                  "JJCourtAppearance disputantNotPresentDtm should be serialized as datetime");
+        
+        // Test deserialization
+        JJCourtAppearance deserializedAppearance = objectMapper.readValue(requestJson, JJCourtAppearance.class);
+        assertEquals(testCourtAppearance.getAppearanceDtm(), deserializedAppearance.getAppearanceDtm(),
+                    "Deserialized appearanceDtm should match original");
+        assertEquals(testCourtAppearance.getDisputantNotPresentDtm(), deserializedAppearance.getDisputantNotPresentDtm(),
+                    "Deserialized disputantNotPresentDtm should match original");
+    }
+
+    @Test
+    void testJJDisputeRemarkJsonSerialization() throws Exception {
+        // Test JJDisputeRemark serialization
+        JJDisputeRemark testRemark = createTestJJDisputeRemark();
+        
+        String requestJson = objectMapper.writeValueAsString(testRemark);
+        
+        // Verify the JSON contains properly formatted datetime
+        assertTrue(requestJson.contains("\"remarksMadeDtm\":\"2024-06-15T11:45:20\""),
+                  "JJDisputeRemark remarksMadeDtm should be serialized as datetime");
+        assertTrue(requestJson.contains("\"entDtm\":\"2024-06-16T09:30:15\""),
+                  "JJDisputeRemark entDtm should be serialized as datetime");
+        
+        // Test deserialization
+        JJDisputeRemark deserializedRemark = objectMapper.readValue(requestJson, JJDisputeRemark.class);
+        assertEquals(testRemark.getRemarksMadeDtm(), deserializedRemark.getRemarksMadeDtm(),
+                    "Deserialized remarksMadeDtm should match original");
+        assertEquals(testRemark.getEntDtm(), deserializedRemark.getEntDtm(),
+                    "Deserialized entDtm should match original");
+    }
+
+    @Test
+    void testAuditLogEntryJsonSerialization() throws Exception {
+        // Test AuditLogEntry serialization
+        AuditLogEntry testAuditEntry = createTestAuditLogEntry();
+        
+        String requestJson = objectMapper.writeValueAsString(testAuditEntry);
+        
+        // Verify the JSON contains properly formatted datetime
+        assertTrue(requestJson.contains("\"entDtm\":\"2024-07-20T13:25:35\""),
+                  "AuditLogEntry entDtm should be serialized as datetime");
+        assertTrue(requestJson.contains("\"updDtm\":\"2024-07-21T15:40:50\""),
+                  "AuditLogEntry updDtm should be serialized as datetime");
+        
+        // Test deserialization
+        AuditLogEntry deserializedEntry = objectMapper.readValue(requestJson, AuditLogEntry.class);
+        assertEquals(testAuditEntry.getEntDtm(), deserializedEntry.getEntDtm(),
+                    "Deserialized entDtm should match original");
+        assertEquals(testAuditEntry.getUpdDtm(), deserializedEntry.getUpdDtm(),
+                    "Deserialized updDtm should match original");
+    }
+
+    @Test
+    void testTimezoneIndependentSerialization() throws Exception {
+        // Test that serialization produces consistent results across different system timezones
+        TimeZone originalTimezone = TimeZone.getDefault();
+        
+        try {
+            // Create test data
+            PingResult pingResult = new PingResult();
+            Calendar cal = Calendar.getInstance();
+            cal.set(2024, Calendar.MAY, 20, 13, 45, 30);
+            cal.set(Calendar.MILLISECOND, 0);
+            Date testDate = cal.getTime();
+            pingResult.setCurrentTimestamp(testDate);
+            pingResult.setStatus("OK");
+            
+            // Serialize in original timezone
+            String jsonInOriginalTz = objectMapper.writeValueAsString(pingResult);
+            
+            // Change system timezone
+            TimeZone.setDefault(TimeZone.getTimeZone("America/New_York"));
+            
+            // Serialize in different timezone
+            String jsonInDifferentTz = objectMapper.writeValueAsString(pingResult);
+            
+            // Change to another timezone
+            TimeZone.setDefault(TimeZone.getTimeZone("Europe/London"));
+            
+            // Serialize in third timezone
+            String jsonInThirdTz = objectMapper.writeValueAsString(pingResult);
+            
+            // All JSON outputs should be identical
+            assertEquals(jsonInOriginalTz, jsonInDifferentTz,
+                        "JSON should be identical across timezone changes (original vs NY)");
+            assertEquals(jsonInOriginalTz, jsonInThirdTz,
+                        "JSON should be identical across timezone changes (original vs London)");
+            
+            // Verify the timestamp format is preserved
+            assertTrue(jsonInOriginalTz.contains("\"currentTimestamp\":\"2024-05-20T13:45:30\""),
+                      "Timestamp should maintain original format regardless of system timezone");
+            
+        } finally {
+            // Restore original timezone
+            TimeZone.setDefault(originalTimezone);
+        }
+    }
+
+    @Test
+    void testGlobalDateSerializerIntegration() throws Exception {
+        // Test that the GlobalDateSerializer correctly determines date vs datetime formats
+        
+        // Create a date with no time component
+        Calendar cal = Calendar.getInstance();
+        cal.set(2024, Calendar.JUNE, 15, 0, 0, 0);
+        cal.set(Calendar.MILLISECOND, 0);
+        Date dateOnly = cal.getTime();
+        
+        // Create a date with time component
+        cal.set(2024, Calendar.JUNE, 16, 14, 30, 45);
+        cal.set(Calendar.MILLISECOND, 0);
+        Date dateTime = cal.getTime();
+        
+        JJDispute dispute = new JJDispute();
+        dispute.setDisputeId("testGlobal");
+        dispute.setDisputantBirthDt(dateOnly);  // Should be serialized as date-only
+        dispute.setJjDecisionDt(dateTime);  // Should be serialized as datetime
+        
+        String json = objectMapper.writeValueAsString(dispute);
+        
+        // Verify the global serializer correctly identifies and formats each type
+        assertTrue(json.contains("\"disputantBirthDt\":\"2024-06-15\""),
+                  "Date with no time component should be serialized as date-only");
+        assertTrue(json.contains("\"jjDecisionDt\":\"2024-06-16T14:30:45\""),
+                  "Date with time component should be serialized as datetime");
+    }
+
+    @Test
+    void testEdgeCaseDateHandling() throws Exception {
+        // Test edge cases for date handling
+        
+        Calendar cal = Calendar.getInstance();
+        
+        // Test midnight (edge case between date-only and datetime)
+        cal.set(2024, Calendar.JULY, 4, 0, 0, 0);
+        cal.set(Calendar.MILLISECOND, 1); // 1 millisecond should trigger datetime format
+        Date midnightWithMillis = cal.getTime();
+        
+        // Test exactly midnight with no sub-second components
+        cal.set(Calendar.MILLISECOND, 0);
+        Date exactMidnight = cal.getTime();
+        
+        JJDispute dispute = new JJDispute();
+        dispute.setDisputeId("edgeCase");
+        dispute.setSubmittedDt(midnightWithMillis);
+        dispute.setJjDecisionDt(exactMidnight);
+        
+        String json = objectMapper.writeValueAsString(dispute);
+        
+        // Even 1 millisecond should trigger datetime format
+        assertTrue(json.contains("\"submittedDt\":\"2024-07-04T00:00:00\""),
+                  "Midnight with milliseconds should be serialized as datetime");
+        
+        // Exact midnight with no time components should still be datetime if detected as having time
+        assertTrue(json.contains("\"jjDecisionDt\":\"2024-07-04T00:00:00\"") || 
+                  json.contains("\"jjDecisionDt\":\"2024-07-04\""),
+                  "Exact midnight should be serialized consistently");
+    }
+
+    @Test
+    void testComplexObjectSerialization() throws Exception {
+        // Test serialization of complex TCO objects with nested date fields
+        JJDispute dispute = createComplexJJDispute();
+        
+        String json = objectMapper.writeValueAsString(dispute);
+        
+        // Verify all date formats are correct in the complex object
+        assertTrue(json.contains("\"disputantBirthDt\":\"2024-08-10\""),
+                  "Complex object date-only field should be serialized correctly");
+        assertTrue(json.contains("\"submittedDt\":\"2024-08-11T10:15:30\""),
+                  "Complex object datetime field should be serialized correctly");
+        
+        // Test deserialization maintains consistency
+        JJDispute deserializedDispute = objectMapper.readValue(json, JJDispute.class);
+        
+        // Verify all nested date fields are preserved
+        assertEquals(dispute.getSubmittedDt(), deserializedDispute.getSubmittedDt(),
+                    "Complex object datetime should be preserved");
+        
+        // Check date components for date-only field
+        Calendar originalCal = Calendar.getInstance();
+        originalCal.setTime(dispute.getDisputantBirthDt());
+        Calendar deserializedCal = Calendar.getInstance();
+        deserializedCal.setTime(deserializedDispute.getDisputantBirthDt());
+        
+        assertEquals(originalCal.get(Calendar.YEAR), deserializedCal.get(Calendar.YEAR));
+        assertEquals(originalCal.get(Calendar.MONTH), deserializedCal.get(Calendar.MONTH));
+        assertEquals(originalCal.get(Calendar.DAY_OF_MONTH), deserializedCal.get(Calendar.DAY_OF_MONTH));
+    }
+
+    private JJDispute createTestJJDispute() {
+        JJDispute dispute = new JJDispute();
+        
+        Calendar cal = Calendar.getInstance();
+        
+        // Date-only field
+        cal.set(2024, Calendar.MARCH, 15, 0, 0, 0);
+        cal.set(Calendar.MILLISECOND, 0);
+        dispute.setDisputantBirthDt(cal.getTime());
+        
+        // Datetime fields
+        cal.set(2024, Calendar.MARCH, 16, 14, 20, 30);
+        cal.set(Calendar.MILLISECOND, 0);
+        dispute.setJjDecisionDt(cal.getTime());
+        
+        cal.set(2024, Calendar.MARCH, 17, 16, 45, 10);
+        cal.set(Calendar.MILLISECOND, 0);
+        dispute.setEntDtm(cal.getTime());
+        
+        dispute.setDisputeId("DISP001");
+        dispute.setEntUserId("testuser");
+        
+        return dispute;
+    }
+
+    private JJDisputeCount createTestJJDisputeCount() {
+        JJDisputeCount disputeCount = new JJDisputeCount();
+        
+        Calendar cal = Calendar.getInstance();
+        
+        // Date-only fields
+        cal.set(2024, Calendar.APRIL, 10, 0, 0, 0);
+        cal.set(Calendar.MILLISECOND, 0);
+        disputeCount.setFineDueDt(cal.getTime());
+        
+        cal.set(2024, Calendar.APRIL, 12, 0, 0, 0);
+        cal.set(Calendar.MILLISECOND, 0);
+        disputeCount.setViolationDt(cal.getTime());
+        
+        // Datetime fields
+        cal.set(2024, Calendar.APRIL, 11, 9, 15, 20);
+        cal.set(Calendar.MILLISECOND, 0);
+        disputeCount.setLatestPleaUpdateDtm(cal.getTime());
+        
+        cal.set(2024, Calendar.APRIL, 13, 16, 45, 10);
+        cal.set(Calendar.MILLISECOND, 0);
+        disputeCount.setAccEntDtm(cal.getTime());
+        
+        disputeCount.setDisputeCountId("COUNT001");
+        disputeCount.setAccEntUserId("testuser");
+        
+        return disputeCount;
+    }
+
+    private JJCourtAppearance createTestJJCourtAppearance() {
+        JJCourtAppearance courtAppearance = new JJCourtAppearance();
+        
+        Calendar cal = Calendar.getInstance();
+        cal.set(2024, Calendar.MAY, 20, 10, 30, 45);
+        cal.set(Calendar.MILLISECOND, 0);
+        courtAppearance.setAppearanceDtm(cal.getTime());
+        
+        cal.set(2024, Calendar.MAY, 21, 14, 20, 30);
+        cal.set(Calendar.MILLISECOND, 0);
+        courtAppearance.setDisputantNotPresentDtm(cal.getTime());
+        
+        courtAppearance.setCourtAppearanceId("COURT001");
+        
+        return courtAppearance;
+    }
+
+    private JJDisputeRemark createTestJJDisputeRemark() {
+        JJDisputeRemark remark = new JJDisputeRemark();
+        
+        Calendar cal = Calendar.getInstance();
+        cal.set(2024, Calendar.JUNE, 15, 11, 45, 20);
+        cal.set(Calendar.MILLISECOND, 0);
+        remark.setRemarksMadeDtm(cal.getTime());
+        
+        cal.set(2024, Calendar.JUNE, 16, 9, 30, 15);
+        cal.set(Calendar.MILLISECOND, 0);
+        remark.setEntDtm(cal.getTime());
+        
+        remark.setDisputeRemarkId("REMARK001");
+        remark.setDisputeId("DISPUTE001");
+        remark.setEntUserId("testuser");
+        
+        return remark;
+    }
+
+    private AuditLogEntry createTestAuditLogEntry() {
+        AuditLogEntry auditEntry = new AuditLogEntry();
+        
+        Calendar cal = Calendar.getInstance();
+        cal.set(2024, Calendar.JULY, 20, 13, 25, 35);
+        cal.set(Calendar.MILLISECOND, 0);
+        auditEntry.setEntDtm(cal.getTime());
+        
+        cal.set(2024, Calendar.JULY, 21, 15, 40, 50);
+        cal.set(Calendar.MILLISECOND, 0);
+        auditEntry.setUpdDtm(cal.getTime());
+        
+        auditEntry.setAuditLogEntryId("AUDIT001");
+        auditEntry.setDisputeId("DISPUTE001");
+        auditEntry.setEntUserId("testuser");
+        
+        return auditEntry;
+    }
+
+    private JJDispute createComplexJJDispute() {
+        JJDispute dispute = new JJDispute();
+        
+        Calendar cal = Calendar.getInstance();
+        
+        // Date-only field
+        cal.set(2024, Calendar.AUGUST, 10, 0, 0, 0);
+        cal.set(Calendar.MILLISECOND, 0);
+        dispute.setDisputantBirthDt(cal.getTime());
+        
+        // Datetime fields
+        cal.set(2024, Calendar.AUGUST, 11, 10, 15, 30);
+        cal.set(Calendar.MILLISECOND, 0);
+        dispute.setSubmittedDt(cal.getTime());
+        
+        cal.set(2024, Calendar.AUGUST, 12, 14, 30, 45);
+        cal.set(Calendar.MILLISECOND, 0);
+        dispute.setEntDtm(cal.getTime());
+        
+        dispute.setDisputeId("COMPLEX001");
+        dispute.setEntUserId("testuser");
+        dispute.setTicketNumberTxt("AA12345678");
+        
+        return dispute;
+    }
+}

--- a/src/backend/oracle-data-api/src/test/java/ca/bc/gov/open/jag/tco/oracledataapi/config/TcoDateSerializationTest.java
+++ b/src/backend/oracle-data-api/src/test/java/ca/bc/gov/open/jag/tco/oracledataapi/config/TcoDateSerializationTest.java
@@ -1,0 +1,436 @@
+package ca.bc.gov.open.jag.tco.oracledataapi.config;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.TimeZone;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import ca.bc.gov.open.jag.tco.oracledataapi.ords.tco.api.model.AuditLogEntry;
+import ca.bc.gov.open.jag.tco.oracledataapi.ords.tco.api.model.JJCourtAppearance;
+import ca.bc.gov.open.jag.tco.oracledataapi.ords.tco.api.model.JJDispute;
+import ca.bc.gov.open.jag.tco.oracledataapi.ords.tco.api.model.JJDisputeCount;
+import ca.bc.gov.open.jag.tco.oracledataapi.ords.tco.api.model.JJDisputeRemark;
+import ca.bc.gov.open.jag.tco.oracledataapi.ords.tco.api.model.PingResult;
+
+/**
+ * Test class to verify that TCO date serialization/deserialization preserves exact database values
+ * without timezone conversion, ensuring consistency across different system timezones.
+ */
+public class TcoDateSerializationTest {
+
+    private ObjectMapper objectMapper;
+
+    private SimpleDateFormat dateOnlyFormat;
+    private SimpleDateFormat dateTimeFormat;
+
+    @BeforeEach
+    void setUp() {
+        // Create ObjectMapper with our custom configuration
+        JacksonConfig jacksonConfig = new JacksonConfig();
+        objectMapper = jacksonConfig.objectMapper();
+        
+        dateOnlyFormat = new SimpleDateFormat("yyyy-MM-dd");
+        dateTimeFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
+        // Ensure formatters are timezone-neutral for testing
+        dateOnlyFormat.setTimeZone(TimeZone.getDefault());
+        dateTimeFormat.setTimeZone(TimeZone.getDefault());
+    }
+
+    @Test
+    void testPingResultCurrentTimestampSerialization() throws JsonProcessingException, ParseException {
+        // Test datetime serialization for PingResult.currentTimestamp
+        PingResult pingResult = new PingResult();
+        
+        // Create a test datetime with specific values
+        Calendar cal = Calendar.getInstance();
+        cal.set(2024, Calendar.JANUARY, 15, 14, 30, 45);
+        cal.set(Calendar.MILLISECOND, 0);
+        Date testDateTime = cal.getTime();
+        
+        pingResult.setCurrentTimestamp(testDateTime);
+        pingResult.setStatus("OK");
+
+        String json = objectMapper.writeValueAsString(pingResult);
+        
+        // Verify the datetime is serialized in the expected format
+        assertTrue(json.contains("\"currentTimestamp\":\"2024-01-15T14:30:45\""), 
+                   "PingResult currentTimestamp should be serialized as datetime format");
+        
+        // Test deserialization preserves the exact value
+        PingResult deserializedResult = objectMapper.readValue(json, PingResult.class);
+        assertEquals(testDateTime, deserializedResult.getCurrentTimestamp(),
+                     "Deserialized datetime should match original exactly");
+    }
+
+    @Test
+    void testJJDisputeDateOnlySerialization() throws JsonProcessingException, ParseException {
+        // Test date-only serialization for JJDispute.disputantBirthDt
+        JJDispute dispute = new JJDispute();
+        
+        // Create a date-only value (no time component)
+        Calendar cal = Calendar.getInstance();
+        cal.set(2024, Calendar.MARCH, 10, 0, 0, 0);
+        cal.set(Calendar.MILLISECOND, 0);
+        Date testDate = cal.getTime();
+        
+        dispute.setDisputantBirthDt(testDate);
+        dispute.setDisputeId("12345");
+
+        String json = objectMapper.writeValueAsString(dispute);
+        
+        // Verify the date is serialized in date-only format
+        assertTrue(json.contains("\"disputantBirthDt\":\"2024-03-10\""), 
+                   "JJDispute disputantBirthDt should be serialized as date-only format");
+        
+        // Test deserialization preserves the date value
+        JJDispute deserializedDispute = objectMapper.readValue(json, JJDispute.class);
+        
+        // Compare only the date components (ignore any time differences due to timezone handling)
+        Calendar originalCal = Calendar.getInstance();
+        originalCal.setTime(testDate);
+        Calendar deserializedCal = Calendar.getInstance();
+        deserializedCal.setTime(deserializedDispute.getDisputantBirthDt());
+        
+        assertEquals(originalCal.get(Calendar.YEAR), deserializedCal.get(Calendar.YEAR));
+        assertEquals(originalCal.get(Calendar.MONTH), deserializedCal.get(Calendar.MONTH));
+        assertEquals(originalCal.get(Calendar.DAY_OF_MONTH), deserializedCal.get(Calendar.DAY_OF_MONTH));
+    }
+
+    @Test
+    void testJJDisputeDateTimeSerialization() throws JsonProcessingException {
+        // Test datetime serialization for JJDispute audit fields
+        JJDispute dispute = new JJDispute();
+        
+        // Create datetime values with specific time components
+        Calendar cal = Calendar.getInstance();
+        cal.set(2024, Calendar.FEBRUARY, 20, 9, 15, 30);
+        cal.set(Calendar.MILLISECOND, 0);
+        Date entDtm = cal.getTime();
+        
+        cal.set(2024, Calendar.FEBRUARY, 21, 16, 45, 15);
+        cal.set(Calendar.MILLISECOND, 0);
+        Date updDtm = cal.getTime();
+
+        dispute.setEntDtm(entDtm);
+        dispute.setUpdDtm(updDtm);
+        dispute.setEntUserId("testuser1");
+        dispute.setUpdUserId("testuser2");
+        dispute.setDisputeId("67890");
+
+        String json = objectMapper.writeValueAsString(dispute);
+        
+        // Verify datetime fields are serialized with time components
+        assertTrue(json.contains("\"entDtm\":\"2024-02-20T09:15:30\""), 
+                   "JJDispute entDtm should be serialized as datetime format");
+        assertTrue(json.contains("\"updDtm\":\"2024-02-21T16:45:15\""), 
+                   "JJDispute updDtm should be serialized as datetime format");
+        
+        // Test deserialization
+        JJDispute deserializedDispute = objectMapper.readValue(json, JJDispute.class);
+        assertEquals(entDtm, deserializedDispute.getEntDtm(),
+                     "Deserialized entDtm should match original exactly");
+        assertEquals(updDtm, deserializedDispute.getUpdDtm(),
+                     "Deserialized updDtm should match original exactly");
+    }
+
+    @Test
+    void testJJDisputeMixedDateSerialization() throws JsonProcessingException {
+        // Test JJDispute with both date-only and datetime fields
+        JJDispute dispute = new JJDispute();
+        
+        Calendar cal = Calendar.getInstance();
+        
+        // Date-only field
+        cal.set(2024, Calendar.APRIL, 10, 0, 0, 0);
+        cal.set(Calendar.MILLISECOND, 0);
+        Date disputantBirthDt = cal.getTime();
+        
+        // Datetime fields
+        cal.set(2024, Calendar.APRIL, 11, 9, 15, 20);
+        cal.set(Calendar.MILLISECOND, 0);
+        Date submittedDt = cal.getTime();
+        
+        cal.set(2024, Calendar.APRIL, 12, 14, 30, 45);
+        cal.set(Calendar.MILLISECOND, 0);
+        Date jjDecisionDt = cal.getTime();
+        
+        dispute.setDisputantBirthDt(disputantBirthDt);
+        dispute.setSubmittedDt(submittedDt);
+        dispute.setJjDecisionDt(jjDecisionDt);
+        dispute.setDisputeId("DISP001");
+
+        String json = objectMapper.writeValueAsString(dispute);
+        
+        // Verify mixed date format serialization
+        assertTrue(json.contains("\"disputantBirthDt\":\"2024-04-10\""),
+                  "JJDispute disputantBirthDt should be serialized as date-only");
+        assertTrue(json.contains("\"submittedDt\":\"2024-04-11T09:15:20\""),
+                  "JJDispute submittedDt should be serialized as datetime");
+        assertTrue(json.contains("\"jjDecisionDt\":\"2024-04-12T14:30:45\""),
+                  "JJDispute jjDecisionDt should be serialized as datetime");
+        
+        // Test deserialization preserves both formats
+        JJDispute deserializedDispute = objectMapper.readValue(json, JJDispute.class);
+        
+        // For date-only field, compare date components
+        Calendar originalCal = Calendar.getInstance();
+        originalCal.setTime(disputantBirthDt);
+        Calendar deserializedCal = Calendar.getInstance();
+        deserializedCal.setTime(deserializedDispute.getDisputantBirthDt());
+        
+        assertEquals(originalCal.get(Calendar.YEAR), deserializedCal.get(Calendar.YEAR));
+        assertEquals(originalCal.get(Calendar.MONTH), deserializedCal.get(Calendar.MONTH));
+        assertEquals(originalCal.get(Calendar.DAY_OF_MONTH), deserializedCal.get(Calendar.DAY_OF_MONTH));
+        
+        // For datetime fields, exact match
+        assertEquals(submittedDt, deserializedDispute.getSubmittedDt());
+        assertEquals(jjDecisionDt, deserializedDispute.getJjDecisionDt());
+    }
+
+    @Test
+    void testJJDisputeCountDateSerialization() throws JsonProcessingException {
+        // Test date and datetime serialization for JJDisputeCount
+        JJDisputeCount disputeCount = new JJDisputeCount();
+        
+        Calendar cal = Calendar.getInstance();
+        
+        // Date-only fields
+        cal.set(2024, Calendar.MAY, 15, 0, 0, 0);
+        cal.set(Calendar.MILLISECOND, 0);
+        Date fineDueDt = cal.getTime();
+        
+        cal.set(2024, Calendar.MAY, 20, 0, 0, 0);
+        cal.set(Calendar.MILLISECOND, 0);
+        Date violationDt = cal.getTime();
+        
+        // Datetime fields
+        cal.set(2024, Calendar.MAY, 16, 10, 30, 0);
+        cal.set(Calendar.MILLISECOND, 0);
+        Date latestPleaUpdateDtm = cal.getTime();
+        
+        cal.set(2024, Calendar.MAY, 17, 14, 45, 30);
+        cal.set(Calendar.MILLISECOND, 0);
+        Date accEntDtm = cal.getTime();
+        
+        disputeCount.setFineDueDt(fineDueDt);
+        disputeCount.setViolationDt(violationDt);
+        disputeCount.setLatestPleaUpdateDtm(latestPleaUpdateDtm);
+        disputeCount.setAccEntDtm(accEntDtm);
+        disputeCount.setDisputeCountId("COUNT001");
+
+        String json = objectMapper.writeValueAsString(disputeCount);
+        
+        // Verify date-only fields
+        assertTrue(json.contains("\"fineDueDt\":\"2024-05-15\""),
+                  "JJDisputeCount fineDueDt should be serialized as date-only");
+        assertTrue(json.contains("\"violationDt\":\"2024-05-20\""),
+                  "JJDisputeCount violationDt should be serialized as date-only");
+        
+        // Verify datetime fields
+        assertTrue(json.contains("\"latestPleaUpdateDtm\":\"2024-05-16T10:30:00\""),
+                  "JJDisputeCount latestPleaUpdateDtm should be serialized as datetime");
+        assertTrue(json.contains("\"accEntDtm\":\"2024-05-17T14:45:30\""),
+                  "JJDisputeCount accEntDtm should be serialized as datetime");
+        
+        // Test deserialization
+        JJDisputeCount deserializedCount = objectMapper.readValue(json, JJDisputeCount.class);
+        
+        // Compare date-only fields (date components only)
+        Calendar originalCal = Calendar.getInstance();
+        Calendar deserializedCal = Calendar.getInstance();
+        
+        originalCal.setTime(fineDueDt);
+        deserializedCal.setTime(deserializedCount.getFineDueDt());
+        assertEquals(originalCal.get(Calendar.YEAR), deserializedCal.get(Calendar.YEAR));
+        assertEquals(originalCal.get(Calendar.MONTH), deserializedCal.get(Calendar.MONTH));
+        assertEquals(originalCal.get(Calendar.DAY_OF_MONTH), deserializedCal.get(Calendar.DAY_OF_MONTH));
+        
+        // Compare datetime fields (exact match)
+        assertEquals(latestPleaUpdateDtm, deserializedCount.getLatestPleaUpdateDtm());
+        assertEquals(accEntDtm, deserializedCount.getAccEntDtm());
+    }
+
+    @Test
+    void testJJCourtAppearanceDateTimeSerialization() throws JsonProcessingException {
+        // Test datetime serialization for JJCourtAppearance
+        JJCourtAppearance courtAppearance = new JJCourtAppearance();
+        
+        Calendar cal = Calendar.getInstance();
+        cal.set(2024, Calendar.JUNE, 8, 11, 45, 20);
+        cal.set(Calendar.MILLISECOND, 0);
+        Date appearanceDtm = cal.getTime();
+        
+        cal.set(2024, Calendar.JUNE, 9, 16, 30, 15);
+        cal.set(Calendar.MILLISECOND, 0);
+        Date disputantNotPresentDtm = cal.getTime();
+        
+        courtAppearance.setAppearanceDtm(appearanceDtm);
+        courtAppearance.setDisputantNotPresentDtm(disputantNotPresentDtm);
+        courtAppearance.setCourtAppearanceId("COURT001");
+
+        String json = objectMapper.writeValueAsString(courtAppearance);
+        
+        assertTrue(json.contains("\"appearanceDtm\":\"2024-06-08T11:45:20\""), 
+                   "JJCourtAppearance appearanceDtm should be serialized as datetime format");
+        assertTrue(json.contains("\"disputantNotPresentDtm\":\"2024-06-09T16:30:15\""), 
+                   "JJCourtAppearance disputantNotPresentDtm should be serialized as datetime format");
+        
+        JJCourtAppearance deserializedAppearance = objectMapper.readValue(json, JJCourtAppearance.class);
+        assertEquals(appearanceDtm, deserializedAppearance.getAppearanceDtm(),
+                     "Deserialized appearanceDtm should match original exactly");
+        assertEquals(disputantNotPresentDtm, deserializedAppearance.getDisputantNotPresentDtm(),
+                     "Deserialized disputantNotPresentDtm should match original exactly");
+    }
+
+    @Test
+    void testJJDisputeRemarkDateTimeSerialization() throws JsonProcessingException {
+        // Test datetime serialization for JJDisputeRemark
+        JJDisputeRemark disputeRemark = new JJDisputeRemark();
+        
+        Calendar cal = Calendar.getInstance();
+        cal.set(2024, Calendar.JULY, 15, 14, 20, 35);
+        cal.set(Calendar.MILLISECOND, 0);
+        Date remarksMadeDtm = cal.getTime();
+        
+        cal.set(2024, Calendar.JULY, 16, 9, 30, 45);
+        cal.set(Calendar.MILLISECOND, 0);
+        Date entDtm = cal.getTime();
+        
+        disputeRemark.setRemarksMadeDtm(remarksMadeDtm);
+        disputeRemark.setEntDtm(entDtm);
+        disputeRemark.setDisputeRemarkId("REMARK001");
+        disputeRemark.setDisputeId("DISPUTE001");
+
+        String json = objectMapper.writeValueAsString(disputeRemark);
+        
+        assertTrue(json.contains("\"remarksMadeDtm\":\"2024-07-15T14:20:35\""), 
+                   "JJDisputeRemark remarksMadeDtm should be serialized as datetime format");
+        assertTrue(json.contains("\"entDtm\":\"2024-07-16T09:30:45\""), 
+                   "JJDisputeRemark entDtm should be serialized as datetime format");
+        
+        JJDisputeRemark deserializedRemark = objectMapper.readValue(json, JJDisputeRemark.class);
+        assertEquals(remarksMadeDtm, deserializedRemark.getRemarksMadeDtm(),
+                     "Deserialized remarksMadeDtm should match original exactly");
+        assertEquals(entDtm, deserializedRemark.getEntDtm(),
+                     "Deserialized entDtm should match original exactly");
+    }
+
+    @Test
+    void testAuditLogEntryDateTimeSerialization() throws JsonProcessingException {
+        // Test datetime serialization for AuditLogEntry audit fields
+        AuditLogEntry auditEntry = new AuditLogEntry();
+        
+        Calendar cal = Calendar.getInstance();
+        cal.set(2024, Calendar.AUGUST, 22, 16, 55, 10);
+        cal.set(Calendar.MILLISECOND, 0);
+        Date entDtm = cal.getTime();
+        
+        cal.set(2024, Calendar.AUGUST, 23, 11, 20, 25);
+        cal.set(Calendar.MILLISECOND, 0);
+        Date updDtm = cal.getTime();
+        
+        auditEntry.setEntDtm(entDtm);
+        auditEntry.setUpdDtm(updDtm);
+        auditEntry.setEntUserId("audituser");
+        auditEntry.setAuditLogEntryId("audit123");
+        auditEntry.setDisputeId("dispute456");
+
+        String json = objectMapper.writeValueAsString(auditEntry);
+        
+        assertTrue(json.contains("\"entDtm\":\"2024-08-22T16:55:10\""), 
+                   "AuditLogEntry entDtm should be serialized as datetime format");
+        assertTrue(json.contains("\"updDtm\":\"2024-08-23T11:20:25\""), 
+                   "AuditLogEntry updDtm should be serialized as datetime format");
+        
+        AuditLogEntry deserializedEntry = objectMapper.readValue(json, AuditLogEntry.class);
+        assertEquals(entDtm, deserializedEntry.getEntDtm(),
+                     "Deserialized entDtm should match original exactly");
+        assertEquals(updDtm, deserializedEntry.getUpdDtm(),
+                     "Deserialized updDtm should match original exactly");
+    }
+
+    @Test
+    void testTimezoneIndependence() throws JsonProcessingException {
+        // Test that serialization is timezone-independent
+        TimeZone originalTimezone = TimeZone.getDefault();
+        
+        try {
+            // Create a test date in the current timezone
+            Calendar cal = Calendar.getInstance();
+            cal.set(2024, Calendar.SEPTEMBER, 10, 12, 30, 45);
+            cal.set(Calendar.MILLISECOND, 0);
+            Date testDate = cal.getTime();
+            
+            PingResult pingResult = new PingResult();
+            pingResult.setCurrentTimestamp(testDate);
+            pingResult.setStatus("OK");
+            
+            // Serialize in original timezone
+            String jsonInOriginalTz = objectMapper.writeValueAsString(pingResult);
+            
+            // Change to a different timezone
+            TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
+            
+            // Serialize in different timezone
+            String jsonInDifferentTz = objectMapper.writeValueAsString(pingResult);
+            
+            // The JSON should be identical regardless of system timezone
+            assertEquals(jsonInOriginalTz, jsonInDifferentTz,
+                        "Serialization should be timezone-independent");
+            
+            // Verify deserialization gives same result in both timezones
+            PingResult deserializedInOriginal = objectMapper.readValue(jsonInOriginalTz, PingResult.class);
+            PingResult deserializedInDifferent = objectMapper.readValue(jsonInDifferentTz, PingResult.class);
+            
+            assertEquals(deserializedInOriginal.getCurrentTimestamp(), 
+                        deserializedInDifferent.getCurrentTimestamp(),
+                        "Deserialization should give same result regardless of timezone");
+            
+        } finally {
+            // Restore original timezone
+            TimeZone.setDefault(originalTimezone);
+        }
+    }
+
+    @Test
+    void testNullDateHandling() throws JsonProcessingException {
+        // Test that null dates are handled properly
+        JJDispute dispute = new JJDispute();
+        dispute.setDisputeId("nulltest");
+        dispute.setDisputantBirthDt(null);
+        dispute.setEntDtm(null);
+        dispute.setUpdDtm(null);
+
+        String json = objectMapper.writeValueAsString(dispute);
+        
+        // Verify null dates are serialized as null or omitted
+        assertTrue(json.contains("\"disputantBirthDt\":null") || !json.contains("\"disputantBirthDt\""), 
+                   "Null disputantBirthDt should be serialized as null or omitted");
+        
+        JJDispute deserializedDispute = objectMapper.readValue(json, JJDispute.class);
+        assertEquals(null, deserializedDispute.getDisputantBirthDt(),
+                     "Null disputantBirthDt should remain null after deserialization");
+    }
+
+    @Test
+    void testObjectMapperConfiguration() {
+        // Verify that the ObjectMapper is properly configured
+        assertNotNull(objectMapper, "ObjectMapper should be available");
+        
+        // Verify that WRITE_DATES_AS_TIMESTAMPS is disabled
+        assertEquals(false, objectMapper.getSerializationConfig().isEnabled(
+                com.fasterxml.jackson.databind.SerializationFeature.WRITE_DATES_AS_TIMESTAMPS),
+                     "WRITE_DATES_AS_TIMESTAMPS should be disabled");
+    }
+}


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- [TCVP-3242](https://jira.justice.gov.bc.ca/browse/TCVP-3242)
- Added global Jackson configuration and custom serialization/deserialization classes to standardize date/time and date only fields formatting.
- New standard date-time formatting is: "yyyy-MM-dd'T'HH:mm:ss".
- New standard date only formatting is: "yyyy-MM-dd".
- Avoid any time zone specification and conversion in order to transmit the data as saved in the database for all occam and tco domain models.
-  Added serialization/deserialization unit and integration tests for occam and tco date/time fields.
- This update requires ORDS packages to be updated to match date/time formatting between Oracle Data API and ORDS endpoints. **Deploying this change without ORDS package updates breaks the environment.**

Sample response from Oracle Data API:
<img width="627" alt="Screenshot 2025-07-02 at 10 45 35 AM" src="https://github.com/user-attachments/assets/fce8dd9c-b902-4b7e-ab21-273000da1676" />


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
