### PR TITLE
TCVP-3434: Prevent duplicate dispute creation for staff

### DIFF
--- a/src/backend/TrafficCourts/Common/Features/DisputeCreation/DisputeAlreadyExistsException.cs
+++ b/src/backend/TrafficCourts/Common/Features/DisputeCreation/DisputeAlreadyExistsException.cs
@@ -1,0 +1,10 @@
+﻿namespace TrafficCourts.Common.Features.DisputeCreation;
+
+public class DisputeAlreadyExistsException : Exception
+{
+    public DisputeAlreadyExistsException() { }
+
+    public DisputeAlreadyExistsException(string message) : base(message) { }
+
+    public DisputeAlreadyExistsException(string message, Exception inner) : base(message, inner) { }
+}

--- a/src/backend/TrafficCourts/Common/Features/DisputeCreation/DisputeCreationService.cs
+++ b/src/backend/TrafficCourts/Common/Features/DisputeCreation/DisputeCreationService.cs
@@ -1,0 +1,28 @@
+﻿using MassTransit;
+using Microsoft.Extensions.Logging;
+using TrafficCourts.Domain.Models;
+using TrafficCourts.Interfaces;
+
+namespace TrafficCourts.Common.Features.DisputeCreation;
+
+public class DisputeCreationService(
+    ILogger<DisputeCreationService> logger,
+    IOracleDataApiService oracleDataApiService,
+    IBus bus)
+    : IDisputeCreationService
+{
+    /// <inheritdoc/>
+    public async Task<bool> CanCreateDispute(string ticketNumber, CancellationToken cancellationToken)
+    {
+        // retrieve existing disputes for this ticket that haven't been rejected
+        IList<DisputeResult> existingDisputes = await oracleDataApiService.SearchDisputeAsync(
+            ticketNumber,
+            null,
+            null,
+            ExcludeStatus2.REJECTED,
+            cancellationToken);
+
+        // if any of the existing disputes have a valid NoticeOfDisputeGuid, a new dispute cannot be created
+        return !existingDisputes.Any(d => Guid.TryParse(d.NoticeOfDisputeGuid, out _));
+    }
+}

--- a/src/backend/TrafficCourts/Common/Features/DisputeCreation/IDisputeCreationService.cs
+++ b/src/backend/TrafficCourts/Common/Features/DisputeCreation/IDisputeCreationService.cs
@@ -1,0 +1,13 @@
+﻿namespace TrafficCourts.Common.Features.DisputeCreation
+{
+    public interface IDisputeCreationService
+    {
+        /// <summary>
+        /// Determines if a dispute can be created for a ticket.
+        /// </summary>
+        /// <param name="ticketNumber">The number of the ticket.</param>
+        /// <param name="cancellationToken">A cancellation token.</param>
+        /// <returns>True if the dispute can be created.</returns>
+        Task<bool> CanCreateDispute(string ticketNumber, CancellationToken cancellationToken);
+    }
+}

--- a/src/backend/TrafficCourts/Common/TrafficCourts.Common.csproj
+++ b/src/backend/TrafficCourts/Common/TrafficCourts.Common.csproj
@@ -9,6 +9,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Hashids.net" Version="1.7.0" />
+		<PackageReference Include="MassTransit.Abstractions" Version="8.3.3" />
 		<PackageReference Include="MediatR" Version="12.4.1" />
 		<PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.4" />
 		<PackageReference Include="Microsoft.Extensions.ApiDescription.Client" Version="9.0.0">

--- a/src/backend/TrafficCourts/Staff.Service/ClaimsPrincipalExtensions.cs
+++ b/src/backend/TrafficCourts/Staff.Service/ClaimsPrincipalExtensions.cs
@@ -1,0 +1,18 @@
+﻿using System.Security.Claims;
+
+namespace TrafficCourts.Staff.Service
+{
+    /// <summary>
+    /// Extension methods for <see cref="ClaimsPrincipal"/>.
+    /// </summary>
+    public static class ClaimsPrincipalExtensions
+    {
+        /// <summary>
+        /// Returns a staff member's username.
+        /// </summary>
+        public static string GetUsername(this ClaimsPrincipal user)
+        {
+            return user?.Identity?.Name ?? string.Empty;
+        }
+    }
+}

