### PR TITLE
TCVP-3492 Fix amendment acknowledgement detection

### DIFF
--- a/src/frontend/staff-portal/src/app/components/jj-dispute-info/jj-dispute/jj-dispute.component.html
+++ b/src/frontend/staff-portal/src/app/components/jj-dispute-info/jj-dispute/jj-dispute.component.html
@@ -80,7 +80,7 @@
         </mat-menu>
       </div>
     </div>
-    @if (type === tabTypes.DECISION_VALIDATION && hasAmendmentData() && !amendmentValidationResult.amendmentsAcknowledged) {
+    @if (type === tabTypes.DECISION_VALIDATION && unacknowledgedAmendmentsExist) {
       <div class="amendment-warning-banner" *appFeatureFlag="featureType.amendments">
         <mat-icon class="amendment-warning-icon">warning</mat-icon>
         <span>This dispute has <strong>amendments on file</strong> that require review and acknowledgment.</span>
@@ -946,8 +946,8 @@
             }
             @if (lastUpdatedJJDispute.status === DisputeStatus.Confirmed && cancelStatusOnly === false && concludeStatusOnly === false) {
               <button fxFlex="20" class="large" mat-flat-button type="button" color="primary" (click)="onAccept()"
-                [disabled]="hasAmendmentData() && !amendmentValidationResult.amendmentsAcknowledged"
-                [matTooltip]="(hasAmendmentData() && !amendmentValidationResult.amendmentsAcknowledged) ? 'All amendments must be completed in JUSTIN before accepting' : ''"
+                [disabled]="unacknowledgedAmendmentsExist"
+                [matTooltip]="unacknowledgedAmendmentsExist ? 'All amendments must be completed in JUSTIN before accepting' : ''"
                 matTooltipPosition="above">
                 Accept
               </button>

--- a/src/frontend/staff-portal/src/app/components/jj-dispute-info/jj-dispute/jj-dispute.component.html
+++ b/src/frontend/staff-portal/src/app/components/jj-dispute-info/jj-dispute/jj-dispute.component.html
@@ -80,7 +80,7 @@
         </mat-menu>
       </div>
     </div>
-    @if (type === tabTypes.DECISION_VALIDATION && hasAmendmentData() && !amendmentValidationResult?.allAmendmentsProcessed) {
+    @if (type === tabTypes.DECISION_VALIDATION && hasAmendmentData() && !amendmentValidationResult.amendmentsAcknowledged) {
       <div class="amendment-warning-banner" *appFeatureFlag="featureType.amendments">
         <mat-icon class="amendment-warning-icon">warning</mat-icon>
         <span>This dispute has <strong>amendments on file</strong> that require review and acknowledgment.</span>
@@ -946,8 +946,8 @@
             }
             @if (lastUpdatedJJDispute.status === DisputeStatus.Confirmed && cancelStatusOnly === false && concludeStatusOnly === false) {
               <button fxFlex="20" class="large" mat-flat-button type="button" color="primary" (click)="onAccept()"
-                [disabled]="hasAmendmentData() && !amendmentValidationResult?.allAmendmentsProcessed"
-                [matTooltip]="(hasAmendmentData() && !amendmentValidationResult?.allAmendmentsProcessed) ? 'All amendments must be completed in JUSTIN before accepting' : ''"
+                [disabled]="hasAmendmentData() && !amendmentValidationResult.amendmentsAcknowledged"
+                [matTooltip]="(hasAmendmentData() && !amendmentValidationResult.amendmentsAcknowledged) ? 'All amendments must be completed in JUSTIN before accepting' : ''"
                 matTooltipPosition="above">
                 Accept
               </button>

--- a/src/frontend/staff-portal/src/app/components/jj-dispute-info/jj-dispute/jj-dispute.component.ts
+++ b/src/frontend/staff-portal/src/app/components/jj-dispute-info/jj-dispute/jj-dispute.component.ts
@@ -1,7 +1,7 @@
 import { Component, ElementRef, EventEmitter, Input, OnInit, Output, ViewChild, TemplateRef } from '@angular/core';
 import { LoggerService } from '@core/services/logger.service';
 import { JJDisputeService, JJDispute } from '../../../services/jj-dispute.service';
-import { AmendmentProcessingStatus, AmendmentValidationResult } from '../staff-amendment-validation/staff-amendment-validation.component';
+import { AmendmentValidationResult } from '../staff-amendment-validation/staff-amendment-validation.component';
 import { Observable, map } from 'rxjs';
 import { JJDisputedCount, JJDisputeStatus, JJDisputedCountRequestReduction, JJDisputedCountRequestTimeToPay, JJDisputeHearingType, JJDisputeCourtAppearanceRoPAppCd, JJDisputeCourtAppearanceRoPCrown, JJDisputeCourtAppearanceRoPDattCd, JJDisputeCourtAppearanceRoPJjSeized, FileMetadata, JJDisputeElectronicTicketYn, JJDisputeNoticeOfHearingYn, TicketImageDataJustinDocumentReportType, DocumentType, JJDisputeContactType, JJDisputedCountRoPFinding, Province, Language, JJDisputeDisputantAttendanceType, JJDisputeAccidentYn, JJDisputeMultipleOfficersYn, JJDisputeSignatoryType, DcfTemplateType, DisputeCaseFileSummary, YesNo, JJDisputeCourtAppearanceAmendments } from 'app/api/model/models';
 import { DialogOptions } from '@shared/dialogs/dialog-options.model';
@@ -145,7 +145,6 @@ export class JJDisputeComponent implements OnInit {
 
   // TCVP-3387: Amendment tracking properties
   amendmentData: JJDisputeCourtAppearanceAmendments | null = null;
-  amendmentProcessingStatuses: AmendmentProcessingStatus[] = [];
   amendmentValidationResult: AmendmentValidationResult = {
     amendmentsAcknowledged: false,
   };

--- a/src/frontend/staff-portal/src/app/components/jj-dispute-info/jj-dispute/jj-dispute.component.ts
+++ b/src/frontend/staff-portal/src/app/components/jj-dispute-info/jj-dispute/jj-dispute.component.ts
@@ -277,6 +277,14 @@ export class JJDisputeComponent implements OnInit {
 
     return !(this.isJJ && onJJPage);
   }
+  
+  get unacknowledgedAmendmentsExist(): boolean {
+    return (
+      this.appConfigService.isFeatureFlagEnabled(featureType.amendments) &&
+      this.hasAmendmentData() &&
+      !this.amendmentValidationResult.amendmentsAcknowledged
+    );
+  }
 
   goTo(id: string) {
     let element: ElementRef;
@@ -524,7 +532,7 @@ export class JJDisputeComponent implements OnInit {
     }
     
     // Check if there are unprocessed amendments
-    if (this.hasAmendmentData() && !this.amendmentValidationResult.amendmentsAcknowledged) {
+    if (this.unacknowledgedAmendmentsExist) {
       const data: DialogOptions = {
         titleKey: "Amendments Not Processed",
         messageKey: "All amendments must be completed before accepting this dispute.",
@@ -836,10 +844,7 @@ export class JJDisputeComponent implements OnInit {
 
   onBackClicked() {
     // Check if on Decision Validation page with unacknowledged amendments
-    if (this.type === TabType.DECISION_VALIDATION && 
-        this.appConfigService.isFeatureFlagEnabled(featureType.amendments) &&
-        this.hasAmendmentData() && 
-        !this.amendmentValidationResult.amendmentsAcknowledged) {
+    if (this.type === TabType.DECISION_VALIDATION && this.unacknowledgedAmendmentsExist) {
       
       const dialogOptions: DialogOptions = {
         titleKey: 'Amendments Not Acknowledged',

--- a/src/frontend/staff-portal/src/app/components/jj-dispute-info/jj-dispute/jj-dispute.component.ts
+++ b/src/frontend/staff-portal/src/app/components/jj-dispute-info/jj-dispute/jj-dispute.component.ts
@@ -147,8 +147,7 @@ export class JJDisputeComponent implements OnInit {
   amendmentData: JJDisputeCourtAppearanceAmendments | null = null;
   amendmentProcessingStatuses: AmendmentProcessingStatus[] = [];
   amendmentValidationResult: AmendmentValidationResult = {
-    allAmendmentsProcessed: false,
-    pendingAmendments: []
+    amendmentsAcknowledged: false,
   };
   amendmentCheckbox: boolean = false;
   showAmendmentSection: boolean = false;
@@ -525,12 +524,10 @@ export class JJDisputeComponent implements OnInit {
     }
     
     // Check if there are unprocessed amendments
-    if (this.hasAmendmentData() && 
-        this.amendmentValidationResult && 
-        !this.amendmentValidationResult.allAmendmentsProcessed) {
+    if (this.hasAmendmentData() && !this.amendmentValidationResult.amendmentsAcknowledged) {
       const data: DialogOptions = {
         titleKey: "Amendments Not Processed",
-        messageKey: `All amendments must be completed before accepting this dispute. Pending amendments for counts: ${this.amendmentValidationResult.pendingAmendments.join(', ')}`,
+        messageKey: "All amendments must be completed before accepting this dispute.",
         actionTextKey: "OK",
         actionType: "warn",
         cancelHide: true,
@@ -842,7 +839,7 @@ export class JJDisputeComponent implements OnInit {
     if (this.type === TabType.DECISION_VALIDATION && 
         this.appConfigService.isFeatureFlagEnabled(featureType.amendments) &&
         this.hasAmendmentData() && 
-        !this.amendmentValidationResult?.allAmendmentsProcessed) {
+        !this.amendmentValidationResult.amendmentsAcknowledged) {
       
       const dialogOptions: DialogOptions = {
         titleKey: 'Amendments Not Acknowledged',
@@ -973,27 +970,12 @@ export class JJDisputeComponent implements OnInit {
   }
 
   /**
-   * Handle amendment processing status changes from Staff component
-   * Called when staff checks/unchecks amendment completion checkboxes
-   */
-  onAmendmentStatusChange(statuses: AmendmentProcessingStatus[]): void {
-    this.logger.log('JJDisputeComponent::onAmendmentStatusChange', statuses);
-    this.amendmentProcessingStatuses = statuses;
-  }
-
-  /**
    * Handle amendment validation result changes
    * Called whenever amendment completion status changes
-   * Controls whether Accept button should be enabled
+   * Controls whether Accept button and amendment confirmation dialogs should be enabled
    */
   onAmendmentValidationChange(result: AmendmentValidationResult): void {
     this.logger.log('JJDisputeComponent::onAmendmentValidationChange', result);
     this.amendmentValidationResult = result;
-    
-    if (!result.allAmendmentsProcessed && result.pendingAmendments.length > 0) {
-      this.logger.warn(
-        `Amendments pending for counts: ${result.pendingAmendments.join(', ')}`
-      );
-    }
   }
 }

--- a/src/frontend/staff-portal/src/app/components/jj-dispute-info/staff-amendment-validation/staff-amendment-validation.component.ts
+++ b/src/frontend/staff-portal/src/app/components/jj-dispute-info/staff-amendment-validation/staff-amendment-validation.component.ts
@@ -9,8 +9,7 @@ export interface AmendmentProcessingStatus {
 }
 
 export interface AmendmentValidationResult {
-  allAmendmentsProcessed: boolean;
-  pendingAmendments: number[];
+  amendmentsAcknowledged: boolean;
 }
 
 @Component({
@@ -23,7 +22,7 @@ export class StaffAmendmentValidationComponent implements OnInit {
   @Input() amendmentData: JJDisputeCourtAppearanceAmendments;
   @Input() isViewOnly: boolean = false;
   @Output() amendmentStatusChange: EventEmitter<AmendmentProcessingStatus[]> = new EventEmitter<AmendmentProcessingStatus[]>();
-  @Output() validationStatusChange: EventEmitter<AmendmentValidationResult> = new EventEmitter<AmendmentValidationResult>();
+  @Output() validationStatusChange = new EventEmitter<AmendmentValidationResult>();
 
   amendmentProcessingStatuses: AmendmentProcessingStatus[] = [];
   hasAmendments: boolean = false;
@@ -85,13 +84,8 @@ export class StaffAmendmentValidationComponent implements OnInit {
   }
 
   emitValidationStatus(): void {
-    const pendingAmendments = this.amendmentProcessingStatuses
-      .filter(status => !status.isCompleted)
-      .map(status => status.countNumber);
-
     const validationResult: AmendmentValidationResult = {
-      allAmendmentsProcessed: pendingAmendments.length === 0 && this.amendmentProcessingStatuses.length > 0,
-      pendingAmendments: pendingAmendments
+      amendmentsAcknowledged: this.isAcknowledged,
     };
 
     this.validationStatusChange.emit(validationResult);

--- a/src/frontend/staff-portal/src/app/components/jj-dispute-info/staff-amendment-validation/staff-amendment-validation.component.ts
+++ b/src/frontend/staff-portal/src/app/components/jj-dispute-info/staff-amendment-validation/staff-amendment-validation.component.ts
@@ -1,13 +1,6 @@
 import { Component, Input, Output, EventEmitter, OnInit } from '@angular/core';
 import { JJDisputeCourtAppearanceAmendments } from 'app/api';
 
-export interface AmendmentProcessingStatus {
-  countNumber: number;
-  isCompleted: boolean;
-  completedBy?: string;
-  completedDate?: Date;
-}
-
 export interface AmendmentValidationResult {
   amendmentsAcknowledged: boolean;
 }
@@ -21,10 +14,8 @@ export interface AmendmentValidationResult {
 export class StaffAmendmentValidationComponent implements OnInit {
   @Input() amendmentData: JJDisputeCourtAppearanceAmendments;
   @Input() isViewOnly: boolean = false;
-  @Output() amendmentStatusChange: EventEmitter<AmendmentProcessingStatus[]> = new EventEmitter<AmendmentProcessingStatus[]>();
   @Output() validationStatusChange = new EventEmitter<AmendmentValidationResult>();
 
-  amendmentProcessingStatuses: AmendmentProcessingStatus[] = [];
   hasAmendments: boolean = false;
   amendedCounts: number[] = [];
   isAcknowledged: boolean = false;
@@ -41,21 +32,7 @@ export class StaffAmendmentValidationComponent implements OnInit {
 
   onAcknowledgedChange(isChecked: boolean): void {
     this.isAcknowledged = isChecked;
-    
-    // Update all amendment statuses based on acknowledged state
-    this.amendmentProcessingStatuses.forEach(status => {
-      status.isCompleted = isChecked;
-      
-      if (isChecked) {
-        status.completedDate = new Date();
-        status.completedBy = 'Current Staff User';
-      } else {
-        status.completedDate = undefined;
-        status.completedBy = undefined;
-      }
-    });
 
-    this.emitStatusChange();
     this.emitValidationStatus();
   }
 
@@ -69,18 +46,8 @@ export class StaffAmendmentValidationComponent implements OnInit {
       if (this.amendmentData.count2ActSectDescTxt || this.amendmentData.count2OtherTxt) this.amendedCounts.push(2);
       if (this.amendmentData.count3ActSectDescTxt || this.amendmentData.count3OtherTxt) this.amendedCounts.push(3);
 
-      // Initialize processing statuses
-      this.amendmentProcessingStatuses = this.amendedCounts.map(countNumber => ({
-        countNumber: countNumber,
-        isCompleted: false
-      }));
-
       this.emitValidationStatus();
     }
-  }
-
-  emitStatusChange(): void {
-    this.amendmentStatusChange.emit(this.amendmentProcessingStatuses);
   }
 
   emitValidationStatus(): void {


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- TCVP-3492
  - Simplifies amendment acknowledgement
    - This fixes detecting amendments that do not contain changes to any of the counts
  - Centralizes logic for checking for amendment acknowledgement
    - This fixes an unlikely bug where the Accept button would be stuck disabled if the latest appearance included amendments, but the amendments feature had been disabled in the environment (preventing the acknowledge checkbox from appearing)
  - Removes references to now-unused AmendmentProcessingStatus

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
