### PR TITLE
fix: TCVP-3455

### DIFF
--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/service/DisputeService.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/service/DisputeService.java
@@ -174,14 +174,11 @@ public class DisputeService {
 					disputeRepository.deleteViolationTicketCountById(existingVtc.getViolationTicketCountId());
 				}
 			}
-			// Rebuild the update list to only include counts still present in the request (matched by countNo)
-			List<ViolationTicketCount> retainedCounts = new ArrayList<>();
-			for (ViolationTicketCount existingVtc : violationTicketCountsToUpdate) {
-				if (incomingCountNos.contains(existingVtc.getCountNo())) {
-					retainedCounts.add(existingVtc);
-				}
-			}
-			violationTicketCountsToUpdate = retainedCounts;
+			// Remove deleted counts from the collection in place.
+			// Do NOT replace the collection reference — replacing the reference on a JPA-managed entity
+			// with orphanRemoval=true causes Hibernate to schedule DELETE + INSERT for unchanged entities,
+			// resulting in unique constraint violations (the H2/JPA test path).
+			violationTicketCountsToUpdate.removeIf(vtc -> !incomingCountNos.contains(vtc.getCountNo()));
 		}
 
 		// Copy dispute count fields from request into DB objects, matched by countNo

--- a/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/service/DisputeService.java
+++ b/src/backend/oracle-data-api/src/main/java/ca/bc/gov/open/jag/tco/oracledataapi/service/DisputeService.java
@@ -158,38 +158,62 @@ public class DisputeService {
 		// TCVP-2748 Replace null province values with NA if specific province IDs are null since db check constraints expect values if IDs are null for provinces
 		replaceProvinceValuesWithNA(disputeToUpdate);
 		
-		// Copy all new dispute counts data to be saved from the request to disputeCountsToUpdate ignoring the disputeCountId, creation audit fields
-		if (dispute.getDisputeCounts() != null && disputeCountsToUpdate != null) {
-			if (dispute.getDisputeCounts().size() == disputeCountsToUpdate.size()) {
-				for (int i = 0; i < dispute.getDisputeCounts().size(); i++) {
-					BeanUtils.copyProperties(dispute.getDisputeCounts().get(i), disputeCountsToUpdate.get(i), "createdBy", "createdTs", "disputeCountId");
-				}
-			} else {
-				logger.warn("Unexpected number of disputeCounts: {}" +
-						" received from the request whereas updatable number of disputeCounts from database is: {}" +
-						". This should not happen with current dispute update use case unless something has been changed",
-						StructuredArguments.value("disputeCounts", dispute.getDisputeCounts().size()),
-						StructuredArguments.value("disputeCountsFromDatabase", dispute.getDisputeCounts().size()));
-				// TODO - determine what to do if the disputeCount list sizes don't match
+		// Delete any ViolationTicketCounts (and their corresponding DisputeCounts) that were removed by staff.
+		// These are counts present in the DB but absent from the incoming request (matched by countNo).
+		if (violationTicketCountsToUpdate != null && dispute.getViolationTicket() != null
+				&& dispute.getViolationTicket().getViolationTicketCounts() != null) {
+			List<Integer> incomingCountNos = new ArrayList<>();
+			for (ViolationTicketCount vtc : dispute.getViolationTicket().getViolationTicketCounts()) {
+				incomingCountNos.add(vtc.getCountNo());
 			}
+			for (ViolationTicketCount existingVtc : violationTicketCountsToUpdate) {
+				if (!incomingCountNos.contains(existingVtc.getCountNo())) {
+					logger.debug("Deleting ViolationTicketCount with countNo {} and id {} as it was removed from the dispute",
+							StructuredArguments.value("countNo", existingVtc.getCountNo()),
+							StructuredArguments.value("violationTicketCountId", existingVtc.getViolationTicketCountId()));
+					disputeRepository.deleteViolationTicketCountById(existingVtc.getViolationTicketCountId());
+				}
+			}
+			// Rebuild the update list to only include counts still present in the request (matched by countNo)
+			List<ViolationTicketCount> retainedCounts = new ArrayList<>();
+			for (ViolationTicketCount existingVtc : violationTicketCountsToUpdate) {
+				if (incomingCountNos.contains(existingVtc.getCountNo())) {
+					retainedCounts.add(existingVtc);
+				}
+			}
+			violationTicketCountsToUpdate = retainedCounts;
+		}
+
+		// Copy dispute count fields from request into DB objects, matched by countNo
+		if (dispute.getDisputeCounts() != null && disputeCountsToUpdate != null) {
+			for (DisputeCount incomingDc : dispute.getDisputeCounts()) {
+				for (DisputeCount dbDc : disputeCountsToUpdate) {
+					if (incomingDc.getCountNo() == dbDc.getCountNo()) {
+						BeanUtils.copyProperties(incomingDc, dbDc, "createdBy", "createdTs", "disputeCountId");
+						break;
+					}
+				}
+			}
+			// Remove DB dispute counts for deleted counts
+			List<Integer> incomingDcCountNos = new ArrayList<>();
+			for (DisputeCount dc : dispute.getDisputeCounts()) {
+				incomingDcCountNos.add(dc.getCountNo());
+			}
+			disputeCountsToUpdate.removeIf(dc -> !incomingDcCountNos.contains(dc.getCountNo()));
 		}
 
 		if (dispute.getViolationTicket() != null) {
 			BeanUtils.copyProperties(dispute.getViolationTicket(), violationTicketToUpdate, "createdBy", "createdTs", "violationTicketId", "violationTicketCounts");
 
+			// Copy violation ticket count fields from request into DB objects, matched by countNo
 			if (dispute.getViolationTicket().getViolationTicketCounts() != null && violationTicketCountsToUpdate != null) {
-				int violationTicketCountSize = dispute.getViolationTicket().getViolationTicketCounts().size();
-				if (violationTicketCountSize == violationTicketCountsToUpdate.size()) {
-					for (int i = 0; i < violationTicketCountSize; i++) {
-						BeanUtils.copyProperties(dispute.getViolationTicket().getViolationTicketCounts().get(i), violationTicketCountsToUpdate.get(i), "createdBy", "createdTs", "violationTicketCountId");
+				for (ViolationTicketCount incomingVtc : dispute.getViolationTicket().getViolationTicketCounts()) {
+					for (ViolationTicketCount dbVtc : violationTicketCountsToUpdate) {
+						if (incomingVtc.getCountNo() == dbVtc.getCountNo()) {
+							BeanUtils.copyProperties(incomingVtc, dbVtc, "createdBy", "createdTs", "violationTicketCountId");
+							break;
+						}
 					}
-				} else {
-					logger.warn("Unexpected number of violationTicketCounts: " +
-							" received from the request whereas updatable number of violationTicketCounts from database is: " +
-							". This should not happen with current dispute update use case unless something has been changed",
-							StructuredArguments.value("violationTicketCounts", violationTicketCountSize),
-							StructuredArguments.value("violationTicketCountsFromDatabase", violationTicketCountsToUpdate.size()));
-					// TODO - determine what to do if the violationTicketCount list sizes don't match
 				}
 			}
 		}

--- a/src/frontend/staff-portal/src/app/components/staff-workbench/ticket-info/ticket-info.component.ts
+++ b/src/frontend/staff-portal/src/app/components/staff-workbench/ticket-info/ticket-info.component.ts
@@ -606,11 +606,15 @@ export class TicketInfoComponent implements OnInit {
         .get('violationTime')
         .value.substring(2, 4);
 
-    // Counts 1,2,3
+    // Rebuild violationTicketCounts only for counts that were not deleted.
+    // Deleted counts are no longer present in lastUpdatedDispute.violationTicket.violationTicketCounts.
+    const survivingCountNos = new Set(
+      this.lastUpdatedDispute.violationTicket.violationTicketCounts.map((x) => x.countNo)
+    );
     putDispute.violationTicket.violationTicketCounts =
       [] as ViolationTicketCount[];
     for (let i = 1; i <= 3; i++) {
-      // stuff 3 violation ticket counts in putDispute
+      if (!survivingCountNos.has(i)) continue;
       let violationTicketCount = this.form
         .get('violationTicket')
         .get('violationTicketCount' + i.toString())
@@ -1299,9 +1303,6 @@ export class TicketInfoComponent implements OnInit {
   }
 
   onDeleteViolationTicketCount(countNumber: number) {
-    let violationTicketCounts =
-      this.lastUpdatedDispute.violationTicket.violationTicketCounts;
-    let count = violationTicketCounts.find((x) => x.countNo == countNumber);
     const data: DialogOptions = {
       titleKey: 'Delete Violation Ticket Count?',
       messageKey:
@@ -1320,30 +1321,19 @@ export class TicketInfoComponent implements OnInit {
             .get('violationTicket')
             .get('violationTicketCount' + countNumber.toString());
           countForm.reset();
-          countForm.get('ticketedAmount').reset();
-          countForm.get('fullDescription').reset();
-          countForm.get('description').reset();
-          countForm.get('actOrRegulationNameCode').reset();
-          countForm.get('section').reset();
-          countForm.get('subsection').reset();
-          countForm.get('paragraph').reset();
-          countForm.get('subparagraph').reset();
           countForm.updateValueAndValidity();
           countForm.markAsTouched();
-          count.ticketedAmount = null;
-          count.description = null;
-          count.actOrRegulationNameCode = null;
-          count.section = null;
-          count.subsection = null;
-          count.paragraph = null;
-          count.subparagraph = null;
+
+          // Remove the count entirely from both violationTicketCounts and disputeCounts
           this.lastUpdatedDispute.violationTicket.violationTicketCounts =
-            violationTicketCounts.filter((x) => x.countNo != countNumber);
-          this.lastUpdatedDispute.violationTicket.violationTicketCounts.splice(
-            countNumber - 1,
-            0,
-            count
-          );
+            this.lastUpdatedDispute.violationTicket.violationTicketCounts.filter(
+              (x) => x.countNo != countNumber
+            );
+          this.lastUpdatedDispute.disputeCounts =
+            this.lastUpdatedDispute.disputeCounts.filter(
+              (x) => x.countNo != countNumber
+            );
+
           this.isViolationTicketCountDeleted = true;
           this.lastUpdatedDispute = { ...this.lastUpdatedDispute };
         }


### PR DESCRIPTION
# Description

This PR is the fix for: https://jira.justice.gov.bc.ca/browse/TCVP-3455

### Problem

When a staff member deleted a violation ticket count during dispute validation, the count was **never actually removed** from the database. After saving and reloading, the dispute would contain mismatched data:

- `violationTicketCounts` still had 3 entries — the "deleted" count preserved with all-null fields (`description`, `ticketedAmount`, `section`, etc.)
- `disputeCounts` still had 3 full entries with plea/court appearance data — completely unchanged

This caused a visual mismatch in the **Ticket Request Information** section of the Staff Portal: the "Additional Information" block rendered stale count entries (e.g. "Count 2 — I want to attend a court hearing and dispute the charge") from the intact `disputeCounts`, while the count offence detail rows were absent because `violationTicketCount.description` was null.

### Root Cause

Three compounding bugs across two layers:

**1. Angular — `onDeleteViolationTicketCount` (ticket-info.component.ts)**  
The method nulled the count's fields, filtered it from the array, then immediately **spliced it back in at the same index**. The count was never removed. `disputeCounts` was never touched.

**2. Angular — `onSubmitViolationTicket` (ticket-info.component.ts)**  
When building the PUT payload, the method always iterated `i = 1` to `3` unconditionally, reading from the fixed `violationTicketCount1/2/3` form groups. This completely overrode any deletion done by `onDeleteViolationTicketCount`, always sending all 3 counts.

**3. Java — `DisputeService.update()` (oracle-data-api)**  
Count fields were copied using **index-based array position** rather than matching by `countNo`. The size-mismatch branch (when the incoming count list was shorter than the DB count list) had a `TODO` comment and did nothing — leaving orphaned DB records untouched.

### Fix

**`ticket-info.component.ts`**
- `onDeleteViolationTicketCount`: Remove the count entry entirely from both `violationTicketCounts` **and** `disputeCounts` via `.filter()`. No re-insertion.
- `onSubmitViolationTicket`: Before the count loop, capture which `countNo` values survive in `lastUpdatedDispute.violationTicket.violationTicketCounts`. Skip (`continue`) any count not in that set, so only surviving counts are included in the PUT payload.

**`DisputeService.java`**
- Before updating, compare incoming `violationTicketCounts` vs DB counts **by `countNo`**. For any DB count absent from the request, call `disputeRepository.deleteViolationTicketCountById()` — this issues a single ORDS call that removes both the `ViolationTicketCount` and its nested `DisputeCount`.
- Replace index-based `BeanUtils.copyProperties` loops with `countNo`-matched loops for both `disputeCounts` and `violationTicketCounts`.
- Use `removeIf` to drop `disputeCountsToUpdate` entries whose `countNo` is no longer present in the incoming request.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [ ] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