--- a/src/backend/TrafficCourts/Staff.Service/Controllers/DisputeController.cs
+++ b/src/backend/TrafficCourts/Staff.Service/Controllers/DisputeController.cs
@@ -5,6 +5,7 @@ using System.Net;
 using TrafficCourts.Cdogs.Client;
 using TrafficCourts.Common.Authorization;
 using TrafficCourts.Common.Errors;
+using TrafficCourts.Common.Features.DisputeCreation;
 using TrafficCourts.Domain.Models;
 using TrafficCourts.Exceptions;
 using TrafficCourts.Staff.Service.Authentication;
@@ -743,6 +744,7 @@ public class DisputeController : StaffControllerBase
     /// <response code="400">The request was not well formed. Check the parameters.</response>
     /// <response code="401">Request lacks valid authentication credentials.</response>
     /// <response code="403">Forbidden, requires dispute:update permission.</response>
+    /// <response code="409">Dispute has already been created for ticket.</response>
     /// <response code="500">There was a server error that prevented the update from completing successfully.</response>
 
     [HttpPost("")]
@@ -750,6 +752,7 @@ public class DisputeController : StaffControllerBase
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(StatusCodes.Status409Conflict)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     [KeycloakAuthorize(Resources.Dispute, Scopes.Update)]
     public async Task<IActionResult> CreateDisputeAsync(Dispute dispute,
@@ -767,6 +770,10 @@ public class DisputeController : StaffControllerBase
         {
             Dispute updatedDispute = await _disputeService.CreateDisputeAsync(User, dispute, timeZoneInfo, cancellationToken);
             return Ok(updatedDispute);
+        }
+        catch (DisputeAlreadyExistsException e)
+        {
+            return new HttpError(StatusCodes.Status409Conflict, e.Message);
         }
         catch (ApiException e) when (e.StatusCode == StatusCodes.Status400BadRequest)
         {

--- a/src/backend/TrafficCourts/Staff.Service/Controllers/DisputeLockController.cs
+++ b/src/backend/TrafficCourts/Staff.Service/Controllers/DisputeLockController.cs
@@ -68,7 +68,7 @@ public class DisputeLockController : StaffControllerBase
     {
         try
         {
-            var result = _disputeLockService.RefreshLock(lockId, GetUserName(User));
+            var result = _disputeLockService.RefreshLock(lockId, User.GetUsername());
             if (result is null) return Task.FromResult<ActionResult<DateTimeOffset>>(NotFound());
             return Task.FromResult<ActionResult<DateTimeOffset>>(Ok(result));
         }
@@ -123,10 +123,5 @@ public class DisputeLockController : StaffControllerBase
             var result = new HttpError(StatusCodes.Status500InternalServerError, ex.Message);
             return Task.FromResult<ActionResult>(result);
         }
-    }
-
-    private static string GetUserName(ClaimsPrincipal user)
-    {
-        return user?.Identity?.Name ?? string.Empty;
     }
 }

