### PR TITLE
Disable staff dispute intake feature in test and prod via config

### DIFF
--- a/gitops/charts/traffic-court-dev-values.yaml
+++ b/gitops/charts/traffic-court-dev-values.yaml
@@ -46,7 +46,8 @@ citizen-web:
         "paymentOptionsLink": "https://www2.gov.bc.ca/gov/content/justice/courthouse-services/fines-payments/pay-dispute-ticket/prov-violation-tickets/pay-ticket",
         "resolutionOptionsLink": "https://www2.gov.bc.ca/gov/content/justice/courthouse-services/fines-payments/pay-dispute-ticket/prov-violation-tickets/dispute-ticket",
         "features": {
-          "dispute":true
+          "dispute": true,
+          "staffDisputeIntake": true
         }
       }
   authConfig: |

--- a/gitops/charts/traffic-court-prod-values.yaml
+++ b/gitops/charts/traffic-court-prod-values.yaml
@@ -52,7 +52,8 @@ citizen-web:
         "paymentOptionsLink": "https://www2.gov.bc.ca/gov/content/justice/courthouse-services/fines-payments/pay-dispute-ticket/prov-violation-tickets/pay-ticket",
         "resolutionOptionsLink": "https://www2.gov.bc.ca/gov/content/justice/courthouse-services/fines-payments/pay-dispute-ticket/prov-violation-tickets/dispute-ticket",
         "features": {
-          "dispute":true
+          "dispute": true,
+          "staffDisputeIntake": false
         }
       }
   authConfig: |

--- a/gitops/charts/traffic-court-test-values.yaml
+++ b/gitops/charts/traffic-court-test-values.yaml
@@ -55,7 +55,8 @@ citizen-web:
         "paymentOptionsLink": "https://www2.gov.bc.ca/gov/content/justice/courthouse-services/fines-payments/pay-dispute-ticket/prov-violation-tickets/pay-ticket",
         "resolutionOptionsLink": "https://www2.gov.bc.ca/gov/content/justice/courthouse-services/fines-payments/pay-dispute-ticket/prov-violation-tickets/dispute-ticket",
         "features": {
-          "dispute":true
+          "dispute": true,
+          "staffDisputeIntake": false
         }
       }
   authConfig: |

--- a/src/frontend/staff-portal/src/app/components/staff-workbench/ticket-inbox/ticket-inbox.component.html
+++ b/src/frontend/staff-portal/src/app/components/staff-workbench/ticket-inbox/ticket-inbox.component.html
@@ -8,7 +8,7 @@
       </div>
     </div>
   </ng-container>
-  <ng-container submitNewDispute>
+  <ng-container submitNewDispute *appFeatureFlag="featureType.staffDisputeIntake">
     <div>
       <div class="vcenter">
         <button mat-button (click)="submitNewDispute()" class="submit-new-dispute">

--- a/src/frontend/staff-portal/src/app/components/staff-workbench/ticket-inbox/ticket-inbox.component.ts
+++ b/src/frontend/staff-portal/src/app/components/staff-workbench/ticket-inbox/ticket-inbox.component.ts
@@ -7,6 +7,7 @@ import { LoggerService } from '@core/services/logger.service';
 import { AuthService, KeycloakProfile } from 'app/services/auth.service';
 import { TableFilter, TableFilterKeys, TableFilterStatusOptions, TicketValidationTableStatusDefault } from '@shared/models/table-filter-options.model';
 import { TableFilterService } from 'app/services/table-filter.service';
+import { featureType } from 'app/shared/directives/feature-flag.directive';
 
 @Component({
   selector: 'app-ticket-inbox',
@@ -20,6 +21,7 @@ export class TicketInboxComponent implements OnInit {
   disputes: Dispute[] = [];
   disputesCollection: PagedDisputeListItemCollection = {};
   dataSource = new MatTableDataSource(this.disputes);
+  featureType = featureType;
 
   tableFilterKeys: TableFilterKeys[] = ["dateSubmittedFrom", "dateSubmittedTo", "disputantSurname", "status", "ticketNumber", /*"courthouseLocation"*/ ]; // TCVP-3258 - temporarily hiding 'courthouseLocation'
   statusFilterOptions = TableFilterStatusOptions;

--- a/src/frontend/staff-portal/src/app/services/app-config.service.ts
+++ b/src/frontend/staff-portal/src/app/services/app-config.service.ts
@@ -22,6 +22,7 @@ export class AppConfig implements IAppConfig {
   apiBaseUrl: string;
   features: {
     dispute: boolean;
+    staffDisputeIntake: boolean;
   };
 }
 

--- a/src/frontend/staff-portal/src/app/shared/directives/feature-flag.directive.ts
+++ b/src/frontend/staff-portal/src/app/shared/directives/feature-flag.directive.ts
@@ -3,6 +3,7 @@ import { AppConfigService } from 'app/services/app-config.service';
 
 export const featureType = {
   dispute: 'dispute',
+  staffDisputeIntake: 'staffDisputeIntake',
 } as const;
 
 @Directive({

--- a/src/frontend/staff-portal/src/assets/app.config.json
+++ b/src/frontend/staff-portal/src/assets/app.config.json
@@ -5,5 +5,6 @@
   "useMockServices": false,
   "apiBaseUrl": "/api",
   "features": {
+    "staffDisputeIntake": true
   }
 }


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- makes the dispute intake feature configurable and disables it in test and prod (TCVP-3374)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes