### PR TITLE
TCVP-3438: Fix validation errors of OCR ticket, (#2227)

### DIFF
--- a/src/backend/TrafficCourts/Citizen.Service/Validators/FormRecognizerValidator.cs
+++ b/src/backend/TrafficCourts/Citizen.Service/Validators/FormRecognizerValidator.cs
@@ -363,11 +363,9 @@ public class FormRecognizerValidator : IFormRecognizerValidator
         rules.Add(new DateOfServiceLT30Rule(violationTicket.Fields[OcrViolationTicket.DateOfService]));
 
         // TCVP-3052 OCR process no longer requires rejecting images when it cannot determine if the MVA or MVR check boxes are checked.
-        /* // LRAFED-2650 Only tickets that have MVA or MVAR checked are permitted.
-        if (ViolationTicketVersion.VT2.Equals(violationTicket.TicketVersion))
-        {
-            rules.Add(new DidCommitIsMVA(violationTicket.Fields[OcrViolationTicket.OffenceIsMVA], violationTicket));
-        } */
+        // LRAFED-2650 Only tickets that have MVA or MVAR checked are permitted.
+        // https://jira.justice.gov.bc.ca/browse/TCVP-3438?focusedCommentId=466537
+        rules.Add(new DidCommitIsMVA(violationTicket.Fields[OcrViolationTicket.OffenceIsMVA], violationTicket));
 
         // Run each rule and aggregate the results
         foreach (var rule in rules)

--- a/src/backend/TrafficCourts/Citizen.Service/Validators/Rules/DidCommitIsMVA.cs
+++ b/src/backend/TrafficCourts/Citizen.Service/Validators/Rules/DidCommitIsMVA.cs
@@ -15,8 +15,6 @@ public class DidCommitIsMVA : ValidationRule
 
     public override Task RunAsync(CancellationToken cancellationToken)
     {
-        bool isMVA = this._violationTicket.Fields[OffenceIsMVA].IsCheckboxSelected() ?? false;
-        bool isMVRA = this._violationTicket.Fields[OffenceIsMVAR].IsCheckboxSelected() ?? false;
         bool isCCLA = this._violationTicket.Fields[OffenceIsCCLA].IsCheckboxSelected() ?? false;
         bool isCTA = this._violationTicket.Fields[OffenceIsCTA].IsCheckboxSelected() ?? false;
         bool isLCLA = this._violationTicket.Fields[OffenceIsLCLA].IsCheckboxSelected() ?? false;
@@ -25,10 +23,9 @@ public class DidCommitIsMVA : ValidationRule
         bool isFVPA = this._violationTicket.Fields[OffenceIsFVPA].IsCheckboxSelected() ?? false;
         bool isOther = this._violationTicket.Fields[OffenceIsOther].IsCheckboxSelected() ?? false;
 
-        // If any Did Commit was selected other than MVA or MVAR, throw an error
-        if (!isMVA && !isMVRA) {
-            AddValidationError(String.Format(ValidationMessages.MVAMustBeSelectedError, this._violationTicket.Fields[OffenceIsMVA].TagName, Field.Value));
-        }
+        // If nothing is selcted we will pass through 
+        // If anything other than MVA/MVAR is selected, then we will fail validation. 
+        // https://jira.justice.gov.bc.ca/browse/TCVP-3438?focusedCommentId=466537
         if (isCCLA)
         {
             AddValidationError(String.Format(ValidationMessages.OnlyMVAMustBeSelectedError, this._violationTicket.Fields[OffenceIsCCLA].TagName, Field.Value));


### PR DESCRIPTION
- reject tickets if a non-MVA and non-MVR Act is checked
- if NO acts are checked, we will allow it through
-  applied validation rules to both VT1 and VT2 version handwritten tickets

# Description

This PR includes the following proposed change(s):

- TCVP-3438

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [ ] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