--- a/src/backend/TrafficCourts/Staff.Service/Controllers/JJController.cs
+++ b/src/backend/TrafficCourts/Staff.Service/Controllers/JJController.cs
@@ -255,7 +255,7 @@ public partial class JJController : StaffControllerBase
             // Otherwise, return the dispute without a lock.
             if (executeUserLock)
             {
-                var lockInfo = _disputeLockService.GetLock(ticketNumber, GetUserName(User));
+                var lockInfo = _disputeLockService.GetLock(ticketNumber, User.GetUsername());
 
                 if (lockInfo is not null)
                 {
@@ -433,7 +433,7 @@ public partial class JJController : StaffControllerBase
         {
             _logger.LogDebug("Updating the JJ Dispute in oracle-data-api");
 
-            var disputeLock = _disputeLockService.GetLock(jjDispute.TicketNumber, GetUserName(User));
+            var disputeLock = _disputeLockService.GetLock(jjDispute.TicketNumber, User.GetUsername());
 
             var updatedJJDispute = await _jjDisputeService.UpdateJJDisputeCascadeAsync(jjDispute, User, timeZoneInfo, cancellationToken);
 
@@ -514,7 +514,7 @@ public partial class JJController : StaffControllerBase
 
         try
         {
-            var disputeLock = _disputeLockService.GetLock(ticketNumber, GetUserName(User));
+            var disputeLock = _disputeLockService.GetLock(ticketNumber, User.GetUsername());
 
             var updatedJJDispute = await _jjDisputeService.SubmitAdminResolutionAsync(jjDisputeId, checkVTC, jjDispute, User, timeZoneInfo, cancellationToken);
 
@@ -649,7 +649,7 @@ public partial class JJController : StaffControllerBase
 
         try
         {
-            var disputeLock = _disputeLockService.GetLock(ticketNumber, GetUserName(User));
+            var disputeLock = _disputeLockService.GetLock(ticketNumber, User.GetUsername());
 
             await _jjDisputeService.ReviewJJDisputeAsync(ticketNumber, null!, checkVTC, User, true, timeZoneInfo, cancellationToken);
             return Ok();
@@ -728,7 +728,7 @@ public partial class JJController : StaffControllerBase
 
         try
         {
-            var disputeLock = _disputeLockService.GetLock(ticketNumber, GetUserName(User));
+            var disputeLock = _disputeLockService.GetLock(ticketNumber, User.GetUsername());
 
             await _jjDisputeService.ReviewJJDisputeAsync(ticketNumber, remark, checkVTC, User, false, timeZoneInfo, cancellationToken);
             return Ok();
@@ -805,7 +805,7 @@ public partial class JJController : StaffControllerBase
 
         try
         {
-            var disputeLock = _disputeLockService.GetLock(ticketNumber, GetUserName(User));
+            var disputeLock = _disputeLockService.GetLock(ticketNumber, User.GetUsername());
             await _jjDisputeService.RequireCourtHearingJJDisputeAsync(ticketNumber, remark, User, timeZoneInfo, cancellationToken);
             return Ok();
         }
@@ -880,7 +880,7 @@ public partial class JJController : StaffControllerBase
 
         try
         {
-            var disputeLock = _disputeLockService.GetLock(ticketNumber, GetUserName(User));
+            var disputeLock = _disputeLockService.GetLock(ticketNumber, User.GetUsername());
             await _jjDisputeService.AcceptJJDisputeAsync(ticketNumber, checkVTC, User, timeZoneInfo, cancellationToken);
             return Ok();
         }
@@ -967,7 +967,7 @@ public partial class JJController : StaffControllerBase
 
         try
         {
-            var disputeLock = _disputeLockService.GetLock(ticketNumber, GetUserName(User));
+            var disputeLock = _disputeLockService.GetLock(ticketNumber, User.GetUsername());
             await _jjDisputeService.ConcludeJJDisputeAsync(ticketNumber, checkVTC, User, timeZoneInfo, cancellationToken);
             return Ok();
         }
@@ -1039,7 +1039,7 @@ public partial class JJController : StaffControllerBase
 
         try
         {
-            var disputeLock = _disputeLockService.GetLock(ticketNumber, GetUserName(User));
+            var disputeLock = _disputeLockService.GetLock(ticketNumber, User.GetUsername());
             await _jjDisputeService.CancelJJDisputeAsync(ticketNumber, checkVTC, User, timeZoneInfo, cancellationToken);
             return Ok();
         }
@@ -1108,7 +1108,7 @@ public partial class JJController : StaffControllerBase
         try
         {
             // TODO: Call Oracle API to update court appearance when TCVP-1999 is completed as per TCVP-1978
-            var disputeLock = _disputeLockService.GetLock(ticketNumber, GetUserName(User));
+            var disputeLock = _disputeLockService.GetLock(ticketNumber, User.GetUsername());
             await _jjDisputeService.RequireCourtHearingJJDisputeAsync(ticketNumber, null, User, timeZoneInfo, cancellationToken);
             return Ok();
         }
@@ -1178,7 +1178,7 @@ public partial class JJController : StaffControllerBase
         try
         {
             // TODO: Call Oracle API to update court appearance when TCVP-1999 is completed as per TCVP-1978
-            var disputeLock = _disputeLockService.GetLock(ticketNumber, GetUserName(User));
+            var disputeLock = _disputeLockService.GetLock(ticketNumber, User.GetUsername());
             await _jjDisputeService.ConfirmJJDisputeAsync(ticketNumber, User, timeZoneInfo, cancellationToken);
             return Ok();
         }
@@ -1250,10 +1250,5 @@ public partial class JJController : StaffControllerBase
             _logger.LogError(e, "Error when generating print version of dispute");
             return new HttpError(StatusCodes.Status500InternalServerError, e.Message);
         }
-    }
-
-    private static string GetUserName(ClaimsPrincipal user)
-    {
-        return user?.Identity?.Name ?? string.Empty;
     }
 }

--- a/src/backend/TrafficCourts/Staff.Service/Services/DisputeService.cs
+++ b/src/backend/TrafficCourts/Staff.Service/Services/DisputeService.cs
@@ -4,6 +4,7 @@ using System;
 using System.Security.Claims;
 using System.Text.Json;
 using TrafficCourts.Collections;
+using TrafficCourts.Common.Features.DisputeCreation;
 using TrafficCourts.Coms.Client;
 using TrafficCourts.Domain.Events;
 using TrafficCourts.Domain.Models;
@@ -55,6 +56,7 @@ public class DisputeService : IDisputeService,
     private readonly IProvinceLookupService _provinceLookupService;
     private readonly IStaffDocumentService _documentService;
     private readonly ITicketSearchService _ticketSearchService;
+    private readonly IDisputeCreationService _disputeCreationService;
 
     public DisputeService(
         IOracleDataApiService oracleDataApi,
@@ -64,6 +66,7 @@ public class DisputeService : IDisputeService,
         IProvinceLookupService provinceLookupService,
         IStaffDocumentService documentService,
         ITicketSearchService ticketSearchService,
+        IDisputeCreationService disputeCreationService,
         IFusionCache cache,
         ILogger<DisputeService> logger)
     {
@@ -76,6 +79,7 @@ public class DisputeService : IDisputeService,
         _ticketSearchService = ticketSearchService ?? throw new ArgumentNullException(nameof(ticketSearchService));
         _cache = cache ?? throw new ArgumentNullException(nameof(cache));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _disputeCreationService = disputeCreationService;
     }
 
 
@@ -131,6 +135,12 @@ public class DisputeService : IDisputeService,
 
     public async Task<Dispute> CreateDisputeAsync(ClaimsPrincipal user, Dispute dispute, TimeZoneInfo timeZone, CancellationToken cancellationToken)
     {
+        bool canCreateDispute = await _disputeCreationService.CanCreateDispute(dispute.TicketNumber, cancellationToken);
+        if (!canCreateDispute)
+        {
+            throw new DisputeAlreadyExistsException("Dispute already exists");
+        }
+        
         dispute.EmailAddressVerified = false;
         dispute.NoticeOfDisputeGuid = Guid.NewGuid().ToString("d");
         dispute.LocalToUtcTime(timeZone);

--- a/src/backend/TrafficCourts/Staff.Service/Services/DisputeService.cs
+++ b/src/backend/TrafficCourts/Staff.Service/Services/DisputeService.cs
@@ -144,7 +144,7 @@ public class DisputeService : IDisputeService,
             Mapper.ToFileHistoryWithNoticeOfDisputeId(
                 savedDispute.NoticeOfDisputeGuid,
                 FileHistoryAuditLogEntryType.FRMK, // VTC staff has added a file remark for saving or updating a dispute in Ticket Validation
-                GetUserName(user),
+                user.GetUsername(),
                 "Staff have Submitted a Dispute on behalf of a Citizen"
             ), cancellationToken);
         
@@ -169,7 +169,7 @@ public class DisputeService : IDisputeService,
         SaveFileHistoryRecord fileHistoryRecord = Mapper.ToFileHistoryWithNoticeOfDisputeId(
             updatedDispute.NoticeOfDisputeGuid,
             FileHistoryAuditLogEntryType.FRMK, // VTC staff has added a file remark for saving or updating a dispute in Ticket Validation
-            GetUserName(user),
+            user.GetUsername(),
             staffComment!);
 
         await _bus.PublishWithLog(_logger, fileHistoryRecord, cancellationToken);
@@ -195,7 +195,7 @@ public class DisputeService : IDisputeService,
         SaveFileHistoryRecord fileHistoryRecord = Mapper.ToFileHistoryWithNoticeOfDisputeId(
             validatedDispute.NoticeOfDisputeGuid,
             FileHistoryAuditLogEntryType.SVAL,  // Handwritten ticket OCR details validated by staff
-            GetUserName(user));
+            user.GetUsername());
         await _bus.PublishWithLog(_logger, fileHistoryRecord, cancellationToken);
     }
 
@@ -211,14 +211,14 @@ public class DisputeService : IDisputeService,
         SaveFileHistoryRecord fileHistoryRecord = Mapper.ToFileHistoryWithNoticeOfDisputeId(
             dispute.NoticeOfDisputeGuid,
             FileHistoryAuditLogEntryType.SCAN, // Dispute canceled by staff
-            GetUserName(user));
+            user.GetUsername());
         await _bus.PublishWithLog(_logger, fileHistoryRecord, cancellationToken);
 
         // Publish file history for cancelled remarks
         SaveFileHistoryRecord fileHistoryRecordRemark = Mapper.ToFileHistoryWithNoticeOfDisputeId(
             dispute.NoticeOfDisputeGuid,
             FileHistoryAuditLogEntryType.FRMK,
-            GetUserName(user),
+            user.GetUsername(),
             cancelledReason);
         await _bus.PublishWithLog(_logger, fileHistoryRecordRemark, cancellationToken);
 
