### PR TITLE
TCVP-3489 Adjust permissions on DCF page

### DIFF
--- a/src/frontend/staff-portal/src/app/components/jj-dispute-info/jj-dispute/jj-dispute.component.html
+++ b/src/frontend/staff-portal/src/app/components/jj-dispute-info/jj-dispute/jj-dispute.component.html
@@ -43,7 +43,7 @@
         </mat-dialog-actions>
       </ng-template>
       <div class="button-container">
-        @if (isVTCStaff && !isSSEditMode) {
+        @if (isVTCStaff && !isSSEditMode && type !== tabTypes.DCF) {
           <button mat-raised-button (click)="onAddRemarks()" class="form-button">
             {{ "Add Remark" | translate }}
           </button>
@@ -798,7 +798,7 @@
               @for (doc of lastUpdatedJJDispute.fileData; track doc.fileId) {
                 <div class="border-bottom py-1">
                   <div fxFlex="50" fxFlex.gt-md="35">
-                    @if (documentManagementAllowed) {
+                    @if (documentRemovalAllowed) {
                       <button fxFlex="none" type="button" class="upload-delete" (click)="onRemoveFile(doc.fileId, doc.fileName)">
                         <mat-icon>delete</mat-icon>
                       </button>
@@ -813,13 +813,17 @@
                   <div fxFlex="50" fxFlex.gt-md="25" fxLayoutAlign="start center" fxLayoutGap="1rem">
                     <div fxFlex="calc(50% - 0.5rem)" class="mat-caption">{{ doc.documentType }}</div>
                     @if (doc.documentType === "Adjournment") {
-                      <mat-form-field fxFlex="calc(50% - 0.5rem)" class="py-0"
-                        [appearance]="doc.documentStatus === DocumentStatus.Pending ? 'outline' : 'fill'">
-                        <mat-select [value]="doc.documentStatus" (selectionChange)="onChangeDocumentStatus(doc, $event.value)">
-                          <mat-option [value]="DocumentStatus.Pending">Pending</mat-option>
-                          <mat-option [value]="DocumentStatus.Resolved">Resolved</mat-option>
-                        </mat-select>
-                      </mat-form-field>
+                      @if (documentStatusChangesAllowed) {
+                        <mat-form-field fxFlex="calc(50% - 0.5rem)" class="py-0"
+                          [appearance]="doc.documentStatus === DocumentStatus.Pending ? 'outline' : 'fill'">
+                          <mat-select [value]="doc.documentStatus" (selectionChange)="onChangeDocumentStatus(doc, $event.value)">
+                            <mat-option [value]="DocumentStatus.Pending">Pending</mat-option>
+                            <mat-option [value]="DocumentStatus.Resolved">Resolved</mat-option>
+                          </mat-select>
+                        </mat-form-field>
+                      } @else {
+                        <div fxFlex="calc(50% - 0.5rem)" class="mat-caption">{{ doc.documentStatus }}</div>
+                      }
                     }
                   </div>
                 </div>
@@ -828,7 +832,7 @@
                 <div>{{ fileUploadError }}</div>
               }
             </div>
-            @if (documentManagementAllowed) {
+            @if (documentUploadAllowed) {
               <div fxLayout="row" fxLayoutAlign="start center" fxLayoutGap="1rem">
                 <label fxFlex="32" fxFlex.gt-md="16">File type for upload:</label>
                 <mat-form-field fxFlex="34" fxFlex.gt-md="17" appearance="outline" style="display: inline-flex;">

--- a/src/frontend/staff-portal/src/app/components/jj-dispute-info/jj-dispute/jj-dispute.component.ts
+++ b/src/frontend/staff-portal/src/app/components/jj-dispute-info/jj-dispute/jj-dispute.component.ts
@@ -274,7 +274,12 @@ export class JJDisputeComponent implements OnInit {
   }
 
   get documentStatusChangesAllowed(): boolean {
-    return this.isSSEditMode || this.type == this.tabTypes.HEARING_INBOX || this.type == this.tabTypes.RETURNED_DECISIONS;
+    return (
+      this.isSSEditMode ||
+      this.type == this.tabTypes.HEARING_INBOX ||
+      this.type == this.tabTypes.RETURNED_DECISIONS ||
+      this.type == this.tabTypes.DECISION_VALIDATION
+    );
   }
   
   get unacknowledgedAmendmentsExist(): boolean {

--- a/src/frontend/staff-portal/src/app/components/jj-dispute-info/jj-dispute/jj-dispute.component.ts
+++ b/src/frontend/staff-portal/src/app/components/jj-dispute-info/jj-dispute/jj-dispute.component.ts
@@ -265,20 +265,16 @@ export class JJDisputeComponent implements OnInit {
     });
   }
 
-  isJjBaseAddress(): boolean {
-    return this.router.url.includes('/jj');
+  get documentUploadAllowed(): boolean {
+    return this.isSSEditMode;
   }
 
-  get documentManagementAllowed(): boolean {
-    const onJJPage =
-      this.isJjBaseAddress() &&
-      (this.type === this.tabTypes.DCF ||
-        this.type === this.tabTypes.WR_ASSIGNMENTS ||
-        this.type === this.tabTypes.WR_INBOX ||
-        this.type === this.tabTypes.HEARING_INBOX ||
-        this.type === this.tabTypes.RETURNED_DECISIONS);
+  get documentRemovalAllowed(): boolean {
+    return this.isSSEditMode;
+  }
 
-    return !(this.isJJ && onJJPage);
+  get documentStatusChangesAllowed(): boolean {
+    return this.isSSEditMode || this.type == this.tabTypes.HEARING_INBOX || this.type == this.tabTypes.RETURNED_DECISIONS;
   }
   
   get unacknowledgedAmendmentsExist(): boolean {


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- Add Remark is no longer allowed on either DCF page.
- Document uploads, removals, and status changes are no longer allowed on the Staff DCF page, except when support staff use the Edit button.
- Document uploads and removals and are no longer allowed on the Decision Validation page while document status changes remain available.
- Document uploads and removals remain unavailable and document status changes remain available on the JJ Hearing Inbox and Returned Decisions pages. All three operations remain unavailable on the JJ DCF page.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
