### PR TITLE
TCVP-3502 - fixed an issue with FR and TTP selections when not guilty

### DIFF
--- a/src/frontend/staff-portal/src/app/components/staff-workbench/manual-dispute-entry/manual-dispute-entry.component.html
+++ b/src/frontend/staff-portal/src/app/components/staff-workbench/manual-dispute-entry/manual-dispute-entry.component.html
@@ -735,12 +735,12 @@
                             <div class="col-md-12">
                               <mat-radio-group formControlName="pleaCode" class="plea-radio-group">
                                 <mat-radio-button value="G" class="mb-3"
-                                  (change)="disputeInfoForm.get('count' + count.countNo).patchValue({__skip: false, pleaCode: 'G'})">
+                                  (change)="disputeInfoForm.get('count' + count.countNo).patchValue({__skip: false, pleaCode: 'G', requestTimeToPay: RequestTimeToPay.Y, requestReduction: RequestReduction.Y })">
                                   The Disputant agrees they committed this offence and would like to request a fine reduction and/or time to pay on this count.
                                 </mat-radio-button>
                                 <div class="or-divider mb-2">or</div>
                                 <mat-radio-button value="N" class="mb-3"
-                                  (change)="disputeInfoForm.get('count' + count.countNo).patchValue({__skip: false, pleaCode: 'N'})">
+                                  (change)="disputeInfoForm.get('count' + count.countNo).patchValue({__skip: false, pleaCode: 'N', requestTimeToPay: RequestTimeToPay.N, requestReduction: RequestReduction.N})">
                                   The Disputant does not agree they committed this offence, but if found guilty, may request a fine reduction and/or time to pay on this count.
                                 </mat-radio-button>
                               </mat-radio-group>


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- TCVP-3502 - fixed an additional issue found with FR and TTP values when the disputant chooses "not guilty" for a hearing dispute

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Tested locally

## Does the change impact or break the Docker build?

- [ ] Yes
- [X] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [X] New and existing unit tests pass locally with my changes