@@ -239,14 +239,14 @@ public class DisputeService : IDisputeService,
         SaveFileHistoryRecord fileHistoryRecord = Mapper.ToFileHistoryWithNoticeOfDisputeId(
             dispute.NoticeOfDisputeGuid,
             FileHistoryAuditLogEntryType.SREJ, // Dispute rejected by staff
-            GetUserName(user));
+            user.GetUsername());
         await _bus.PublishWithLog(_logger, fileHistoryRecord, cancellationToken);
 
         // Publish file history for rejected remarks
         SaveFileHistoryRecord fileHistoryRecordRemark = Mapper.ToFileHistoryWithNoticeOfDisputeId(
             dispute.NoticeOfDisputeGuid,
             FileHistoryAuditLogEntryType.FRMK,
-            GetUserName(user),
+            user.GetUsername(),
             rejectedReason);
         await _bus.PublishWithLog(_logger, fileHistoryRecordRemark, cancellationToken);
 
@@ -305,7 +305,7 @@ public class DisputeService : IDisputeService,
         SaveFileHistoryRecord fileHistoryRecord = Mapper.ToFileHistoryWithNoticeOfDisputeId(
             dispute.NoticeOfDisputeGuid,
             FileHistoryAuditLogEntryType.SPRC, // Dispute submitted to ARC by staff
-            GetUserName(user));
+            user.GetUsername());
         await _bus.PublishWithLog(_logger, fileHistoryRecord, cancellationToken);
 
         // publish file history of email sent
