### PR TITLE
TCVP-3444: Fix feature config for staff-web/citizen-web

### DIFF
--- a/gitops/charts/traffic-court-dev-values.yaml
+++ b/gitops/charts/traffic-court-dev-values.yaml
@@ -46,8 +46,7 @@ citizen-web:
         "paymentOptionsLink": "https://www2.gov.bc.ca/gov/content/justice/courthouse-services/fines-payments/pay-dispute-ticket/prov-violation-tickets/pay-ticket",
         "resolutionOptionsLink": "https://www2.gov.bc.ca/gov/content/justice/courthouse-services/fines-payments/pay-dispute-ticket/prov-violation-tickets/dispute-ticket",
         "features": {
-          "dispute": true,
-          "staffDisputeIntake": true
+          "dispute": true
         }
       }
   authConfig: |
@@ -246,7 +245,7 @@ staff-web:
         "useMockServices": false,
         "apiBaseUrl": "/api",
         "features": {
-          "dispute":true
+          "staffDisputeIntake": true
         }
       }
 

--- a/gitops/charts/traffic-court-prod-values.yaml
+++ b/gitops/charts/traffic-court-prod-values.yaml
@@ -52,8 +52,7 @@ citizen-web:
         "paymentOptionsLink": "https://www2.gov.bc.ca/gov/content/justice/courthouse-services/fines-payments/pay-dispute-ticket/prov-violation-tickets/pay-ticket",
         "resolutionOptionsLink": "https://www2.gov.bc.ca/gov/content/justice/courthouse-services/fines-payments/pay-dispute-ticket/prov-violation-tickets/dispute-ticket",
         "features": {
-          "dispute": true,
-          "staffDisputeIntake": false
+          "dispute": true
         }
       }
   authConfig: |
@@ -287,7 +286,7 @@ staff-web:
         "useMockServices": false,
         "apiBaseUrl": "/api",
         "features": {
-          "dispute":true
+          "staffDisputeIntake": false
         }
       }
   courtHouseDataConfig: |

--- a/gitops/charts/traffic-court-test-values.yaml
+++ b/gitops/charts/traffic-court-test-values.yaml
@@ -55,8 +55,7 @@ citizen-web:
         "paymentOptionsLink": "https://www2.gov.bc.ca/gov/content/justice/courthouse-services/fines-payments/pay-dispute-ticket/prov-violation-tickets/pay-ticket",
         "resolutionOptionsLink": "https://www2.gov.bc.ca/gov/content/justice/courthouse-services/fines-payments/pay-dispute-ticket/prov-violation-tickets/dispute-ticket",
         "features": {
-          "dispute": true,
-          "staffDisputeIntake": false
+          "dispute": true
         }
       }
   authConfig: |
@@ -264,7 +263,7 @@ staff-web:
         "useMockServices": false,
         "apiBaseUrl": "/api",
         "features": {
-          "dispute":true
+          "staffDisputeIntake": true
         }
       }
   courtHouseDataConfig: |

--- a/src/frontend/staff-portal/src/app/services/app-config.service.ts
+++ b/src/frontend/staff-portal/src/app/services/app-config.service.ts
@@ -21,7 +21,6 @@ export class AppConfig implements IAppConfig {
   useMockServices: boolean;
   apiBaseUrl: string;
   features: {
-    dispute: boolean;
     staffDisputeIntake: boolean;
   };
 }
@@ -60,11 +59,6 @@ export class AppConfigService {
 
   get apiBaseUrl(): string {
     return this.appConfig?.apiBaseUrl;
-  }
-
-  get featureFlagDispute(): boolean {
-    const flag = this.appConfig?.features?.dispute;
-    return flag ? flag : false;
   }
 
   public isFeatureFlagEnabled(featureName: string): boolean {


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- updates values for the Helm charts
  - moves the "staffDisputeIntake" feature from the citizen-web appConfig to the staff-web appConfig
  - removes unused "dispute" feature from the staff-web appConfig
    - it is used in citizen-web and was copied to staff-web when it was initialized, where it is not used
- removes unused "dispute" feature from the appConfig model in the staff-portal app-config.service.ts

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
