### PR TITLE
TCVP-3497 Stop visiting unauthorized page before logging in

### DIFF
--- a/src/frontend/staff-portal/src/app/core/guards/auth-guard.ts
+++ b/src/frontend/staff-portal/src/app/core/guards/auth-guard.ts
@@ -24,6 +24,7 @@ const isAccessAllowed = async (
   let permission: boolean;
   if (!authenticated) {
     await authService.login();
+    return true;
   }
 
   // Get the roles required from the route.

--- a/src/frontend/staff-portal/src/app/services/auth.service.ts
+++ b/src/frontend/staff-portal/src/app/services/auth.service.ts
@@ -155,7 +155,7 @@ export class AuthService {
   }
 
   async login() {
-    this.keycloak.login({ redirectUri: window.location.toString() });
+    await this.keycloak.login({ redirectUri: window.location.toString() });
   }
 
   async logout() {


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- ensures unauthenticated users are not sometimes routed to the unauthorized page before the redirect to the KeyCloak login triggers
- this resolves the issue where KeyCloak might redirect to the unauthorized page after logging in, instead of the originally requested page

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