@@ -350,7 +350,7 @@ public class DisputeService : IDisputeService,
         // - call oracle-data-api to update request status in OCCAM.
         // - send confirmation email indicating request was accepted
         // - populate file/email history records
-        DisputeUpdateRequestAccepted message = new(updateStatusId, GetUserName(user));
+        DisputeUpdateRequestAccepted message = new(updateStatusId, user.GetUsername());
         await _bus.PublishWithLog(_logger, message, cancellationToken);
     }
 
@@ -367,7 +367,7 @@ public class DisputeService : IDisputeService,
         // - call oracle-data-api to update request status in OCCAM.
         // - send confirmation email indicating request was rejected
         // - populate file/email history records
-        DisputeUpdateRequestRejected message = new(updateStatusId, GetUserName(user));
+        DisputeUpdateRequestRejected message = new(updateStatusId, user.GetUsername());
         await _bus.PublishWithLog(_logger, message, cancellationToken);
     }
 
@@ -664,8 +664,6 @@ public class DisputeService : IDisputeService,
         Coms.Client.File file = await _objectManagementService.GetFileAsync(searchResult.Id, cancellationToken);
         return file;
     }
-
-    private string GetUserName(ClaimsPrincipal user) => user.Identity?.Name ?? string.Empty;
 
     private async Task<List<DisputeListItem>> GetCachedDisputesAsync(CancellationToken cancellationToken)
     {

--- a/src/backend/TrafficCourts/Staff.Service/Services/JJDisputeService.cs
+++ b/src/backend/TrafficCourts/Staff.Service/Services/JJDisputeService.cs
@@ -330,7 +330,7 @@ public partial class JJDisputeService : IJJDisputeService
         SaveFileHistoryRecord fileHistoryRecord = new();
         fileHistoryRecord.TicketNumber = jjDispute.TicketNumber;
         fileHistoryRecord.AuditLogEntryType = FileHistoryAuditLogEntryType.SADM; // Dispute updated by Support Admin Staff 
-        fileHistoryRecord.ActionByApplicationUser = GetUserName(user);
+        fileHistoryRecord.ActionByApplicationUser = user.GetUsername();
         await _bus.PublishWithLog(_logger, fileHistoryRecord, cancellationToken);
 
         return dispute;
@@ -356,7 +356,7 @@ public partial class JJDisputeService : IJJDisputeService
             SaveFileHistoryRecord fileHistoryRecord = Mapper.ToFileHistoryWithTicketNumber(
                 jjDispute.TicketNumber,
                 FileHistoryAuditLogEntryType.JPRG, // Dispute decision details saved for later
-                GetUserName(user));
+                user.GetUsername());
             await _bus.PublishWithLog(_logger, fileHistoryRecord, cancellationToken);
         }
         else if (dispute.Status == JJDisputeStatus.CONFIRMED)
@@ -364,7 +364,7 @@ public partial class JJDisputeService : IJJDisputeService
             SaveFileHistoryRecord fileHistoryRecord = Mapper.ToFileHistoryWithTicketNumber(
                 jjDispute.TicketNumber,
                 FileHistoryAuditLogEntryType.JCNF, // Dispute decision confirmed/submitted by JJ
-                GetUserName(user));
+                user.GetUsername());
             await _bus.PublishWithLog(_logger, fileHistoryRecord, cancellationToken);
         }
 
@@ -393,7 +393,7 @@ public partial class JJDisputeService : IJJDisputeService
         SaveFileHistoryRecord fileHistoryRecord = Mapper.ToFileHistoryWithTicketNumber(
             dispute.TicketNumber,
             fileHistoryType,
-            GetUserName(user));
+            user.GetUsername());
 
         await _bus.PublishWithLog(_logger, fileHistoryRecord, cancellationToken);
 
@@ -412,7 +412,7 @@ public partial class JJDisputeService : IJJDisputeService
             SaveFileHistoryRecord fileHistoryRecord = Mapper.ToFileHistoryWithTicketNumber(
                 dispute.TicketNumber,
                 FileHistoryAuditLogEntryType.JDIV, 
-                GetUserName(user)); // Dispute change of plea required / Divert to court appearance
+                user.GetUsername()); // Dispute change of plea required / Divert to court appearance
 
             await _bus.PublishWithLog(_logger, fileHistoryRecord, cancellationToken);
 
@@ -439,7 +439,7 @@ public partial class JJDisputeService : IJJDisputeService
         SaveFileHistoryRecord fileHistoryRecord = Mapper.ToFileHistoryWithTicketNumber(
             dispute.TicketNumber, 
             FileHistoryAuditLogEntryType.VSUB, 
-            GetUserName(user)); // Dispute approved for resulting by staff
+            user.GetUsername()); // Dispute approved for resulting by staff
 
         await _bus.PublishWithLog(_logger, fileHistoryRecord, cancellationToken);
 
@@ -476,7 +476,7 @@ public partial class JJDisputeService : IJJDisputeService
         SaveFileHistoryRecord fileHistoryRecord = Mapper.ToFileHistoryWithTicketNumber(
             dispute.TicketNumber,
             FileHistoryAuditLogEntryType.JCNF, 
-            GetUserName(user)); // Dispute decision confirmed/submitted by JJ
+            user.GetUsername()); // Dispute decision confirmed/submitted by JJ
         await _bus.PublishWithLog(_logger, fileHistoryRecord, cancellationToken);
 
         return dispute;
@@ -580,11 +580,6 @@ public partial class JJDisputeService : IJJDisputeService
         }
 
         return displayName;
-    }
-
-    private static string GetUserName(ClaimsPrincipal user)
-    {
-        return user?.Identity?.Name ?? string.Empty;
     }
 
     private void AddUnique(List<TrafficCourts.Domain.Models.FileMetadata> target, List<TrafficCourts.Domain.Models.FileMetadata> files)

--- a/src/backend/TrafficCourts/Staff.Service/Services/StaffDocumentService.cs
+++ b/src/backend/TrafficCourts/Staff.Service/Services/StaffDocumentService.cs
@@ -3,6 +3,7 @@ using System.Security.Claims;
 using TrafficCourts.Domain.Models;
 using TrafficCourts.Coms.Client;
 using TrafficCourts.Messaging.MessageContracts;
+using TrafficCourts.Staff.Service;
 
 namespace TrafficCourts.Staff.Service.Services;
 
@@ -72,7 +73,7 @@ public partial class StaffDocumentService : IStaffDocumentService
         {
             NoticeOfDisputeId = properties?.NoticeOfDisputeId?.ToString("d"),
             AuditLogEntryType = FileHistoryAuditLogEntryType.FDLS,
-            ActionByApplicationUser = GetUserName(user)
+            ActionByApplicationUser = user.GetUsername()
         };
 
         await _bus.PublishWithLog(_logger, fileHistoryRecord, cancellationToken);
@@ -148,7 +149,7 @@ public partial class StaffDocumentService : IStaffDocumentService
             {
                 NoticeOfDisputeId = properties.NoticeOfDisputeId?.ToString("d"),
                 AuditLogEntryType = FileHistoryAuditLogEntryType.SUPL,
-                ActionByApplicationUser = GetUserName(user)
+                ActionByApplicationUser = user.GetUsername()
             };
 
             await _bus.PublishWithLog(_logger, fileHistoryRecord, cancellationToken);
@@ -169,13 +170,6 @@ public partial class StaffDocumentService : IStaffDocumentService
 
         return memoryStream;
     }
-
-    private static string GetUserName(ClaimsPrincipal user)
-    {
-        string? username = user.Identity?.Name;
-        return username ?? string.Empty;
-    }
-
 
     [LoggerMessage(EventId = 0, Level = LogLevel.Information, Message = "Filename from search results does not match document property filename")]
     public partial void LogFilenameDoesNotMatch(

--- a/src/backend/TrafficCourts/Staff.Service/Startup.cs
+++ b/src/backend/TrafficCourts/Staff.Service/Startup.cs
@@ -9,6 +9,7 @@ using TrafficCourts.Caching;
 using TrafficCourts.Common;
 using TrafficCourts.Common.Authentication;
 using TrafficCourts.Common.Configuration;
+using TrafficCourts.Common.Features.DisputeCreation;
 using TrafficCourts.Messaging;
 using TrafficCourts.OrdsDataService;
 using TrafficCourts.Staff.Service.Authentication;
@@ -107,6 +108,7 @@ public static class Startup
 
         // Add DisputeService
         builder.Services.AddTransient<IDisputeService, DisputeService>();
+        builder.Services.AddTransient<IDisputeCreationService, DisputeCreationService>();
         builder.Services.AddTransient<IFileHistoryService, FileHistoryService>();
         builder.Services.AddTransient<IEmailHistoryService, EmailHistoryService>();
         builder.Services.AddTransient<IJJDisputeService, JJDisputeService>();

--- a/src/backend/TrafficCourts/TrafficCourts.Staff.Service.Test/Services/PrintDigialCaseFile/PrintDigitalCaseFileIntegrationTest.cs
+++ b/src/backend/TrafficCourts/TrafficCourts.Staff.Service.Test/Services/PrintDigialCaseFile/PrintDigitalCaseFileIntegrationTest.cs
@@ -11,6 +11,7 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using TrafficCourts.Cdogs.Client;
+using TrafficCourts.Common.Features.DisputeCreation;
 using TrafficCourts.Common.OpenAPIs.KeycloakAdminApi.v22_0;
 using TrafficCourts.Coms.Client;
 using TrafficCourts.Domain.Models;
@@ -63,6 +64,7 @@ namespace TrafficCourts.Staff.Service.Test.Services.PrintDigialCaseFile
                 Mock.Of<IProvinceLookupService>(),
                 mock.Object,
                 Substitute.For<ITicketSearchService>(),
+                Mock.Of<IDisputeCreationService>(),
                 Mock.Of<IFusionCache>(),
                 Mock.Of<ILogger<DisputeService>>());
 

--- a/src/frontend/staff-portal/src/app/app.component.ts
+++ b/src/frontend/staff-portal/src/app/app.component.ts
@@ -34,6 +34,7 @@ export class AppComponent implements OnInit {
         'toaster.dispute_validation_error',
         'toaster.ticket_error',
         'toaster.dispute_create_error',
+        'toaster.dispute_create_duplicate_error',
         'toaster.dispute_error',
         'toaster.statute_error',
         'toaster.language_error'
@@ -57,6 +58,9 @@ export class AppComponent implements OnInit {
         );
         this.configService.dispute_create_error$.next(
           this.translateService.instant('toaster.dispute_create_error')
+        );
+        this.configService.dispute_create_duplicate_error$.next(
+          this.translateService.instant('toaster.dispute_create_duplicate_error')
         );
         this.configService.statute_error$.next(
           this.translateService.instant('toaster.statute_error')

--- a/src/frontend/staff-portal/src/app/config/config.service.ts
+++ b/src/frontend/staff-portal/src/app/config/config.service.ts
@@ -27,6 +27,8 @@ export class ConfigService {
   private historyError: BehaviorSubject<string> = new BehaviorSubject<string>('');
   private disputeCreateError: BehaviorSubject<string> =
     new BehaviorSubject<string>('');
+  private disputeCreateDuplicateError: BehaviorSubject<string> =
+    new BehaviorSubject<string>('');
   private statuteError: BehaviorSubject<string> = new BehaviorSubject<string>('');
   private languageError: BehaviorSubject<string> = new BehaviorSubject<string>('');
   private provinceError: BehaviorSubject<string> = new BehaviorSubject<string>('');
@@ -158,6 +160,14 @@ export class ConfigService {
 
   public get dispute_create_error(): string {
     return this.disputeCreateError.value;
+  }
+
+  public get dispute_create_duplicate_error$(): BehaviorSubject<string> {
+    return this.disputeCreateDuplicateError;
+  }
+
+  public get dispute_create_duplicate_error(): string {
+    return this.disputeCreateDuplicateError.value;
   }
 
   public get provincesAndStates(): ProvinceCodeValue[] {

--- a/src/frontend/staff-portal/src/app/services/dispute.service.ts
+++ b/src/frontend/staff-portal/src/app/services/dispute.service.ts
@@ -266,7 +266,10 @@ export class DisputeService implements IDisputeService {
           return response;
         }),
         catchError((error: any) => {
-          var errorMsg = error?.error?.detail != null ? error.error.detail : this.configService.dispute_error;
+          let errorMsg = error?.error?.detail ?? this.configService.dispute_create_error;
+          if (error?.status === 409) {
+            errorMsg = this.configService.dispute_create_duplicate_error;
+          }
           this.toastService.openErrorToast(errorMsg);
           this.logger.error('DisputeService::createDispute error has occurred: ', error);
           throw error;

--- a/src/frontend/staff-portal/src/assets/i18n/en.json
+++ b/src/frontend/staff-portal/src/assets/i18n/en.json
@@ -245,6 +245,7 @@
     "dispute_validation_error": "Your dispute has an error that needs to be corrected before you will be able to submit",
     "ticket_error": "Ticket could not be retrieved",
     "dispute_create_error": "Dispute could not be created",
+    "dispute_create_duplicate_error": "A dispute for this violation ticket already exists",
     "statute_error": "Statutes could not be loaded",
     "language_error": "Languages could not be loaded",
     "agency_error": "Agencies could not be loaded",

--- a/src/frontend/staff-portal/src/assets/i18n/fr.json
+++ b/src/frontend/staff-portal/src/assets/i18n/fr.json
@@ -244,6 +244,7 @@
     "dispute_validation_error": "Votre litige comporte une erreur qui doit être corrigée avant que vous ne puissiez soumettre",
     "ticket_error": "Le ticket n'a pas pu être récupéré",
     "dispute_create_error": "Le litige n'a pas pu être créé",
+    "dispute_create_duplicate_error": "Un litige pour cette ticket de violation existe déjà",
     "statute_error": "Les statuts n’ont pas pu être chargés",
     "language_error": "Les langs n’ont pas pu être chargés",
     "agency_error": "Les agences n’ont pas pu être chargées",


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- refactors duplicated GetUsername() code into an extension method
- adds DisputeCreationService in Common project
  - functionality shared between Staff.Service and Workflow.Service could be placed here to reduce code duplication and remove the overhead of unnecessary message bus usage from the staff back-end
  - it currently contains just CanCreateDispute()
  - I've left the logical next step (of moving the code for dispute creation from the staff's DisputeService and the Workflow.Service's SubmitNoticeOfDisputeConsumer) for another time
- updates dispute creation in Staff.Service to use the new method to check for existing disputes and return an HTTP 409 Conflict response if it finds any
- updates staff-portal to display a new error message if it receives an HTTP 409 response from the dispute creation endpoint
  - the new message is the same as the one in the citizen-portal: "A dispute for this violation ticket already exists" / "Un litige pour cette ticket de violation existe déjà"

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes